### PR TITLE
Updated translation sequence info and added a note

### DIFF
--- a/guides/v2.2/frontend-dev-guide/translations/theme_dictionary.md
+++ b/guides/v2.2/frontend-dev-guide/translations/theme_dictionary.md
@@ -20,9 +20,9 @@ When the [locale](https://glossary.magento.com/locale) is changed for a store, M
 1. Magento database (translations located in this database take precedence and override translations stored in other locations.)  Refer to the [user guide](https://docs.magento.com/m2/ce/user_guide/system/translate-inline.html) for more information.
 
 {:.bs-callout .bs-callout-info}
-The priority follows the inverse sequence, being that "module translations" with the lowest priority and the "magento database" with the most priority.
+Translation priority follows the inverse sequence, with "module translations" having the lowest priority and "magento database" having the hightest priority.
 
-If there are different translations for one string, the theme dictionary translations have priority over the [module](https://glossary.magento.com/module) translations, and child theme translations have priority over parent theme translations.
+If there are competing translations for one string, the theme dictionary translations have priority over the [module](https://glossary.magento.com/module) translations, and child theme translations have priority over parent theme translations.
 
 ## Creating a theme dictionary to override parent strings for default locale
 

--- a/guides/v2.2/frontend-dev-guide/translations/theme_dictionary.md
+++ b/guides/v2.2/frontend-dev-guide/translations/theme_dictionary.md
@@ -10,14 +10,17 @@ Modify default strings in your custom [theme](https://glossary.magento.com/theme
 
 ## How Magento applies locales
 
-When the [locale](https://glossary.magento.com/locale) is changed for a store, Magento searches for and applies translations in the corresponding dictionaries:
+When the [locale](https://glossary.magento.com/locale) is changed for a store, Magento searches and applies translations in the corresponding dictionaries in the following sequence:
 
 1. Module translations: `<module_dir>/i18n/`
+1. Translation package: `app/i18n/`
 1. Theme translations:
    1. `<parent_theme_dir>/i18n/` (iterated through all ancestor themes)
    1. `<current_theme_dir>/i18n/`
-1. Translation package: `app/i18n/`
 1. Magento database (translations located in this database take precedence and override translations stored in other locations.)  Refer to the [user guide](https://docs.magento.com/m2/ce/user_guide/system/translate-inline.html) for more information.
+
+{:.bs-callout .bs-callout-info}
+The priority follows the inverse sequence, being that "module translations" with the lowest priority and the "magento database" with the most priority.
 
 If there are different translations for one string, the theme dictionary translations have priority over the [module](https://glossary.magento.com/module) translations, and child theme translations have priority over parent theme translations.
 


### PR DESCRIPTION
## Purpose of this pull request

This pull request (PR) changed the translation sequence info, following the Magento sequence listed at the `Magento/Framework/Translate.php` file, and add a note explaining the priority.

## Affected DevDocs pages

- https://devdocs.magento.com/guides/v2.3/frontend-dev-guide/translations/theme_dictionary.html#how-magento-applies-locales

## Fixed issues

#5862

## Links to Magento source code

-  https://github.com/magento/magento2/blob/68d21376fa18895276e00931fe382c120d7a4e17/lib/internal/Magento/Framework/Translate.php#L218
