### PR TITLE
Need chance link reference

### DIFF
--- a/guides/v2.2/ui_comp_guide/concepts/ui_comp_linking_concept.md
+++ b/guides/v2.2/ui_comp_guide/concepts/ui_comp_linking_concept.md
@@ -171,7 +171,7 @@ Example of using `listens` in a component's configuration `.xml` file:
 </argument>
 ```
 
-For example of `listens` usage in Magento code see [`new_category_form.xml`, line 92]({{ site.mage2bloburl }}/{{ page.guide_version }}/app/code/Magento/Catalog/view/adminhtml/ui_component/new_category_form.xml#L92)
+For example of `listens` usage in Magento code see [`new_category_form.xml`, line 84]({{ site.mage2bloburl }}/{{ page.guide_version }}/app/code/Magento/Catalog/view/adminhtml/ui_component/new_category_form.xml#L84)
 
 ## Template strings usage {#string_templ}
 


### PR DESCRIPTION
Need chance link reference on page: /guides/v2.2/ui_comp_guide/concepts/ui_comp_linking_concept.html
When we are reading the "listens property" Observe the following excerpt:
"For an example of listens usage in Magento code see line 92." The link is incorrect because the line has changed, now the line is 84

## Steps to reproduce
Step 1
Access the link:
https://devdocs.magento.com/guides/v2.2/ui_comp_guide/concepts/ui_comp_linking_concept.html#listens-property
Step 2
Read the following excerpt on listens property:
On the part XLM example after the code example the link " new_category_form.xml, line 92", observe that this line into the code needs change to line 84.

## Purpose of this pull request
The text needs to be changed to line 84

## Affected DevDocs pages

[https://devdocs.magento.com/guides/v2.2/ui_comp_guide/concepts/ui_comp_linking_concept.html](https://devdocs.magento.com/guides/v2.2/ui_comp_guide/concepts/ui_comp_linking_concept.html)

