### PR TITLE
Corrected the topic's number sequence

### DIFF
--- a/guides/v2.3/config-guide/elasticsearch/es-config-stopwords.md
+++ b/guides/v2.3/config-guide/elasticsearch/es-config-stopwords.md
@@ -42,11 +42,11 @@ To edit stopwords:
 
 1. Use a text editor to open a stopword file in the `<magento_root>/vendor/magento/module-elasticsearch/etc/stopwords` directory.
 
- `.csv` files use the naming convention `stopwords_<locale_code>.csv`. For example, the German stopword file is named `stopwords_de_DE.csv`.
+   `.csv` files use the naming convention `stopwords_<locale_code>.csv`. For example, the German stopword file is named `stopwords_de_DE.csv`.
 
 1. Add words, remove words, or change words in the file.
 
- (Each stopword in a file starts on a new line.)
+    (Each stopword in a file starts on a new line.)
 
 1. Save your changes and exit the text editor.
 1. Clean the Magento configuration cache.

--- a/guides/v2.3/config-guide/elasticsearch/es-config-stopwords.md
+++ b/guides/v2.3/config-guide/elasticsearch/es-config-stopwords.md
@@ -46,7 +46,7 @@ To edit stopwords:
 
 1. Add words, remove words, or change words in the file.
 
-    (Each stopword in a file starts on a new line.)
+   (Each stopword in a file starts on a new line.)
 
 1. Save your changes and exit the text editor.
 1. Clean the Magento configuration cache.

--- a/guides/v2.3/config-guide/elasticsearch/es-config-stopwords.md
+++ b/guides/v2.3/config-guide/elasticsearch/es-config-stopwords.md
@@ -39,7 +39,6 @@ See one of the following topics for more information:
 To edit stopwords:
 
 1. Log in to your Magento server, or switch to, the [Magento file system owner]({{page.baseurl}}/install-gde/prereq/apache-user.html).
-
 1. Use a text editor to open a stopword file in the `<magento_root>/vendor/magento/module-elasticsearch/etc/stopwords` directory.
 
    `.csv` files use the naming convention `stopwords_<locale_code>.csv`. For example, the German stopword file is named `stopwords_de_DE.csv`.


### PR DESCRIPTION
## Purpose of this pull request

- Corrected the topic's number sequence.

## Affected DevDocs pages

-  https://devdocs.magento.com/guides/v2.2/config-guide/elasticsearch/es-config-stopwords.html#config-edit-stopwords
- https://devdocs.magento.com/guides/v2.3/config-guide/elasticsearch/es-config-stopwords.html#config-edit-stopwords

## Links to Magento source code

-  N/A

## Screenshot
![screenshot-devdocs magento com-2019 10 30-10_29_15](https://user-images.githubusercontent.com/783102/67830313-2d4b6b80-fb00-11e9-8b5c-5399ec171fa4.png)
