### PR TITLE
Incorrect reference url fixed

### DIFF
--- a/guides/v2.2/architecture/archi_perspectives/service_layer.md
+++ b/guides/v2.2/architecture/archi_perspectives/service_layer.md
@@ -76,5 +76,5 @@ Related topics
 *  [Architectural diagrams]({{page.baseurl}}/architecture/archi_perspectives/arch_diagrams.html)
 *  [Architectural layers overview]({{page.baseurl}}/architecture/archi_perspectives/ALayers_intro.html)
 
-[catalog-api]: {{ site.mage2bloburl }}/{{ page.guide_version }}/app/code/Magento/Customer/Api
-[catalog-api-data]: {{ site.mage2bloburl }}/{{ page.guide_version }}/app/code/Magento/Customer/Api/Data
+[catalog-api]: {{ site.mage2bloburl }}/{{ page.guide_version }}/app/code/Magento/Catalog/Api
+[catalog-api-data]: {{ site.mage2bloburl }}/{{ page.guide_version }}/app/code/Magento/Catalog/Api/Data


### PR DESCRIPTION
The reference url was pointing to Customer/Api instead of Catalog/Api

## Purpose of this pull request

This pull request (PR) is to fix the incorrect reference urls in devdocs service layer page

## Affected DevDocs pages

<!-- REQUIRED List the affected pages on devdocs.magento.com (URLs). Not needed for large numbers of files. -->

-  https://devdocs.magento.com/guides/v2.3/architecture/archi_perspectives/service_layer.html

## Links to Magento source code

<!--  OPTIONAL - REMOVE THIS SECTION IF NOT USED. If this pull request references a file in a Magento codebase repository, add it here. -->

-  https://github.com/magento/magento2/tree/2.3//app/code/Magento/Catalog/Api/Data

<!--
If you are fixing a GitHub issue, note it using GitHub keyword format (https://help.github.com/en/articles/closing-issues-using-keywords#closing-an-issue-in-a-different-repository) to close the issue when this pull request is merged. Example: `Fixes #1234`

`master` is the default branch. Merged pull requests to `master` go live on the site automatically. Any requested changes to content on the `master` branch must be related to the released codebase. Any content related to future releases goes in the `develop` branch.

See Contribution guidelines (https://github.com/magento/devdocs/blob/master/.github/CONTRIBUTING.md) for more information.
-->
