### PR TITLE
magento/devdocs#5249: Markdown linting: Spaces after list markers (MD030). Folder - extension-dev-guide. Part 02.

### DIFF
--- a/guides/v2.2/extension-dev-guide/build/XSD-XML-validation.md
+++ b/guides/v2.2/extension-dev-guide/build/XSD-XML-validation.md
@@ -12,8 +12,8 @@ Magento uses [Uniform Resource Names](https://en.wikipedia.org/wiki/Uniform_Reso
 
 Magento supported URNs begin with `urn:magento`. Magento supports two XSD reference types:
 
-* Module XSD
-* Framework XSD
+*  Module XSD
+*  Framework XSD
 
 {: .bs-callout-info }
 You cannot change the XSD for any XML files provided with the Magento application.
@@ -29,7 +29,7 @@ where
 *  `urn:magento` is the URN identifier
 *  `module` is the reference type identifier
 *  `Magento_Flow` is the name of the module. This must be exactly the same as the module specified by ComponentRegistrar in the [registration.php]({{ page.baseurl }}/extension-dev-guide/build/component-registration.html) file.
-* `flows/content.xsd` is the relative path to the module&#8217;s directory.
+*  `flows/content.xsd` is the relative path to the module&#8217;s directory.
 
 ### Framework XSD
 
@@ -41,7 +41,7 @@ where
 
 *  `urn:magento` is the URN identifier
 *  `framework` is the reference type identifier. You can also add additional framework libraries as separate components with `framework-<sub-name>`
-* `Api/etc/extension_attributes.xsd` is the relative path to the framework&#8217;s directory.
+*  `Api/etc/extension_attributes.xsd` is the relative path to the framework&#8217;s directory.
 
 ### Referencing a XSD from another XSD
 

--- a/guides/v2.2/extension-dev-guide/build/composer-integration.md
+++ b/guides/v2.2/extension-dev-guide/build/composer-integration.md
@@ -88,8 +88,8 @@ The Magento application uses this `composer.json` file for its framework package
 
 **Locations:**
 
-* `app/code/<vendor-name>/<module-name>/composer.json`
-* `vendor/<vendor-name>/<module-name>/composer.json`
+*  `app/code/<vendor-name>/<module-name>/composer.json`
+*  `vendor/<vendor-name>/<module-name>/composer.json`
 
 **Name:** `<vendor-name>/<package-name>`
 
@@ -103,8 +103,8 @@ The `composer.json` file for a [module](https://glossary.magento.com/module) ext
 
 **Locations:**
 
-* `app/design/frontend/<vendor-name>/<theme-name>/composer.json`
-* `app/design/adminhtml/<vendor-name>/<theme-name>/composer.json`
+*  `app/design/frontend/<vendor-name>/<theme-name>/composer.json`
+*  `app/design/adminhtml/<vendor-name>/<theme-name>/composer.json`
 
 **Name:** `<vendor-name>/<package-name>`
 

--- a/guides/v2.2/extension-dev-guide/build/create_component.md
+++ b/guides/v2.2/extension-dev-guide/build/create_component.md
@@ -9,9 +9,9 @@ You give a name to your component in its `composer.json` and `module.xml` files.
 
 Before you continue, make sure you have completed all of the following tasks:
 
-*   Create a [file structure]({{page.baseurl}}/extension-dev-guide/build/module-file-structure.html).
-*   Create the [configuration files]({{page.baseurl}}/extension-dev-guide/build/required-configuration-files.html) you'll need.
-*   [Register]({{page.baseurl}}/extension-dev-guide/build/component-registration.html) your component.
+*  Create a [file structure]({{page.baseurl}}/extension-dev-guide/build/module-file-structure.html).
+*  Create the [configuration files]({{page.baseurl}}/extension-dev-guide/build/required-configuration-files.html) you'll need.
+*  [Register]({{page.baseurl}}/extension-dev-guide/build/component-registration.html) your component.
 
 ## Add the component's `module.xml` file {#add-component-xml}
 
@@ -37,9 +37,9 @@ Avoid using "Ui" for your custom module name because the <code>%Vendor%_Ui</code
 
 In addition, the [Component Manager]({{ page.baseurl }}/comp-mgr/module-man/compman-start.html) looks for a `composer.json` in a component's root directory and can perform actions on the component and its dependencies:
 
-* If a component has `composer.json` *and* the component was installed using [Composer](https://glossary.magento.com/composer) (including from packagist, the Magento Marketplace, or other source), the Component Manager can update, uninstall, enable, or disable the component.
-* If the component has `composer.json` but was *not* installed using Composer (for example, custom code a developer wrote), Component Manager can still enable or disable the component.
-* We strongly recommend you include `composer.json` in your component's root directory whether or not you intend to distribute it to other Magento merchants.
+*  If a component has `composer.json` *and* the component was installed using [Composer](https://glossary.magento.com/composer) (including from packagist, the Magento Marketplace, or other source), the Component Manager can update, uninstall, enable, or disable the component.
+*  If the component has `composer.json` but was *not* installed using Composer (for example, custom code a developer wrote), Component Manager can still enable or disable the component.
+*  We strongly recommend you include `composer.json` in your component's root directory whether or not you intend to distribute it to other Magento merchants.
 
 ### Example `composer.json` file
 
@@ -75,14 +75,14 @@ In addition, the [Component Manager]({{ page.baseurl }}/comp-mgr/module-man/comp
 
 In this example:
 
-* `name` is the name of your component.
-* `description` is a concise explanation of your component's purpose.
-* `require` lists any components your component depends on.
-* `suggest` lists soft dependencies. The component can operate without them, but if the components are active, this component might impact their functionality. `Suggest` does not affect component load order.
-* `type` determines what the [Magento component](https://glossary.magento.com/magento-component) type. Choose from *magento2-theme*, *magento2-language*, or *magento2-module*.
-* `version` lists the version of the component.
-* `license` lists applicable licenses that apply to your component.
-* `autoload` instructs Composer to load the specified files.
+*  `name` is the name of your component.
+*  `description` is a concise explanation of your component's purpose.
+*  `require` lists any components your component depends on.
+*  `suggest` lists soft dependencies. The component can operate without them, but if the components are active, this component might impact their functionality. `Suggest` does not affect component load order.
+*  `type` determines what the [Magento component](https://glossary.magento.com/magento-component) type. Choose from *magento2-theme*, *magento2-language*, or *magento2-module*.
+*  `version` lists the version of the component.
+*  `license` lists applicable licenses that apply to your component.
+*  `autoload` instructs Composer to load the specified files.
 
 {: .bs-callout-info }
 Magento does not currently support the [`path`](https://getcomposer.org/doc/05-repositories.md#path) repository.

--- a/guides/v2.2/extension-dev-guide/build/di-xml-file.md
+++ b/guides/v2.2/extension-dev-guide/build/di-xml-file.md
@@ -299,8 +299,8 @@ The lifestyle of an object determines the number of instances that can exist of 
 
 You can configure dependencies in Magento to have the following lifestyles:
 
-* **Singleton**(default) - One instance of this class exists. The object manager creates it at the first request. Requesting the class again returns the same instance. Disposing or ending the container registered to it releases the instance.
-* **Transient** - The object manager creates a new instance of the class for every request.
+*  **Singleton**(default) - One instance of this class exists. The object manager creates it at the first request. Requesting the class again returns the same instance. Disposing or ending the container registered to it releases the instance.
+*  **Transient** - The object manager creates a new instance of the class for every request.
 
 The `shared` property determines the lifestyle of both `argument` and `type` configurations.
 

--- a/guides/v2.2/extension-dev-guide/build/enable-module.md
+++ b/guides/v2.2/extension-dev-guide/build/enable-module.md
@@ -31,9 +31,9 @@ After you have built the component and are ready to enable it in your Magento en
 
 The general order of operations for `setup:upgrade` is:
 
-1.  **Schema install/upgrade.**
-1.  **Schema post-upgrade**— handles any additional updates. These recurring upgrades occur independently and regardless of any changes to the schema.
-1.  **Data install/upgrade** — installs the data. Taken from `setup/InstallData.php`.
+1. **Schema install/upgrade.**
+1. **Schema post-upgrade**— handles any additional updates. These recurring upgrades occur independently and regardless of any changes to the schema.
+1. **Data install/upgrade** — installs the data. Taken from `setup/InstallData.php`.
 
 ## Disable a component
 

--- a/guides/v2.2/extension-dev-guide/build/module-file-structure.md
+++ b/guides/v2.2/extension-dev-guide/build/module-file-structure.md
@@ -20,26 +20,26 @@ A typical file structure for a Magento 2 [module](https://glossary.magento.com/m
 {:.no_toc}
 Following are some common module directories:
 
-* `Block`: contains [PHP](https://glossary.magento.com/php) view classes as part of Model View Controller(MVC) vertical implementation of module logic.
-* `Controller`: contains PHP controller classes as part of MVC vertical implementation of module logic.
-* `etc`: contains configuration files; in particular, `module.xml`, which is required.
-* `Model`: contains PHP model classes as part of MVC vertical implementation of module logic.
-* `Setup`: contains classes for module database structure and data setup which are invoked when installing or upgrading.
+*  `Block`: contains [PHP](https://glossary.magento.com/php) view classes as part of Model View Controller(MVC) vertical implementation of module logic.
+*  `Controller`: contains PHP controller classes as part of MVC vertical implementation of module logic.
+*  `etc`: contains configuration files; in particular, `module.xml`, which is required.
+*  `Model`: contains PHP model classes as part of MVC vertical implementation of module logic.
+*  `Setup`: contains classes for module database structure and data setup which are invoked when installing or upgrading.
 
 #### Additional directories
 {:.no_toc}
 Additional folders can be added for configuration and other ancillary functions for items like [plugin-ins]({{ page.baseurl }}/extension-dev-guide/plugins.html), localization, and [layout](https://glossary.magento.com/layout) files.
 
-* `Api`: contains any PHP classes exposed to the [API](https://glossary.magento.com/api).
-* `Console`: contains CLI commands. For more info, see [Add CLI commands]({{ page.baseurl }}/extension-dev-guide/cli-cmds/cli-add.html).
-* `Cron`: contains cron job definitions.
-* `CustomerData`: contains section files.
-* `Helper`: contains aggregated functionality.
-* `i18n`: contains localization files.
-* `Observer`: contains files for executing commands from the listener.
-* `Plugin`: contains any needed [plug-ins]({{ page.baseurl }}/extension-dev-guide/plugins.html).
-* `UI`: contains data generation files.
-* `view`: contains view files, including static view files, design templates, email templates, and layout files.
+*  `Api`: contains any PHP classes exposed to the [API](https://glossary.magento.com/api).
+*  `Console`: contains CLI commands. For more info, see [Add CLI commands]({{ page.baseurl }}/extension-dev-guide/cli-cmds/cli-add.html).
+*  `Cron`: contains cron job definitions.
+*  `CustomerData`: contains section files.
+*  `Helper`: contains aggregated functionality.
+*  `i18n`: contains localization files.
+*  `Observer`: contains files for executing commands from the listener.
+*  `Plugin`: contains any needed [plug-ins]({{ page.baseurl }}/extension-dev-guide/plugins.html).
+*  `UI`: contains data generation files.
+*  `view`: contains view files, including static view files, design templates, email templates, and layout files.
 
 ### Theme file structure
 
@@ -87,16 +87,16 @@ A typical [theme](https://glossary.magento.com/theme) file structure can look li
 {:.no_toc}
 Typical theme directories are:
 
-* `etc`: Contains configuration files such as the `view.xml` file which contains image configurations for all images and thumbnails.
-* `i18n`: [Translation dictionaries]({{ page.baseurl }}/frontend-dev-guide/translations/xlate.html#m2devgde-xlate-dictionaries), if any.
-* `media`: Theme preview images (screen capture of your theme) can be put in here.
-* `web`: Optional directory that contains [static files](https://glossary.magento.com/static-files) organized into the following subdirectories:
+*  `etc`: Contains configuration files such as the `view.xml` file which contains image configurations for all images and thumbnails.
+*  `i18n`: [Translation dictionaries]({{ page.baseurl }}/frontend-dev-guide/translations/xlate.html#m2devgde-xlate-dictionaries), if any.
+*  `media`: Theme preview images (screen capture of your theme) can be put in here.
+*  `web`: Optional directory that contains [static files](https://glossary.magento.com/static-files) organized into the following subdirectories:
 
-   * `css/source`: Contains a theme's `less` configuration files that invoke mixins for global elements from the [Magento UI library]({{ page.baseurl }}/frontend-dev-guide/css-topics/theme-ui-lib.html), and the `theme.less` file that overrides the default variables values.
-   * `css/source/lib`: Contains view files that override the [UI library]({{ page.baseurl }}/frontend-dev-guide/css-topics/theme-ui-lib.html) files stored in `lib/web/css/source/lib`.
-   * `fonts`: The folder to place the different fonts for your theme.
-   * `images`: Static images folder.
-   * `js`: The folder for your JavaScript files.
+   *  `css/source`: Contains a theme's `less` configuration files that invoke mixins for global elements from the [Magento UI library]({{ page.baseurl }}/frontend-dev-guide/css-topics/theme-ui-lib.html), and the `theme.less` file that overrides the default variables values.
+   *  `css/source/lib`: Contains view files that override the [UI library]({{ page.baseurl }}/frontend-dev-guide/css-topics/theme-ui-lib.html) files stored in `lib/web/css/source/lib`.
+   *  `fonts`: The folder to place the different fonts for your theme.
+   *  `images`: Static images folder.
+   *  `js`: The folder for your JavaScript files.
 
 For more details on the theme folder structure, see [Magento theme structure]({{ page.baseurl }}/frontend-dev-guide/themes/theme-structure.html).
 

--- a/guides/v2.2/extension-dev-guide/build/optimal-dev-environment.md
+++ b/guides/v2.2/extension-dev-guide/build/optimal-dev-environment.md
@@ -27,28 +27,28 @@ You can enable this mode with the command `bin/magento deploy:mode:set developer
 
 The following is a list of the different ways you can install Magento 2 locally:
 
-* **Manual installation**\\
-  If you are developing on a local machine that meets the system requirements, you can follow the same steps as [installing Magento]({{ page.baseurl }}/install-gde/bk-install-guide.html) on a production server.
-* **Virtual Machine (VM) installation**\\
-  Installing Magento 2 in a virtual environment allows you to run Magento 2 without the need to install a local [LAMP](https://en.wikipedia.org/wiki/LAMP_(software_bundle)){:target="_blank"} stack.
+*  **Manual installation**\\
+   If you are developing on a local machine that meets the system requirements, you can follow the same steps as [installing Magento]({{ page.baseurl }}/install-gde/bk-install-guide.html) on a production server.
+*  **Virtual Machine (VM) installation**\\
+   Installing Magento 2 in a virtual environment allows you to run Magento 2 without the need to install a local [LAMP](https://en.wikipedia.org/wiki/LAMP_(software_bundle)){:target="_blank"} stack.
 
-  You can use a VM tool, such as [VirtualBox](https://www.virtualbox.org/wiki/VirtualBox){:target="_blank"}, together with a virtual environment tool, such as [Vagrant](https://www.vagrantup.com/){:target="_blank"} or [Docker](https://www.docker.com/){:target="_blank"}, to create reusable and shareable instances of Magento for development.
+   You can use a VM tool, such as [VirtualBox](https://www.virtualbox.org/wiki/VirtualBox){:target="_blank"}, together with a virtual environment tool, such as [Vagrant](https://www.vagrantup.com/){:target="_blank"} or [Docker](https://www.docker.com/){:target="_blank"}, to create reusable and shareable instances of Magento for development.
 
-  A search for ["magento developer box"](https://github.com/search?utf8=%E2%9C%93&q=magento+developer+box){:target="_blank"} in GitHub provides a list of unofficial virtual machines configured for Magento development.
+   A search for ["magento developer box"](https://github.com/search?utf8=%E2%9C%93&q=magento+developer+box){:target="_blank"} in GitHub provides a list of unofficial virtual machines configured for Magento development.
 
 ### Optimal Configuration
 
 The following is a list of optimizations you can make on your local development machine
 
-* Magento recommends installing and using the latest supported version of [PHP](https://glossary.magento.com/php) 7 to increase performance.
-* Replace your MySQL database with [Percona](https://www.percona.com/software/mysql-database/percona-server){:target="_blank"}.
-* Make sure you install and enable [PHP OPcache](http://php.net/manual/en/intro.opcache.php){:target="_blank"}.
-* Xdebug is off by default. Enable this feature only when you need it because it requires a lot of memory and degrades performance.
-  The `xdebug.max_nesting_level` configuration needs to be set to 200 or greater for Magento.
-  You can increase the memory available to PHP to get an increase in performance with Xdebug on.
-* If you need sample data, you can install it using [composer]({{ page.baseurl }}/install-gde/install/web/install-web-sample-data-composer.html) or by [cloning repositories]({{ page.baseurl }}/install-gde/install/web/install-web-sample-data-clone.html).
-* To speed up frontend development, [turn off merging of CSS and JavaScript](http://docs.magento.com/m2/ee/user_guide/system/file-optimization.html){:target="_blank"}.
-* Make sure [caching]({{ page.baseurl }}/config-guide/cache.html) is turned on (this is the default behavior).
-  Generally, only page [cache](https://glossary.magento.com/cache) and block cache should be turned off for development and turned back on when testing.
-* [Opcache timestamp validation](http://php.net/manual/en/opcache.configuration.php#ini.opcache.validate-timestamps){:target="_blank"} should always be on for development.
-  Development is impossible with opcache on and revalidation off because any PHP modification would require a cache reset.
+*  Magento recommends installing and using the latest supported version of [PHP](https://glossary.magento.com/php) 7 to increase performance.
+*  Replace your MySQL database with [Percona](https://www.percona.com/software/mysql-database/percona-server){:target="_blank"}.
+*  Make sure you install and enable [PHP OPcache](http://php.net/manual/en/intro.opcache.php){:target="_blank"}.
+*  Xdebug is off by default. Enable this feature only when you need it because it requires a lot of memory and degrades performance.
+   The `xdebug.max_nesting_level` configuration needs to be set to 200 or greater for Magento.
+   You can increase the memory available to PHP to get an increase in performance with Xdebug on.
+*  If you need sample data, you can install it using [composer]({{ page.baseurl }}/install-gde/install/web/install-web-sample-data-composer.html) or by [cloning repositories]({{ page.baseurl }}/install-gde/install/web/install-web-sample-data-clone.html).
+*  To speed up frontend development, [turn off merging of CSS and JavaScript](http://docs.magento.com/m2/ee/user_guide/system/file-optimization.html){:target="_blank"}.
+*  Make sure [caching]({{ page.baseurl }}/config-guide/cache.html) is turned on (this is the default behavior).
+   Generally, only page [cache](https://glossary.magento.com/cache) and block cache should be turned off for development and turned back on when testing.
+*  [Opcache timestamp validation](http://php.net/manual/en/opcache.configuration.php#ini.opcache.validate-timestamps){:target="_blank"} should always be on for development.
+   Development is impossible with opcache on and revalidation off because any PHP modification would require a cache reset.

--- a/guides/v2.2/extension-dev-guide/build/required-configuration-files.md
+++ b/guides/v2.2/extension-dev-guide/build/required-configuration-files.md
@@ -19,43 +19,43 @@ Unlike Magento 1, there is no monolithic configuration file in Magento 2.
 
 Magento 2 looks for configuration information for each module in that module's `etc` directory. Depending on the needs of your module, you might have the following configuration files at the top level of your module's `etc` directory:
 
-* `acl.xml`
-* `config.xml`
-* `di.xml`
-* `module.xml`
-* `webapi.xml`
+*  `acl.xml`
+*  `config.xml`
+*  `di.xml`
+*  `module.xml`
+*  `webapi.xml`
 
 {: .bs-callout-info }
 Additions you make to those configuration files are applied *globally* to your module.
 
 In addition to those files, a Magento 2 module also has nested configuration directories in the `etc` directory for any required administration html, frontend, API REST, or API SOAP specific configuration. Additions you make to files in these directories override the settings in the global configuration files for the respective functionality only. That is, if you add a `config.xml` file to `etc/frontend`, the settings you make in that file overrides the settings in `etc/config.xml` for [storefront](https://glossary.magento.com/storefront) functionality *only*.
 
-* `<your module root dir>/etc/adminhtml/`
-* `<your module root dir>/etc/frontend/`
-* `<your module root dir>/etc/webapi_rest/`
-* `<your module root dir>/etc/webapi_soap/`
+*  `<your module root dir>/etc/adminhtml/`
+*  `<your module root dir>/etc/frontend/`
+*  `<your module root dir>/etc/webapi_rest/`
+*  `<your module root dir>/etc/webapi_soap/`
 
 ### Configuration files
 
-* Configuration files that are in the top level of that module's `etc` directory are global to that component.
-* Configuration files placed in subdirectories (`adminhtml`, `frontend`, `webapi_rest`, `webapi_soap`) apply only to those respective functional areas.
+*  Configuration files that are in the top level of that module's `etc` directory are global to that component.
+*  Configuration files placed in subdirectories (`adminhtml`, `frontend`, `webapi_rest`, `webapi_soap`) apply only to those respective functional areas.
 
 ### Tailor your configuration files for what your module does
 
 The exact set of configuration files required for your module depends on what your new module does. The required configuration files depend on how you plan to use the module: will the module be manifested on the storefront UI, or in the [Magento Admin](https://glossary.magento.com/magento-admin) panel, or as a [backend](https://glossary.magento.com/backend) [extension](https://glossary.magento.com/extension) that makes a service call? Or all of the above. For example, if your module performs a function in the Admin, you should add any necessary configuration files for those functions to `etc/adminhtml/`, like:
 
-* `<your module root dir>/etc/adminhtml/di.xml`
-* `<your module root dir>/etc/adminhtml/routes.xml`
+*  `<your module root dir>/etc/adminhtml/di.xml`
+*  `<your module root dir>/etc/adminhtml/routes.xml`
 
 Similarly, if your module changes the UI, you should add the needed configuration files to `~/etc/frontend/`. For example:
 
-* `<your module root dir>/etc/frontend/di.xml`
-* `<your module root dir>/etc/frontend/page_types.xml`
+*  `<your module root dir>/etc/frontend/di.xml`
+*  `<your module root dir>/etc/frontend/page_types.xml`
 
 If the module is a service that may call an API, or does some other work that is not manifested in the UI you should add any needed configuration files in the REST and/or SOAP webapi configuration directories, like this:
 
-* `<your module root dir>/etc/webapi_rest/di.xml`
-* `<your module root dir>/etc/webapi_soap/di.xml`
+*  `<your module root dir>/etc/webapi_rest/di.xml`
+*  `<your module root dir>/etc/webapi_soap/di.xml`
 
 Keep in mind that you might be able to handle your module's configuration solely with configuration files at the top level of your module's `etc` directory, but the nested directory is a useful way to keep the configuration neatly compartmentalized.
 

--- a/guides/v2.2/extension-dev-guide/cache/page-caching/public-content.md
+++ b/guides/v2.2/extension-dev-guide/cache/page-caching/public-content.md
@@ -67,16 +67,16 @@ class DynamicController extends \Magento\Framework\App\Action\Action
 
 Most caching servers and proxies use a [URL](https://glossary.magento.com/url) as a key for cache records. However, Magento URLs are not unique *enough* to allow caching by URL only. Cookie and session data in the URL can also lead to undesirable side effects,  including:
 
--   Collisions in cache storage
--   Unwanted information leaks (e.g., French language website partially visible on an English language website, prices for customer group visible in public, etc.)
+-  Collisions in cache storage
+-  Unwanted information leaks (e.g., French language website partially visible on an English language website, prices for customer group visible in public, etc.)
 
 To make each cached URL totally unique, we use *HTTP context variables*. Context variables enable the Magento application to serve different content on the same URL based on:
 
--   Customer group
--   Selected language
--   Selected store
--   Selected currency
--   Whether a customer is logged in or not
+-  Customer group
+-  Selected language
+-  Selected store
+-  Selected currency
+-  Whether a customer is logged in or not
 
 Context variables should not be specific to individual users because variables are used in cache keys for public content. In other words, a context variable per user results in a separate copy of content cached on the server for each user.
 

--- a/guides/v2.2/extension-dev-guide/cache/partial-caching.md
+++ b/guides/v2.2/extension-dev-guide/cache/partial-caching.md
@@ -41,9 +41,9 @@ The preceding lists all cache types and shows they are all enabled.
 
 The following topics discuss how to set up caching:
 
-* [Create a cache type]({{ page.baseurl }}/extension-dev-guide/cache/partial-caching/create-cache-type.html)
-* [Create or extend configuration types]({{ page.baseurl }}/config-guide/config/config-create.html)
-* [Associate cache frontends with cache types]({{ page.baseurl }}/config-guide/cache/cache-types.html)
-* [Low-level cache options]({{ page.baseurl }}/config-guide/cache/cache-options.html)
-* [Configure and use Varnish]({{ page.baseurl }}/config-guide/varnish/config-varnish.html)
-* [Configure Redis]({{ page.baseurl }}/config-guide/redis/config-redis.html)
+*  [Create a cache type]({{ page.baseurl }}/extension-dev-guide/cache/partial-caching/create-cache-type.html)
+*  [Create or extend configuration types]({{ page.baseurl }}/config-guide/config/config-create.html)
+*  [Associate cache frontends with cache types]({{ page.baseurl }}/config-guide/cache/cache-types.html)
+*  [Low-level cache options]({{ page.baseurl }}/config-guide/cache/cache-options.html)
+*  [Configure and use Varnish]({{ page.baseurl }}/config-guide/varnish/config-varnish.html)
+*  [Configure Redis]({{ page.baseurl }}/config-guide/redis/config-redis.html)

--- a/guides/v2.2/extension-dev-guide/cache/partial-caching/create-cache-type.md
+++ b/guides/v2.2/extension-dev-guide/cache/partial-caching/create-cache-type.md
@@ -24,9 +24,9 @@ class %Namespace%\%Module%\Model\Cache\Type extends \Magento\Framework\Cache\Fro
 
 You must specify the following parameters:
 
-* `Namespace\Module` defines the name of a [module](https://glossary.magento.com/module) that uses a cache type. A module can use several cache types and a cache type can be used in several modules.
-* `%cache_type_id%` defines unique identifier of a cache type.
-* `%CACHE_TYPE_TAG%` defines unique tag to be used in the cache type scoping.
+*  `Namespace\Module` defines the name of a [module](https://glossary.magento.com/module) that uses a cache type. A module can use several cache types and a cache type can be used in several modules.
+*  `%cache_type_id%` defines unique identifier of a cache type.
+*  `%CACHE_TYPE_TAG%` defines unique tag to be used in the cache type scoping.
 
 ## More information about caching
 

--- a/guides/v2.2/extension-dev-guide/cli-cmds/cli-add.md
+++ b/guides/v2.2/extension-dev-guide/cli-cmds/cli-add.md
@@ -9,7 +9,7 @@ menu_order: 1
 
 You [module](https://glossary.magento.com/module) can optionally use Magento 2's Symfony-based [command-line interface (CLI)]({{ page.baseurl }}/config-guide/cli/config-cli.html#config-new-cli-intro) to provide commands for users to interact with. To use the CLI, see the following topics:
 
-* [Command naming guidelines]({{ page.baseurl }}/extension-dev-guide/cli-cmds/cli-naming-guidelines.html)
-* [How to add CLI commands]({{ page.baseurl }}/extension-dev-guide/cli-cmds/cli-howto.html)
-* [List of Magento CLI commands]({{ page.baseurl }}/reference/cli/magento.html)
+*  [Command naming guidelines]({{ page.baseurl }}/extension-dev-guide/cli-cmds/cli-naming-guidelines.html)
+*  [How to add CLI commands]({{ page.baseurl }}/extension-dev-guide/cli-cmds/cli-howto.html)
+*  [List of Magento CLI commands]({{ page.baseurl }}/reference/cli/magento.html)
 

--- a/guides/v2.2/extension-dev-guide/cli-cmds/cli-naming-guidelines.md
+++ b/guides/v2.2/extension-dev-guide/cli-cmds/cli-naming-guidelines.md
@@ -35,8 +35,8 @@ bin/magento list
 
 `group` represents a group of related commands. Commands in a group display in a list, which in turn makes it easier for the user to find the desired command. To find a group name for a command, imagine an subject area where it can be used. The subject area can be any of the following:
 
-* *Domain* area (for example, `module` for actions with modules, `info` for commands that provide some information)
-* *Workflow* area (for example, `admin` for commands that can be used by an administrator, `dev` for a developer)
+*  *Domain* area (for example, `module` for actions with modules, `info` for commands that provide some information)
+*  *Workflow* area (for example, `admin` for commands that can be used by an administrator, `dev` for a developer)
 
 ### subject
 `subject` is a subject for the action. The subject is optional, but it can be useful for defining sets of commands that work with the same object. If a subject is represented by a compound word, use a dash or hyphen character to separate the words.
@@ -93,12 +93,12 @@ Use arguments when you need required data from the user. We recommend as few arg
 
 To make it simpler for the user, we recommend the following:
 
-* Run the CLI multiple times for providing multiple similar values instead of running it once with 20 values
-* Use default values for required arguments where possible.
+*  Run the CLI multiple times for providing multiple similar values instead of running it once with 20 values
+*  Use default values for required arguments where possible.
 
    You can then use options instead of arguments to minimize the amount of required data the user must enter.
 
-* Replace arguments with options: options are named, so the user can provide them in any order. This requires additional data validation (by default, all options are optional).
+*  Replace arguments with options: options are named, so the user can provide them in any order. This requires additional data validation (by default, all options are optional).
 
 ### Command Options
 
@@ -140,8 +140,8 @@ Where:
 
 Use options for:
 
-* Optional data
-* Required data that has a default value
+*  Optional data
+*  Required data that has a default value
 
 Example:
 
@@ -160,9 +160,9 @@ magento module:disable -f=yes Magento_Catalog
 
 To avoid naming your command the same as another command, we recommend:
 
-* Looking at other extensions in the Magento Marketplace before you choose a name for your commands. By planning ahead, you can avoid naming collisions entirely.
+*  Looking at other extensions in the Magento Marketplace before you choose a name for your commands. By planning ahead, you can avoid naming collisions entirely.
 
-* Restricting command names to start with a unique name, such as a vendor name. The [usability](https://glossary.magento.com/usability) of the command depends on what you choose for a vendor name.
+*  Restricting command names to start with a unique name, such as a vendor name. The [usability](https://glossary.magento.com/usability) of the command depends on what you choose for a vendor name.
 
    For example, `myname:dev:theme:create` is not obvious and is hard to remember.
 

--- a/guides/v2.2/extension-dev-guide/configuration/sensitive-and-environment-settings.md
+++ b/guides/v2.2/extension-dev-guide/configuration/sensitive-and-environment-settings.md
@@ -23,10 +23,10 @@ _Sensitive_ configuration values hold restricted or confidential information.
 
 Examples of sensitive information include:
 
-* Keys (such as API keys)
-* Usernames and passwords
-* E-mail addresses
-* Any personally identifiable information (e.g., address, phone number, date of birth, government identification number, etc.)
+*  Keys (such as API keys)
+*  Usernames and passwords
+*  E-mail addresses
+*  Any personally identifiable information (e.g., address, phone number, date of birth, government identification number, etc.)
 
 ### Environment or system-specific values
 
@@ -34,16 +34,16 @@ _Environment_ or _system-specific_ values are unique to the system where Magento
 
 Examples of environment or system-specific values include:
 
-* URLs
-* IP addresses
-* Ports
-* Hostnames
-* Domain names
-* Paths (e.g., custom paths, proxy host, proxy port)
-* "modes" (e.g, sandbox mode, debug mode, test mode)
-* SSL (only for non-payment)
-* E-mail recipients
-* Administrative settings between systems (e.g., password expiration limits)
+*  URLs
+*  IP addresses
+*  Ports
+*  Hostnames
+*  Domain names
+*  Paths (e.g., custom paths, proxy host, proxy port)
+*  "modes" (e.g, sandbox mode, debug mode, test mode)
+*  SSL (only for non-payment)
+*  E-mail recipients
+*  Administrative settings between systems (e.g., password expiration limits)
 
 ## How to specify values as sensitive or system-specific
 
@@ -96,10 +96,10 @@ To set a configuration setting as both sensitive and system-specific, create two
 {:.ref-header}
 Related topics
 
-* [Configuration importers][config-importers]
-* [The di.xml file][di-xml]
-* [Developer roadmap]({{ page.baseurl }}/extension-dev-guide/intro/developers_roadmap.html)
-* [Dependency injection]({{ page.baseurl }}/extension-dev-guide/depend-inj.html)
+*  [Configuration importers][config-importers]
+*  [The di.xml file][di-xml]
+*  [Developer roadmap]({{ page.baseurl }}/extension-dev-guide/intro/developers_roadmap.html)
+*  [Dependency injection]({{ page.baseurl }}/extension-dev-guide/depend-inj.html)
 
 [typepool]: {{ site.mage2bloburl }}/{{ page.guide_version }}/app/code/Magento/Config/Model/Config/TypePool.php
 [di-xml]: {{ page.baseurl }}/extension-dev-guide/build/di-xml-file.html

--- a/guides/v2.2/extension-dev-guide/extension_attributes/adding-attributes.md
+++ b/guides/v2.2/extension-dev-guide/extension_attributes/adding-attributes.md
@@ -71,9 +71,9 @@ public function afterGet
 
 This is the simplest way to add extension attributes without causing a conflict:
 
-- We get the [entity's](https://glossary.magento.com/entity) extension attributes, if they are already set.
-- We add our [extension attribute](https://glossary.magento.com/extension-attribute).
-- Finally set the extension attribute on the entity with ours included.
+-  We get the [entity's](https://glossary.magento.com/entity) extension attributes, if they are already set.
+-  We add our [extension attribute](https://glossary.magento.com/extension-attribute).
+-  Finally set the extension attribute on the entity with ours included.
 
 AfterGetList is similar to afterGet.
 


### PR DESCRIPTION

## Purpose of this pull request

This pull request provides changes regarding `Markdown linting: Spaces after list markers (MD030)` rule in the following folders:

- `guides/v2.2/extension-dev-guide`


## Affected DevDocs pages

<!-- REQUIRED List the affected pages on devdocs.magento.com (URLs). Not needed for large numbers of files. -->

- ...

## Links to Magento source code

<!--  OPTIONAL - REMOVE THIS SECTION IF NOT USED. If this pull request references a file in a Magento codebase repository, add it here. -->

- ...

<!--
If you are fixing a GitHub issue, note it using GitHub keyword format (https://help.github.com/en/articles/closing-issues-using-keywords#closing-an-issue-in-a-different-repository) to close the issue when this pull request is merged. Example: `Fixes #1234`

`master` is the default branch. Merged pull requests to `master` go live on the site automatically. Any requested changes to content on the `master` branch must be related to the released codebase. Any content related to future releases goes in the `develop` branch.

See Contribution guidelines (https://github.com/magento/devdocs/blob/master/.github/CONTRIBUTING.md) for more information.
-->
