### PR TITLE
Add rule in backwards compatibility section about adding new configuration path

### DIFF
--- a/guides/v2.2/extension-dev-guide/versioning/codebase-changes.md
+++ b/guides/v2.2/extension-dev-guide/versioning/codebase-changes.md
@@ -141,7 +141,9 @@ Any change not listed below is considered a PATCH level change.
 | | Obligatory node/attribute added| MAJOR|
 | | Node/attribute removed | MAJOR|
 | | New optional node/attribute added| MINOR|
-| **Structure of System Configuration fields used by module** | Config path removed/renamed| MAJOR|
+| **Structure of System Configuration fields used by module**
+| | Config path added| MINOR|
+| | Config path removed/renamed| MAJOR|
 | **Database structure**| Table removed| MAJOR|
 | | Table added| MINOR|
 | | Column removed | MAJOR|


### PR DESCRIPTION
## Purpose of this pull request

Updates backwards compatibility rules.

## Affected DevDocs pages

https://devdocs.magento.com/guides/v2.3/extension-dev-guide/versioning/codebase-changes.html
-  ...

## Links to Magento source code

<!--  OPTIONAL - REMOVE THIS SECTION IF NOT USED. If this pull request references a file in a Magento codebase repository, add it here. -->

-  ...

<!--
If you are fixing a GitHub issue, note it using GitHub keyword format (https://help.github.com/en/articles/closing-issues-using-keywords#closing-an-issue-in-a-different-repository) to close the issue when this pull request is merged. Example: `Fixes #1234`

`master` is the default branch. Merged pull requests to `master` go live on the site automatically. Any requested changes to content on the `master` branch must be related to the released codebase. Any content related to future releases goes in the `develop` branch.

See Contribution guidelines (https://github.com/magento/devdocs/blob/master/.github/CONTRIBUTING.md) for more information.
-->
