### PR TITLE
Add supported service versions of RabbitMQ

### DIFF
--- a/guides/v2.2/cloud/project/project-conf-files_services-rabbit.md
+++ b/guides/v2.2/cloud/project/project-conf-files_services-rabbit.md
@@ -43,11 +43,7 @@ To enable RabbitMQ:
 
 For information on how these changes affect your environments, see [`services.yaml`]({{ page.baseurl }}/cloud/project/project-conf-files_services.html).
 
-**Cloud Supported RabbitMQ Versions**
-
-* 3.5
-* 3.6
-* 3.7
+[Supported service versions]({{page.baseurl}}/cloud/project/project-conf-files_services.html#service-versions)
 
 ## Connect to RabbitMQ for debugging {#connect}
 

--- a/guides/v2.2/cloud/project/project-conf-files_services-rabbit.md
+++ b/guides/v2.2/cloud/project/project-conf-files_services-rabbit.md
@@ -43,6 +43,12 @@ To enable RabbitMQ:
 
 For information on how these changes affect your environments, see [`services.yaml`]({{ page.baseurl }}/cloud/project/project-conf-files_services.html).
 
+**Cloud Supported RabbitMQ Versions**
+
+* 3.5
+* 3.6
+* 3.7
+
 ## Connect to RabbitMQ for debugging {#connect}
 
 For debugging purposes, it is useful to directly connect to a service instance in one of the following ways:


### PR DESCRIPTION
## Purpose of this pull request

Document the available versions of RabbitMQ from platform.sh docs.
From the platform.sh docs https://docs.platform.sh/configuration/services/rabbitmq.html

## Affected DevDocs pages

- https://devdocs.magento.com/guides/v2.3/cloud/project/project-conf-files_services-rabbit.html

