### PR TITLE
GraphQL: Deprecate use_for_shipping attribute

### DIFF
--- a/guides/v2.3/graphql/mutations/set-billing-address.md
+++ b/guides/v2.3/graphql/mutations/set-billing-address.md
@@ -5,7 +5,7 @@ redirect from:
   - /guides/v2.3/graphql/reference/quote-set-billing-address.html
 ---
 
-The `setBillingAddressOnCart` mutation sets the billing address for a specific cart. If you set the `use_for_shipping` attribute to `true`, Magento assigns the same address as the shipping address.
+The `setBillingAddressOnCart` mutation sets the billing address for a specific cart. If you set the `same_as_shipping` attribute to `true`, Magento assigns the same address as the shipping address.
 
 ## Syntax
 
@@ -35,7 +35,7 @@ mutation {
           telephone: "8675309"
           save_in_address_book: true
         }
-        use_for_shipping: false
+        same_as_shipping: false
       }
     }
   ) {
@@ -96,7 +96,8 @@ Attribute |  Data Type | Description
 --- | --- | ---
 `address` | [CartAddressInput](#CartAddressInput) | The billing address for the cart
 `customer_address_id` | Int | The unique ID that identifies the customer's address
-`use_for_shipping` | Boolean | Specifies whether to use the billing address for the shipping address (`True`/`False`)
+`same_as_shipping` | Boolean | Specifies whether to use the billing address for the shipping address (`True`/`False`)
+`use_for_shipping` | Boolean | Deprecated. Use `same_as_shipping instead
 
 ### CartAddressInput object {#CartAddressInput}
 

--- a/guides/v2.3/graphql/mutations/set-billing-address.md
+++ b/guides/v2.3/graphql/mutations/set-billing-address.md
@@ -97,7 +97,7 @@ Attribute |  Data Type | Description
 `address` | [CartAddressInput](#CartAddressInput) | The billing address for the cart
 `customer_address_id` | Int | The unique ID that identifies the customer's address
 `same_as_shipping` | Boolean | Specifies whether to use the billing address for the shipping address (`True`/`False`)
-`use_for_shipping` | Boolean | Deprecated. Use `same_as_shipping instead
+`use_for_shipping` | Boolean | Deprecated. Use `same_as_shipping` instead
 
 ### CartAddressInput object {#CartAddressInput}
 

--- a/guides/v2.3/graphql/mutations/set-shipping-address.md
+++ b/guides/v2.3/graphql/mutations/set-shipping-address.md
@@ -8,7 +8,7 @@ redirect from:
 The `setShippingAddressesOnCart` mutation sets one or more shipping addresses on a specific cart. The shipping address does not need to be specified in the following circumstances:
 
 *  The cart contains only virtual items
-*  When you defined the billing address, you set the `use_for_shipping` attribute to `true`. Magento assigns the same address as the shipping address.
+*  When you defined the billing address, you set the `same_for_shipping` attribute to `true`. Magento assigns the same address as the shipping address.
 
 ## Syntax
 

--- a/guides/v2.3/graphql/tutorials/checkout/checkout-billing-address.md
+++ b/guides/v2.3/graphql/tutorials/checkout/checkout-billing-address.md
@@ -103,7 +103,7 @@ mutation {
 
 ## Add a new address for billing and shipping
 
-The following mutation includes the `use_for_shipping` attribute, which allows the same address to be used for billing and shipping.
+The following mutation includes the `same_as_shipping` attribute, which allows the same address to be used for billing and shipping.
 
 **Request**
 
@@ -125,7 +125,7 @@ mutation {
             telephone: "123-456-0000"
             save_in_address_book: false
           }
-          use_for_shipping: true
+          same_as_shipping: true
       }
     }
   ) {


### PR DESCRIPTION
## Purpose of this pull request

This pull request (PR) deprecates the `use_for_shipping` attribute in favor of `same_as_shipping`.

Related PR: https://github.com/magento/graphql-ce/pull/943

## Affected DevDocs pages

- https://devdocs.magento.com/guides/v2.3/graphql/mutations/set-billing-address.html (Primary)
