### PR TITLE
Added info about new docker:build option, --sync-engine=native

### DIFF
--- a/src/guides/v2.2/cloud/docker/docker-config.md
+++ b/src/guides/v2.2/cloud/docker/docker-config.md
@@ -20,7 +20,7 @@ The `docker:build` command overwrites the existing `docker-compose.yml` configur
       -  [php@7.2][php72]
    -  [Composer]
    -  [Docker]
-   -  File synchronization required for developer mode—use one of the following:
+   -  On MacOS and Windows, file synchronization is required for developer mode—use one of the following:
       -  [docker-sync]
       -  [mutagen]
 

--- a/src/guides/v2.2/cloud/docker/docker-mode-developer.md
+++ b/src/guides/v2.2/cloud/docker/docker-mode-developer.md
@@ -14,7 +14,7 @@ The `{{site.data.var.ct}}` version 2002.0.18 and later supports developer mode.
 
 When you launch the Docker environment in developer mode, you must select a file synchronization option:
 
--  On Windows or MacOS, use [docker-sync][dsync-install] or [mutagen][mutagen-install], `docker-sync` is the default value
+-  On Windows or MacOS, use [docker-sync][dsync-install] or [mutagen][mutagen-install], `docker-sync` is the default option
 -  On Linux, use the `native` option to disable file synchronization, which is not required for local Docker development
 
 Large files (>1 GB) can cause a period of inactivity. DB dumps and archive files—ZIP, SQL, GZ, and BZ2—are not necessary to sync. You can find exclusions to these file types in the `docker-sync.yml` and `mutagen.sh` files.

--- a/src/guides/v2.2/cloud/docker/docker-mode-developer.md
+++ b/src/guides/v2.2/cloud/docker/docker-mode-developer.md
@@ -37,24 +37,24 @@ To launch the Docker environment in developer mode:
    -  [Docker-sync Installation instructions][dsync-install]
    -  [Mutagen.io Installation instructions][mutagen-install]
 
-1. In your local environment, start the Docker configuration generator. You can use the service keys, such as `--php`, to [specify a version][services].
+1. In your local environment, generate the Docker Compose configuration file. You can use the service keys, such as `--php`, to [specify a version][services].
 
    ```bash
    ./vendor/bin/ece-tools docker:build --mode="developer"
    ```
 
-   By default, the docker-compose configuration uses 'docker-sync' for file synchronization. To use 'mutagen.io' for file synchronization on Windows or MacOS, you must run the command with the `--sync-engine=mutagen` option.
+   By default, the `docker-build` command generates the Docker Compose configuration file using 'docker-sync' for file synchronization. To use 'mutagen.io' for file synchronization on Windows or MacOS, you must run the command with the `--sync-engine="mutagen"` option.
 
    For example:
 
    ```bash
-   ./vendor/bin/ece-tools docker:build --mode="developer" --sync-engine=mutagen
+   ./vendor/bin/ece-tools docker:build --mode="developer" --sync-engine="mutagen"
    ```
 
-   On Linux, use the `native` option when starting the Docker configuration generator:
+   On Linux, use the `native` option to generate the Docker Compose configuration file:
 
    ```bash
-   ./vendor/bin/ece-tools docker:build --mode="developer" --sync-engine=native
+   ./vendor/bin/ece-tools docker:build --mode="developer" --sync-engine="native"
    ```
 
 1. _Optional_: If you have a custom PHP configuration file, copy the default configuration DIST file to your custom configuration file and make any necessary changes.
@@ -76,7 +76,7 @@ To launch the Docker environment in developer mode:
    If this is the first installation, expect to wait a few minutes for file synchronization.
 
    {: .bs-callout-info}
-   If you use the `mutagen.io` or `native` option for file synchronization, skip this step. You start `mutagen.io` _after_ deploying the docker containers.
+   If you use the `mutagen.io` or `native` option for file synchronization, skip this step. You start `mutagen.io` _after_ deploying the Docker containers.
 
 1. Build files to containers and run in the background.
 
@@ -84,7 +84,7 @@ To launch the Docker environment in developer mode:
    docker-compose up -d
    ```
 
-1. Start the file synchronization with `mutagen.io`. If you use the `docker-sync` or `native` options when you started the Docker generator, skip this step.
+1. Start the file synchronization with `mutagen.io`. If you use the `docker-sync` or `native` options to generate the Docker Compose configuration file, skip this step.
 
    ```bash
    bash ./mutagen.sh

--- a/src/guides/v2.2/cloud/docker/docker-mode-developer.md
+++ b/src/guides/v2.2/cloud/docker/docker-mode-developer.md
@@ -35,7 +35,7 @@ To launch the Docker environment in developer mode:
 1. Install the selected file synchronization tool if required:
 
    -  [Docker-sync Installation instructions][dsync-install]
-   -  [Mutagen.io Installation instructions][mutagen-install].
+   -  [Mutagen.io Installation instructions][mutagen-install]
 
 1. In your local environment, start the Docker configuration generator. You can use the service keys, such as `--php`, to [specify a version][services].
 

--- a/src/guides/v2.2/cloud/docker/docker-mode-developer.md
+++ b/src/guides/v2.2/cloud/docker/docker-mode-developer.md
@@ -12,10 +12,10 @@ Developer mode supports an active development environment with full, writable fi
 {: .bs-callout-info }
 The `{{site.data.var.ct}}` version 2002.0.18 and later supports developer mode.
 
-File synchronization is required for developer mode. Use one of the following tools:
+When you launch the Docker environment in developer mode, you must select a file synchronization option:
 
--  [docker-sync][dsync-install]
--  [mutagen][mutagen-install]
+-  On Windows or MacOS, use [docker-sync][dsync-install] or [mutagen][mutagen-install], `docker-sync` is the default value
+-  On Linux, use the `native` option to disable file synchronization, which is not required for local Docker development
 
 Large files (>1 GB) can cause a period of inactivity. DB dumps and archive files—ZIP, SQL, GZ, and BZ2—are not necessary to sync. You can find exclusions to these file types in the `docker-sync.yml` and `mutagen.sh` files.
 
@@ -32,9 +32,10 @@ To launch the Docker environment in developer mode:
    composer install
    ```
 
-1. Install the `docker-sync` tool using the [Installation instructions][dsync-install].
+1. Install the selected file synchronization tool if required:
 
-   Optionally, you can install the `mutagen.io` tool using the [Installation instructions][mutagen-install]. If you have it installed, continue to the next step.
+   -  [Docker-sync Installation instructions][dsync-install]
+   -  [Mutagen.io Installation instructions][mutagen-install].
 
 1. In your local environment, start the Docker configuration generator. You can use the service keys, such as `--php`, to [specify a version][services].
 
@@ -42,12 +43,18 @@ To launch the Docker environment in developer mode:
    ./vendor/bin/ece-tools docker:build --mode="developer"
    ```
 
-   By default, the docker-compose configuration uses 'docker-sync' for file synchronization. To use 'mutagen.io' for file synchronization, you must run the command with the `--sync-engine=mutagen` option.
+   By default, the docker-compose configuration uses 'docker-sync' for file synchronization. To use 'mutagen.io' for file synchronization on Windows or MacOS, you must run the command with the `--sync-engine=mutagen` option.
 
    For example:
 
    ```bash
    ./vendor/bin/ece-tools docker:build --mode="developer" --sync-engine=mutagen
+   ```
+
+   On Linux, use the `native` option when starting the Docker configuration generator:
+
+   ```bash
+   ./vendor/bin/ece-tools docker:build --mode="developer" --sync-engine=native
    ```
 
 1. _Optional_: If you have a custom PHP configuration file, copy the default configuration DIST file to your custom configuration file and make any necessary changes.
@@ -69,7 +76,7 @@ To launch the Docker environment in developer mode:
    If this is the first installation, expect to wait a few minutes for file synchronization.
 
    {: .bs-callout-info}
-   If you use `mutagen.io` for file synchronization, skip this step. You start `mutagen.io` _after_ deploying the docker containers.
+   If you use the `mutagen.io` or `native` option for file synchronization, skip this step. You start `mutagen.io` _after_ deploying the docker containers.
 
 1. Build files to containers and run in the background.
 
@@ -77,7 +84,7 @@ To launch the Docker environment in developer mode:
    docker-compose up -d
    ```
 
-1. Start the file synchronization with `mutagen.io`. If you use the `docker-sync` tool for file synchronization, skip this step.
+1. Start the file synchronization with `mutagen.io`. If you use the `docker-sync` or `native` options when you started the Docker generator, skip this step.
 
    ```bash
    bash ./mutagen.sh

--- a/src/guides/v2.2/cloud/docker/docker-quick-reference.md
+++ b/src/guides/v2.2/cloud/docker/docker-quick-reference.md
@@ -38,7 +38,8 @@ docker-compose -f docker-compose.yml -f docker-compose-custom.yml [-f more-custo
 
 | Option       | Key              | Available values
 | ------------ | ---------------- | ------------------
-| Mode         | `--mode`, `-m`   | production, developer
+| [Mode]({{page.baseurl}}/cloud/docker/docker-config.html#launch-modes)         | `--mode`, `-m`   | production, developer
+| [File synchronization engine]({{page.baseurl}}/cloud/docker/docker-config.html#launch-modes) | `--sync-engine` | docker-sync, mutagen, native
 
 ## bin/docker
 

--- a/src/guides/v2.2/cloud/release-notes/mcd-release-notes.md
+++ b/src/guides/v2.2/cloud/release-notes/mcd-release-notes.md
@@ -23,7 +23,6 @@ The release notes include:
 
 -  {:.new}Added DB dumps and archive files—ZIP, SQL, GZ, and BZ2—to the exclusion list in the `dist/docker-sync.yml` and `dist/mutagen.sh` files. Large files (>1 GB) can cause a period of inactivity and are not necessary to sync.<!--MAGECLOUD-3979-->
 
--  {:.new}Docker for Linux does not require a third party utility to support file syncing because binding a host directory to a container does not cause the same performance issues. Added the `--sync-enggine=native` option.<!--MAGECLOUD4351-->
 
 -  {:.new}Added the `--rm` option to `./bin/magento-docker` commands for the build and deploy containers. This removes the container after the task is complete.<!--MAGECLOUD-4205-->
 

--- a/src/guides/v2.2/cloud/release-notes/mcd-release-notes.md
+++ b/src/guides/v2.2/cloud/release-notes/mcd-release-notes.md
@@ -27,4 +27,4 @@ The release notes include:
 
 -  {:.new}Added the `--rm` option to `./bin/magento-docker` commands for the build and deploy containers. This removes the container after the task is complete.<!--MAGECLOUD-4205-->
 
--  {:.new}Added the `--sync-engine=native` option to the `docker-build` command to disable file synchronization when launching the Docker generator in developer mode. Use this option when developing on  Linux systems, which do not require file synchronization for local Docker development.<!--MAGECLOUD-4351-->
+-  {:.new}Added the `--sync-engine=native` option to the `docker-build` command to disable file synchronization when launching the Docker generator in developer mode. Use this option when developing on Linux systems, which do not require file synchronization for local Docker development.<!--MAGECLOUD-4351-->

--- a/src/guides/v2.2/cloud/release-notes/mcd-release-notes.md
+++ b/src/guides/v2.2/cloud/release-notes/mcd-release-notes.md
@@ -26,3 +26,5 @@ The release notes include:
 -  {:.new}Docker for Linux does not require a third party utility to support file syncing because binding a host directory to a container does not cause the same performance issues. Added the `--sync-enggine=native` option.<!--MAGECLOUD4351-->
 
 -  {:.new}Added the `--rm` option to `./bin/magento-docker` commands for the build and deploy containers. This removes the container after the task is complete.<!--MAGECLOUD-4205-->
+
+-  {:.new}Added the `--sync-engine=native` option to the `docker-build` command to disable file synchronization when launching the Docker generator in developer mode. Use this option when developing on  Linux systems, which do not require file synchronization for local Docker development.<!--MAGECLOUD-4351-->

--- a/src/guides/v2.2/cloud/release-notes/mcd-release-notes.md
+++ b/src/guides/v2.2/cloud/release-notes/mcd-release-notes.md
@@ -27,4 +27,4 @@ The release notes include:
 
 -  {:.new}Added the `--rm` option to `./bin/magento-docker` commands for the build and deploy containers. This removes the container after the task is complete.<!--MAGECLOUD-4205-->
 
--  {:.new}Added the `--sync-engine=native` option to the `docker-build` command to disable file synchronization when launching the Docker generator in developer mode. Use this option when developing on Linux systems, which do not require file synchronization for local Docker development.<!--MAGECLOUD-4351-->
+-  {:.new}Added the `--sync-engine="native"` option to the `docker-build` command to disable file synchronization when you generate the Docker Compose configuration file in developer mode. Use this option when developing on Linux systems, which do not require file synchronization for local Docker development.<!--MAGECLOUD-4351-->


### PR DESCRIPTION
## Purpose of this pull request

Added the `--sync-engine=native` option to the `docker-build` command to disable file synchronization when launching the Docker generator in developer mode. Use this option when developing on Linux systems, which do not require file synchronization for local Docker development.

- [ ] Updated prerequisites to include information about `native` option to disable file sync on Linux
- [ ] Updated Docker developer mode topic to include information about `native` option, and specify different sync engine options available for local Docker development mode
- [ ] Added release note for new sync option

## Affected DevDocs pages

- https://devdocs.magento.com/guides/v2.3/cloud/docker/docker-config.html#developer-mode

## Links to Magento source code

https://github.com/magento/magento-cloud-docker/commit/733e87bd29182977dd5343998c911105107c0820