### PR TITLE
Change wee -> weee in weee module page

### DIFF
--- a/_data/codebase/mrg/ce/Weee.yaml
+++ b/_data/codebase/mrg/ce/Weee.yaml
@@ -8,10 +8,10 @@ content: |
   The Magento_Weee module enables the application of fees/fixed product taxes (FPT) on certain types of products, usually related to electronic devices and recycling.
   Fixed product taxes can be used to setup a WEEE tax that is a fixed amount, rather than a percentage of the product price. FPT can be configured to be displayed at various places in Magento. Rules, amounts, and display options can be configured in the backend. This module extends the existing functionality of Magento_Tax.
 
-  The Magento_Wee module includes the following:
+  The Magento_Weee module includes the following:
 
   * ability to add different number of fixed product taxes to product. They are treated as a product attribute;
-  * configuration of where Weee appears (on category, product, sales, invoice, or credit memo pages) and whether FPT should be taxed;
+  * configuration of where WEEE appears (on category, product, sales, invoice, or credit memo pages) and whether FPT should be taxed;
   * a new line item in the totals section.
 
   # System requirements


### PR DESCRIPTION
## Purpose of this pull request

This pull request (PR) changes an instance of `wee` in the WEEE module documentation to `weee`.
My childish brain thought a module called `weee` was funny, so I wanted to check available docs to see what it _actually_ did. My childish brain thought the misspelling was even funnier.

## Affected DevDocs pages

<!-- REQUIRED List the affected pages on devdocs.magento.com (URLs). Not needed for large numbers of files. -->

-  https://devdocs.magento.com/guides/v2.3/mrg/ce/Weee.html

<!--
If you are fixing a GitHub issue, note it using GitHub keyword format (https://help.github.com/en/articles/closing-issues-using-keywords#closing-an-issue-in-a-different-repository) to close the issue when this pull request is merged. Example: `Fixes #1234`

`master` is the default branch. Merged pull requests to `master` go live on the site automatically. Any requested changes to content on the `master` branch must be related to the released codebase. Any content related to future releases goes in the `develop` branch.

See Contribution guidelines (https://github.com/magento/devdocs/blob/master/.github/CONTRIBUTING.md) for more information.
-->
