### PR TITLE
Removing Cloud BI Import API From TOC

### DIFF
--- a/_data/toc/mbi.yml
+++ b/_data/toc/mbi.yml
@@ -10,10 +10,6 @@ pages:
   url: /mbi/docs/import-api.html
   versionless: true
 
-- label: Cloud onboarding API
-  url: /mbi/docs/cloud-api.html
-  versionless: true
-
 - label: Libraries
   url: /mbi/docs/libraries.html
   versionless: true


### PR DESCRIPTION
## Purpose of this pull request

This pull request (PR) updates the mbi TOC to remove a reference to content that is actually private. This PR handles actually removing the file: https://github.com/magento/devdocs-mbi/pull/7

## Affected DevDocs pages

-  https://devdocs.magento.com/mbi/docs/
