### PR TITLE
Fix the 'last_updated_at' page plugin

### DIFF
--- a/_plugins/generators/mrg_pages.rb
+++ b/_plugins/generators/mrg_pages.rb
@@ -19,7 +19,6 @@ module Jekyll
       # Data from '_data/codebase/mrg' as a Hash where
       # the filename is a key and its content is a value.
       mrg_data = @site.data['codebase']['mrg']
-
       # Loop through the hash where a key is assigned to a 'mod' (module is a
       # special token in Ruby and should not be used) and value is assigned to
       # 'metadata'.

--- a/_plugins/page-params/last-modified-at.rb
+++ b/_plugins/page-params/last-modified-at.rb
@@ -8,23 +8,31 @@
 # the original file.
 # For available date formats, refer to https://git-scm.com/docs/git-log#git-log---dateltformatgt
 #
-Jekyll::Hooks.register :pages, :pre_render do |page|
+Jekyll::Hooks.register :pages, :post_init do |page|
   # Do nothing in serving mode
   next if page.site.config['serving']
-  # Do nothing if the date is already set
-  next if page.data['last_modified_at']
+
   # Process only files with 'md' and 'html' extensions
   next unless File.extname(page.path).match?(/md|html/)
-  # Do nothing for redirects
+
+  # Skip redirects
   next if page.name == 'redirect.html'
 
+  # Skip pages where the parameter is already set
+  next if page.data['last_modified_at']
+
+  # Skip pages created by custom generators like 'mrg_pages'
+  next if page.kind_of? Jekyll::PageWithoutAFile
+
+  # Read real path of the page. If this is a symlink read it to get path of the real file with content.
   real_filepath = File.realpath page.path
 
   dir = File.dirname real_filepath
-  filename = File.basename real_filepath
 
-  # Read date of the last commit and assign it to last_modified_at parameter
-  # of the page.
-  page.data['last_modified_at'] =
-    `cd #{dir} && git log -1 --format=%cd --date=iso -- #{filename}`.strip
+  # Change directory to the parent directory of the page to read from the corresponding git history.
+  Dir.chdir(dir) do
+    # Read date of the last commit and assign it to last_modified_at parameter
+    # of the page.
+    page.data['last_modified_at'] = `git log -1 --format=%cd --date=iso -- #{page.name}`.strip
+  end
 end


### PR DESCRIPTION
## Purpose of this pull request

This pull request fixes the plugin that generates `page.last_updated_at` parameter. It was accidentally broken by the MRG generator implementation.

The fix changes the hook layer to `post_init` and adds a skipping condition for pages generated without a source file ([PageWithoutAFile](https://www.rubydoc.info/gems/jekyll/Jekyll/PageWithoutAFile)).

Staging: 1005