### PR TITLE
Added missing example for i18n Magento binding syntax

### DIFF
--- a/guides/v2.2/ui_comp_guide/concepts/knockout-bindings.md
+++ b/guides/v2.2/ui_comp_guide/concepts/knockout-bindings.md
@@ -225,7 +225,9 @@ The `i18n` binding is used to translate a string according to the currently enab
 **Usage example**:
 
 ```html
-<div data-bind="i18n: 'Translate as a standard knockout binding'"></div>
+<!-- ko i18n: 'Translate using the virtual element' --><!-- /ko -->
+
+<div data-bind="i18n: 'Translate using the standard knockout binding'"></div>
 
 <div translate="'Translate using the attribute'"></div>
 


### PR DESCRIPTION
## Purpose of this pull request

This pull request (PR) adds the missing example for the `i18n` Magento binding syntaxes

## Affected DevDocs pages

-  https://devdocs.magento.com/guides/v2.3/ui_comp_guide/concepts/knockout-bindings.html
-  https://devdocs.magento.com/guides/v2.2/ui_comp_guide/concepts/knockout-bindings.html