### PR TITLE
JS variable declaration let and const over var

### DIFF
--- a/guides/v2.2/coding-standards/code-standard-javascript.md
+++ b/guides/v2.2/coding-standards/code-standard-javascript.md
@@ -354,7 +354,7 @@ Remember that `let` and `const` are block scoped!
 let foo = 'bar',
     num = 1,
     arr = [1, 2, 3];
-    
+
 const identifier = 'CUSTOM_IDENTIFIER';
 ```
 

--- a/guides/v2.2/coding-standards/code-standard-javascript.md
+++ b/guides/v2.2/coding-standards/code-standard-javascript.md
@@ -345,14 +345,17 @@ Modifying other built-ins like `Function.prototype` is less dangerous but leads 
 
 ### Variable declarations
 
-Declare a variable with `var` wherever possible to avoid overwriting existing global values.
+Declare a variable with `let` as the default scope assignment for a variable. Use `const` when the variable will not be reassigned. Never use `var` unless you need to function scope a variable.
 
-Using only one var per scope promotes readability.
+{: .bs-callout-info }
+Remember that `let` and `const` are block scoped!
 
 ```javascript
-var foo = 'bar',
+let foo = 'bar',
     num = 1,
     arr = [1, 2, 3];
+    
+const identifier = 'CUSTOM_IDENTIFIER';
 ```
 
 [jquery]: https://jquery.com/

--- a/guides/v2.2/coding-standards/code-standard-javascript.md
+++ b/guides/v2.2/coding-standards/code-standard-javascript.md
@@ -345,10 +345,10 @@ Modifying other built-ins like `Function.prototype` is less dangerous but leads 
 
 ### Variable declarations
 
-Declare a variable with `let` as the default scope assignment for a variable. Use `const` when the variable will not be reassigned. Never use `var` unless you need to function scope a variable.
+Declare a variable with `let` as the default scope assignment for a variable. Use `const` when the variable will not be reassigned. Never use `var` unless you need to function scope a variable. Remember that `let` and `const` are block scoped.
 
 {: .bs-callout-info }
-Remember that `let` and `const` are block scoped!
+IE11 doesn't support `let` entirely. It has some issues while using in `for` loops. Use with caution.
 
 ```javascript
 let foo = 'bar',


### PR DESCRIPTION
## Purpose of this pull request

This pull request (PR) is a **preliminary PR to discuss** about the preferred scoping of variable in Javscript in Magento. I'm ready to work on this more after discussion. ES6 recommends usage of only `let` and `const`, unless `var` is _necessary_. Looking for a discussion on this, regarding Javascript in Magento

## Affected DevDocs pages
- https://devdocs.magento.com/guides/v2.3/coding-standards/code-standard-javascript.html
- https://devdocs.magento.com/guides/v2.2/coding-standards/code-standard-javascript.html
