### PR TITLE
Updated view-models.md

### DIFF
--- a/guides/v2.2/extension-dev-guide/view-models.md
+++ b/guides/v2.2/extension-dev-guide/view-models.md
@@ -21,13 +21,14 @@ The following example shows how to add functionality to a core template with cus
 ```xml
 <?xml version="1.0"?>
 <page xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="urn:magento:framework:View/Layout/etc/page_configuration.xsd">
-<body>
-  <referenceBlock name="checkout.cart.item.renderers.default">
-    <arguments>
-      <argument name="view_model" xsi:type="object">Vendor\CustomModule\ViewModel\MyClass</argument>
-    </arguments>
-  </referenceBlock>
-</body>
+    <body>
+        <referenceBlock name="checkout.cart.item.renderers.default">
+        <arguments>
+            <argument name="view_model" xsi:type="object">Vendor\CustomModule\ViewModel\MyClass</argument>
+          </arguments>
+        </referenceBlock>
+    </body>
+</page>
 ```
 
 You must implement the right interface in your `view_model` class (for example `ArgumentInterface`):


### PR DESCRIPTION
I wasn't closing a tag page

## Purpose of this pull request

I was trying to use the documentation example and it was not working, was showing error in XML, I took a look and found that I was not closing the <page> tag, I took advantage and

## Affected DevDocs pages

<!-- REQUIRED List the affected pages on devdocs.magento.com (URLs). Not needed for large numbers of files. -->

-  View models https://devdocs.magento.com/guides/v2.3/extension-dev-guide/view-models.html

## Links to Magento source code

<!--  OPTIONAL - REMOVE THIS SECTION IF NOT USED. If this pull request references a file in a Magento codebase repository, add it here. -->

- No have

<!--
If you are fixing a GitHub issue, note it using GitHub keyword format (https://help.github.com/en/articles/closing-issues-using-keywords#closing-an-issue-in-a-different-repository) to close the issue when this pull request is merged. Example: `Fixes #1234`

`master` is the default branch. Merged pull requests to `master` go live on the site automatically. Any requested changes to content on the `master` branch must be related to the released codebase. Any content related to future releases goes in the `develop` branch.

See Contribution guidelines (https://github.com/magento/devdocs/blob/master/.github/CONTRIBUTING.md) for more information.
-->
