### PR TITLE
GraphQL: Add mergeCarts mutation

### DIFF
--- a/_data/toc/graphql.yml
+++ b/_data/toc/graphql.yml
@@ -172,6 +172,9 @@ pages:
         - label: handlePayflowProResponse mutation
           url: /graphql/mutations/handle-payflow-pro-response.html
 
+        - label: mergeCarts mutation
+          url: /graphql/mutations/merge-carts.html
+
         - label: placeOrder mutation
           url: /graphql/mutations/place-order.html
 

--- a/_includes/graphql/cart-object.md
+++ b/_includes/graphql/cart-object.md
@@ -6,8 +6,8 @@ Attribute |  Data Type | Description
 `applied_store_credit` | [`AppliedStoreCredit`][AppliedStoreCredit] | Contains store credit information applied to the cart. `applied_store_credit` is a Commerce-only attribute, defined in the CustomerBalanceGraphQl module
 `available_payment_methods` | [[AvailablePaymentMethod]][AvailablePaymentMethod] | Available payment methods
 `billing_address` | [BillingCartAddress][BillingCartAddress] | Contains the billing address specified in the customer's cart
-`cart_id` | ID! | The ID of the cart
 `email` | String | The customer's email address
+`id` | ID! | The ID of the cart
 `is_virtual` | Boolean | Indicates whether the cart contains only virtual products
 `items` | [[CartItemInterface]][CartItemInterface] | Contains the items in the customer's cart
 `prices` | [CartPrices][CartPrices] | Contains subtotals and totals

--- a/_includes/graphql/cart-object.md
+++ b/_includes/graphql/cart-object.md
@@ -5,7 +5,7 @@ Attribute |  Data Type | Description
 `applied_gift_cards` | [[`AppliedGiftCard`]][AppliedGiftCard] | An array of `AppliedGiftCard` objects. An `AppliedGiftCard` object contains the `code` text attribute, which specifies the gift card code. `applied_gift_cards` is a Commerce-only attribute, defined in the GiftCardAccountGraphQl module
 `applied_store_credit` | [`AppliedStoreCredit`][AppliedStoreCredit] | Contains store credit information applied to the cart. `applied_store_credit` is a Commerce-only attribute, defined in the CustomerBalanceGraphQl module
 `available_payment_methods` | [[AvailablePaymentMethod]][AvailablePaymentMethod] | Available payment methods
-`billing_address` | [BillingCartAddress][BillingCartAddress]! | Contains the billing address specified in the customer's cart
+`billing_address` | [BillingCartAddress][BillingCartAddress] | Contains the billing address specified in the customer's cart
 `email` | String | The customer's email address
 `is_virtual` | Boolean | Indicates whether the cart contains only virtual products
 `items` | [[CartItemInterface]][CartItemInterface] | Contains the items in the customer's cart

--- a/guides/v2.3/graphql/mutations/merge-carts.md
+++ b/guides/v2.3/graphql/mutations/merge-carts.md
@@ -68,7 +68,7 @@ mutation {
 Attribute |  Data Type | Description
 --- | --- | ---
 `destination_cart_id` | String! | The ID of the logged-in customer's cart
-`source_cart_id` | String! | The ID of the guest cart 
+`source_cart_id` | String! | The ID of the guest cart
 
 ## Output attributes
 

--- a/guides/v2.3/graphql/mutations/merge-carts.md
+++ b/guides/v2.3/graphql/mutations/merge-carts.md
@@ -5,7 +5,7 @@ title: mergeCarts mutation
 
 The `mergeCarts` mutation transfers the contents of a guest cart into the cart of a logged-in customer. This mutation must be run on behalf of a logged-in customer.
 
-The mutation retains any items that were already in the logged-in custmer's cart. If both the guest and customer carts contain the same item, adds the quantities. Upon success, the mutation deletes the original guest cart.
+The mutation retains any items that were already in the logged-in customer's cart. If both the guest and customer carts contain the same item, adds the quantities. Upon success, the mutation deletes the original guest cart.
 
 Use the `customerCart` query to determine the value of the `destination_cart_id` attribute.
 

--- a/guides/v2.3/graphql/mutations/merge-carts.md
+++ b/guides/v2.3/graphql/mutations/merge-carts.md
@@ -7,7 +7,7 @@ The `mergeCarts` mutation transfers the contents of a guest cart into the cart o
 
 The mutation retains any items that were already in the logged-in customer's cart. If both the guest and customer carts contain the same item, adds the quantities. Upon success, the mutation deletes the original guest cart.
 
-Use the `customerCart` query to determine the value of the `destination_cart_id` attribute.
+Use the [`customerCart` query]({{page.baseurl}}/graphql/queries/customer-cart.html) to determine the value of the `destination_cart_id` attribute.
 
 ## Syntax
 

--- a/guides/v2.3/graphql/mutations/merge-carts.md
+++ b/guides/v2.3/graphql/mutations/merge-carts.md
@@ -3,15 +3,19 @@ group: graphql
 title: mergeCarts mutation
 ---
 
-The `mergeCarts` mutation transfers the contents of a guest cart into the cart of a logged-in customer. 
+The `mergeCarts` mutation transfers the contents of a guest cart into the cart of a logged-in customer. This mutation must be run on behalf of a logged-in customer.
 
-Once a customer logs in (uses it's token), an existing guest cart needs to be transferred/merged/imported to the customer cart. Also the registered customer should be able to work with the same shopping cart on multiple devices that we use that token once we 'login', for example, add products to cart using a laptop and complete checkout using a smartphone using the same customer. We used the term 'login' in quotes, because there's really no state/session in graphql.
+The mutation retains any items that were already in the logged-in custmer's cart. If both the guest and customer carts contain the same item, adds the quantities. Upon success, the mutation deletes the original guest cart.
+
+Use the `customerCart` query to determine the value of the `destination_cart_id` attribute.
 
 ## Syntax
 
 `mergeCarts(source_cart_id: String, destination_cart_id: String): Cart!`
 
 ## Example usage
+
+In the following example, the customer had one Overnight Duffle in the cart (`CYmiiQRjPVc2gJUc5r7IsBmwegVIFO43`) before a guest cart (`mPKE05OOtcxErbk1Toej6gw6tcuxvT9O`) containing a Radiant Tee and another Overnight Duffle was merged. The cart now includes three items, including two Overnight Duffles.
 
 **Request**
 
@@ -38,26 +42,18 @@ mutation {
     "mergeCarts": {
       "items": [
         {
-          "id": "11",
+          "id": "14",
           "product": {
-            "name": "Strive Shoulder Pack",
-            "sku": "24-MB04"
+            "name": "Overnight Duffle",
+            "sku": "24-WB07"
           },
-          "quantity": 1
+          "quantity": 2
         },
         {
-          "id": "12",
+          "id": "17",
           "product": {
             "name": "Radiant Tee",
             "sku": "WS12"
-          },
-          "quantity": 1
-        },
-        {
-          "id": "14",
-          "product": {
-            "name": "Strive Shoulder Pack",
-            "sku": "24-MB04"
           },
           "quantity": 1
         }

--- a/guides/v2.3/graphql/mutations/merge-carts.md
+++ b/guides/v2.3/graphql/mutations/merge-carts.md
@@ -11,7 +11,7 @@ Use the `customerCart` query to determine the value of the `destination_cart_id`
 
 ## Syntax
 
-`mergeCarts(source_cart_id: String, destination_cart_id: String): Cart!`
+`mergeCarts(source_cart_id: String!, destination_cart_id: String!): Cart!`
 
 ## Example usage
 

--- a/guides/v2.3/graphql/mutations/merge-carts.md
+++ b/guides/v2.3/graphql/mutations/merge-carts.md
@@ -7,7 +7,7 @@ The `mergeCarts` mutation
 
 ## Syntax
 
-``
+`mergeCarts(source_cart_id: String, destination_cart_id: String): Cart!`
 
 ## Example usage
 
@@ -27,5 +27,18 @@ The `mergeCarts` mutation
 
 Attribute |  Data Type | Description
 --- | --- | ---
+source_cart_id
 
 ## Output attributes
+
+The `` object contains the `Cart` object.
+
+Attribute |  Data Type | Description
+--- | --- | ---
+`cart` |[Cart!](#CartObject) | Describes the contents of the specified shopping cart
+
+### Cart object {#CartObject}
+
+{% include graphql/cart-object.md %}
+
+[Cart query output]({{page.baseurl}}/graphql/queries/cart.html#cart-output) provides more information about the `Cart` object.

--- a/guides/v2.3/graphql/mutations/merge-carts.md
+++ b/guides/v2.3/graphql/mutations/merge-carts.md
@@ -3,7 +3,9 @@ group: graphql
 title: mergeCarts mutation
 ---
 
-The `mergeCarts` mutation 
+The `mergeCarts` mutation transfers the contents of a guest cart into the cart of a logged-in customer. 
+
+Once a customer logs in (uses it's token), an existing guest cart needs to be transferred/merged/imported to the customer cart. Also the registered customer should be able to work with the same shopping cart on multiple devices that we use that token once we 'login', for example, add products to cart using a laptop and complete checkout using a smartphone using the same customer. We used the term 'login' in quotes, because there's really no state/session in graphql.
 
 ## Syntax
 
@@ -14,24 +16,67 @@ The `mergeCarts` mutation
 **Request**
 
 ```graphql
-
+mutation {
+  mergeCarts(source_cart_id: "mPKE05OOtcxErbk1Toej6gw6tcuxvT9O", destination_cart_id: "CYmiiQRjPVc2gJUc5r7IsBmwegVIFO43") {
+    items {
+      id
+      product {
+        name
+        sku
+      }
+      quantity
+    }
+  }
+}
 ```
 
 **Response**
 
 ```json
-
+{
+  "data": {
+    "mergeCarts": {
+      "items": [
+        {
+          "id": "11",
+          "product": {
+            "name": "Strive Shoulder Pack",
+            "sku": "24-MB04"
+          },
+          "quantity": 1
+        },
+        {
+          "id": "12",
+          "product": {
+            "name": "Radiant Tee",
+            "sku": "WS12"
+          },
+          "quantity": 1
+        },
+        {
+          "id": "14",
+          "product": {
+            "name": "Strive Shoulder Pack",
+            "sku": "24-MB04"
+          },
+          "quantity": 1
+        }
+      ]
+    }
+  }
+}
 ```
 
 ## Input attributes
 
 Attribute |  Data Type | Description
 --- | --- | ---
-source_cart_id
+`destination_cart_id` | String! | The ID of the logged-in customer's cart
+`source_cart_id` | String! | The ID of the guest cart 
 
 ## Output attributes
 
-The `` object contains the `Cart` object.
+The `mergeCarts` mutation returns a `Cart` object.
 
 Attribute |  Data Type | Description
 --- | --- | ---

--- a/guides/v2.3/graphql/mutations/merge-carts.md
+++ b/guides/v2.3/graphql/mutations/merge-carts.md
@@ -1,0 +1,31 @@
+---
+group: graphql
+title: mergeCarts mutation
+---
+
+The `mergeCarts` mutation 
+
+## Syntax
+
+``
+
+## Example usage
+
+**Request**
+
+```graphql
+
+```
+
+**Response**
+
+```json
+
+```
+
+## Input attributes
+
+Attribute |  Data Type | Description
+--- | --- | ---
+
+## Output attributes

--- a/guides/v2.3/graphql/queries/cart.md
+++ b/guides/v2.3/graphql/queries/cart.md
@@ -781,8 +781,8 @@ The `CartAddressCountry` object can contain the following attributes.
 
 Attribute |  Data Type | Description
 --- | --- | ---
-`code` | String | The country code
-`label` | String | The display label for the country
+`code` | String! | The country code
+`label` | String! | The display label for the country
 
 ### CartAddressInterface {#CartAddressInterface}
 
@@ -790,16 +790,16 @@ The `CartAddressInterface` contains the following attributes.
 
 Attribute |  Data Type | Description
 --- | --- | ---
-`city` | String | The city specified for the billing address
+`city` | String! | The city specified for the billing address
 `company` | String | The company specified for the billing address
-`country` | [CartAddressCountry](#CartAddressCountry) | The country code and label for the billing address
+`country` | [CartAddressCountry!](#CartAddressCountry) | The country code and label for the billing address
 `customer_notes` | String | Comments made to the customer that accompanies the order
-`firstname` | String | The customer's first name
-`lastname` | String | The customer's last name
+`firstname` | String! | The customer's first name
+`lastname` | String! | The customer's last name
 `postcode` | String | The postal code for the billing address
 `region` | [CartAddressRegion](#CartAddressRegion) | An object containing the region label and code
-`street` | [String] | The street for the billing address
-`telephone` | String | The telephone number for the billing address
+`street` | [String!]! | The street for the billing address
+`telephone` | String! | The telephone number for the billing address
 
 ### CartAddressRegion object {#CartAddressRegion}
 
@@ -807,8 +807,8 @@ The `CartAddressRegion` object can contain the following attributes.
 
 Attribute |  Data Type | Description
 --- | --- | ---
-`code` | String | The state or province code
-`label` | String | The display label for the region
+`code` | String! | The state or province code
+`label` | String! | The display label for the region
 
 ### CartDiscount object {#CartDiscount}
 

--- a/guides/v2.3/graphql/queries/customer-cart.md
+++ b/guides/v2.3/graphql/queries/customer-cart.md
@@ -10,7 +10,7 @@ The `customerCart` query differs from the `cart` query in the following ways:
 -  The `customerCart` query must be run on behalf of a logged-in customer. If you run this query on behalf of a guest, an exception will be thrown.
 -  The `cart` query requires a `cart_id` value as input. The `customerCart` query does not take any input parameters.
 
-You can define the query to return the `cart_id` attribute. You can use the value of the `cart_id` attribute as the `destination_cart_id` input parameter in the [`mergeCarts` mutation]({{page.baseurl}}/graphql/mutations/merge-carts.html). (The `mergeCarts` mutation provides the ability to merge a guest cart with the logged-in customer's cart.)
+You can define the query to return the `id` attribute. You can use the value of this attribute as the `destination_cart_id` input parameter in the [`mergeCarts` mutation]({{page.baseurl}}/graphql/mutations/merge-carts.html). (The `mergeCarts` mutation provides the ability to merge a guest cart with the logged-in customer's cart.)
 
 {: .bs-callout-tip }
 If you know the value of the logged-in customer's cart ID, you can allow the customer to start an order on one device and complete it on another.
@@ -28,7 +28,7 @@ The following query lists the products in the logged-in customer's cart:
 ```graphql
 {
   customerCart {
-    cart_id
+    id
     items {
       id
       product {

--- a/guides/v2.3/graphql/queries/customer-cart.md
+++ b/guides/v2.3/graphql/queries/customer-cart.md
@@ -10,7 +10,7 @@ The `customerCart` query differs from the `cart` query in the following ways:
 -  The `customerCart` query must be run on behalf of a logged-in customer. If you run this query on behalf of a guest, an exception will be thrown.
 -  The `cart` query requires a `cart_id` value as input. The `customerCart` query does not take any input parameters.
 
-You can define the query to return the `cart_id` attribute. You can use the value of the `cart_id` attribute as the `destination_cart_id` input parameter in the `mergeCarts` mutation. (The `mergeCarts` mutation provides the ability to merge a guest cart with the logged-in customer's cart.)
+You can define the query to return the `cart_id` attribute. You can use the value of the `cart_id` attribute as the `destination_cart_id` input parameter in the [`mergeCarts` mutation]({{page.baseurl}}/graphql/mutations/merge-carts.html). (The `mergeCarts` mutation provides the ability to merge a guest cart with the logged-in customer's cart.)
 
 {: .bs-callout-tip }
 If you know the value of the logged-in customer's cart ID, you can allow the customer to start an order on one device and complete it on another.


### PR DESCRIPTION
## Purpose of this pull request

This pull request (PR) documents the `mergeCarts` mutation, which was created in internal ticket MC-22181. 

## Affected DevDocs pages

- guides/v2.3/graphql/mutations/merge-carts.md

whatsnew
Added the [`mergeCarts` mutation](https://devdocs.magento.com/guides/v2.3/graphql/mutations/merge-carts.html)