### PR TITLE
GraphQL: Change cart_id to id in customerCart query

### DIFF
--- a/guides/v2.3/graphql/queries/customer-cart.md
+++ b/guides/v2.3/graphql/queries/customer-cart.md
@@ -47,7 +47,7 @@ The following query lists the products in the logged-in customer's cart:
 {
   "data": {
     "customerCart": {
-      "cart_id": "CYmiiQRjPVc2gJUc5r7IsBmwegVIFO43",
+      "id": "CYmiiQRjPVc2gJUc5r7IsBmwegVIFO43",
       "items": [
         {
           "id": "11",


### PR DESCRIPTION
## Purpose of this pull request

This pull request (PR) updates the output for the `customerCart` query. The attribute was renamed from `cart_id` to `id`.

## Affected DevDocs pages

<!-- REQUIRED List the affected pages on devdocs.magento.com (URLs). Not needed for large numbers of files. -->

-  guides/v2.3/graphql/queries/customer-cart.md
