### PR TITLE
Fixing the LESS snippet syntax

### DIFF
--- a/guides/v2.2/javascript-dev-guide/javascript/js-resources.md
+++ b/guides/v2.2/javascript-dev-guide/javascript/js-resources.md
@@ -146,7 +146,7 @@ To include a 3rd party library and use it within the entire website (using the [
 
 1. Copy `slick.less` and `slick-theme.less` to the `<theme_path>/web/css/source` folder. Also add both files to `<theme_path>/web/css/source/_extend.less`.
 
-   ```less
+   ```scss
    @import "slick.less";
    @import "slick-theme.less";
    ```


### PR DESCRIPTION
## Purpose of this pull request

Fix the LESS snippet syntax.

## Affected DevDocs pages

-  https://devdocs.magento.com/guides/v2.3/javascript-dev-guide/javascript/js-resources.html#including-third-party-javascript-libraries
- https://devdocs.magento.com/guides/v2.2/javascript-dev-guide/javascript/js-resources.html#including-third-party-javascript-libraries

## Links to Magento source code

- https://github.com/magento/devdocs/issues/5967
