### PR TITLE
Need chance link reference on page

### DIFF
--- a/guides/v2.2/ui_comp_guide/concepts/ui_comp_linking_concept.md
+++ b/guides/v2.2/ui_comp_guide/concepts/ui_comp_linking_concept.md
@@ -67,7 +67,7 @@ Example of setting `exports` in a component's configuration `.xml` file:
 </argument>
 ```
 
-For an example of `exports` usage in Magento code see [`product_form.xml`, line 81]({{ site.mage2bloburl }}/{{ page.guide_version }}/app/code/Magento/CatalogInventory/view/adminhtml/ui_component/product_form.xml#L81)
+For an example of `exports` usage in Magento code see [`product_form.xml`, line 76]({{ site.mage2bloburl }}/{{ page.guide_version }}/app/code/Magento/CatalogInventory/view/adminhtml/ui_component/product_form.xml#L76)
 
 ## `imports` property
 The `imports` property is used for tracking changes of an external entity property. `imports`'s value is an object, composed of the following:
@@ -136,7 +136,7 @@ Example of using `links` in a component's configuration `.xml` file:
 </argument>
 ```
 
-For an example of `links` usage in Magento code see [`text.js`, line 19]({{ site.mage2bloburl }}/{{ page.guide_version }}/app/code/Magento/Ui/view/base/web/js/form/element/text.js#L19)
+For an example of `links` usage in Magento code see [`text.js`, line 22]({{ site.mage2bloburl }}/{{ page.guide_version }}/app/code/Magento/Ui/view/base/web/js/form/element/text.js#L22)
 
 ## `listens` property
 The `listens` property is used to track the changes of a component's property. `listens`'s value is an object, composed of the following:
@@ -171,7 +171,7 @@ Example of using `listens` in a component's configuration `.xml` file:
 </argument>
 ```
 
-For example of `listens` usage in Magento code see [`new_category_form.xml`, line 92]({{ site.mage2bloburl }}/{{ page.guide_version }}/app/code/Magento/Catalog/view/adminhtml/ui_component/new_category_form.xml#L92)
+For example of `listens` usage in Magento code see [`new_category_form.xml`, line 84]({{ site.mage2bloburl }}/{{ page.guide_version }}/app/code/Magento/Catalog/view/adminhtml/ui_component/new_category_form.xml#L84)
 
 ## Template strings usage {#string_templ}
 


### PR DESCRIPTION
Need chance links references on page: /guides/v2.2/ui_comp_guide/concepts/ui_comp_linking_concept.html

## Purpose of this pull request

Need chance link reference on page: /guides/v2.2/ui_comp_guide/concepts/ui_comp_linking_concept.html
When we are reading the "listens property" Observe the following excerpt:
"For an example of links usage in Magento code see text.js, line 19" The link is incorrect because the line has changed, now the line is 22
"For an example of exports usage in Magento code see product_form.xml, line 81" The link is incorrect because the line has changed, now the line is 76
"For an example of listens usage in Magento code see line 92." The link is incorrect because the line has changed, now the line is 84

## Affected DevDocs pages

[https://devdocs.magento.com/guides/v2.2/ui_comp_guide/concepts/ui_comp_linking_concept.html](https://devdocs.magento.com/guides/v2.2/ui_comp_guide/concepts/ui_comp_linking_concept.html)