### PR TITLE
magento/devdocs#: Fix callout block on “setPaymentMethodAndPlaceOrder mutation“ page

### DIFF
--- a/guides/v2.3/graphql/mutations/set-payment-place-order.md
+++ b/guides/v2.3/graphql/mutations/set-payment-place-order.md
@@ -7,7 +7,8 @@ redirect from:
   - /guides/v2.3/graphql/reference/quote-set-payment-place-order.html
 ---
 
-{:.bs-callout-info} The `setPaymentMethodAndPlaceOrder` mutation will be deprecated in the next patch release. Use the `setPaymentMethodOnCart` and `placeOrder` mutations instead. You can run the two methods in the same call if your use case allows it.
+{: .bs-callout-info }
+The `setPaymentMethodAndPlaceOrder` mutation will be deprecated in the next patch release. Use the `setPaymentMethodOnCart` and `placeOrder` mutations instead. You can run the two methods in the same call if your use case allows it.
 
 The `setPaymentMethodAndPlaceOrder` mutation sets the cart payment method and converts the cart into an order. The
 mutation returns the resulting order ID. You cannot manage orders with GraphQL, because orders are part of the backend.


### PR DESCRIPTION
## Purpose of this pull request

This pull request (PR) fixes callout visual issue on [setPaymentMethodAndPlaceOrder mutation](https://devdocs.magento.com/guides/v2.3/graphql/mutations/set-payment-place-order.html) page:

<img width="1295" alt="5880" src="https://user-images.githubusercontent.com/13585327/67848700-d5b3fc80-fb0d-11e9-972f-e1f55bca1468.png">


## Affected DevDocs pages

<!-- REQUIRED List the affected pages on devdocs.magento.com (URLs). Not needed for large numbers of files. -->

-  https://devdocs.magento.com/guides/v2.3/graphql/mutations/set-payment-place-order.html

## Links to Magento source code

<!--  OPTIONAL - REMOVE THIS SECTION IF NOT USED. If this pull request references a file in a Magento codebase repository, add it here. -->

-  ...

<!--
If you are fixing a GitHub issue, note it using GitHub keyword format (https://help.github.com/en/articles/closing-issues-using-keywords#closing-an-issue-in-a-different-repository) to close the issue when this pull request is merged. Example: `Fixes #1234`

`master` is the default branch. Merged pull requests to `master` go live on the site automatically. Any requested changes to content on the `master` branch must be related to the released codebase. Any content related to future releases goes in the `develop` branch.

See Contribution guidelines (https://github.com/magento/devdocs/blob/master/.github/CONTRIBUTING.md) for more information.
-->
