### PR TITLE
Increment RabbitMQ version support for 2.3.4

### DIFF
--- a/guides/v2.3/install-gde/system-requirements-tech.md
+++ b/guides/v2.3/install-gde/system-requirements-tech.md
@@ -119,7 +119,7 @@ Mail Transfer Agent (MTA) or an SMTP server
 
       Follow the instructions in [Change Elasticsearch Module][].
 
-*  RabbitMQ 3.7.x (compatible with 2.0 and later)
+*  RabbitMQ 3.8.x (compatible with 2.0 and later)
 
    [RabbitMQ][]{:target="_blank"} can be used to publish messages to queue and to define the consumers that receive the messages asynchronously.
 


### PR DESCRIPTION
## Purpose of this pull request

This pull request (PR) increments the RabbitMQ supported version number to 3.8.

https://jira.corp.magento.com/browse/MC-22620

## Affected DevDocs pages

-  https://devdocs.magento.com/guides/v2.3/install-gde/system-requirements-tech.html#technologies-magento-can-use