### PR TITLE
Issue #1049 [graphql documentation] addBundleProductsToCart mutation

### DIFF
--- a/_data/toc/graphql.yml
+++ b/_data/toc/graphql.yml
@@ -121,6 +121,9 @@ pages:
         - label: Using mutations
           url: /graphql/mutations/index.html
 
+        - label: addBundleProductsToCart mutation
+          url: /graphql/mutations/add-bundle-products.html
+
         - label: addConfigurableProductsToCart mutation
           url: /graphql/mutations/add-configurable-products.html
 

--- a/guides/v2.3/graphql/mutations/add-bundle-products.md
+++ b/guides/v2.3/graphql/mutations/add-bundle-products.md
@@ -16,19 +16,17 @@ SKU of this product is: **24-WG080**
 
 This example adds one bundle product with following children to the specified shopping cart:
 
-- Sprite Stasis Ball 65 cm (x1)
-- Sprite Foam Yoga Brick (x2)
-- Sprite Yoga Strap 10 foot (x1)
-- Sprite Foam Roller (x1)
-
+-  Sprite Stasis Ball 65 cm (x1)
+-  Sprite Foam Yoga Brick (x2)
+-  Sprite Yoga Strap 10 foot (x1)
+-  Sprite Foam Roller (x1)
 
 The `cart_id` used in this example was [generated]({{ page.baseurl }}/graphql/mutations/create-empty-cart.html) by creating an empty cart.
-
 
 **Request**
 
 ```graphql
-mutation {  
+mutation {
   addBundleProductsToCart(
     input: {
       cart_id: "wARFaDnHva0tgzuforUYR4rvXincj5eu"
@@ -218,8 +216,6 @@ Attribute | Type | Description
 The `CustomizableOptionInput` object must contain the following attributes:
 
 {% include graphql/customizable-option-input.md %}
-
-
 
 ## Output attributes
 

--- a/guides/v2.3/graphql/mutations/add-bundle-products.md
+++ b/guides/v2.3/graphql/mutations/add-bundle-products.md
@@ -1,6 +1,8 @@
 ---
 group: graphql
 title: addBundleProductsToCart mutation
+contributor_name: Atwix
+contributor_link: https://www.atwix.com/
 ---
 
 Use the `addBundleProductsToCart` mutation to add bundle products to a specific cart.

--- a/guides/v2.3/graphql/mutations/add-bundle-products.md
+++ b/guides/v2.3/graphql/mutations/add-bundle-products.md
@@ -12,7 +12,7 @@ Use the `addBundleProductsToCart` mutation to add bundle products to a specific 
 ## Example usage
 
 The following example uses a bundle product "Sprite Yoga Companion Kit" from Magento sample data.
-SKU of this product is: **24-WG080**
+The SKU of this product is: **24-WG080**
 
 This example adds one bundle product with following children to the specified shopping cart:
 
@@ -173,14 +173,16 @@ mutation {
 
 ## Input attributes
 
+The top-level `AddBundleProductsToCartInput` object is listed first. All interfaces and child objects are listed in alphabetical order.
+
 ### AddBundleProductsToCartInput object
 
 The `AddBundleProductsToCartInput` object contains the following attributes:
 
 Attribute | Type | Description
 --- | --- | ---
-`cart_id` | String | The unique ID that identifies the customer's cart.
-`cart_items` | [[BundleProductCartItemInput]](#bundleProductCartItemInput) | An array of bundle items to add to the cart.
+`cart_id` | String! | The unique ID that identifies the customer's cart
+`cart_items` | [[BundleProductCartItemInput!]](#bundleProductCartItemInput) | An array of bundle items to add to the cart
 
 ### BundleProductCartItemInput object {#bundleProductCartItemInput}
 
@@ -188,18 +190,9 @@ The `BundleProductCartItemInput` object contains the following attributes:
 
 Attribute | Type | Description
 --- | --- | ---
-`data` | [CartItemInput!](#cartItemInput) | An object that contains the quantity and SKU of the bundle product.
-`bundle_options` | [BundleOptionInput](#bundleOptionInput) | An object that contains an array of options of the bundle product with chosen value and quantity of each option.
-`customizable_options` | [CustomizableOptionInput](#customOptionInput) | An object that contains the ID and value of the product.
-
-### CartItemInput object {#cartItemInput}
-
-The `CartItemInput` object contains the following attributes:
-
-Attribute | Type | Description
---- | --- | ---
-`quantity` | Float! | The number of items to add to the cart.
-`sku` | String! | The SKU of the product.
+`bundle_options` | [[BundleOptionInput!]](#bundleOptionInput) | An object that contains an array of options of the bundle product with the chosen value and quantity of each option
+`customizable_options` | [[CustomizableOptionInput]](#customOptionInput) | An object that contains the ID and value of the product
+`data` | [CartItemInput!](#cartItemInput) | An object that contains the quantity and SKU of the bundle product
 
 ### BundleOptionInput object {#bundleOptionInput}
 
@@ -207,9 +200,18 @@ The `BundleOptionInput` object contains the following attributes:
 
 Attribute | Type | Description
 --- | --- | ---
-`id` | Int! | ID of the option.
-`quantity` | Float! | The number of items to add to the cart (i.e. what number of the particular child product we need to add).
-`value` | [String!]! | An array with the chosen value of the option.
+`id` | Int! | ID of the option
+`quantity` | Float! | The number of a specific child item to add to the cart
+`value` | [String!]! | An array with the chosen value of the option
+
+### CartItemInput object {#cartItemInput}
+
+The `CartItemInput` object contains the following attributes:
+
+Attribute | Type | Description
+--- | --- | ---
+`quantity` | Float! | The number of items to add to the cart
+`sku` | String! | The SKU of the product
 
 ### CustomizableOptionInput object {#customOptionInput}
 
@@ -223,7 +225,7 @@ The `AddBundleProductsToCartOutput` object contains the `Cart` object.
 
 Attribute |  Data Type | Description
 --- | --- | ---
-`cart` |[Cart!](#CartObject) | Describes the contents of the specified shopping cart.
+`cart` |[Cart!](#CartObject) | Describes the contents of the specified shopping cart
 
 ### Cart object {#CartObject}
 

--- a/guides/v2.3/graphql/mutations/add-bundle-products.md
+++ b/guides/v2.3/graphql/mutations/add-bundle-products.md
@@ -1,0 +1,240 @@
+---
+group: graphql
+title: addBundleProductsToCart mutation
+---
+
+Use the `addBundleProductsToCart` mutation to add bundle products to a specific cart.
+
+## Syntax
+
+`mutation: {addBundleProductsToCart(input: AddBundleProductsToCartInput): {AddBundleProductsToCartOutput}}`
+
+## Example usage
+
+The following example uses a bundle product "Sprite Yoga Companion Kit" from Magento sample data.
+SKU of this product is: **24-WG080**
+
+This example adds one bundle product with following children to the specified shopping cart:
+
+- Sprite Stasis Ball 65 cm (x1)
+- Sprite Foam Yoga Brick (x2)
+- Sprite Yoga Strap 10 foot (x1)
+- Sprite Foam Roller (x1)
+
+
+The `cart_id` used in this example was [generated]({{ page.baseurl }}/graphql/mutations/create-empty-cart.html) by creating an empty cart.
+
+
+**Request**
+
+```graphql
+mutation {  
+  addBundleProductsToCart(
+    input: {
+      cart_id: "wARFaDnHva0tgzuforUYR4rvXincj5eu"
+      cart_items: [
+      {
+        data: {
+          sku: "24-WG080"
+          quantity: 1
+        }
+        bundle_options: [
+          {
+            id: 1
+            quantity: 1
+            value: [
+              "2"
+            ]
+          },
+          {
+            id: 2
+            quantity: 2
+            value: [
+              "4"
+            ]
+          },
+          {
+            id: 3
+            quantity: 1
+            value: [
+              "7"
+            ]
+          },
+          {
+            id: 4
+            quantity: 1
+            value: [
+              "8"
+            ]
+          }
+        ]
+      },
+    ]
+  }) {
+    cart {
+      items {
+        id
+        quantity
+        product {
+          sku
+        }
+        ... on BundleCartItem {
+          bundle_options {
+            id
+            label
+            type
+            values {
+              id
+              label
+              price
+              quantity
+            }
+          }
+        }
+      }
+    }
+  }
+}
+```
+
+**Response**
+
+```json
+{
+  "data": {
+    "addBundleProductsToCart": {
+      "cart": {
+        "items": [
+          {
+            "id": "7",
+            "quantity": 1,
+            "product": {
+              "sku": "24-WG080"
+            },
+            "bundle_options": [
+              {
+                "id": 1,
+                "label": "Sprite Stasis Ball",
+                "type": "radio",
+                "values": [
+                  {
+                    "id": 2,
+                    "label": "Sprite Stasis Ball 65 cm",
+                    "price": 27,
+                    "quantity": 1
+                  }
+                ]
+              },
+              {
+                "id": 2,
+                "label": "Sprite Foam Yoga Brick",
+                "type": "radio",
+                "values": [
+                  {
+                    "id": 4,
+                    "label": "Sprite Foam Yoga Brick",
+                    "price": 5,
+                    "quantity": 2
+                  }
+                ]
+              },
+              {
+                "id": 3,
+                "label": "Sprite Yoga Strap",
+                "type": "radio",
+                "values": [
+                  {
+                    "id": 7,
+                    "label": "Sprite Yoga Strap 10 foot",
+                    "price": 21,
+                    "quantity": 1
+                  }
+                ]
+              },
+              {
+                "id": 4,
+                "label": "Sprite Foam Roller",
+                "type": "radio",
+                "values": [
+                  {
+                    "id": 8,
+                    "label": "Sprite Foam Roller",
+                    "price": 19,
+                    "quantity": 1
+                  }
+                ]
+              }
+            ]
+          }
+        ]
+      }
+    }
+  }
+}
+```
+
+## Input attributes
+
+### AddBundleProductsToCartInput object
+
+The `AddBundleProductsToCartInput` object contains the following attributes:
+
+Attribute | Type | Description
+--- | --- | ---
+`cart_id` | String | The unique ID that identifies the customer's cart.
+`cart_items` | [[BundleProductCartItemInput]](#bundleProductCartItemInput) | An array of bundle items to add to the cart.
+
+### BundleProductCartItemInput object {#bundleProductCartItemInput}
+
+The `BundleProductCartItemInput` object contains the following attributes:
+
+Attribute | Type | Description
+--- | --- | ---
+`data` | [CartItemInput!](#cartItemInput) | An object that contains the quantity and SKU of the bundle product.
+`bundle_options` | [BundleOptionInput](#bundleOptionInput) | An object that contains an array of options of the bundle product with chosen value and quantity of each option.
+`customizable_options` | [CustomizableOptionInput](#customOptionInput) | An object that contains the ID and value of the product.
+
+### CartItemInput object {#cartItemInput}
+
+The `CartItemInput` object contains the following attributes:
+
+Attribute | Type | Description
+--- | --- | ---
+`quantity` | Float! | The number of items to add to the cart.
+`sku` | String! | The SKU of the product.
+
+### BundleOptionInput object {#bundleOptionInput}
+
+The `BundleOptionInput` object contains the following attributes:
+
+Attribute | Type | Description
+--- | --- | ---
+`id` | Int! | ID of the option.
+`quantity` | Float! | The number of items to add to the cart (i.e. what number of the particular child product we need to add).
+`value` | [String!]! | An array with the chosen value of the option.
+
+### CustomizableOptionInput object {#customOptionInput}
+
+The `CustomizableOptionInput` object must contain the following attributes:
+
+{% include graphql/customizable-option-input.md %}
+
+
+
+## Output attributes
+
+The `AddBundleProductsToCartOutput` object contains the `Cart` object.
+
+Attribute |  Data Type | Description
+--- | --- | ---
+`cart` |[Cart!](#CartObject) | Describes the contents of the specified shopping cart.
+
+### Cart object {#CartObject}
+
+{% include graphql/cart-object.md %}
+
+[Cart query output]({{page.baseurl}}/graphql/queries/cart.html#cart-output) provides more information about the `Cart` object.
+
+## Related topics
+
+-  [Bundle product data types]({{page.baseurl}}/graphql/product/bundle-product.html)


### PR DESCRIPTION
## Purpose of this pull request

[Documentation] addBundleProductsToCart mutation.

Related PR: https://github.com/magento/graphql-ce/pull/396
## Affected DevDocs pages

New page: https://devdocs.magento.com/guides/v2.3/graphql/mutations/add-bundle-products.html

whatsnew
Added the [`addBundleProductsToCart` mutation](https://devdocs.magento.com/guides/v2.3/graphql/mutations/add-bundle-products.html) to the _GraphQL Developer Guide_.

