### PR TITLE
Fix the mdl version to 0.7.0 in the GH workflow

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -17,6 +17,6 @@ jobs:
       with:
         ruby-version: 2.6
     - name: Install mdl gem
-      run: gem install mdl
+      run: gem install mdl -v '0.7.0'
     - name: Run mdl
       run: mdl --style=_checks/styles/style-rules-prod --ignore-front-matter --git-recurse -- .


### PR DESCRIPTION
## Purpose of this pull request

This pull request fixes the mdl version to 0.7.0 in the GH workflow, as an attempt to fix the failing checks in PRs after the upgrade to 0.8.0