### PR TITLE
Clarify global scoped config options

### DIFF
--- a/src/guides/v2.3/test/integration/annotations/magento-config-fixture.md
+++ b/src/guides/v2.3/test/integration/annotations/magento-config-fixture.md
@@ -3,32 +3,32 @@ group: testing
 title: Configuration fixture annotation
 ---
 
-To set the Magento configuration values for individual tests and revert them after the test execution, use the `@magentoConfigFixture` annotation.
+To set Magento configuration values for individual tests and revert them after the test execution, use the `@magentoConfigFixture` annotation.
 
 ## Format
 
-```php?start_inline=1
+```php
 /**
  * @magentoConfigFixture [<store_code>_store] <config_path> <config_value>
  */
 ```
 
--  `<store_code>` is a code of the store to be configured.
-  When global scope is required, this needs to be omited and the config path needs to be prefixed with `default/`, see below for an example.
-  To specify the current store, use `current`.
--  `<config_path>` is an XPath to the configuration option.
-  See [configuration reference][] for available options.
+-  `<store_code>` is the code of the store to be configured.
+   When a global scope is required, this should be omitted and the `config path` is prefixed with `default/`. See below for an example.
+   To specify the current store, use `current`.
+-  `<config_path>` is the XPath to the configuration option.
+   See [configuration reference][] for available options.
 -  `<config_value>` is a fixture value for the configuration option.
 
 ## Principles
 
-1. The `@magentoConfigFixture` is available at a test method level only.
-   It is not available on a test case level.
-1. A test can contain several configuration options.
+1. The `@magentoConfigFixture` is available at the test method level only.
+   It is not available on the test case level.
+1. A test may contain several configuration options.
 
 ## Example
 
-```php?start_inline=1
+```php
 <?php
 
 /**

--- a/src/guides/v2.3/test/integration/annotations/magento-config-fixture.md
+++ b/src/guides/v2.3/test/integration/annotations/magento-config-fixture.md
@@ -14,7 +14,7 @@ To set the Magento configuration values for individual tests and revert them aft
 ```
 
 -  `<store_code>` is a code of the store to be configured.
-  By default, the configuration option is applied globally.
+  When global scope is required, this needs to be omited and the config path needs to be prefixed with `default/`, see below for an example.
   To specify the current store, use `current`.
 -  `<config_path>` is an XPath to the configuration option.
   See [configuration reference][] for available options.
@@ -128,6 +128,44 @@ class ConfigFixtureTest extends \PHPUnit\Framework\TestCase
      * @magentoConfigFixture admin_store dev/restrict/allow_ips 192.168.0.2
      */
     public function testSpecificStoreConfig()
+    {
+        $this->_object->expects(
+            $this->at(0)
+        )->method(
+            '_getConfigValue'
+        )->with(
+            'dev/restrict/allow_ips',
+            'admin'
+        )->will(
+            $this->returnValue('192.168.0.1')
+        );
+        $this->_object->expects(
+            $this->at(1)
+        )->method(
+            '_setConfigValue'
+        )->with(
+            'dev/restrict/allow_ips',
+            '192.168.0.2',
+            'admin'
+        );
+        $this->_object->startTest($this);
+
+        $this->_object->expects(
+            $this->once()
+        )->method(
+            '_setConfigValue'
+        )->with(
+            'dev/restrict/allow_ips',
+            '192.168.0.1',
+            'admin'
+        );
+        $this->_object->endTest($this);
+    }
+
+     /**
+     * @magentoConfigFixture default/dev/restrict/allow_ips 192.168.0.2
+     */
+    public function testGlobalStoreConfig()
     {
         $this->_object->expects(
             $this->at(0)


### PR DESCRIPTION
## Purpose of this pull request

At the moment this isn't clear and can take people a while to figure out how to do this even after having read the documentation.
This modification should make it clear to people how to configure config options in the global scope.

## Affected DevDocs pages

-  https://devdocs.magento.com/guides/v2.3/test/integration/annotations/magento-config-fixture.html
