### PR TITLE
Updated chapter pages links

### DIFF
--- a/guides/v2.2/frontend-dev-guide/layouts/layout-overview.md
+++ b/guides/v2.2/frontend-dev-guide/layouts/layout-overview.md
@@ -108,13 +108,14 @@ Layout validations and error handling depends on the [application mode] in which
 
 *  production or default modes: syntax is validated in `.xml` and `.xsd` files. If validation fails, errors are logged to the `var/log` directory without throwing an exception. The validation according to the xsd schema is not performed.
 
-{:.ref-header}
-Related topics
+## Chapter Contents
 
 *  [Layout instructions]
-*  [Common layout customization tasks]
+*  [Layout file types]
+*  [Product layouts]
 *  [Extend a layout][extend]
 *  [Override a layout][override]
+*  [Common layout customization tasks]
 *  [Customizing layout - step-by-step illustration]
 
 <!-- Link definitions -->
@@ -124,6 +125,7 @@ Related topics
 [inherited]: {{ page.baseurl }}/frontend-dev-guide/themes/theme-inherit.html
 [application mode]: {{ page.baseurl }}/config-guide/bootstrap/magento-modes.html
 [Layout instructions]: {{ page.baseurl }}/frontend-dev-guide/layouts/xml-instructions.html
+[Product layouts]: {{ page.baseurl }}/frontend-dev-guide/layouts/product-layouts.html
 [Common layout customization tasks]: {{ page.baseurl }}/frontend-dev-guide/layouts/xml-manage.html
 [Customizing layout - step-by-step illustration]: {{ page.baseurl }}/frontend-dev-guide/layouts/layout-practice.html
 


### PR DESCRIPTION
## Purpose of this pull request

This pull request (PR) adds the missing chapter links and updates heading

## Affected DevDocs pages

-  https://devdocs.magento.com/guides/v2.3/frontend-dev-guide/layouts/layout-overview.html
-  https://devdocs.magento.com/guides/v2.2/frontend-dev-guide/layouts/layout-overview.html