### PR TITLE
DOC-35: Add note about declarative schema to DB video tutorial

### DIFF
--- a/_includes/layout/page-header.html
+++ b/_includes/layout/page-header.html
@@ -15,5 +15,11 @@
 <h1 class="page-subtitle">{{ page.subtitle }}</h1>
 {% endif %}
 
+{% if page.title == "How to Add a New Table to a Database" %}
+  <div class="message-banner">
+    This tutorial applies to Magento 2.2.x only. For Magento 2.3.x, see <a href="https://devdocs.magento.com/guides/v2.3/extension-dev-guide/declarative-schema">Declarative Schema</a>.
+  </div>
+{% endif %}
+
 <h1 class="page-heading">{{ page.title }}</h1>
 </section>


### PR DESCRIPTION
## Purpose of this pull request

This pull request (PR) adds a banner message to the top of the [How to Add a New Table to a Database](https://devdocs.magento.com/videos/fundamentals/add-a-new-table-to-database/) video topic advising users that for Magento 2.3.x they should use [Declarative Schema](https://devdocs.magento.com/guides/v2.3/extension-dev-guide/declarative-schema/).

When Magento 2.2.x reaches end-of-life on 12/2019, we should remove this topic.

See DOC-35 for a link to the staging build.

## Affected DevDocs pages

-  https://devdocs.magento.com/videos/fundamentals/add-a-new-table-to-database/