### PR TITLE
Add attributes to ProductFilterInput

### DIFF
--- a/guides/v2.3/graphql/queries/products.md
+++ b/guides/v2.3/graphql/queries/products.md
@@ -90,10 +90,13 @@ small_image_label
 special_from_date
 special_price
 special_to_date
+swatch_image
 thumbnail
 thumbnail_label
 tier_price
 updated_at
+url_key
+url_path
 weight
 ```
 


### PR DESCRIPTION
## Purpose of this pull request

This pull request (PR) fixes #5919 and adds three items to the list of filterable attributes in the `products` query.

## Affected DevDocs pages

- https://devdocs.magento.com/guides/v2.3/graphql/queries/products.html#ProductFilterInput