### PR TITLE
docs(links): duplicate scheme in fastly.com link.

### DIFF
--- a/guides/v2.2/cloud/project/projects.md
+++ b/guides/v2.2/cloud/project/projects.md
@@ -44,7 +44,7 @@ With your {{site.data.var.ece}} account created, you can log into the Project We
 
 Your project includes [Fastly]({{ page.baseurl }}/cloud/cdn/cloud-fastly.html), [New Relic]({{ page.baseurl }}/cloud/project/new-relic.html), and [Blackfire]({{ page.baseurl }}/cloud/project/project-integrate-blackfire.html) services. The project details display information for your project plan and important licenses and tokens for these integrations. Only the Account Owner has initial access to the credentials and services. You should provide these credentials to technical and developer resources as needed.
 
--  [Fastly](https://https://www.fastly.com/) provides content delivery (CDN), image optimization, and security services (DDoS and WAF) for your {{ site.data.var.ece }} projects. See [Get Fastly credentials]({{ page.baseurl }}/cloud/cdn/configure-fastly.html).
+-  [Fastly](https://www.fastly.com/) provides content delivery (CDN), image optimization, and security services (DDoS and WAF) for your {{ site.data.var.ece }} projects. See [Get Fastly credentials]({{ page.baseurl }}/cloud/cdn/configure-fastly.html).
 
 -  [Blackfire.io Profiler](https://blackfire.io/magento) provides tools for reviewing and optimizing Magento and your store in your environments. The profiler checks every method and call, determining what occurs with performance metrics per step.
 


### PR DESCRIPTION
Removed additional `https://` scheme in fastly.com (CDN service) link

## Purpose of this pull request

Fix link to fastly.com

## Affected DevDocs pages

- https://devdocs.magento.com/guides/v2.3/cloud/project/projects.html
- https://devdocs.magento.com/guides/v2.2/cloud/project/projects.html

This is the same page (sym link)

## Links to Magento source code

-  guides/v2.2/cloud/project/projects.md