### PR TITLE
Added new section for 2.3 parity

### DIFF
--- a/guides/v2.2/frontend-dev-guide/layouts/xml-manage.md
+++ b/guides/v2.2/frontend-dev-guide/layouts/xml-manage.md
@@ -549,6 +549,42 @@ As result, the `<body>` tag has a new `my-new-body-class` class on all product p
 <referenceBlock name="customer-account-navigation-return-history-link" remove="true"/>
 ```
 
+## Create cms-page/product/category-specific layouts
+
+As of Magento 2.2.11, merchants can select layout updates to be applied to specific Category/Product/CMS Page pages on the frontend. These layout
+updates are made by creating layout XML files following specific naming conventions.
+
+For Categories:
+
+-  `catalog_category_view_selectable_<Category ID>_<Layout Update Name>.xml`
+
+where:
+
+-  _Category ID_ is desired category ID
+-  _Layout Update Name_ is what is shown as the option for __Custom layout update__ field of __Design__ section on _Category Edit_ page.
+
+For Products:
+
+-  `catalog_product_view_selectable_<Product SKU>_<Layout Update Name>.xml`
+
+where:
+
+-  _Product SKU_ is the desired product's SKU encoded as a URI.
+  _example_: "My Product SKU" -> "My%20Product%20SKU"
+-  _Layout Update Name_ is what is shown as the option for __Custom layout update__ field of __Design__ section on _Product Edit_ page
+
+For CMS Pages:
+
+-  `cms_page_view_selectable_<CMS Page Identifier>_<Layout Update Name>.xml`
+
+where:
+
+-  _CMS Page Identifier_ is the desired page's _URL Key_ with "/" symbols replaced with "_"
+-  _Layout Update Name_ is what is shown as the option for __Custom layout update__ field of __Design__
+  section on _CMS Page Edit_ page
+
+These files must be placed in the appropriate folders for layout XML files. They will be available as __Custom Layout Update__ options for Merchants after flushing the cache.
+
 {:.ref-header}
 Related topics
 

--- a/guides/v2.2/frontend-dev-guide/layouts/xml-manage.md
+++ b/guides/v2.2/frontend-dev-guide/layouts/xml-manage.md
@@ -571,7 +571,7 @@ where:
 
 -  _Product SKU_ is the desired product's SKU encoded as a URI.
   _example_: "My Product SKU" -> "My%20Product%20SKU"
--  _Layout Update Name_ is what is shown as the option for __Custom layout update__ field of __Design__ section on _Product Edit_ page
+-  _Layout Update Name_ is shown as the option for the __Custom layout update__ field of the __Design__ section on the _Product Edit_ page.
 
 For CMS Pages:
 

--- a/guides/v2.2/frontend-dev-guide/layouts/xml-manage.md
+++ b/guides/v2.2/frontend-dev-guide/layouts/xml-manage.md
@@ -580,7 +580,7 @@ For CMS Pages:
 where:
 
 -  _CMS Page Identifier_ is the desired page's _URL Key_ with "/" symbols replaced with "_"
--  _Layout Update Name_ is what is shown as the option for __Custom layout update__ field of __Design__
+-  _Layout Update Name_ is shown as the option for the __Custom layout update__ field of the __Design__
   section on _CMS Page Edit_ page
 
 These files must be placed in the appropriate folders for layout XML files. They will be available as __Custom Layout Update__ options for Merchants after flushing the cache.

--- a/guides/v2.2/frontend-dev-guide/layouts/xml-manage.md
+++ b/guides/v2.2/frontend-dev-guide/layouts/xml-manage.md
@@ -560,7 +560,7 @@ For Categories:
 
 where:
 
--  _Category ID_ is desired category ID
+-  _Category ID_ is the desired category ID.
 -  _Layout Update Name_ is what is shown as the option for __Custom layout update__ field of __Design__ section on _Category Edit_ page.
 
 For Products:

--- a/guides/v2.2/frontend-dev-guide/layouts/xml-manage.md
+++ b/guides/v2.2/frontend-dev-guide/layouts/xml-manage.md
@@ -561,7 +561,7 @@ For Categories:
 where:
 
 -  _Category ID_ is the desired category ID.
--  _Layout Update Name_ is what is shown as the option for __Custom layout update__ field of __Design__ section on _Category Edit_ page.
+-  _Layout Update Name_ is shown as the option for the __Custom layout update__ field of the __Design__ section on the _Category Edit_ page.
 
 For Products:
 

--- a/guides/v2.2/frontend-dev-guide/layouts/xml-manage.md
+++ b/guides/v2.2/frontend-dev-guide/layouts/xml-manage.md
@@ -579,9 +579,8 @@ For CMS Pages:
 
 where:
 
--  _CMS Page Identifier_ is the desired page's _URL Key_ with "/" symbols replaced with "_"
--  _Layout Update Name_ is shown as the option for the __Custom layout update__ field of the __Design__
-  section on _CMS Page Edit_ page
+-  _CMS Page Identifier_ is the desired page's _URL Key_ with "/" symbols replaced with "_".
+-  _Layout Update Name_ is shown as the option for the __Custom layout update__ field of the __Design__ section on _CMS Page Edit_ page.
 
 These files must be placed in the appropriate folders for layout XML files. They will be available as __Custom Layout Update__ options for Merchants after flushing the cache.
 


### PR DESCRIPTION
Custom layout updates flow has been changed for 2.3.4 and 2.2.11, here's a guide reflecting those changes

## Purpose of this pull request

This pull request (PR) will guide front-end devs and merchants on the new flow of providing custom layout updates for cms pages, categories and products

## Affected DevDocs pages

-  https://devdocs.magento.com/guides/v2.2/frontend-dev-guide/layouts/xml-manage.html

whatsnew
Added the 'Create cms-page/product/category-specific layouts' section to [Common layout customization tasks](https://devdocs.magento.com/guides/v2.2/frontend-dev-guide/layouts/xml-manage.html).