### PR TITLE
Magento Shipping announcement for Magento 2.3.3 release notes

### DIFF
--- a/guides/v2.3/release-notes/release-notes-2-3-3-commerce.md
+++ b/guides/v2.3/release-notes/release-notes-2-3-3-commerce.md
@@ -144,6 +144,8 @@ The Google Shopping ads Channel Marketplace extension is now available as a bund
 
 ### Magento Shipping
 
+Due to the impending shutdown of Temando (the provider of the technology behind Magento Shipping), it is no longer possible to create a new Magento Shipping account. Support for current Magento Shipping deployments for all existing customers will continue. For detailed status information and recommendations for new shipping implementations in Magento, see our product information page.
+
 This release of Magento Shipping includes:
 
 *  Improvements to batch-order processing, carrier integration, shipping method preview in the shipping portal, checkout.
@@ -941,6 +943,10 @@ We have fixed hundreds of issues in the Magento 2.3.3 core code.
 
 <!--- MC-15163-->
 *  The `oauth` handshake is now followed by a redirect as expected for third-party integrations.
+
+### Magento Shipping
+
+Due to the impending shutdown of Temando (the provider of the technology behind Magento Shipping), it is no longer possible to create a new Magento Shipping account. Support for current Magento Shipping deployments for all existing customers will continue. For detailed status information and recommendations for new shipping implementations in Magento, see our product information page.
 
 ### Newsletter
 

--- a/guides/v2.3/release-notes/release-notes-2-3-3-open-source.md
+++ b/guides/v2.3/release-notes/release-notes-2-3-3-open-source.md
@@ -130,6 +130,8 @@ The Google Shopping ads Channel Marketplace extension is now available as a bund
 
 ### Magento Shipping
 
+Due to the impending shutdown of Temando (the provider of the technology behind Magento Shipping), it is no longer possible to create a new Magento Shipping account. Support for current Magento Shipping deployments for all existing customers will continue. For detailed status information and recommendations for new shipping implementations in Magento, see our product information page.
+
 This release of Magento Shipping includes:
 
 *  Improvements to batch-order processing, carrier integration, shipping method preview in the shipping portal, checkout.
@@ -782,6 +784,10 @@ We've fixed hundreds of issues in the Magento 2.3.3 core code.
 
 <!--- MC-15163-->
 *  The `oauth` handshake is now followed by a redirect as expected for third-party integrations.
+
+### Magento Shipping
+
+Due to the impending shutdown of Temando (the provider of the technology behind Magento Shipping), it is no longer possible to create a new Magento Shipping account. Support for current Magento Shipping deployments for all existing customers will continue. For detailed status information and recommendations for new shipping implementations in Magento, see our product information page.
 
 ### Newsletter
 


### PR DESCRIPTION
## Purpose of this pull request

This pull request (PR) adds information about the change in availability of Magento Shipping. 

## Affected DevDocs pages
https://devdocs.magento.com/guides/v2.3/release-notes/release-notes-2-3-3-commerce.html
https://devdocs.magento.com/guides/v2.3/release-notes/release-notes-2-3-3-open-source.html

whatsnew
Changes to the status of Magento Shipping are now described in the [Magento Commerce 2.3.3 Release Notes](https://devdocs.magento.com/guides/v2.3/release-notes/release-notes-2-3-3-commerce.html)  and the [Magento Open Source 2.3.3 Release Notes](https://devdocs.magento.com/guides/v2.3/release-notes/release-notes-2-3-3-open-source.html).