### PR TITLE
Fixed non-escaping unintended variable replacement

### DIFF
--- a/guides/v2.2/frontend-dev-guide/translations/translate_theory.md
+++ b/guides/v2.2/frontend-dev-guide/translations/translate_theory.md
@@ -32,11 +32,11 @@ In this example, the _'Hello %1'_ string is added to the dictionary when the i18
 ## Strings added in email templates {#add_strings_email}
 
 If your theme contains [custom email templates], their strings can be added to the dictionary as well.
-To add the email template strings to the dictionary, use the `{{trans}}` [directive].
+To add the email template strings to the dictionary, use the {% raw %} `{{trans}}` {% endraw %} [directive].
 
 Custom email templates [added using the Admin panel] are not stored in the file system, and their strings are not added to the dictionary.
 
-To ensure that your new string is added to the dictionary and translated, use the `trans` method when outputting a string in an [email template]({{ site.mage2bloburl }}/{{ page.guide_version }}/app/code/Magento/Customer/view/frontend/email/account_new.html).
+To ensure that your new string is added to the dictionary and translated, use the {% raw %} `{{trans}}` {% endraw %} [directive] when outputting a string in an [email template]({{ site.mage2bloburl }}/{{ page.guide_version }}/app/code/Magento/Customer/view/frontend/email/account_new.html).
 
 For example:
 


### PR DESCRIPTION
## Purpose of this pull request

This pull request (PR) fixes the bug of `{{trans}}` being parsed in the below files

## Affected DevDocs pages
-  https://devdocs.magento.com/guides/v2.3/frontend-dev-guide/translations/translate_theory.html
-  https://devdocs.magento.com/guides/v2.2/frontend-dev-guide/translations/translate_theory.html