### PR TITLE
Add new custom layout update guide

### DIFF
--- a/guides/v2.3/frontend-dev-guide/layouts/xml-manage.md
+++ b/guides/v2.3/frontend-dev-guide/layouts/xml-manage.md
@@ -551,11 +551,10 @@ You can remove navigation links from the 'My Account' dashboard on the storefron
 <!-- "My Returns" link -->
 <referenceBlock name="customer-account-navigation-return-history-link" remove="true"/>
 ```
- 
-## Create cms-page/product/category-specific layouts
-  _since Magento 2.3.4/2.2.11_
 
-Merchants can select layout updates to be applied to specific Category/Product/CMS Page pages on the frontend. These layout
+## Create cms-page/product/category-specific layouts
+
+As of Magento 2.3.4/2.2.11, merchants can select layout updates to be applied to specific Category/Product/CMS Page pages on the frontend. These layout
 updates are made by creating layout XML files following specific naming conventions.
 
 For Categories:
@@ -588,7 +587,7 @@ where:
   section on _CMS Page Edit_ page
 
 These files must be placed in the appropriate folders for layout XML files. They will be available as __Custom Layout Update__ options for Merchants after flushing the cache.
- 
+
 {:.ref-header}
 Related topics
 

--- a/guides/v2.3/frontend-dev-guide/layouts/xml-manage.md
+++ b/guides/v2.3/frontend-dev-guide/layouts/xml-manage.md
@@ -551,7 +551,44 @@ You can remove navigation links from the 'My Account' dashboard on the storefron
 <!-- "My Returns" link -->
 <referenceBlock name="customer-account-navigation-return-history-link" remove="true"/>
 ```
+ 
+## Create cms-page/product/category-specific layouts
+  _since Magento 2.3.4/2.2.11_
 
+Merchants can select layout updates to be applied to specific Category/Product/CMS Page pages on the frontend. These layout
+updates are made by creating layout XML files following specific naming conventions.
+
+For Categories:
+
+-  `catalog_category_view_selectable_<Category ID>_<Layout Update Name>.xml`
+
+where:
+
+-  _Category ID_ is desired category ID
+-  _Layout Update Name_ is what is shown as the option for __Custom layout update__ field of __Design__ section on _Category Edit_ page.
+
+For Products:
+
+-  `catalog_product_view_selectable_<Product SKU>_<Layout Update Name>.xml`
+
+where:
+
+-  _Product SKU_ is the desired product's SKU encoded as a URI.
+  _example_: "My Product SKU" -> "My%20Product%20SKU"
+-  _Layout Update Name_ is what is shown as the option for __Custom layout update__ field of __Design__ section on _Product Edit_ page
+
+For CMS Pages:
+
+-  `cms_page_view_selectable_<CMS Page Identifier>_<Layout Update Name>.xml`
+
+where:
+
+-  _CMS Page Identifier_ is the desired page's _URL Key_ with "/" symbols replaced with "_"
+-  _Layout Update Name_ is what is shown as the option for __Custom layout update__ field of __Design__
+  section on _CMS Page Edit_ page
+
+These files must be placed in the appropriate folders for layout XML files. They will be available as __Custom Layout Update__ options for Merchants after flushing the cache.
+ 
 {:.ref-header}
 Related topics
 

--- a/guides/v2.3/frontend-dev-guide/layouts/xml-manage.md
+++ b/guides/v2.3/frontend-dev-guide/layouts/xml-manage.md
@@ -554,7 +554,7 @@ You can remove navigation links from the 'My Account' dashboard on the storefron
 
 ## Create cms-page/product/category-specific layouts
 
-As of Magento 2.3.4/2.2.11, merchants can select layout updates to be applied to specific Category/Product/CMS Page pages on the frontend. These layout
+As of Magento 2.3.4, merchants can select layout updates to be applied to specific Category/Product/CMS Page pages on the frontend. These layout
 updates are made by creating layout XML files following specific naming conventions.
 
 For Categories:


### PR DESCRIPTION
Custom layout updates flow has been changed for 2.3.4 and 2.2.11, here's a guide reflecting those changes

## Purpose of this pull request

This pull request (PR) will guide front-end devs and merchants on the new flow of providing custom layout updates for cms pages, categories and products

## Affected DevDocs pages

<!-- REQUIRED List the affected pages on devdocs.magento.com (URLs). Not needed for large numbers of files. -->

-  https://devdocs.magento.com/guides/v2.3/frontend-dev-guide/layouts/xml-manage.html
-  https://devdocs.magento.com/guides/v2.2/frontend-dev-guide/layouts/xml-manage.html

## Related changes to Magento 2 codebase
-  https://github.com/magento/magento2ce/pull/4969 (v2.2.11)
-  https://github.com/magento/magento2ce/pull/4967 (v2.3.4)

whatsnew
Added the 'Create cms-page/product/category-specific layouts' section to [Common layout customization tasks](https://devdocs.magento.com/guides/v2.3/frontend-dev-guide/layouts/xml-manage.html).