### PR TITLE
GraphQL: add to list of deprecated filter attributes

### DIFF
--- a/guides/v2.3/graphql/queries/products.md
+++ b/guides/v2.3/graphql/queries/products.md
@@ -166,10 +166,12 @@ small_image_label
 special_from_date
 special_price
 special_to_date
+swatch_image
 thumbnail
 thumbnail_label
 tier_price
 updated_at
+url_path
 weight
 ```
 


### PR DESCRIPTION
## Purpose of this pull request

This pull request (PR) is related to #5930, except it affects the `develop` branch instead of `master`.

#5930 added 3 items to the list of attributes that can be used in a product query filter. Two of those attributes were deprecated for 2.3.4. The third, `url_key` is still valid and has already been documented.

## Affected DevDocs pages

-  guides/v2.3/graphql/queries/products.md

