### PR TITLE
Moved info about WAF availability to opening para

### DIFF
--- a/guides/v2.2/cloud/architecture/cloud-architecture.md
+++ b/guides/v2.2/cloud/architecture/cloud-architecture.md
@@ -41,7 +41,7 @@ For comparison, each plan includes the following infrastructure features and sup
       <td>
         <ul>
           <li>Continuous cloud integration tools with unlimited users</li>
-          <li>Fastly Content Delivery Network (CDN), Web Application Firewall (WAF), Image Optimization (IO), and added security with generous bandwidth allowances</li>
+          <li>Fastly Content Delivery Network (CDN), Image Optimization (IO), and added security with generous bandwidth allowances. The Web Application Firewall (WAF) service is available only on Production environments.</li>
           <li>
             <a href="{{ page.baseurl }}/cloud/project/new-relic.html">New Relic</a> APM (Performance Monitoring) on 3 branches: <code>master</code> and 2 of your choice
           </li>
@@ -54,7 +54,7 @@ For comparison, each plan includes the following infrastructure features and sup
       <td>
         <ul>
           <li>Continuous cloud integration tools with unlimited users</li>
-          <li>Fastly Content Delivery Network (CDN), Web Application Firewall (WAF), Image Optimization (IO), and added security with generous bandwidth allowances</li>
+          <li>Fastly Content Delivery Network (CDN), Image Optimization (IO), and added security with generous bandwidth allowances. The Web Application Firewall (WAF) service is available only on Production environments.</li>
           <li>
             <a href="{{ page.baseurl }}/cloud/project/new-relic.html">New Relic</a> Infrastructure on Production + APM (Performance Monitoring) on Staging and Production
           </li>

--- a/guides/v2.2/cloud/architecture/cloud-architecture.md
+++ b/guides/v2.2/cloud/architecture/cloud-architecture.md
@@ -41,7 +41,7 @@ For comparison, each plan includes the following infrastructure features and sup
       <td>
         <ul>
           <li>Continuous cloud integration tools with unlimited users</li>
-          <li>Fastly Content Delivery Network (CDN), Image Optimization (IO), and added security with generous bandwidth allowances</li>
+          <li>Fastly Content Delivery Network (CDN), Web Application Firewall (WAF), Image Optimization (IO), and added security with generous bandwidth allowances</li>
           <li>
             <a href="{{ page.baseurl }}/cloud/project/new-relic.html">New Relic</a> APM (Performance Monitoring) on 3 branches: <code>master</code> and 2 of your choice
           </li>

--- a/guides/v2.2/cloud/cdn/cloud-fastly.md
+++ b/guides/v2.2/cloud/cdn/cloud-fastly.md
@@ -29,7 +29,7 @@ Fastly provides the following services to optimize and secure content delivery o
 
 -  **Security**—After you set up your {{ site.data.var.ece }} project to use the Fastly CDN, additional security features are available to protect your sites and network.
    -  [**DDoS protection**](#ddos-protection)—Built-in protection against common attacks like Ping of Death, Smurf attacks, as well as other ICMP-based floods.
-   -  **[Web Application Firewall]({{ page.baseurl }}/cloud/cdn/fastly-waf-service.html)**—Managed web application firewall service that provides PCI-compliant protection to block malicious traffic before it can damage your production {{ site.data.var.ece }} sites and network.
+   -  **[Web Application Firewall]({{ page.baseurl }}/cloud/cdn/fastly-waf-service.html)**—Managed web application firewall service that provides PCI-compliant protection to block malicious traffic before it can damage your production {{ site.data.var.ece }} sites and network. WAF is available only on Pro and Starter Production environments.
 -  **Image optimization**—Offloads image processing and resizing load to the Fastly service freeing servers to process orders and conversions efficiently. See [Fastly image optimization]({{ page.baseurl }}/cloud/cdn/fastly-image-optimization.html).
 
 We highly recommend using Fastly for your CDN, security, and image optimization needs, unless you are using {{ site.data.var.ee}} in a headless deployment.

--- a/guides/v2.2/cloud/cdn/fastly-waf-service.md
+++ b/guides/v2.2/cloud/cdn/fastly-waf-service.md
@@ -6,7 +6,7 @@ functional_areas:
   - Install
 ---
 
-Powered by Fastly, the web application firewall (WAF) service for {{ site.data.var.ece }} detects, logs, and blocks malicious request traffic before it can damage your sites or network.
+Powered by Fastly, the web application firewall (WAF) service for {{ site.data.var.ece }} detects, logs, and blocks malicious request traffic before it can damage your sites or network. The WAF service is available only on Production environments for all {{ site.data.var.ece }} Pro and Starter plans at no additional cost.
 
 The WAF service provides the following benefits:
 
@@ -18,9 +18,7 @@ The WAF service provides the following benefits:
    -  Magento triages customer support tickets related to WAF service issues that block legitimate traffic as Priority 1 issues.
    -  Automated upgrades to the WAF service version ensure immediate coverage for new or evolving exploits. See [WAF maintenance and upgrades](#waf-maintenance-and-updates).
 
-The WAF service is available on Production environments for all {{ site.data.var.ece }} Pro and Starter plans at no additional cost.
-
-{:.bs-callout .bs-callout-tip}
+{:.bs-callout-tip}
 For additional information about maintaining PCI compliance for your {{ site.var.data.ece }} stores, see [Magento Approach to PCI compliance](https://magento.com/pci-compliance).
 
 ### Enabling the WAF

--- a/guides/v2.2/cloud/cdn/fastly-waf-service.md
+++ b/guides/v2.2/cloud/cdn/fastly-waf-service.md
@@ -6,7 +6,7 @@ functional_areas:
   - Install
 ---
 
-Powered by Fastly, the web application firewall (WAF) service for {{ site.data.var.ece }} detects, logs, and blocks malicious request traffic before it can damage your sites or network. The WAF service is available only on Production environments for all {{ site.data.var.ece }} Pro and Starter plans at no additional cost.
+Powered by Fastly, the web application firewall (WAF) service for {{ site.data.var.ece }} detects, logs, and blocks malicious request traffic before it can damage your sites or network. The WAF service is available only on production environments.
 
 The WAF service provides the following benefits:
 


### PR DESCRIPTION
WAF is available only on Pro and Starter Production environments.
Moved the info about this to intro because people missed that.

## Purpose of this pull request
WAF is available only on Pro and Starter Production environments.
Moved the info about this to intro because people missed that.

## Affected DevDocs pages

- https://devdocs.magento.com/guides/v2.3/cloud/cdn/fastly-waf-service.html
