### PR TITLE
magento/devdocs#5249: Markdown linting: Spaces after list markers (MD030). Folder - extension-dev-guide. Part 04.

### DIFF
--- a/guides/v2.2/extension-dev-guide/test/test_object-mgr.md
+++ b/guides/v2.2/extension-dev-guide/test/test_object-mgr.md
@@ -17,9 +17,9 @@ Do not use the ObjectManager helper class for classes with a small number of dep
 
 The ObjectManager public interface methods are:
 
--   [getObject method](#getobject). Creates class instances with automatically mocked dependencies.
--   [getCollectionMock method](#getCollectionMock). Lists mocked constructor arguments.
--   [getConstructArguments method](#getConstructArguments). Creates collection instances that contain specified elements.
+-  [getObject method](#getobject). Creates class instances with automatically mocked dependencies.
+-  [getCollectionMock method](#getCollectionMock). Lists mocked constructor arguments.
+-  [getConstructArguments method](#getConstructArguments). Creates collection instances that contain specified elements.
 
 ### getObject method {#getobject}
 

--- a/guides/v2.2/extension-dev-guide/validate/test-module.md
+++ b/guides/v2.2/extension-dev-guide/validate/test-module.md
@@ -48,10 +48,10 @@ Before you publish your component, test installing it using the [Magento Compone
 
 See these resources for testing in [PHP](https://glossary.magento.com/php) and validating Magento components:
 
-* The [Magento Coding Standard] provides a set of rules and sniffs for the [PHP_CodeSniffer] tool
-* [Technical Deep Dive: How to Pass the Magento Marketplace Extension Quality Program] (video) from Magento Imagine 2017
-* [Extension Quality Program] in the Magento Marketplace User Guide
-* [01 The Module Skeleton Kata] (video) by [Mage2Katas]
+*  The [Magento Coding Standard] provides a set of rules and sniffs for the [PHP_CodeSniffer] tool
+*  [Technical Deep Dive: How to Pass the Magento Marketplace Extension Quality Program] (video) from Magento Imagine 2017
+*  [Extension Quality Program] in the Magento Marketplace User Guide
+*  [01 The Module Skeleton Kata] (video) by [Mage2Katas]
 
 [Magento Testing Overview]: {{ page.baseurl }}/test/testing.html
 [Functional Testing Framework]: {{ page.baseurl }}/mtf/mtf_introduction.html

--- a/guides/v2.2/extension-dev-guide/validate/validate.md
+++ b/guides/v2.2/extension-dev-guide/validate/validate.md
@@ -5,6 +5,6 @@ title: Validate
 
 After your [module](https://glossary.magento.com/module) is built, you need to test it. Read through the Definition of Done to confirm that your module and coding practice is compliant with Magento.
 
-* [Definition of done]({{ page.baseurl }}/contributor-guide/contributing_dod.html) in the Contributor Guide.
-* [Coding Standards]({{ page.baseurl }}/coding-standards/bk-coding-standards.html)
-* [Testing]({{ page.baseurl }}/extension-dev-guide/validate/test-module.html)
+*  [Definition of done]({{ page.baseurl }}/contributor-guide/contributing_dod.html) in the Contributor Guide.
+*  [Coding Standards]({{ page.baseurl }}/coding-standards/bk-coding-standards.html)
+*  [Testing]({{ page.baseurl }}/extension-dev-guide/validate/test-module.html)

--- a/guides/v2.2/extension-dev-guide/versioning/check-version.md
+++ b/guides/v2.2/extension-dev-guide/versioning/check-version.md
@@ -7,10 +7,10 @@ contributor_link: https://www.atwix.com/
 
 Use any of the following ways to determine which version of Magento is installed:
 
-- From the command line
-- With an HTTP GET request
-- From within the Magento Admin
-- By viewing the `composer.lock` file
+-  From the command line
+-  With an HTTP GET request
+-  From within the Magento Admin
+-  By viewing the `composer.lock` file
 
 ## Command line
 

--- a/guides/v2.2/extension-dev-guide/versioning/codebase-changes.md
+++ b/guides/v2.2/extension-dev-guide/versioning/codebase-changes.md
@@ -162,15 +162,15 @@ Any change not listed below is considered a PATCH level change.
 
 Though inheritance is discouraged in Magento, the following classes are still acceptable for extension at the moment:
 
-* \Magento\Framework\Model\AbstractExtensibleModel
-* \Magento\Framework\Api\AbstractExtensibleObject
-* \Magento\Framework\Api\AbstractSimpleObject
-* \Magento\Framework\Model\AbstractModel
-* \Magento\Framework\App\Action\Action
-* \Magento\Backend\App\Action
-* \Magento\Backend\App\AbstractAction
-* \Magento\Framework\App\Action\AbstractAction
-* \Magento\Framework\View\Element\AbstractBlock
-* \Magento\Framework\View\Element\Template
+*  \Magento\Framework\Model\AbstractExtensibleModel
+*  \Magento\Framework\Api\AbstractExtensibleObject
+*  \Magento\Framework\Api\AbstractSimpleObject
+*  \Magento\Framework\Model\AbstractModel
+*  \Magento\Framework\App\Action\Action
+*  \Magento\Backend\App\Action
+*  \Magento\Backend\App\AbstractAction
+*  \Magento\Framework\App\Action\AbstractAction
+*  \Magento\Framework\View\Element\AbstractBlock
+*  \Magento\Framework\View\Element\Template
 
 As Magento framework improves, this list should be reduced and, eventually, eliminated.

--- a/guides/v2.2/extension-dev-guide/versioning/dependencies.md
+++ b/guides/v2.2/extension-dev-guide/versioning/dependencies.md
@@ -19,13 +19,13 @@ To achieve this, all third-party modules must obey the following rules:
 
 A PHP Interface in Magento can be used in several ways by the core product and extension developers.
 
-* **As an API**. An interface is called by PHP code.
-* **As a Service Provider Interface (SPI)**. An interface can be implemented, allowing code to provide functionality to the platform.
-* **As both**. For example, in a service contract, we expect all calls to a [module](https://glossary.magento.com/module) to be done through the Interface (API), but we also have support for third parties to provide alternate implementations (SPI). APIs and SPIs are not mutually exclusive. Therefore, we do not distinguish them separately. SPIs are annotated the same as APIs.
+*  **As an API**. An interface is called by PHP code.
+*  **As a Service Provider Interface (SPI)**. An interface can be implemented, allowing code to provide functionality to the platform.
+*  **As both**. For example, in a service contract, we expect all calls to a [module](https://glossary.magento.com/module) to be done through the Interface (API), but we also have support for third parties to provide alternate implementations (SPI). APIs and SPIs are not mutually exclusive. Therefore, we do not distinguish them separately. SPIs are annotated the same as APIs.
 
 However, the dependency rules are different:
 
-* If a module uses (calls) an API, it should be dependent on the MAJOR version and the system provides backward compatibility in scope of current major version.
+*  If a module uses (calls) an API, it should be dependent on the MAJOR version and the system provides backward compatibility in scope of current major version.
 
   **API dependency example**
 
@@ -39,7 +39,7 @@ However, the dependency rules are different:
     }
     ```
 
-* If a module implements an API/SPI, it should be dependent on the MAJOR+MINOR version, and the system provides backward compatibility in scope of the current minor version.
+*  If a module implements an API/SPI, it should be dependent on the MAJOR+MINOR version, and the system provides backward compatibility in scope of the current minor version.
 
    **SPI dependency example**
 

--- a/guides/v2.2/extension-dev-guide/versioning/index.md
+++ b/guides/v2.2/extension-dev-guide/versioning/index.md
@@ -18,9 +18,9 @@ The `version` field in a modules [`composer.json`][composer-json] file specifies
 
 The format follows [Semantic Versioning][semantic-versioning] rules:
 
-* The MAJOR version increments when incompatible API changes are made.
-* The MINOR version increments when backward-compatible functionality has been added.
-* The PATCH version increments when backward-compatible bug fixes occur.
+*  The MAJOR version increments when incompatible API changes are made.
+*  The MINOR version increments when backward-compatible functionality has been added.
+*  The PATCH version increments when backward-compatible bug fixes occur.
 
 ### Pre-release versions
 
@@ -35,9 +35,9 @@ For pre-release versions, the format is:
 
 Magento's module versioning policy complies with the following specifications:
 
-* [Semantic Versioning][semantic-versioning]{:target="_blank"}
-* [Composer version specification][composer-versioning]{:target="_blank"}
-* [PHP `version_compare()` specification][php-version-compare]{:target="_blank"}
+*  [Semantic Versioning][semantic-versioning]{:target="_blank"}
+*  [Composer version specification][composer-versioning]{:target="_blank"}
+*  [PHP `version_compare()` specification][php-version-compare]{:target="_blank"}
 
 ## Where versioning is used
 

--- a/guides/v2.2/extension-dev-guide/webapi/request-processor-pool.md
+++ b/guides/v2.2/extension-dev-guide/webapi/request-processor-pool.md
@@ -29,10 +29,10 @@ Processor name | Class | URL pattern | Description
 
 To create a custom processor, you must perform the following tasks:
 
-* Define the custom processor in `webapi_rest/di.xml`.
-* Create a processor class and implement the `Magento\Webapi\Controller\Rest\RequestProcessorInterface` interface.
-* Define the processing rules in the `canProcess` method.
-* Create the processor logic in the `process` method.
+*  Define the custom processor in `webapi_rest/di.xml`.
+*  Create a processor class and implement the `Magento\Webapi\Controller\Rest\RequestProcessorInterface` interface.
+*  Define the processing rules in the `canProcess` method.
+*  Create the processor logic in the `process` method.
 
 ### Define the custom processor
 

--- a/guides/v2.3/extension-dev-guide/async-operations.md
+++ b/guides/v2.3/extension-dev-guide/async-operations.md
@@ -31,8 +31,8 @@ When the client code needs the result, the `get()` method will be called to retr
 
 There are 2 types of asynchronous operations where `DeferredInterface` can be used to describe the result:
 
-* With asynchronous operations in progress, calling `get()` would wait for them to finish and return their result.
-* With deferred operations, `get()` would actually start the operation, wait for it to finish, and then return the result.
+*  With asynchronous operations in progress, calling `get()` would wait for them to finish and return their result.
+*  With deferred operations, `get()` would actually start the operation, wait for it to finish, and then return the result.
 
 Sometimes developers require more control over long asynchronous operations.
 That is why there is an extended deferred variant - `Magento\Framework\Async\CancelableDeferredInterface`:

--- a/guides/v2.3/extension-dev-guide/attributes.md
+++ b/guides/v2.3/extension-dev-guide/attributes.md
@@ -5,11 +5,11 @@ title: EAV and extension attributes
 
 There are two types of attributes you can use to extend Magento functionality:
 
-* Custom and Entity-Attribute-Value (EAV) attributes—Custom attributes are those added on behalf of a merchant. For example, a merchant might need to add attributes to describe products, such as shape or volume. A merchant can add these attributes in the [Magento Admin](https://glossary.magento.com/magento-admin) panel. See the [merchant documentation](http://docs.magento.com/m2/ce/user_guide/stores/attributes.html) for information about managing custom attributes.
+*  Custom and Entity-Attribute-Value (EAV) attributes—Custom attributes are those added on behalf of a merchant. For example, a merchant might need to add attributes to describe products, such as shape or volume. A merchant can add these attributes in the [Magento Admin](https://glossary.magento.com/magento-admin) panel. See the [merchant documentation](http://docs.magento.com/m2/ce/user_guide/stores/attributes.html) for information about managing custom attributes.
 
    Custom attributes are a subset of EAV attributes. Objects that use EAV attributes typically store values in several MySQL tables. The `Customer` and `Catalog` modules are the primary models that use EAV attributes. Other modules, such as `ConfigurableProduct`, `GiftMessage`, and `Tax`, use the EAV functionality for `Catalog`.
 
-* [Extension attributes](https://glossary.magento.com/extension-attribute). Extension attributes are new in Magento 2. They are used to extend functionality and often use more [complex data](https://glossary.magento.com/complex-data) types than custom attributes. These attributes do not appear in the Magento Admin.
+*  [Extension attributes](https://glossary.magento.com/extension-attribute). Extension attributes are new in Magento 2. They are used to extend functionality and often use more [complex data](https://glossary.magento.com/complex-data) types than custom attributes. These attributes do not appear in the Magento Admin.
 
 ## EAV and custom attributes {#custom}
 
@@ -17,20 +17,20 @@ There are two types of attributes you can use to extend Magento functionality:
 
 A [module](https://glossary.magento.com/module) has a set of built-in attributes that are always available. The `Catalog` module has several attributes that are defined as EAV attributes, but are treated as built-in attributes. These attributes include:
 
-* attribute_set_id
-* created_at
-* group_price
-* media_gallery
-* name
-* price
-* [sku](https://glossary.magento.com/sku)
-* status
-* store_id
-* tier_price
-* type_id
-* updated_at
-* visibility
-* weight
+*  attribute_set_id
+*  created_at
+*  group_price
+*  media_gallery
+*  name
+*  price
+*  [sku](https://glossary.magento.com/sku)
+*  status
+*  store_id
+*  tier_price
+*  type_id
+*  updated_at
+*  visibility
+*  weight
 
 In this case, when `getCustomAttributes()` is called, the system returns only custom attributes that are not in this list.
 

--- a/guides/v2.3/extension-dev-guide/bk-extension-dev-guide.md
+++ b/guides/v2.3/extension-dev-guide/bk-extension-dev-guide.md
@@ -9,11 +9,11 @@ The [PHP](https://glossary.magento.com/php) Developer Guide contains information
 
 The Magento application is made up of *Modules*, *Themes*, and *Language Packages*:
 
-* [**Modules**]({{ page.baseurl }}/architecture/archi_perspectives/components/modules/mod_intro.html) interact with other parts of the application to accomplish a particular business function or provide a feature. A [module](https://glossary.magento.com/module) can contain a user interface for displaying information or interacting with the user. It can also contain application interfaces that another Magento module or code chunk might call.
+*  [**Modules**]({{ page.baseurl }}/architecture/archi_perspectives/components/modules/mod_intro.html) interact with other parts of the application to accomplish a particular business function or provide a feature. A [module](https://glossary.magento.com/module) can contain a user interface for displaying information or interacting with the user. It can also contain application interfaces that another Magento module or code chunk might call.
 
-* [**Themes**]({{ page.baseurl }}/frontend-dev-guide/themes/theme-general.html) provide a personalized touch for each Magento installation by changing the look and feel of the [storefront](https://glossary.magento.com/storefront) or [Admin](https://glossary.magento.com/admin). Two themes are already available within the default Magento 2.x code structure: Blank theme and Luma theme. Refer to these default themes when creating custom themes.
+*  [**Themes**]({{ page.baseurl }}/frontend-dev-guide/themes/theme-general.html) provide a personalized touch for each Magento installation by changing the look and feel of the [storefront](https://glossary.magento.com/storefront) or [Admin](https://glossary.magento.com/admin). Two themes are already available within the default Magento 2.x code structure: Blank theme and Luma theme. Refer to these default themes when creating custom themes.
 
-* [**Language packages**]({{ page.baseurl }}/frontend-dev-guide/translations/xlate.html) assist in internationalization(i18n) and localization by providing translations for strings that display on the storefront and Admin.
+*  [**Language packages**]({{ page.baseurl }}/frontend-dev-guide/translations/xlate.html) assist in internationalization(i18n) and localization by providing translations for strings that display on the storefront and Admin.
 
 {: .bs-callout-info }
 You must follow a [PSR-4 compliant](http://www.php-fig.org/psr/psr-4/) structure when building a module.
@@ -21,6 +21,6 @@ You must follow a [PSR-4 compliant](http://www.php-fig.org/psr/psr-4/) structure
 {:.ref-header}
 Related topics
 
-* [Developer roadmap]({{ page.baseurl }}/extension-dev-guide/intro/developers_roadmap.html)
-* [Introduction to Composer]({{ page.baseurl }}/extension-dev-guide/intro/intro-composer.html)
-* [Glossary of common terms]({{ page.baseurl }}/extension-dev-guide/intro/intro-composer-gloss.html)
+*  [Developer roadmap]({{ page.baseurl }}/extension-dev-guide/intro/developers_roadmap.html)
+*  [Introduction to Composer]({{ page.baseurl }}/extension-dev-guide/intro/intro-composer.html)
+*  [Glossary of common terms]({{ page.baseurl }}/extension-dev-guide/intro/intro-composer-gloss.html)

--- a/guides/v2.3/extension-dev-guide/build/create_component.md
+++ b/guides/v2.3/extension-dev-guide/build/create_component.md
@@ -9,9 +9,9 @@ You give a name to your component in its `composer.json` and `module.xml` files.
 
 Before you continue, make sure you have completed all of the following tasks:
 
-*   Create a [file structure]({{page.baseurl}}/extension-dev-guide/build/module-file-structure.html).
-*   Create the [configuration files]({{page.baseurl}}/extension-dev-guide/build/required-configuration-files.html) you'll need.
-*   [Register]({{page.baseurl}}/extension-dev-guide/build/component-registration.html) your component.
+*  Create a [file structure]({{page.baseurl}}/extension-dev-guide/build/module-file-structure.html).
+*  Create the [configuration files]({{page.baseurl}}/extension-dev-guide/build/required-configuration-files.html) you'll need.
+*  [Register]({{page.baseurl}}/extension-dev-guide/build/component-registration.html) your component.
 
 ## Add the component's `module.xml` file {#add-component-xml}
 
@@ -38,9 +38,9 @@ Avoid using "Ui" for your custom module name, because the `%Vendor%_Ui` notation
 
 In addition, the [Component Manager]({{ page.baseurl }}/comp-mgr/module-man/compman-start.html) looks for a `composer.json` in a component's root directory and can perform actions on the component and its dependencies:
 
-* If a component has `composer.json` *and* the component was installed using [Composer](https://glossary.magento.com/composer) (including from packagist, the Magento Marketplace, or other source), the Component Manager can update, uninstall, enable, or disable the component.
-* If the component has `composer.json` but was *not* installed using Composer (for example, custom code a developer wrote), Component Manager can still enable or disable the component.
-* We strongly recommend you include `composer.json` in your component's root directory whether or not you intend to distribute it to other Magento merchants.
+*  If a component has `composer.json` *and* the component was installed using [Composer](https://glossary.magento.com/composer) (including from packagist, the Magento Marketplace, or other source), the Component Manager can update, uninstall, enable, or disable the component.
+*  If the component has `composer.json` but was *not* installed using Composer (for example, custom code a developer wrote), Component Manager can still enable or disable the component.
+*  We strongly recommend you include `composer.json` in your component's root directory whether or not you intend to distribute it to other Magento merchants.
 
 Refer to [Module version dependencies]({{ page.baseurl }}/extension-dev-guide/versioning/dependencies.html) to determine versioning requirements.
 
@@ -78,14 +78,14 @@ Refer to [Module version dependencies]({{ page.baseurl }}/extension-dev-guide/ve
 
 In this example:
 
-* `name` is the name of your component.
-* `description` is a concise explanation of your component's purpose.
-* `require` lists any components your component depends on.
-* `suggest` lists soft dependencies. The component can operate without them, but if the components are active, this component might impact their functionality. `Suggest` does not affect component load order.
-* `type` determines what the [Magento component](https://glossary.magento.com/magento-component) type. Choose from *magento2-theme*, *magento2-language*, or *magento2-module*.
-* `version` lists the version of the component.
-* `license` lists applicable licenses that apply to your component.
-* `autoload` instructs Composer to load the specified files.
+*  `name` is the name of your component.
+*  `description` is a concise explanation of your component's purpose.
+*  `require` lists any components your component depends on.
+*  `suggest` lists soft dependencies. The component can operate without them, but if the components are active, this component might impact their functionality. `Suggest` does not affect component load order.
+*  `type` determines what the [Magento component](https://glossary.magento.com/magento-component) type. Choose from *magento2-theme*, *magento2-language*, or *magento2-module*.
+*  `version` lists the version of the component.
+*  `license` lists applicable licenses that apply to your component.
+*  `autoload` instructs Composer to load the specified files.
 
 {: .bs-callout-info }
 Magento does not currently support the [`path`](https://getcomposer.org/doc/05-repositories.md#path) repository.

--- a/guides/v2.3/extension-dev-guide/depend-inj.md
+++ b/guides/v2.3/extension-dev-guide/depend-inj.md
@@ -108,13 +108,13 @@ To get around this limitation, injectable objects can depend on [factories] that
 {:.ref-header}
 Related topics
 
-* [The `di.xml` file]({{ page.baseurl }}/extension-dev-guide/build/di-xml-file.html)
-* [ObjectManager]({{ page.baseurl }}/extension-dev-guide/object-manager.html)
-* [Plugins]({{ page.baseurl }}/extension-dev-guide/plugins.html)
-* [Routing]({{ page.baseurl }}/extension-dev-guide/routing.html)
-* [Magento application initialization and bootstrap]({{ page.baseurl }}/config-guide/bootstrap/magento-bootstrap.html)
-* [Module Dependencies]({{ page.baseurl }}/architecture/archi_perspectives/components/modules/mod_depend.html)
-* [Programming concepts]({{ page.baseurl }}/extension-dev-guide/api-concepts.html)
+*  [The `di.xml` file]({{ page.baseurl }}/extension-dev-guide/build/di-xml-file.html)
+*  [ObjectManager]({{ page.baseurl }}/extension-dev-guide/object-manager.html)
+*  [Plugins]({{ page.baseurl }}/extension-dev-guide/plugins.html)
+*  [Routing]({{ page.baseurl }}/extension-dev-guide/routing.html)
+*  [Magento application initialization and bootstrap]({{ page.baseurl }}/config-guide/bootstrap/magento-bootstrap.html)
+*  [Module Dependencies]({{ page.baseurl }}/architecture/archi_perspectives/components/modules/mod_depend.html)
+*  [Programming concepts]({{ page.baseurl }}/extension-dev-guide/api-concepts.html)
 
 [Dependency Injection]: https://en.wikipedia.org/wiki/Dependency_injection
 [dependency inversion principle]: http://www.oodesign.com/dependency-inversion-principle.html

--- a/guides/v2.3/extension-dev-guide/indexer-batch.md
+++ b/guides/v2.3/extension-dev-guide/indexer-batch.md
@@ -72,11 +72,11 @@ catalog_product_attribute (Product Attribute)| `Magento/Catalog/etc/di.xml` | `M
 
 Changing the batch size can help you optimize indexer running time. For example, for a store with the following characteristics:
 
-* 10 websites
-* 10 store groups
-* 20 store views
-* 300 tier prices
-* About 40,000 products (of which 254 are configurable)
+*  10 websites
+*  10 store groups
+*  20 store views
+*  300 tier prices
+*  About 40,000 products (of which 254 are configurable)
 
 Reducing the batch size for `catalog_product_price` indexer from 5000 to 1000 decreases the execution time from about 4 hours to less than 2 hours. You can experiment to determine the ideal batch size. In general, halving the batch size can decrease the indexer execution time.
 
@@ -131,9 +131,9 @@ As of Magento 2.3, under certain circumstances, you can disable this indexer to 
 
 The following conditions must apply to disable Product EAV indexer:
 
-* You are using a search engine other than MySQL (such as Elasticsearch). If you are using MySQL as the search engine, you cannot disable the Product EAV indexer.
+*  You are using a search engine other than MySQL (such as Elasticsearch). If you are using MySQL as the search engine, you cannot disable the Product EAV indexer.
 
-* You have not installed any 3rd-party extensions that rely on the Product EAV indexer.
+*  You have not installed any 3rd-party extensions that rely on the Product EAV indexer.
 
 {:.bs-callout .bs-callout-info}
 To determine whether any 3rd-party extensions are using the Product EAV indexer, check the `catalog_product_index_eav` table for reading/writing activity.
@@ -143,5 +143,5 @@ To disable the Product EAV indexer in the Admin, go to **Stores** > Settings > *
 {:.ref-header}
 Related topics
 
-* [Indexing overview]({{ page.baseurl }}/extension-dev-guide/indexing.html)
-* [Adding a custom indexer]({{ page.baseurl }}/extension-dev-guide/indexing-custom.html)
+*  [Indexing overview]({{ page.baseurl }}/extension-dev-guide/indexing.html)
+*  [Adding a custom indexer]({{ page.baseurl }}/extension-dev-guide/indexing-custom.html)

--- a/guides/v2.3/extension-dev-guide/routing.md
+++ b/guides/v2.3/extension-dev-guide/routing.md
@@ -49,11 +49,11 @@ A Magento [URL](https://glossary.magento.com/url) that uses the standard router 
 
 Where:
 
-* `<store-url>` - specifies the base URL for the Magento instance
-* `<store-code>` - specifies the store context
-* `<front-name>` - specifies the `frontName` of the [FrontController] to use
-* `<controller-name>` - specifies the name of the controller
-* `<action-name>` - specifies the [action class] to execute on the controller class
+*  `<store-url>` - specifies the base URL for the Magento instance
+*  `<store-code>` - specifies the store context
+*  `<front-name>` - specifies the `frontName` of the [FrontController] to use
+*  `<controller-name>` - specifies the name of the controller
+*  `<action-name>` - specifies the [action class] to execute on the controller class
 
 The standard router parses this URL format and matches it to the correct controller and action.
 
@@ -90,10 +90,10 @@ To add your custom router to the list of routers for the `FrontController`, add 
 
 Where:
 
-* `%name%` - The unique name of your router in Magento.
-* `%classpath%` - The path to your router class.
-    Example: [`Magento\Robots\Controller\Router`]
-* `%sortorder%` - The sort order of this entry in the router list.
+*  `%name%` - The unique name of your router in Magento.
+*  `%classpath%` - The path to your router class.
+   Example: [`Magento\Robots\Controller\Router`]
+*  `%sortorder%` - The sort order of this entry in the router list.
 
 ## `routes.xml`
 
@@ -114,11 +114,11 @@ The content of this file uses the following format:
 
 Where:
 
-* `%routerId` - specifies the name of the router in Magento.
+*  `%routerId` - specifies the name of the router in Magento.
     See the reference tables in the [Router class section].
-* `%routeId%` - specifies the unique node id for this route in Magento, is also the first segment of its associated layout handle XML filename (`routeId_controller_action.xml`).
-* `%frontName%` - specifies the first segment after the base URL of a request.
-* `%moduleName%` - specifies the name of your module.
+*  `%routeId%` - specifies the unique node id for this route in Magento, is also the first segment of its associated layout handle XML filename (`routeId_controller_action.xml`).
+*  `%frontName%` - specifies the first segment after the base URL of a request.
+*  `%moduleName%` - specifies the name of your module.
 
 For more details, see [`routes.xsd`].
 


### PR DESCRIPTION
## Purpose of this pull request

This pull request provides changes regarding `Markdown linting: Spaces after list markers (MD030)` rule in the following folders:

- `guides/v2.2/extension-dev-guide`
- `guides/v2.3/extension-dev-guide`

## Affected DevDocs pages

<!-- REQUIRED List the affected pages on devdocs.magento.com (URLs). Not needed for large numbers of files. -->

- ...

## Links to Magento source code

<!--  OPTIONAL - REMOVE THIS SECTION IF NOT USED. If this pull request references a file in a Magento codebase repository, add it here. -->

- ...

<!--
If you are fixing a GitHub issue, note it using GitHub keyword format (https://help.github.com/en/articles/closing-issues-using-keywords#closing-an-issue-in-a-different-repository) to close the issue when this pull request is merged. Example: `Fixes #1234`

`master` is the default branch. Merged pull requests to `master` go live on the site automatically. Any requested changes to content on the `master` branch must be related to the released codebase. Any content related to future releases goes in the `develop` branch.

See Contribution guidelines (https://github.com/magento/devdocs/blob/master/.github/CONTRIBUTING.md) for more information.
-->
