### PR TITLE
Removed unnecessary and improperly rendered example link

### DIFF
--- a/guides/v2.2/frontend-dev-guide/themes/theme-structure.md
+++ b/guides/v2.2/frontend-dev-guide/themes/theme-structure.md
@@ -83,7 +83,7 @@ The directories and files structure described below is the most extended one. It
         optional
       </td>
       <td colspan="1">
-          Module-specific styles (<code>.css</code> and/or <code>.less</code> files). General styles for the module are in the <code>_module.less</code> file, and styles for widgets are in <code>_widgets.less</code><br/><br/>Ex: [Module_Theme]({{ site.mage2bloburl }}/{{ page.guide_version }}/app/code/Magento/Theme/view/frontend/web/css) or description field should be corrected.
+          Module-specific styles (<code>.css</code> and/or <code>.less</code> files). General styles for the module are in the <code>_module.less</code> file, and styles for widgets are in <code>_widgets.less</code>
       </td>
     </tr>
     <tr>


### PR DESCRIPTION
## Purpose of this pull request

This pull request (PR) removes unnecessary and improperly rendered example link

## Affected DevDocs pages
-  https://devdocs.magento.com/guides/v2.3/frontend-dev-guide/themes/theme-structure.html
-  https://devdocs.magento.com/guides/v2.2/frontend-dev-guide/themes/theme-structure.html