### PR TITLE
GraphQL: Deprecate ProductInterfaces attributes 

### DIFF
--- a/guides/v2.3/graphql/product/product-interface.md
+++ b/guides/v2.3/graphql/product/product-interface.md
@@ -59,14 +59,14 @@ Attribute | Data type | Description
 `thumbnail` | [ProductImage](#ProductImage) | An object that contains the URL and label for the product's thumbnail image
 `tier_price` | Float | Deprecated. Use `price_tiers` instead
 `tier_prices` | [ProductTierPrices] | Deprecated. Use `price_tiers` instead
-`type_id` | String | One of `simple`, `virtual`, `bundle`, `downloadable`,`grouped`, `configurable`
+`type_id` | String | Deprecated. Use the GraphQL `__typname` meta attribute instead
 `updated_at` | String | The timestamp indicating when the product was last updated
 `upsell_products` | [ProductInterface] | An array of up-sell products
 `url_key` | String | The part of the URL that identifies the product. This attribute is defined in the `CatalogUrlRewriteGraphQl` module
 `url_path` | String | Deprecated. Use `canonical_url` instead
 `url_suffix` | String | The part of the URL that is appended to the `url_key`, such as `.html`. This attribute is defined in the `CatalogUrlRewriteGraphQl` module
 `url_rewrites` | [[UrlRewrite]](#urlRewriteObject) | A list of URL rewrites
-`websites` | [[Website]](#websiteObject) | An array of websites in which the product is available
+`websites` | [[Website]](#websiteObject) | Deprecated. This attribute is not applicable for GraphQL
 
 ### ProductPrices object {#ProductPrices}
 
@@ -251,6 +251,9 @@ Attribute | Type | Description
 `quantity` | Float | The minimum number of items that must be purchased to qualify for this price tier
 
 ### Website object {#websiteObject}
+
+{:.bs-callout-info}
+The `Website` object has been deprecated because it is not applicable for GraphQL.
 
 Use the `Website` attributes to retrieve information about the website's configuration, which includes the website name, website code, and default group ID. The `Website` object is defined in the StoreGraphQl module.
 

--- a/guides/v2.3/graphql/product/product-interface.md
+++ b/guides/v2.3/graphql/product/product-interface.md
@@ -59,7 +59,7 @@ Attribute | Data type | Description
 `thumbnail` | [ProductImage](#ProductImage) | An object that contains the URL and label for the product's thumbnail image
 `tier_price` | Float | Deprecated. Use `price_tiers` instead
 `tier_prices` | [ProductTierPrices] | Deprecated. Use `price_tiers` instead
-`type_id` | String | Deprecated. Use the GraphQL `__typname` meta attribute instead
+`type_id` | String | Deprecated. Use the GraphQL `__typename` meta attribute instead
 `updated_at` | String | The timestamp indicating when the product was last updated
 `upsell_products` | [ProductInterface] | An array of up-sell products
 `url_key` | String | The part of the URL that identifies the product. This attribute is defined in the `CatalogUrlRewriteGraphQl` module

--- a/guides/v2.3/graphql/queries/products.md
+++ b/guides/v2.3/graphql/queries/products.md
@@ -1203,55 +1203,6 @@ query {
 }
 ```
 
-### Include website information with `products` query results {#inclWebsiteInfoExample}
-
-The [ProductInterface]({{ page.baseurl }}/graphql/product/product-interface.html) can include information about the `Website` object.
-
-**Request:**
-
-```graphql
-{
-    products(filter: {sku: {eq: "24-WB04"}})
-    {
-        items{
-            websites {
-              id
-              name
-              code
-              sort_order
-              default_group_id
-              is_default
-            }
-        }
-    }
-}
-```
-
-**Response:**
-
-```json
-{
-  "data": {
-    "products": {
-      "items": [
-        {
-          "websites": [
-            {
-              "id": 1,
-              "name": "Main Website",
-              "code": "base",
-              "sort_order": 0,
-              "default_group_id": "1",
-              "is_default": true
-            }
-          ]
-        }
-      ]
-    }
-  }
-}
-```
-
 ### Query a URL's rewrite information {#urlRewriteExample}
 
 The following product query returns URL rewrite information about the Joust Duffle Bag.


### PR DESCRIPTION
## Purpose of this pull request

This pull request (PR) deprecates attributes per internal ticket MC-23124

## Affected DevDocs pages

-  guides/v2.3/graphql/product/product-interface.md
-  guides/v2.3/graphql/queries/products.md
