### PR TITLE
Adding information about theme's variables

### DIFF
--- a/_data/toc/frontend-developer-guide.yml
+++ b/_data/toc/frontend-developer-guide.yml
@@ -49,7 +49,7 @@ pages:
         - label: Adding custom favicons
           url: /frontend-dev-guide/themes/favicon.html
 
-        - label: Configure theme's properties
+        - label: Configure theme properties
           url: /frontend-dev-guide/themes/theme-images.html
 
         - label: Configure product video

--- a/_data/toc/frontend-developer-guide.yml
+++ b/_data/toc/frontend-developer-guide.yml
@@ -49,7 +49,7 @@ pages:
         - label: Adding custom favicons
           url: /frontend-dev-guide/themes/favicon.html
 
-        - label: Configure images properties for a theme
+        - label: Configure theme's properties
           url: /frontend-dev-guide/themes/theme-images.html
 
         - label: Configure product video

--- a/guides/v2.2/frontend-dev-guide/themes/theme-images.md
+++ b/guides/v2.2/frontend-dev-guide/themes/theme-images.md
@@ -1,6 +1,6 @@
 ---
 group: frontend-developer-guide
-title: Configure images properties for a theme
+title: Configure theme's properties
 functional_areas:
   - Frontend
   - Theme
@@ -25,9 +25,11 @@ For example, here is the `view.xml` of the Magento Blank theme: [`app/design/fro
 In `view.xml`, image properties are configured in the scope of `<images module="Magento_Catalog">` element:
 
 ```xml
-<images module="Magento_Catalog">
-...
-<images/>
+<media>
+    <images module="Magento_Catalog">
+    ...
+    </images>
+</media>
 ```
 
 Image properties are configured for each image type defined by the `id` and `type` attributes of the `<image>` element:
@@ -37,7 +39,7 @@ Image properties are configured for each image type defined by the `id` and `typ
    <image id="unique_image_id" type="image_type">
    ...
    </image>
-<images/>
+</images>
 ```
 
 The following table describes the attributes in detail:
@@ -130,3 +132,49 @@ php <magento install dir>/bin/magento catalog:images:resize
 This command has no arguments or options. A progress indicator displays while the command runs.
 
 The message `Product images resized successfully` displays to confirm the command succeeded.
+
+## Configure variables in view.xml {#view_xml_vars}
+
+The variable properties `vars` are configured for each module individually, defined by `module` name.
+
+```xml
+<vars module="Magento_Catalog">
+    <var name="breakpoints">
+        <var name="mobile">
+            <var name="conditions">
+                <var name="max-width">767px</var>
+            </var>
+            ...
+        </var>
+    </var>
+    ...
+</vars>
+```
+
+Any block that extends [`AbstractBlock`]({{ site.mage2bloburl }}/{{ page.guide_version }}/lib/internal/Magento/Framework/View/Element/AbstractBlock.php), can fetch the variable values by using the `getVar` method:
+
+```php
+$block->getVar($name, $module = null)
+```
+
+| Parameter | Required | Description |
+| --- | --- | --- |
+| `name` | `Yes` | The first level variable name |
+| `module` | `No` | The module name where the variable is added. If not passed, it will be determined automatically based on the current module. |
+
+Lets check the following example used for getting the breakpoints variable by [`Gallery`]({{ site.mage2bloburl }}/{{ page.guide_version }}/app/code/Magento/Catalog/Block/Product/View/Gallery.php) block:
+
+```php
+/**
+ * Return breakpoints options
+ *
+ * @return string
+ */
+public function getBreakpoints()
+{
+    return $this->jsonEncoder->encode($this->getVar('breakpoints'));
+}
+```
+
+{: .bs-callout-info }
+The variables can even be used in scope of other modules than the defined one.

--- a/guides/v2.2/frontend-dev-guide/themes/theme-images.md
+++ b/guides/v2.2/frontend-dev-guide/themes/theme-images.md
@@ -151,7 +151,7 @@ The variable properties `vars` are configured for each module individually, defi
 </vars>
 ```
 
-Any block that extends [`AbstractBlock`]({{ site.mage2bloburl }}/{{ page.guide_version }}/lib/internal/Magento/Framework/View/Element/AbstractBlock.php), can fetch the variable values by using the `getVar` method:
+Any block that extends [`AbstractBlock`]({{ site.mage2bloburl }}/{{ page.guide_version }}/lib/internal/Magento/Framework/View/Element/AbstractBlock.php), can fetch variable values with the `getVar` method:
 
 ```php
 $block->getVar($name, $module = null)
@@ -162,7 +162,7 @@ $block->getVar($name, $module = null)
 | `name` | `Yes` | The first level variable name |
 | `module` | `No` | The module name where the variable is added. If not passed, it will be determined automatically based on the current module. |
 
-Lets check the following example used for getting the breakpoints variable by [`Gallery`]({{ site.mage2bloburl }}/{{ page.guide_version }}/app/code/Magento/Catalog/Block/Product/View/Gallery.php) block:
+Check the following example on getting the breakpoints variable by the [`Gallery`]({{ site.mage2bloburl }}/{{ page.guide_version }}/app/code/Magento/Catalog/Block/Product/View/Gallery.php) block:
 
 ```php
 /**
@@ -177,4 +177,4 @@ public function getBreakpoints()
 ```
 
 {: .bs-callout-info }
-The variables can even be used in scope of other modules than the defined one.
+Variables may be used within the scope of modules than the defined one.

--- a/guides/v2.2/frontend-dev-guide/themes/theme-images.md
+++ b/guides/v2.2/frontend-dev-guide/themes/theme-images.md
@@ -1,6 +1,6 @@
 ---
 group: frontend-developer-guide
-title: Configure theme's properties
+title: Configure theme properties
 functional_areas:
   - Frontend
   - Theme


### PR DESCRIPTION
## Purpose of this pull request

This pull request (PR) updates the `Configure images properties for a theme` topic, and renames it to a more generic name (`Configure theme's properties`), in order to add additional information to the topic on how to use `view.xml` while configuring the theme's variables.

It also fixes the wrong closure tags.

## Affected DevDocs pages

<!-- REQUIRED List the affected pages on devdocs.magento.com (URLs). Not needed for large numbers of files. -->

-  https://devdocs.magento.com/guides/v2.2/frontend-dev-guide/themes/theme-images.html
- https://devdocs.magento.com/guides/v2.3/frontend-dev-guide/themes/theme-images.html

## Links to Magento source code

<!--  OPTIONAL - REMOVE THIS SECTION IF NOT USED. If this pull request references a file in a Magento codebase repository, add it here. -->

-  https://github.com/magento/magento2/blob/2.3/app/design/frontend/Magento/luma/etc/view.xml#L195
- https://github.com/magento/magento2/blob/2.3-develop/app/code/Magento/Catalog/Block/Product/View/Gallery.php#L125

whatsnew
Added the 'Configure variables in view.xml' section to [Configure images properties for a theme](https://devdocs.magento.com/guides/v2.3/frontend-dev-guide/themes/theme-images.html
)