### PR TITLE
Corrected data type and default value

### DIFF
--- a/guides/v2.2/javascript-dev-guide/widgets/widget-row-builder.md
+++ b/guides/v2.2/javascript-dev-guide/widgets/widget-row-builder.md
@@ -199,9 +199,9 @@ Max number of rows.
 
 The message selector of an element which appears when the max number of rows has been exceeded.
 
-**Type**: Integer
+**Type**: String
 
-**Default value**: `1000`
+**Default value**: `#max-registrant-message`
 
 ## Code sample
 


### PR DESCRIPTION
## Purpose of this pull request

- Corrected the data type and default value of `maxRowsMsg` option

## Affected DevDocs pages

-  https://devdocs.magento.com/guides/v2.2/javascript-dev-guide/widgets/widget-row-builder.html
-  https://devdocs.magento.com/guides/v2.3/javascript-dev-guide/widgets/widget-row-builder.html

## Links to Magento source code
-  https://github.com/magento/magento2/blob/2.2/app/code/Magento/Theme/view/frontend/web/js/row-builder.js#L57
-  https://github.com/magento/magento2/blob/2.3/app/code/Magento/Theme/view/frontend/web/js/row-builder.js#L57
