### PR TITLE
Fixed inconsistent casing

### DIFF
--- a/guides/v2.2/frontend-dev-guide/themes/theme-structure.md
+++ b/guides/v2.2/frontend-dev-guide/themes/theme-structure.md
@@ -150,7 +150,7 @@ The directories and files structure described below is the most extended one. It
       <td colspan="1">
         <code>/media</code>
       </td>
-      <td colspan="1">Optional</td>
+      <td colspan="1">optional</td>
       <td colspan="1">
         This directory contains a theme preview (a screenshot of your theme).
       </td>


### PR DESCRIPTION
## Purpose of this pull request
This pull request (PR) fixes inconsistent casing of the word "optional"

## Affected DevDocs pages
-  https://devdocs.magento.com/guides/v2.3/frontend-dev-guide/themes/theme-structure.html
-  https://devdocs.magento.com/guides/v2.2/frontend-dev-guide/themes/theme-structure.html