### PR TITLE
GraphQL: Deprecate wishlist query

### DIFF
--- a/_includes/graphql/customer-output.md
+++ b/_includes/graphql/customer-output.md
@@ -17,5 +17,6 @@ Attribute |  Data Type | Description
 `prefix` | String | An honorific, such as Dr., Mr., or Mrs.
 `suffix` | String | A value such as Sr., Jr., or III
 `taxvat` | String | The customer's Tax/VAT number (for corporate customers)
+`wishlist` | Wishlist! | Contains the contents of the customer's wish lists
 
 {% include graphql/customer-address-output.md %}

--- a/guides/v2.3/graphql/queries/customer.md
+++ b/guides/v2.3/graphql/queries/customer.md
@@ -188,7 +188,83 @@ query {
   }
 }
 ```
+### Retrieve the customer's wish list
 
+The following query returns the customer's wish list:
+
+**Request**
+
+```graphql
+{
+  customer {
+    wishlist {
+      items {
+        id
+        description
+        qty
+        product {
+          sku
+          name
+          price_range {
+            maximum_price {
+              regular_price {
+                value
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+}
+```
+
+**Response**
+
+```json
+{
+  "data": {
+    "customer": {
+      "wishlist": {
+        "items": [
+          {
+            "id": 1,
+            "description": "I need this",
+            "qty": 1,
+            "product": {
+              "sku": "24-WG080",
+              "name": "Sprite Yoga Companion Kit",
+              "price_range": {
+                "maximum_price": {
+                  "regular_price": {
+                    "value": 77
+                  }
+                }
+              }
+            }
+          },
+          {
+            "id": 2,
+            "description": null,
+            "qty": 1,
+            "product": {
+              "sku": "24-UG04",
+              "name": "Zing Jump Rope",
+              "price_range": {
+                "maximum_price": {
+                  "regular_price": {
+                    "value": 12
+                  }
+                }
+              }
+            }
+          }
+        ]
+      }
+    }
+  }
+}
+```
 ## Output attributes
 
 ### Customer attributes {#customerAttributes}
@@ -196,6 +272,26 @@ query {
 The `customer` object can contain the following attributes:
 
 {% include graphql/customer-output.md %}
+
+### Wishlist attributes {#Wishlist}
+
+Attribute | Data type | Description
+--- | --- | ---
+`items` | [WishlistItem](#wishlistitem) | An array of items in the customer's wish list
+`items_count` | Int | The number of items in the wish list
+`id` | ID | The unique identifier of the wish list
+`sharing_code` | String | An encrypted code that Magento uses to link to the wish list
+`updated_at` | String | The time of the last modification to the wish list
+
+### WishlistItem attributes {#wishlistitem}
+
+Attribute | Data type | Description
+--- | --- | ---
+`added_at` | String | The time when the customer added the item to the wish list
+`description` | String | The customer's comment about this item
+`id` | Int | The wish list item ID
+`product` | [ProductInterface]({{ page.baseurl }}/graphql/product/product-interface.html) | The ProductInterface contains attributes that are common to all types of products. Note that descriptions may not be available for custom and EAV attributes
+`qty` | Float | The quantity of this wish list item
 
 ### Store credit attributes
 

--- a/guides/v2.3/graphql/queries/wishlist.md
+++ b/guides/v2.3/graphql/queries/wishlist.md
@@ -5,6 +5,9 @@ redirect_from:
   - /guides/v2.3/graphql/reference/wishlist.html
 ---
 
+{:.bs-callout-warning}
+The `wishlist` query has been deprecated. Wish list information is now provided by the [customer]({{page.baseurl}}/graphql/queries/customer.html) query.
+
 Use the `wishlist` query to retrieve information about a customer's wish list. [Get customer authorization token]({{page.baseurl}}/graphql/get-customer-authorization-token.html) describes how to supply an authorization token for a specific customer.
 
 ## Syntax


### PR DESCRIPTION
## Purpose of this pull request

This pull request (PR) deprecates the `wishlist` query. Wish list information is now returned in the `customer` query.

Related PR: https://github.com/magento/graphql-ce/pull/957

## Affected DevDocs pages

- https://devdocs.magento.com/guides/v2.3/graphql/queries/wishlist.html
- https://devdocs.magento.com/guides/v2.3/graphql/queries/customer.html

whatsnew
The `wishlist` query has been deprecated. Wish list information is now returned in the [`customer` query](https://devdocs.magento.com/guides/v2.3/graphql/queries/customer.html
).