### PR TITLE
magento/devdocs#5249: Markdown linting: Spaces after list markers (MD030). Folder - extension-dev-guide. Part 05.

### DIFF
--- a/guides/v2.3/extension-dev-guide/build/module-file-structure.md
+++ b/guides/v2.3/extension-dev-guide/build/module-file-structure.md
@@ -18,26 +18,26 @@ A typical file structure for a Magento 2 [module](https://glossary.magento.com/m
 {:.no_toc}
 Following are some common module directories:
 
-* `Block`: contains [PHP](https://glossary.magento.com/php) view classes as part of Model View Controller(MVC) vertical implementation of module logic.
-* `Controller`: contains PHP controller classes as part of MVC vertical implementation of module logic.
-* `etc`: contains configuration files; in particular, `module.xml`, which is required.
-* `Model`: contains PHP model classes as part of MVC vertical implementation of module logic.
-* `Setup`: contains classes for module database structure and data setup which are invoked when installing or upgrading.
+*  `Block`: contains [PHP](https://glossary.magento.com/php) view classes as part of Model View Controller(MVC) vertical implementation of module logic.
+*  `Controller`: contains PHP controller classes as part of MVC vertical implementation of module logic.
+*  `etc`: contains configuration files; in particular, `module.xml`, which is required.
+*  `Model`: contains PHP model classes as part of MVC vertical implementation of module logic.
+*  `Setup`: contains classes for module database structure and data setup which are invoked when installing or upgrading.
 
 #### Additional directories
 {:.no_toc}
 Additional folders can be added for configuration and other ancillary functions for items like [plugin-ins]({{ page.baseurl }}/extension-dev-guide/plugins.html), localization, and [layout](https://glossary.magento.com/layout) files.
 
-* `Api`: contains any PHP classes exposed to the [API](https://glossary.magento.com/api).
-* `Console`: contains CLI commands. For more info, see [Add CLI commands]({{ page.baseurl }}/extension-dev-guide/cli-cmds/cli-add.html).
-* `Cron`: contains cron job definitions.
-* `CustomerData`: contains section files.
-* `Helper`: contains aggregated functionality.
-* `i18n`: contains localization files.
-* `Observer`: contains files for executing commands from the listener.
-* `Plugin`: contains any needed [plug-ins]({{ page.baseurl }}/extension-dev-guide/plugins.html).
-* `UI`: contains data generation files.
-* `view`: contains view files, including static view files, design templates, email templates, and layout files.
+*  `Api`: contains any PHP classes exposed to the [API](https://glossary.magento.com/api).
+*  `Console`: contains CLI commands. For more info, see [Add CLI commands]({{ page.baseurl }}/extension-dev-guide/cli-cmds/cli-add.html).
+*  `Cron`: contains cron job definitions.
+*  `CustomerData`: contains section files.
+*  `Helper`: contains aggregated functionality.
+*  `i18n`: contains localization files.
+*  `Observer`: contains files for executing commands from the listener.
+*  `Plugin`: contains any needed [plug-ins]({{ page.baseurl }}/extension-dev-guide/plugins.html).
+*  `UI`: contains data generation files.
+*  `view`: contains view files, including static view files, design templates, email templates, and layout files.
 
 ### Theme file structure
 
@@ -85,16 +85,16 @@ A typical [theme](https://glossary.magento.com/theme) file structure can look li
 {:.no_toc}
 Typical theme directories are:
 
-* `etc`: Contains configuration files such as the `view.xml` file which contains image configurations for all images and thumbnails.
-* `i18n`: [Translation dictionaries]({{ page.baseurl }}/frontend-dev-guide/translations/xlate.html#m2devgde-xlate-dictionaries), if any.
-* `media`: Theme preview images (screen capture of your theme) can be put in here.
-* `web`: Optional directory that contains [static files](https://glossary.magento.com/static-files) organized into the following subdirectories:
+*  `etc`: Contains configuration files such as the `view.xml` file which contains image configurations for all images and thumbnails.
+*  `i18n`: [Translation dictionaries]({{ page.baseurl }}/frontend-dev-guide/translations/xlate.html#m2devgde-xlate-dictionaries), if any.
+*  `media`: Theme preview images (screen capture of your theme) can be put in here.
+*  `web`: Optional directory that contains [static files](https://glossary.magento.com/static-files) organized into the following subdirectories:
 
-   * `css/source`: Contains a theme's `less` configuration files that invoke mixins for global elements from the [Magento UI library]({{ page.baseurl }}/frontend-dev-guide/css-topics/theme-ui-lib.html), and the `theme.less` file that overrides the default variables values.
-   * `css/source/lib`: Contains view files that override the [UI library]({{ page.baseurl }}/frontend-dev-guide/css-topics/theme-ui-lib.html) files stored in `lib/web/css/source/lib`.
-   * `fonts`: The folder to place the different fonts for your theme.
-   * `images`: Static images folder.
-   * `js`: The folder for your JavaScript files.
+   *  `css/source`: Contains a theme's `less` configuration files that invoke mixins for global elements from the [Magento UI library]({{ page.baseurl }}/frontend-dev-guide/css-topics/theme-ui-lib.html), and the `theme.less` file that overrides the default variables values.
+   *  `css/source/lib`: Contains view files that override the [UI library]({{ page.baseurl }}/frontend-dev-guide/css-topics/theme-ui-lib.html) files stored in `lib/web/css/source/lib`.
+   *  `fonts`: The folder to place the different fonts for your theme.
+   *  `images`: Static images folder.
+   *  `js`: The folder for your JavaScript files.
 
 For more details on the theme folder structure, see [Magento theme structure]({{ page.baseurl }}/frontend-dev-guide/themes/theme-structure.html).
 

--- a/guides/v2.3/extension-dev-guide/build/required-configuration-files.md
+++ b/guides/v2.3/extension-dev-guide/build/required-configuration-files.md
@@ -15,43 +15,43 @@ Unlike Magento 1, there is no monolithic configuration file in Magento 2.
 
 Magento 2 looks for configuration information for each module in that module's `etc` directory. Depending on the needs of your module, you might have the following configuration files at the top level of your module's `etc` directory:
 
-* `acl.xml`
-* `config.xml`
-* `di.xml`
-* `module.xml`
-* `webapi.xml`
+*  `acl.xml`
+*  `config.xml`
+*  `di.xml`
+*  `module.xml`
+*  `webapi.xml`
 
 {: .bs-callout-info }
 Additions you make to those configuration files are applied *globally* to your module.
 
 In addition to those files, a Magento 2 module also has nested configuration directories in the `etc` directory for any required administration html, frontend, API REST, or API SOAP specific configuration. Additions you make to files in these directories override the settings in the global configuration files for the respective functionality only. That is, if you add a `config.xml` file to `etc/frontend`, the settings you make in that file overrides the settings in `etc/config.xml` for [storefront](https://glossary.magento.com/storefront) functionality *only*.
 
-* `<your module root dir>/etc/adminhtml/`
-* `<your module root dir>/etc/frontend/`
-* `<your module root dir>/etc/webapi_rest/`
-* `<your module root dir>/etc/webapi_soap/`
+*  `<your module root dir>/etc/adminhtml/`
+*  `<your module root dir>/etc/frontend/`
+*  `<your module root dir>/etc/webapi_rest/`
+*  `<your module root dir>/etc/webapi_soap/`
 
 ### Configuration files
 
-* Configuration files that are in the top level of that module's `etc` directory are global to that component.
-* Configuration files placed in subdirectories (`adminhtml`, `frontend`, `webapi_rest`, `webapi_soap`) apply only to those respective functional areas.
+*  Configuration files that are in the top level of that module's `etc` directory are global to that component.
+*  Configuration files placed in subdirectories (`adminhtml`, `frontend`, `webapi_rest`, `webapi_soap`) apply only to those respective functional areas.
 
 ### Tailor your configuration files for what your module does
 
 The exact set of configuration files required for your module depends on what your new module does. The required configuration files depend on how you plan to use the module: will the module be manifested on the storefront UI, or in the [Magento Admin](https://glossary.magento.com/magento-admin) panel, or as a [backend](https://glossary.magento.com/backend) [extension](https://glossary.magento.com/extension) that makes a service call? Or all of the above. For example, if your module performs a function in the Admin, you should add any necessary configuration files for those functions to `etc/adminhtml/`, like:
 
-* `<your module root dir>/etc/adminhtml/di.xml`
-* `<your module root dir>/etc/adminhtml/routes.xml`
+*  `<your module root dir>/etc/adminhtml/di.xml`
+*  `<your module root dir>/etc/adminhtml/routes.xml`
 
 Similarly, if your module changes the UI, you should add the needed configuration files to `~/etc/frontend/`. For example:
 
-* `<your module root dir>/etc/frontend/di.xml`
-* `<your module root dir>/etc/frontend/page_types.xml`
+*  `<your module root dir>/etc/frontend/di.xml`
+*  `<your module root dir>/etc/frontend/page_types.xml`
 
 If the module is a service that may call an API, or does some other work that is not manifested in the UI you should add any needed configuration files in the REST and/or SOAP webapi configuration directories, like this:
 
-* `<your module root dir>/etc/webapi_rest/di.xml`
-* `<your module root dir>/etc/webapi_soap/di.xml`
+*  `<your module root dir>/etc/webapi_rest/di.xml`
+*  `<your module root dir>/etc/webapi_soap/di.xml`
 
 Keep in mind that you might be able to handle your module's configuration solely with configuration files at the top level of your module's `etc` directory, but the nested directory is a useful way to keep the configuration neatly compartmentalized.
 

--- a/guides/v2.3/extension-dev-guide/message-queues/bulk-operations.md
+++ b/guides/v2.3/extension-dev-guide/message-queues/bulk-operations.md
@@ -20,9 +20,9 @@ OperationManagementInterface | Changes the status of an operation
 
 Three clients call bulk operation APIs:
 
-* A publisher, which pushes messages to the message queue
-* A consumer, which handles each specific operation
-* A client that gets the status of the bulk operation and shows the list of failed operations
+*  A publisher, which pushes messages to the message queue
+*  A consumer, which handles each specific operation
+*  A client that gets the status of the bulk operation and shows the list of failed operations
 
 ### Publish bulk operations
 
@@ -104,5 +104,5 @@ Value | Constant
 
 #### Related Topic
 
-* [Message Queues Overview]( {{page.baseurl}}/config-guide/mq/rabbitmq-overview.html)
-* [Example bulk operations implementation]({{page.baseurl}}/extension-dev-guide/message-queues/implement-bulk.html)
+*  [Message Queues Overview]( {{page.baseurl}}/config-guide/mq/rabbitmq-overview.html)
+*  [Example bulk operations implementation]({{page.baseurl}}/extension-dev-guide/message-queues/implement-bulk.html)

--- a/guides/v2.3/extension-dev-guide/message-queues/config-mq.md
+++ b/guides/v2.3/extension-dev-guide/message-queues/config-mq.md
@@ -13,20 +13,20 @@ The message queue topology is a {{site.data.var.ce}} feature. It can be included
 
 Configuring the message queue topology involves creating and modifying the following configuration files in the `<module>/etc` directory:
 
-* [`queue.xml`](#queuexml) - Defines brokers that processes topics. Use for `db` ([MySQL]) connections only. Do not create this file for `amqp` ([RabbitMQ]) connections.
-* [`communication.xml`](#communicationxml) - Defines aspects of the message queue system that all communication types have in common.
-* [`queue_consumer.xml`](#queueconsumerxml) - Defines the relationship between an existing queue and its consumer.
-* [`queue_topology.xml`](#queuetopologyxml) - Defines the message routing rules and declares queues and exchanges.
-* [`queue_publisher.xml`](#queuepublisherxml) - Defines the exchange where a topic is published.
+*  [`queue.xml`](#queuexml) - Defines brokers that processes topics. Use for `db` ([MySQL]) connections only. Do not create this file for `amqp` ([RabbitMQ]) connections.
+*  [`communication.xml`](#communicationxml) - Defines aspects of the message queue system that all communication types have in common.
+*  [`queue_consumer.xml`](#queueconsumerxml) - Defines the relationship between an existing queue and its consumer.
+*  [`queue_topology.xml`](#queuetopologyxml) - Defines the message routing rules and declares queues and exchanges.
+*  [`queue_publisher.xml`](#queuepublisherxml) - Defines the exchange where a topic is published.
 
 ### Use Cases
 
 Depending on your needs, you may only need to create and configure `communication.xml` and one or two of these files.
 
-* If you only want to publish to an existing queue created by a 3rd party system, you will only need the `queue_publisher.xml` file.
-* If you only want to consume from an existing queue,  you will only need the `queue_consumer.xml` config file.
-* In cases where you want to configure the local queue and publish to it for 3rd party systems to consume, you will need the `queue_publisher.xml` and `queue_topology.xml` files.
-* When you want to configure the local queue and consume messages published by 3rd party system, you will need the `queue_topology.xml` and `queue_consumer.xml` files.
+*  If you only want to publish to an existing queue created by a 3rd party system, you will only need the `queue_publisher.xml` file.
+*  If you only want to consume from an existing queue,  you will only need the `queue_consumer.xml` config file.
+*  In cases where you want to configure the local queue and publish to it for 3rd party systems to consume, you will need the `queue_publisher.xml` and `queue_topology.xml` files.
+*  When you want to configure the local queue and consume messages published by 3rd party system, you will need the `queue_topology.xml` and `queue_consumer.xml` files.
 
 ### `queue.xml` {#queuexml}
 
@@ -146,10 +146,10 @@ The `queue_consumer.xml` file contains one or more `consumer` elements:
 
 The `queue_topology.xml` file defines the message routing rules and declares queues and exchanges. It contains the following elements:
 
-* `exchange`
-* `exchange/binding`(optional)
-* `exchange/arguments` (optional)
-* `exchange/binding/arguments` (optional)
+*  `exchange`
+*  `exchange/binding`(optional)
+*  `exchange/arguments` (optional)
+*  `exchange/binding/arguments` (optional)
 
 #### Example `queue_topology.xml` file
 {:.no_toc}
@@ -236,8 +236,8 @@ The following illustrates an `arguments` block:
 
 The `queue_publisher.xml` file defines which connection and exchange to use to publish messages for a specific topic. It contains the following elements:
 
-* [publisher](https://glossary.magento.com/publisher-subscriber-pattern)
-* publisher/connection
+*  [publisher](https://glossary.magento.com/publisher-subscriber-pattern)
+*  publisher/connection
 
 #### Example `queue_publisher.xml` file
 {:.no_toc}
@@ -281,9 +281,9 @@ See [Migrate message queue configuration]({{page.baseurl}}/extension-dev-guide/m
 
 ### Related Topics
 
-* [Message Queues Overview]({{page.baseurl}}/config-guide/mq/rabbitmq-overview.html)
-* [Manage message queues with MySQL]({{page.baseurl}}/config-guide/mq/manage-mysql.html)
-* [Install RabbitMQ]({{page.baseurl}}/install-gde/prereq/install-rabbitmq.html)
+*  [Message Queues Overview]({{page.baseurl}}/config-guide/mq/rabbitmq-overview.html)
+*  [Manage message queues with MySQL]({{page.baseurl}}/config-guide/mq/manage-mysql.html)
+*  [Install RabbitMQ]({{page.baseurl}}/install-gde/prereq/install-rabbitmq.html)
 
 <!-- Link definitions -->
 [MySQL]: https://www.mysql.com/

--- a/guides/v2.3/extension-dev-guide/message-queues/implement-bulk.md
+++ b/guides/v2.3/extension-dev-guide/message-queues/implement-bulk.md
@@ -7,9 +7,9 @@ functional_areas:
 
 This document describes how bulk operations can be implemented. There are three primary tasks to accomplish this:
 
-* Create a [publisher](https://glossary.magento.com/publisher-subscriber-pattern) that sends messages to the message queue
-* Create a consumer that receives and processes messages
-* Configure the message queues
+*  Create a [publisher](https://glossary.magento.com/publisher-subscriber-pattern) that sends messages to the message queue
+*  Create a consumer that receives and processes messages
+*  Configure the message queues
 
 ### Create a publisher {#createpublisher}
 
@@ -278,11 +278,11 @@ class Consumer
 
 The message queue topology must be configured to implement bulk operations. Create or edit the following files in the module's `app/code/<vendor>/<module_name>/etc` directory.
 
-* `communication.xml`
-* `di.xml`
-* `queue_consumer.xml`
-* `queue_publisher.xml`
-* `queue_topology.xml`
+*  `communication.xml`
+*  `di.xml`
+*  `queue_consumer.xml`
+*  `queue_publisher.xml`
+*  `queue_topology.xml`
 
 For more information about the `di.xml` file, see [Dependency Injection]({{page.baseurl}}/extension-dev-guide/depend-inj.html). For information the other files, see [Configure message queues]({{page.baseurl}}/extension-dev-guide/message-queues/config-mq.html).
 
@@ -348,6 +348,6 @@ The `queue_topology.xml` file defines the message routing rules and declares que
 
 #### Related Topics
 
-* [Message Queues Overview]({{page.baseurl}}/config-guide/mq/rabbitmq-overview.html)
-* [Bulk Operations]({{page.baseurl}}/extension-dev-guide/message-queues/bulk-operations.html)
-* [Configure message queues]({{page.baseurl}}/extension-dev-guide/message-queues/config-mq.html)
+*  [Message Queues Overview]({{page.baseurl}}/config-guide/mq/rabbitmq-overview.html)
+*  [Bulk Operations]({{page.baseurl}}/extension-dev-guide/message-queues/bulk-operations.html)
+*  [Configure message queues]({{page.baseurl}}/extension-dev-guide/message-queues/config-mq.html)

--- a/guides/v2.3/extension-dev-guide/message-queues/message-queues-stores.md
+++ b/guides/v2.3/extension-dev-guide/message-queues/message-queues-stores.md
@@ -123,9 +123,9 @@ The plugin checks the message headers and sets the current store value in `store
 
 #### Related Topics
 
-* [Message Queues Overview]
-* [Configure message queues]
-* [Install RabbitMQ]
+*  [Message Queues Overview]
+*  [Configure message queues]
+*  [Install RabbitMQ]
 
 <!-- Link definitions -->
 [RabbitMQ]: http://www.rabbitmq.com

--- a/guides/v2.3/extension-dev-guide/message-queues/message-queues.md
+++ b/guides/v2.3/extension-dev-guide/message-queues/message-queues.md
@@ -62,9 +62,9 @@ The following sample introduces a runtime configuration that allows you to redef
 
 ### Related Topics
 
-* [Message Queues Overview]
-* [Configure message queues]
-* [Install RabbitMQ]
+*  [Message Queues Overview]
+*  [Configure message queues]
+*  [Install RabbitMQ]
 
 <!-- Link definitions -->
 [RabbitMQ]: http://www.rabbitmq.com

--- a/guides/v2.3/extension-dev-guide/message-queues/queue-migration.md
+++ b/guides/v2.3/extension-dev-guide/message-queues/queue-migration.md
@@ -12,9 +12,9 @@ functional_areas:
 
 To upgrade the message queues from Magento 2.1, you must create the following files in the `<module>/etc` directory for each [module](https://glossary.magento.com/module) that will use the message queue framework.
 
-* `queue_consumer.xml` - Defines the relationship between an existing queue and its consumer.
-* `queue_topology.xml`- Defines the message routing rules and declares queues and exchanges.
-* `queue_publisher.xml` -   Defines the exchange where a topic is published.
+*  `queue_consumer.xml` - Defines the relationship between an existing queue and its consumer.
+*  `queue_topology.xml`- Defines the message routing rules and declares queues and exchanges.
+*  `queue_publisher.xml` -   Defines the exchange where a topic is published.
 
 The existing `queue.xml` file is deprecated.
 
@@ -71,9 +71,9 @@ The first column in the following table lists the all the parameters in the `que
 
 To upgrade from Magento 2.0, you must create the following files in the `<module>/etc` directory for each module that will use the message queue framework.
 
-* `queue_consumer.xml` - Defines the relationship between an existing queue and its consumer.
-* `queue_topology.xml`- Defines the message routing rules.
-* `queue_publisher.xml` - Defines the relationship between a topic and its [publisher](https://glossary.magento.com/publisher-subscriber-pattern).
+*  `queue_consumer.xml` - Defines the relationship between an existing queue and its consumer.
+*  `queue_topology.xml`- Defines the message routing rules.
+*  `queue_publisher.xml` - Defines the relationship between a topic and its [publisher](https://glossary.magento.com/publisher-subscriber-pattern).
 
 The existing `queue.xml` file is deprecated.
 
@@ -126,5 +126,5 @@ The first column in the following table lists the all the parameters in the `que
 {:.ref-header}
 Related topics
 
-* [Message Queues Overview]({{page.baseurl}}/config-guide/mq/rabbitmq-overview.html)
-* [Configure message queues]({{page.baseurl}}/extension-dev-guide/message-queues/config-mq.html)
+*  [Message Queues Overview]({{page.baseurl}}/config-guide/mq/rabbitmq-overview.html)
+*  [Configure message queues]({{page.baseurl}}/extension-dev-guide/message-queues/config-mq.html)

--- a/guides/v2.3/extension-dev-guide/package/package_module.md
+++ b/guides/v2.3/extension-dev-guide/package/package_module.md
@@ -12,9 +12,9 @@ The Magento application uses [Composer](https://glossary.magento.com/composer) p
 
 To package a component, you must:
 
-*   Create a Magento Composer file (`composer.json`).
-*   Register the component using `registration.php`
-*   Package and publish your component.
+*  Create a Magento Composer file (`composer.json`).
+*  Register the component using `registration.php`
+*  Package and publish your component.
 
     Use our [validation tool](https://github.com/magento/marketplace-tools){:target="_blank"} to check your package before you distribute it.
 

--- a/guides/v2.3/extension-dev-guide/prepare/ext-repo-structure.md
+++ b/guides/v2.3/extension-dev-guide/prepare/ext-repo-structure.md
@@ -7,11 +7,11 @@ title: Extension Repository Structure
 
 For Magento 2.3 module, theme, and language pack extension repositories, we recommend five best practices:
 
-* Flatter hierarchy
-* One *extension type* (module, theme, or language pack) per repository
-* Multiple components per repository
-* One component per repository
-* One functional test suite per module component
+*  Flatter hierarchy
+*  One *extension type* (module, theme, or language pack) per repository
+*  Multiple components per repository
+*  One component per repository
+*  One functional test suite per module component
 
 ### Flatter hierarchy
 

--- a/guides/v2.3/extension-dev-guide/prepare/lifecycle.md
+++ b/guides/v2.3/extension-dev-guide/prepare/lifecycle.md
@@ -13,10 +13,10 @@ These executable classes can perform tasks that set up the database, update data
 
 Follow these guidelines when developing your executable classes to have them run during specific lifecycle stages:
 
-* Put your executable class in the `Setup` directory inside your module's root directory.
-* Use the specific file and class name for your class's target lifecycle stage.
-* Implement the specific class interface and function for your class's target stage.
-* Follow Magento's [versioning policy] when changing your module's version.
+*  Put your executable class in the `Setup` directory inside your module's root directory.
+*  Use the specific file and class name for your class's target lifecycle stage.
+*  Implement the specific class interface and function for your class's target stage.
+*  Follow Magento's [versioning policy] when changing your module's version.
 
 ## Schema initialization stages
 
@@ -298,7 +298,7 @@ Avoid this situation by not including dependencies in your uninstall event class
 
 **Related Topics**
 
-* Magento's [versioning policy]
+*  Magento's [versioning policy]
 
 [versioning policy]: {{ page.baseurl }}/extension-dev-guide/versioning/
 [schema upgrade]: #schema-upgrade

--- a/guides/v2.3/extension-dev-guide/validate/test-module.md
+++ b/guides/v2.3/extension-dev-guide/validate/test-module.md
@@ -46,10 +46,10 @@ Before you publish your component, test installing it using the [Magento Compone
 
 See these resources for testing in [PHP](https://glossary.magento.com/php) and validating Magento components:
 
-* The [Magento Coding Standard] provides a set of rules and sniffs for the [PHP_CodeSniffer] tool
-* [Technical Deep Dive: How to Pass the Magento Marketplace Extension Quality Program] (video) from Magento Imagine 2017
-* [Extension Quality Program] in the Magento Marketplace User Guide
-* [01 The Module Skeleton Kata] (video) by [Mage2Katas]
+*  The [Magento Coding Standard] provides a set of rules and sniffs for the [PHP_CodeSniffer] tool
+*  [Technical Deep Dive: How to Pass the Magento Marketplace Extension Quality Program] (video) from Magento Imagine 2017
+*  [Extension Quality Program] in the Magento Marketplace User Guide
+*  [01 The Module Skeleton Kata] (video) by [Mage2Katas]
 
 [Magento Testing Overview]: {{ page.baseurl }}/test/testing.html
 [Functional Testing Framework]: {{ page.baseurl }}/mtf/mtf_introduction.html

--- a/guides/v2.3/extension-dev-guide/versioning/index.md
+++ b/guides/v2.3/extension-dev-guide/versioning/index.md
@@ -20,9 +20,9 @@ The `version` field in a modules [`composer.json`][composer-json] file specifies
 
 The format follows [Semantic Versioning][semantic-versioning] rules for any `@api` annotated by `code`:
 
-* The MAJOR version increments when incompatible API changes are made.
-* The MINOR version increments when backward-compatible functionality has been added or if the module's customization points have changed.
-* The PATCH version increments when backward-compatible bug fixes occur.
+*  The MAJOR version increments when incompatible API changes are made.
+*  The MINOR version increments when backward-compatible functionality has been added or if the module's customization points have changed.
+*  The PATCH version increments when backward-compatible bug fixes occur.
 
 ### Pre-release versions
 
@@ -35,9 +35,9 @@ For pre-release versions, the format is:
 
 Magento's module versioning policy complies with the following specifications:
 
-* [Semantic Versioning][semantic-versioning]{:target="_blank"}
-* [Composer version specification][composer-versioning]{:target="_blank"}
-* [PHP `version_compare()` specification][php-version-compare]{:target="_blank"}
+*  [Semantic Versioning][semantic-versioning]{:target="_blank"}
+*  [Composer version specification][composer-versioning]{:target="_blank"}
+*  [PHP `version_compare()` specification][php-version-compare]{:target="_blank"}
 
 ## Where versioning is used
 

--- a/guides/v2.3/extension-dev-guide/webapi/custom-routes.md
+++ b/guides/v2.3/extension-dev-guide/webapi/custom-routes.md
@@ -21,8 +21,8 @@ To define custom routes, create an `etc/webapi_async.xml` file in your module th
 
 This example redefines two routes:
 
-* All requests made on endpoint `POST /createWidget` will be forwarded to `POST V1/widgets`
-* All requests made on endpoint `PUT /asyncBulkUpdateWidgets` will be forwarded to `PUT async/bulk/V1/widget`
+*  All requests made on endpoint `POST /createWidget` will be forwarded to `POST V1/widgets`
+*  All requests made on endpoint `PUT /asyncBulkUpdateWidgets` will be forwarded to `PUT async/bulk/V1/widget`
 
 The following table defines the `route` node attributes:
 

--- a/guides/v2.3/extension-dev-guide/webapi/request-processor-pool.md
+++ b/guides/v2.3/extension-dev-guide/webapi/request-processor-pool.md
@@ -28,10 +28,10 @@ Processor name | Class | URL pattern | Description
 
 To create a custom processor, you must perform the following tasks:
 
-* Define the custom processor in `webapi_rest/di.xml`.
-* Create a processor class and implement the `Magento\Webapi\Controller\Rest\RequestProcessorInterface` interface.
-* Define the processing rules in the `canProcess` method.
-* Create the processor logic in the `process` method.
+*  Define the custom processor in `webapi_rest/di.xml`.
+*  Create a processor class and implement the `Magento\Webapi\Controller\Rest\RequestProcessorInterface` interface.
+*  Define the processing rules in the `canProcess` method.
+*  Create the processor logic in the `process` method.
 
 ### Define the custom processor
 


### PR DESCRIPTION


## Purpose of this pull request

This pull request provides changes regarding `Markdown linting: Spaces after list markers (MD030)` rule in the following folders:

- `guides/v2.2/extension-dev-guide`
- `guides/v2.3/extension-dev-guide`

## Affected DevDocs pages

<!-- REQUIRED List the affected pages on devdocs.magento.com (URLs). Not needed for large numbers of files. -->

- ...

## Links to Magento source code

<!--  OPTIONAL - REMOVE THIS SECTION IF NOT USED. If this pull request references a file in a Magento codebase repository, add it here. -->

- ...

<!--
If you are fixing a GitHub issue, note it using GitHub keyword format (https://help.github.com/en/articles/closing-issues-using-keywords#closing-an-issue-in-a-different-repository) to close the issue when this pull request is merged. Example: `Fixes #1234`

`master` is the default branch. Merged pull requests to `master` go live on the site automatically. Any requested changes to content on the `master` branch must be related to the released codebase. Any content related to future releases goes in the `develop` branch.

See Contribution guidelines (https://github.com/magento/devdocs/blob/master/.github/CONTRIBUTING.md) for more information.
-->
