### PR TITLE
Configured the imgbot app to ignore SVG files

### DIFF
--- a/.imgbotconfig
+++ b/.imgbotconfig
@@ -1,0 +1,6 @@
+{
+	"ignoredFiles": [
+		"*.svg"
+	],
+	"aggressiveCompression": false
+}


### PR DESCRIPTION
The imgbot app breaks drawio SVGs when it tries to optimize them

## Purpose of this pull request

This pull request (PR) configures the ImgBot app to ignore SVG files because it is breaking the styling within SVGs created with draw.io. Ignoring is the best option because the ImgBot does not support more granular settings.  

## Affected DevDocs pages

GraphQL pages with SVG images, such as https://devdocs.magento.com/guides/v2.3/graphql/payment-methods/authorize-net.html