### PR TITLE
Make it explicit that DB logging is disabled by default

### DIFF
--- a/guides/v2.3/config-guide/cli/logging.md
+++ b/guides/v2.3/config-guide/cli/logging.md
@@ -47,7 +47,7 @@ As of Magento 2.3.1, you can no longer use the `bin/magento config:set dev/debug
 
 ## Database logging
 
-By default, Magento writes database activity logs to the `var/debug/db.log` file inside the Magento application directory.
+By default, Magento writes database activity logs to the `var/debug/db.log` file inside the Magento application directory. Datase logging is disabled by default.
 
 ### To enable database logging
 

--- a/guides/v2.3/config-guide/cli/logging.md
+++ b/guides/v2.3/config-guide/cli/logging.md
@@ -47,7 +47,7 @@ As of Magento 2.3.1, you can no longer use the `bin/magento config:set dev/debug
 
 ## Database logging
 
-By default, Magento writes database activity logs to the `var/debug/db.log` file inside the Magento application directory. Datase logging is disabled by default.
+By default, Magento writes database activity logs to the `var/debug/db.log` file inside the Magento application directory. Database logging is disabled by default.
 
 ### To enable database logging
 


### PR DESCRIPTION
## Purpose of this pull request

This pull request (PR) makes it clear that DB logging is disabled by default when you install Magento.

## Affected DevDocs pages

https://devdocs.magento.com/guides/v2.3/config-guide/cli/logging.html#database-logging
