### PR TITLE
Add MBI to search and update site switcher

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,6 +1,6 @@
 GIT
   remote: https://github.com/magento-devdocs/devdocs-theme.git
-  revision: 7628949ce6d16a6232a0582b32465757a6e446a9
+  revision: 42b6ebb8748ae5a3dc836d6891063dbebf31cbfe
   specs:
     devdocs (7)
       jekyll (>= 4.0)

--- a/_includes/layout/header-scripts.html
+++ b/_includes/layout/header-scripts.html
@@ -25,6 +25,11 @@
       baseUrl: "https://docs.magento.com/m2/ee/user_guide"
     },
     {
+      label: "MBI User Guide",
+      name: "merchdocs-mbi",
+      baseUrl: "https://docs.magento.com/mbi"
+    },
+    {
       label: "PWA",
       name: "pwa-devdocs",
       baseUrl: "https://magento.github.io/pwa-studio"


### PR DESCRIPTION
## Purpose of this pull request

This pull request (PR) add MBI User Guide to federated search and update the link in site switcher.

## Affected DevDocs pages

<!-- REQUIRED List the affected pages on devdocs.magento.com (URLs). Not needed for large numbers of files. -->

-  ...

## Links to Magento source code

<!--  OPTIONAL - REMOVE THIS SECTION IF NOT USED. If this pull request references a file in a Magento codebase repository, add it here. -->

-  ...

<!--
If you are fixing a GitHub issue, note it using GitHub keyword format (https://help.github.com/en/articles/closing-issues-using-keywords#closing-an-issue-in-a-different-repository) to close the issue when this pull request is merged. Example: `Fixes #1234`

`master` is the default branch. Merged pull requests to `master` go live on the site automatically. Any requested changes to content on the `master` branch must be related to the released codebase. Any content related to future releases goes in the `develop` branch.

See Contribution guidelines (https://github.com/magento/devdocs/blob/master/.github/CONTRIBUTING.md) for more information.
-->
