### PR TITLE
Fixed incorrect syntax for custom KO checked binding

### DIFF
--- a/guides/v2.2/ui_comp_guide/concepts/magento-bindings.md
+++ b/guides/v2.2/ui_comp_guide/concepts/magento-bindings.md
@@ -81,5 +81,5 @@ The table below shows examples of how the Knockout bindings map to their Magento
 |textInput      |`<input data-bind="textInput: value"/>`                                        | `<input textInput="value"/>`                                          |
 |value          |`<input data-bind="value: value"/>`                                            | `<input ko-value="value"/>`                                           |
 |checked        |`<input type="checkbox" data-bind="checked: isChecked"/>`                      | `<input type="checkbox" ko-checked="isChecked"/>`                     |
-|                |`<input type="radio" data-bind="value: value,checked: isSelected" />`                      | `<input type="radio" ko-checked="element.isSelected" ko-value="value" />`                     |
-|checkedValue   |`<input type="checkbox" data-bind="checkedValue: $data, checked: isChecked"/>` | `<input type="checkbox" checkedValue="$data" checked="isChecked"/>`   |
+|                |`<input type="radio" data-bind="value: value, checked: isSelected" />`                      | `<input type="radio" ko-checked="element.isSelected" ko-value="value" />`                     |
+|checkedValue   |`<input type="checkbox" data-bind="checkedValue: $data, checked: isChecked"/>` | `<input type="checkbox" checkedValue="$data" ko-checked="isChecked"/>`   |


### PR DESCRIPTION
## Purpose of this pull request

This pull request (PR) fixes the incorrect syntax for custom KO checked binding. It's not `checked` attribute, but rather, it is `ko-checked` attribute as mentioned in the examples above the incorrect syntax.

## Affected DevDocs pages

-  https://devdocs.magento.com/guides/v2.3/ui_comp_guide/concepts/magento-bindings.html
-  https://devdocs.magento.com/guides/v2.2/ui_comp_guide/concepts/magento-bindings.html
