### PR TITLE
Fixed incorrect link syntax

### DIFF
--- a/guides/v2.2/howdoi/checkout/checkout_customize.md
+++ b/guides/v2.2/howdoi/checkout/checkout_customize.md
@@ -10,7 +10,7 @@ functional_areas:
   - Checkout
 ---
 
-This topic contains the basic information about how to customize the view of an existing [checkout](https://glossary.magento.com/checkout) step. In the Magento application, checkout is implemented using UI components. You can customize each step by [changing the [JavaScript](https://glossary.magento.com/javascript) implementation or template](#change-component) for a component, [adding](#add), [disabling](#disable), or [removing](#remove) a component.
+This topic contains the basic information about how to customize the view of an existing [checkout](https://glossary.magento.com/checkout) step. In the Magento application, checkout is implemented using UI components. You can customize each step by [changing the JavaScript implementation or template](#change-component) for a component, [adding](#add), [disabling](#disable), or [removing](#remove) a component.
 
 ## Change the component's .js implementation and template {#change-component}
 


### PR DESCRIPTION
## Purpose of this pull request

This pull request (PR) removes a nested link (how would that even work?)

## Affected DevDocs pages

-  https://devdocs.magento.com/guides/v2.3/howdoi/checkout/checkout_customize.html
-  https://devdocs.magento.com/guides/v2.2/howdoi/checkout/checkout_customize.html