### PR TITLE
Add a guide for entity-specific layouts

### DIFF
--- a/guides/v2.3/frontend-dev-guide/layouts/xml-manage.md
+++ b/guides/v2.3/frontend-dev-guide/layouts/xml-manage.md
@@ -551,7 +551,49 @@ You can remove navigation links from the 'My Account' dashboard on the storefron
 <!-- "My Returns" link -->
 <referenceBlock name="customer-account-navigation-return-history-link" remove="true"/>
 ```
-
+ 
+ 
+## Create cms-page/product/category-specific layouts
+  _since Magento 2.3.4/2.2.11_
+ 
+Merchants can select layout updates to be applied to specific Category/Product/CMS Page pages on frontend. These layout
+updates are being made available to select by creating layout XML files following naming conventions.
+ 
+For Categories:
+ 
+* `catalog_category_view_selectable_<Category ID>_<Layout Update Name>.xml`
+ 
+Where:
+ 
+* _Category ID_ is desired category ID
+* _Layout Update Name_ is what's going to be shown as the option for __Custom layout update__ field of __Design__
+  section on _Category Edit_ page
+ 
+For Products:
+ 
+* `catalog_product_view_selectable_<Product SKU>_<Layout Update Name>.xml`
+ 
+Where:
+ 
+* _Product SKU_ is desired product's SKU encoded as URI
+  _example_: "My Product SKU" -> "My%20Product%20SKU"
+* _Layout Update Name_ is what's going to be shown as the option for __Custom layout update__ field of __Design__
+  section on _Product Edit_ page
+ 
+For CMS Pages:
+ 
+* `cms_page_view_selectable_<CMS Page Identifier>_<Layout Update Name>.xml`
+ 
+Where:
+ 
+* _CMS Page Identifier_ is desired page's _URL Key_ with "/" symbols replaces as "_"
+* _Layout Update Name_ is what's going to be shown as the option for __Custom layout update__ field of __Design__
+  section on _CMS Page Edit_ page
+ 
+These files must be placed in folders appropriate for layout XML files. They will be available as
+__Custom Layout Update__ options for Merchants after cache flush.
+ 
+ 
 {:.ref-header}
 Related topics
 


### PR DESCRIPTION
in 2.3.4 we changed how merchants can set-up custom layout updates for cms pages, categories and products.

## Purpose of this pull request

This pull request (PR) will guide front-end devs and merchants on the new flow of providing custom layout updates for cms pages, categories and products

## Affected DevDocs pages

<!-- REQUIRED List the affected pages on devdocs.magento.com (URLs). Not needed for large numbers of files. -->

-  https://devdocs.magento.com/guides/v2.3/frontend-dev-guide/layouts/xml-manage.html
-  https://devdocs.magento.com/guides/v2.2/frontend-dev-guide/layouts/xml-manage.html

 
## Related changes to Magento 2 codebase
- https://github.com/magento/magento2ce/pull/4969 (v.2.2.11)
- https://github.com/magento/magento2ce/pull/4967 (v2.3.4) 

<!--
If you are fixing a GitHub issue, note it using GitHub keyword format (https://help.github.com/en/articles/closing-issues-using-keywords#closing-an-issue-in-a-different-repository) to close the issue when this pull request is merged. Example: `Fixes #1234`

`master` is the default branch. Merged pull requests to `master` go live on the site automatically. Any requested changes to content on the `master` branch must be related to the released codebase. Any content related to future releases goes in the `develop` branch.

See Contribution guidelines (https://github.com/magento/devdocs/blob/master/.github/CONTRIBUTING.md) for more information.
-->
