### PR TITLE
Fixing the git config url after moving the content to /src folder

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -197,8 +197,8 @@ m1xgithuburl: https://github.com/magento/devdocs-m1/tree/master
 
 # 2.2 variables
 gdeurl22: /guides/v2.2/
-githuburl22: https://github.com/magento/devdocs/tree/master/guides/v2.2/
+githuburl22: https://github.com/magento/devdocs/tree/master/src/guides/v2.2/
 
 # 2.3 variables
 gdeurl23: /guides/v2.3/
-githuburl23: https://github.com/magento/devdocs/tree/master/guides/v2.3/
+githuburl23: https://github.com/magento/devdocs/tree/master/src/guides/v2.3/


### PR DESCRIPTION
## Purpose of this pull request

This pull request (PR) fixes the config setting after moving the content to `/src` folder.

## Affected DevDocs pages

<!-- REQUIRED List the affected pages on devdocs.magento.com (URLs). Not needed for large numbers of files. -->

-  https://devdocs.magento.com/guides/v2.2/extension-dev-guide/Contribute_edg.html
- https://devdocs.magento.com/guides/v2.3/extension-dev-guide/Contribute_edg.html

## Links to Magento source code

N/A

<!--
If you are fixing a GitHub issue, note it using GitHub keyword format (https://help.github.com/en/articles/closing-issues-using-keywords#closing-an-issue-in-a-different-repository) to close the issue when this pull request is merged. Example: `Fixes #1234`

`master` is the default branch. Merged pull requests to `master` go live on the site automatically. Any requested changes to content on the `master` branch must be related to the released codebase. Any content related to future releases goes in the `develop` branch.

See Contribution guidelines (https://github.com/magento/devdocs/blob/master/.github/CONTRIBUTING.md) for more information.
-->

Fixes #6116