### PR TITLE
Fix endpoint domain names

### DIFF
--- a/marketplace/eqp/v1/api.md
+++ b/marketplace/eqp/v1/api.md
@@ -16,7 +16,7 @@ The Magento EQP REST APIs are completely separate from those provided with Magen
 The APIs only accept encrypted communications using HTTPS at the following base URLs:
 
     https://developer-api.magento.com - Production
-    https://developer-api-sandbox.magento.com - Sandbox
+    https://developer-stg-api.magento.com - Sandbox
 
 EQP APIs are based on REST concepts and use standard HTTP verbs:
 

--- a/marketplace/eqp/v1/auth.md
+++ b/marketplace/eqp/v1/auth.md
@@ -105,5 +105,5 @@ For example, to access a user profile with a User Session Token:
 ```bash
 curl -X GET \
      -H 'Authorization: Bearer baGXoStRuR9VCDFQGZNzgNqbqu5WUwlr.cAxZJ9m22Le7' \
-     https://developer-api.magento.com/rest/v1/users/MAG123456789
+     https://developer-stg-api.magento.com/rest/v1/users/MAG123456789
 ```

--- a/marketplace/eqp/v1/files.md
+++ b/marketplace/eqp/v1/files.md
@@ -54,7 +54,7 @@ If it is omitted, then a batch response will be returned: an array of records fo
 ```bash
 curl -X GET \
      -H 'Authorization: Bearer baGXoStRuR9VCDFQGZNzgNqbqu5WUwlr.cAxZJ9m22Le7' \
-     https://developer-api.magento.com/rest/v1/files/uploads/dhsiXjdksW17623
+     https://developer-stg-api.magento.com/rest/v1/files/uploads/dhsiXjdksW17623
 ```
 
 **Response**
@@ -150,7 +150,7 @@ curl -X POST \
      -H 'Authorization: Bearer baGXoStRuR9VCDFQGZNzgNqbqu5WUwlr.cAxZJ9m22Le7' \
      -H "Content-Type: multipart/form-data; boundary=----------287032381131322" \
      --data-binary  @/tmp/files-payload \
-     https://developer-api.magento.com/rest/v1/files/uploads
+     https://developer-stg-api.magento.com/rest/v1/files/uploads
 ```
 
 **Response**

--- a/marketplace/eqp/v1/filtering.md
+++ b/marketplace/eqp/v1/filtering.md
@@ -59,7 +59,7 @@ The following request filters all `themes` sorted by `platform` in ascending ord
 ```bash
 curl -X GET \
      -H 'Authorization: Bearer baGXoStRuR9VCDFQGZNzgNqbqu5WUwlr.cAxZJ9m22Le7' \
-     https://developer-api.magento.com/rest/v1/products/packages?type=theme&sort=+platform,-created_time
+     https://developer-stg-api.magento.com/rest/v1/products/packages?type=theme&sort=+platform,-created_time
 ```
 
 **Response**

--- a/marketplace/eqp/v1/packages.md
+++ b/marketplace/eqp/v1/packages.md
@@ -580,7 +580,7 @@ curl -X POST \
      -H 'Authorization: Bearer baGXoStRuR9VCDFQGZNzgNqbqu5WUwlr.cAxZJ9m22Le7' \
      -H 'Content-Type: application/json' \
      --data-binary  @/tmp/one-click-submission-1.0.0.json \
-     https://developer-api.magento.com/rest/v1/products/packages
+     https://developer-stg-api.magento.com/rest/v1/products/packages
 ```
 
 **Response**
@@ -640,7 +640,7 @@ curl -X PUT \
      -H 'Authorization: Bearer baGXoStRuR9VCDFQGZNzgNqbqu5WUwlr.cAxZJ9m22Le7' \
      -H 'Content-Type: application/json' \
      -d '{ "action" : { "overall" : "publish"} }' \
-     https://developer-api.magento.com/rest/v1/products/packages/f4eacd72be
+     https://developer-stg-api.magento.com/rest/v1/products/packages/f4eacd72be
 ```
 
 The HTTP response code will indicate success or failure.
@@ -735,7 +735,7 @@ This sample call lists all packages belonging to a user:
 ```bash
 curl -X GET \
      -H 'Authorization: Bearer baGXoStRuR9VCDFQGZNzgNqbqu5WUwlr.cAxZJ9m22Le7' \
-     https://developer-api.magento.com/rest/v1/products/packages
+     https://developer-stg-api.magento.com/rest/v1/products/packages
 ```
 
 **Response**
@@ -894,7 +894,7 @@ In the previous example, submission `f4eacd72be` failed. Specify the submission_
 ```bash
 curl -X GET \
      -H 'Authorization: Bearer baGXoStRuR9VCDFQGZNzgNqbqu5WUwlr.cAxZJ9m22Le7' \
-     https://developer-api.magento.com/rest/v1/products/packages/f4eacd72be/status
+     https://developer-stg-api.magento.com/rest/v1/products/packages/f4eacd72be/status
 ```
 
 **Response**
@@ -981,7 +981,7 @@ A sample cURL request filtering all `themes` sorted by `platform` in ascending o
 ```bash
 curl -X GET \
      -H 'Authorization: Bearer baGXoStRuR9VCDFQGZNzgNqbqu5WUwlr.cAxZJ9m22Le7' \
-     https://developer-api.magento.com/rest/v1/products/packages?type=theme&sort=+platform,-created_time
+     https://developer-stg-api.magento.com/rest/v1/products/packages?type=theme&sort=+platform,-created_time
 ```
 
 **Response**

--- a/marketplace/eqp/v1/users.md
+++ b/marketplace/eqp/v1/users.md
@@ -32,7 +32,7 @@ The following example shows the request/response body for retrieving all profile
 ```bash
 curl -X GET \
      -H 'Authorization: Bearer baGXoStRuR9VCDFQGZNzgNqbqu5WUwlr.cAxZJ9m22Le7' \
-     https://developer-api.magento.com/rest/v1/users/MAG123456789
+     https://developer-stg-api.magento.com/rest/v1/users/MAG123456789
 ```
 
 **Response**
@@ -137,7 +137,7 @@ The following example shows the request/response body for retrieving a subset of
 ```bash
 curl -X GET \
      -H 'Authorization: Bearer baGXoStRuR9VCDFQGZNzgNqbqu5WUwlr.cAxZJ9m22Le7' \
-     https://developer-api.magento.com/rest/v1/users/MAG123456789?style=summary
+     https://developer-stg-api.magento.com/rest/v1/users/MAG123456789?style=summary
 ```
 
 **Response**
@@ -191,7 +191,7 @@ curl -X PUT \
      -H 'Authorization: Bearer baGXoStRuR9VCDFQGZNzgNqbqu5WUwlr.cAxZJ9m22Le7' \
      -H 'Content-Type: application/json' \
      -d '{ "action" : "publish", "personal_profile" : { "bio" : "My extensions have won Nobel Prizes in both literature and physics." } }' \
-     https://developer-api.magento.com/rest/v1/users/MAG123456789
+     https://developer-stg-api.magento.com/rest/v1/users/MAG123456789
 ```
 
 A 200 OK HTTP response code indicates a successful update.
@@ -229,7 +229,7 @@ The following example shows the request/response body for retrieving keys withou
 ```bash
 curl -X GET \
      -H 'Authorization: Bearer baGXoStRuR9VCDFQGZNzgNqbqu5WUwlr.cAxZJ9m22Le7' \
-     https://developer-api.magento.com/rest/v1/users/MAG123456789/keys
+     https://developer-stg-api.magento.com/rest/v1/users/MAG123456789/keys
 ```
 
 **Response**
@@ -301,7 +301,7 @@ curl -X POST \
      -H 'Authorization: Bearer baGXoStRuR9VCDFQGZNzgNqbqu5WUwlr.cAxZJ9m22Le7' \
      -H 'Content-Type: application/json' \
      -d '{ "m2": [ { "label" : "key_for_alice" }, { "label" : "key_for_charlie" } ] }' \
-     https://developer-api.magento.com/rest/v1/users/MAG123456789/keys
+     https://developer-stg-api.magento.com/rest/v1/users/MAG123456789/keys
 ```
 
 **Response**
@@ -349,7 +349,7 @@ curl -X PUT \
      -H 'Authorization: Bearer baGXoStRuR9VCDFQGZNzgNqbqu5WUwlr.cAxZJ9m22Le7' \
      -H 'Content-Type: application/json' \
      -d '{ "m2" : [ { "is_enabled" :  true } ] }' \
-     https://developer-api.magento.com/rest/v1/users/MAG123456789/keys/key_for_bob
+     https://developer-stg-api.magento.com/rest/v1/users/MAG123456789/keys/key_for_bob
 ```
 
 **Response**
@@ -382,7 +382,7 @@ The following curl example illustrates the call to be made:
 ```bash
 curl -X DELETE \
      -H 'Authorization: Bearer baGXoStRuR9VCDFQGZNzgNqbqu5WUwlr.cAxZJ9m22Le7' \
-     https://developer-api.magento.com/rest/v1/users/MAG123456789/keys/key_for_charlie
+     https://developer-stg-api.magento.com/rest/v1/users/MAG123456789/keys/key_for_charlie
 ```
 
 A 204 No Content HTTP response code indicates a successful update.


### PR DESCRIPTION
## Purpose of this pull request

- Fix one outdated sandbox domain name in the api.html page.
- Change all example domain names to point to sandbox, throughout.

## Affected DevDocs pages

https://devdocs.magento.com/marketplace/eqp/v1/api.html
https://devdocs.magento.com/marketplace/eqp/v1/auth.html
https://devdocs.magento.com/marketplace/eqp/v1/users.html
https://devdocs.magento.com/marketplace/eqp/v1/files.html
https://devdocs.magento.com/marketplace/eqp/v1/packages.html
https://devdocs.magento.com/marketplace/eqp/v1/filtering.html
