### PR TITLE
magento/devdocs#5632: Incorrect link to JSCS site.

### DIFF
--- a/guides/v2.2/coding-standards/code-standard-javascript.md
+++ b/guides/v2.2/coding-standards/code-standard-javascript.md
@@ -16,7 +16,7 @@ For the jQuery widget coding standard, see [jQuery widget coding standard][jquer
 
 ## Eslint and JSCS tools
 
-Use [ESLint][eslint] and [JSCS][jscs] to ensure the quality of your JavaScript code.
+Use [ESLint][eslint] and `JSCS` to ensure the quality of your JavaScript code.
 
 ESLint is a community-driven tool that detects errors and potential problems in JavaScript code.
 It can use custom rules to enforce specific coding standards.
@@ -359,6 +359,5 @@ var foo = 'bar',
 [jquery-widgets]: http://api.jqueryui.com/category/widgets
 [jquery-widget-coding-standard]: {{ page.baseurl }}/coding-standards/code-standard-jquery-widgets.html
 [eslint]: http://eslint.org/
-[jscs]: http://jscs.info/
 [eslint-rules]: {{ site.mage2bloburl }}/{{ page.guide_version }}/dev/tests/static/testsuite/Magento/Test/Js/_files/eslint/.eslintrc-magento
 [jscs-rules]: {{ site.mage2bloburl }}/{{ page.guide_version }}/dev/tests/static/testsuite/Magento/Test/Js/_files/jscs/.jscsrc


### PR DESCRIPTION
## Purpose of this pull request

This pull request (PR) fixes https://github.com/magento/devdocs/issues/5632 issue

## Affected DevDocs pages

<!-- REQUIRED List the affected pages on devdocs.magento.com (URLs). Not needed for large numbers of files. -->

- https://devdocs.magento.com/guides/v2.2/coding-standards/code-standard-javascript.html
- https://devdocs.magento.com/guides/v2.3/coding-standards/code-standard-javascript.html


## Links to Magento source code

<!--  OPTIONAL - REMOVE THIS SECTION IF NOT USED. If this pull request references a file in a Magento codebase repository, add it here. -->

-  ...

<!--
If you are fixing a GitHub issue, note it using GitHub keyword format (https://help.github.com/en/articles/closing-issues-using-keywords#closing-an-issue-in-a-different-repository) to close the issue when this pull request is merged. Example: `Fixes #1234`

`master` is the default branch. Merged pull requests to `master` go live on the site automatically. Any requested changes to content on the `master` branch must be related to the released codebase. Any content related to future releases goes in the `develop` branch.

See Contribution guidelines (https://github.com/magento/devdocs/blob/master/.github/CONTRIBUTING.md) for more information.
-->

Thank you!
