### PR TITLE
GraphQl: Corrected typo error in Products.md

### DIFF
--- a/guides/v2.3/graphql/queries/products.md
+++ b/guides/v2.3/graphql/queries/products.md
@@ -100,8 +100,8 @@ weight
 The following attributes are not used in responses:
 
 *  `or` - The keyword required to perform a logical OR comparison.
-*  `news_from_date` - This attribute is transformed to `news_from_date` in a response.
-*  `news_to_date` - This attribute is transformed to `news_to_date` in a response.
+*  `news_from_date` - This attribute is transformed to `new_from_date` in a response.
+*  `news_to_date` - This attribute is transformed to `new_to_date` in a response.
 
 {%
 include note.html


### PR DESCRIPTION

## Purpose of this pull request
Corrected typo error "news_from_date" and "news_to_date" to new names "new_from_date" and "new_to_date" in product graphQl response respectively.

## Affected DevDocs pages

https://devdocs.magento.com/guides/v2.3/graphql/queries/products.html
