### PR TITLE
Add IP addresses for Security Scanner tool

### DIFF
--- a/src/guides/v2.2/cloud/live/live.md
+++ b/src/guides/v2.2/cloud/live/live.md
@@ -44,7 +44,7 @@ content='The security scan tool uses the following public IP addresses:
 52.87.98.44
 ```
 
-You must whitelist these IP addresses in your network firewall rules to allow the tool to scan your site.'
+You must whitelist these IP addresses in your network firewall rules to allow the tool to scan your site. the tool posts requests to ports 80 and 443 only.'
 %}
 
 The Magento Security Scan Tool enables you to regularly monitor your store websites and receive updates for known security risks, malware, and out-of-date software. This is a free service available for all implementations and versions of {{site.data.var.ece}}. You access the tool through your [Magento Marketplace account](https://account.magento.com/customer/account/login).
@@ -55,6 +55,15 @@ The Magento Security Scan Tool enables you to regularly monitor your store websi
 See the [Magento User Guide](http://docs.magento.com/m2/ee/user_guide/magento/security-scan.html) for information about setting up and using the security scan tool. Typically, you start using this tool when you begin user acceptance testing (UAT).
 
 Each site you scan must be registered through the Magento Security Scan tab. During the registration process, you must accept the Magento disclaimer before you can begin scanning.  You control both the schedule and authorizing the user to receive notifications when each scan is complete.  You can schedule scans for a specific, recurring date and time, or run a scan on demand as needed.
+
+The Magento Security Scan Tool uses several user agent strings to simulate real-life malware activity. You might see the following user agents in your analytics or access logs:
+
+```text
+Mozilla/5.0 (Windows NT 10.0; Win64; x64; rv:57.0) Gecko/20100101 Firefox/57.0
+GuzzleHttp/6.3.3 curl/7.29.0 PHP/7.1.18
+Mozilla/5.0 (Windows NT 6.1; WOW64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/37.0.2062.120 Safari/537.36
+Visbot/2.0 (+http://www.visvo.com/en/webmasters.jsp;bot@visvo.com)
+```
 
 ## Scan your site
 

--- a/src/guides/v2.2/cloud/live/live.md
+++ b/src/guides/v2.2/cloud/live/live.md
@@ -52,7 +52,7 @@ content='The security scan tool uses the following public IP addresses:
 52.86.204.1
 52.87.98.44
 ```
-  
+
 You must whitelist these IP addresses in your network firewall rules to allow the tool to scan your site.'
 %}
 

--- a/src/guides/v2.2/cloud/live/live.md
+++ b/src/guides/v2.2/cloud/live/live.md
@@ -33,15 +33,6 @@ We strongly recommend testing in these environments due to the complexity of you
 
 ## Set up Magento Security Scan Tool {#security-scan}
 
-The Magento Security Scan Tool enables you to regularly monitor your store websites and receive updates for known security risks, malware, and out-of-date software. This is a free service available for all implementations and versions of {{site.data.var.ece}}. You access the tool through your [Magento Marketplace account](https://account.magento.com/customer/account/login).
-
-*  Monitor your sites security status and applied security updates
-*  Receive security updates and site-specific notifications
-
-See the [Magento User Guide](http://docs.magento.com/m2/ee/user_guide/magento/security-scan.html) for information about setting up and using the security scan tool. Typically, you start using this tool when you begin user acceptance testing (UAT).
-
-Each site you scan must be registered through the Magento Security Scan tab. During the registration process, you must accept the Magento disclaimer before you can begin scanning.  You control both the schedule and authorizing the user to receive notifications when each scan is complete.  You can schedule scans for a specific, recurring date and time, or run a scan on demand as needed.
-
 {%
 include note.html
 type='info'
@@ -55,6 +46,15 @@ content='The security scan tool uses the following public IP addresses:
 
 You must whitelist these IP addresses in your network firewall rules to allow the tool to scan your site.'
 %}
+
+The Magento Security Scan Tool enables you to regularly monitor your store websites and receive updates for known security risks, malware, and out-of-date software. This is a free service available for all implementations and versions of {{site.data.var.ece}}. You access the tool through your [Magento Marketplace account](https://account.magento.com/customer/account/login).
+
+*  Monitor your sites security status and applied security updates
+*  Receive security updates and site-specific notifications
+
+See the [Magento User Guide](http://docs.magento.com/m2/ee/user_guide/magento/security-scan.html) for information about setting up and using the security scan tool. Typically, you start using this tool when you begin user acceptance testing (UAT).
+
+Each site you scan must be registered through the Magento Security Scan tab. During the registration process, you must accept the Magento disclaimer before you can begin scanning.  You control both the schedule and authorizing the user to receive notifications when each scan is complete.  You can schedule scans for a specific, recurring date and time, or run a scan on demand as needed.
 
 ## Scan your site
 
@@ -74,8 +74,9 @@ To review the report:
 The report lists issues including Failed Scans, Unidentified Results, and Successful Scans. Each entry provides detailed information for the scan, a list of issues to investigate, and actions to take. Some of these actions may require downloading and installing security patches. You can add those to a development branch on your local workstation.
 
 Scan results include a label that describes scan pass or fail status with detailed information about the checks performed:
--  "Failed" indicates that the website contains a serious vulnerability
--  "Unidentified" suggests that a deeper review is required by your team or hosting provider to determine if further action is required.
+
+*  "Failed" indicates that the website contains a serious vulnerability.
+*  "Unidentified" suggests that a deeper review is required by your team or hosting provider to determine if further action is required.
 
 The scan results also provide suggested remediation steps for each failed security test. Security scan results are protected and viewable only by the registered user. Only users designated in the site registration process receive scan completion notifications.
 

--- a/src/guides/v2.2/cloud/live/live.md
+++ b/src/guides/v2.2/cloud/live/live.md
@@ -63,7 +63,7 @@ To scan your site:
 
 1. Access your [Magento Marketplace account](https://account.magento.com/customer/account/login).
 1. Click the Security Scan tab and select **Go to Security Scan**.
-1. In the **Actions** column for the site, select **Run Scan**. A notification status displays the scheduled scan.
+1. In the _Actions_ column for the site, select **Run Scan**. A notification status displays the scheduled scan.
 
 {:.procedure}
 To review the report:

--- a/src/guides/v2.2/cloud/live/live.md
+++ b/src/guides/v2.2/cloud/live/live.md
@@ -44,7 +44,7 @@ content='The security scan tool uses the following public IP addresses:
 52.87.98.44
 ```
 
-You must whitelist these IP addresses in your network firewall rules to allow the tool to scan your site. the tool posts requests to ports 80 and 443 only.'
+You must whitelist these IP addresses in your network firewall rules to allow the tool to scan your site. The tool posts requests to ports 80 and 443 only.'
 %}
 
 The Magento Security Scan Tool enables you to regularly monitor your store websites and receive updates for known security risks, malware, and out-of-date software. This is a free service available for all implementations and versions of {{site.data.var.ece}}. You access the tool through your [Magento Marketplace account](https://account.magento.com/customer/account/login).

--- a/src/guides/v2.2/cloud/live/live.md
+++ b/src/guides/v2.2/cloud/live/live.md
@@ -38,9 +38,9 @@ The Magento Security Scan Tool enables you to regularly monitor your store websi
 *  Monitor your sites security status and applied security updates
 *  Receive security updates and site-specific notifications
 
-For detailed instructions to set up and perform scans, see the [Magento User Guide](http://docs.magento.com/m2/ee/user_guide/magento/security-scan.html). Typically, you want to start using this tool as you enter user acceptance testing (UAT).
+See the [Magento User Guide](http://docs.magento.com/m2/ee/user_guide/magento/security-scan.html) for information about setting up and using the security scan tool. Typically, you start using this tool when you begin user acceptance testing (UAT).
 
-Each site you scan must be registered through the Magento Security Scan tab. The registration process requires you to accept Magento’s disclaimer prior to scanning. You control both scan scheduling and the authorization of personnel to be notified when each scan is complete. You can schedule scans for a specific, recurring date and time or on demand as required.
+Each site you scan must be registered through the Magento Security Scan tab. During the registration process, you must accept the Magento disclaimer before you can begin scanning.  You control both the schedule and authorizing the user to receive notifications when each scan is complete.  You can schedule scans for a specific, recurring date and time, or run a scan on demand as needed.
 
 {%
 include note.html
@@ -73,7 +73,11 @@ To review the report:
 
 The report lists issues including Failed Scans, Unidentified Results, and Successful Scans. Each entry provides detailed information for the scan, a list of issues to investigate, and actions to take. Some of these actions may require downloading and installing security patches. You can add those to a development branch on your local workstation.
 
-Scan results include a general label that describes whether a site passed or failed, plus detailed information about the checks performed. "Failed" indicates that the website contains a serious vulnerability, while "Unidentified" suggests that a deeper review is required by your team or hosting provider to determine if further action is required. We also provide suggested remediation steps for each failed security test. Security scan results are protected and viewable only by the registered user. Only users designated in the site registration process receive scan completion notifications.
+Scan results include a label that describes scan pass or fail status with detailed information about the checks performed:
+-  "Failed" indicates that the website contains a serious vulnerability
+-  "Unidentified" suggests that a deeper review is required by your team or hosting provider to determine if further action is required.
+
+The scan results also provide suggested remediation steps for each failed security test. Security scan results are protected and viewable only by the registered user. Only users designated in the site registration process receive scan completion notifications.
 
 ## Ready to go live {#ready}
 

--- a/src/guides/v2.2/cloud/live/live.md
+++ b/src/guides/v2.2/cloud/live/live.md
@@ -1,10 +1,6 @@
 ---
 group: cloud-guide
-subgroup: 165_live
 title: Go live and launch
-menu_title: Go live and launch
-menu_order: 1
-menu_node: parent
 functional_areas:
   - Cloud
 ---

--- a/src/guides/v2.2/cloud/live/live.md
+++ b/src/guides/v2.2/cloud/live/live.md
@@ -42,12 +42,14 @@ For detailed instructions to set up and perform scans, see the [Magento User Gui
 
 Each site you scan must be registered through the Magento Security Scan tab. The registration process requires you to accept Magento’s disclaimer prior to scanning. You control both scan scheduling and the authorization of personnel to be notified when each scan is complete. You can schedule scans for a specific, recurring date and time or on demand as required.
 
+{.:procedure}
 To scan your site:
 
 1. Access your [Magento Marketplace account](https://account.magento.com/customer/account/login).
 1. Click the Security Scan tab and select **Go to Security Scan**.
 1. In the **Actions** column for the site, select **Run Scan**. A notification status displays the scheduled scan.
 
+{:.procedure}
 To review the report:
 
 1. When the report completes, a notification displays.
@@ -59,7 +61,7 @@ Scan results include a general label that describes whether a site passed or fai
 
 ## Ready to go live {#ready}
 
-When you are ready to begin the go-live process, see the following steps:
+When you are ready to begin the go-live process, see the following:
 
 *  [Go live checklist]({{ page.baseurl }}/cloud/live/go-live-checklist.html)
 *  [Launch steps]({{ page.baseurl }}/cloud/live/launch-steps.html)

--- a/src/guides/v2.2/cloud/live/live.md
+++ b/src/guides/v2.2/cloud/live/live.md
@@ -42,6 +42,8 @@ For detailed instructions to set up and perform scans, see the [Magento User Gui
 
 Each site you scan must be registered through the Magento Security Scan tab. The registration process requires you to accept Magento’s disclaimer prior to scanning. You control both scan scheduling and the authorization of personnel to be notified when each scan is complete. You can schedule scans for a specific, recurring date and time or on demand as required.
 
+## Scan your site
+
 {.:procedure}
 To scan your site:
 

--- a/src/guides/v2.2/cloud/live/live.md
+++ b/src/guides/v2.2/cloud/live/live.md
@@ -42,9 +42,23 @@ For detailed instructions to set up and perform scans, see the [Magento User Gui
 
 Each site you scan must be registered through the Magento Security Scan tab. The registration process requires you to accept Magento’s disclaimer prior to scanning. You control both scan scheduling and the authorization of personnel to be notified when each scan is complete. You can schedule scans for a specific, recurring date and time or on demand as required.
 
+{%
+include note.html
+type='info'
+content='The security scan tool uses the following public IP addresses:
+
+```text
+52.72.230.169
+52.86.204.1
+52.87.98.44
+```
+  
+You must whitelist these IP addresses in your network firewall rules to allow the tool to scan your site.'
+%}
+
 ## Scan your site
 
-{.:procedure}
+{:.procedure}
 To scan your site:
 
 1. Access your [Magento Marketplace account](https://account.magento.com/customer/account/login).

--- a/src/guides/v2.2/cloud/live/live.md
+++ b/src/guides/v2.2/cloud/live/live.md
@@ -33,20 +33,20 @@ We strongly recommend testing in these environments due to the complexity of you
 
 ## Set up Magento Security Scan Tool {#security-scan}
 
-The Magento Security Scan Tool enables you to regularly monitor your store websites and receive updates for known security risks, malware, and out of date software. This is a free service available for all implementations and versions of {{site.data.var.ece}}. You access the tool through your [Magento Marketplace account](https://account.magento.com/customer/account/login).
+The Magento Security Scan Tool enables you to regularly monitor your store websites and receive updates for known security risks, malware, and out-of-date software. This is a free service available for all implementations and versions of {{site.data.var.ece}}. You access the tool through your [Magento Marketplace account](https://account.magento.com/customer/account/login).
 
 *  Monitor your sites security status and applied security updates
-*  Receive security updates and site specific notifications
+*  Receive security updates and site-specific notifications
 
-For detailed instructions to set up and perform scans, see the [Magento User Guide](http://docs.magento.com/m2/ee/user_guide/magento/security-scan.html). Typically, you want to start using this tool as you enter UAT testing.
+For detailed instructions to set up and perform scans, see the [Magento User Guide](http://docs.magento.com/m2/ee/user_guide/magento/security-scan.html). Typically, you want to start using this tool as you enter user acceptance testing (UAT).
 
-Each site to be scanned must be registered through Magento Security Scan tab. This registration process includes acceptance of Magento’s disclaimer prior to scanning. You control both scan scheduling and the authorization of personnel to be notified when each scan is completed. Scans can be scheduled for either a specific, recurring date and time or on-demand as required.
+Each site you scan must be registered through the Magento Security Scan tab. The registration process requires you to accept Magento’s disclaimer prior to scanning. You control both scan scheduling and the authorization of personnel to be notified when each scan is complete. You can schedule scans for a specific, recurring date and time or on demand as required.
 
 To scan your site:
 
 1. Access your [Magento Marketplace account](https://account.magento.com/customer/account/login).
 1. Click the Security Scan tab and select **Go to Security Scan**.
-1. In the **Actions** column for the site, select Run Scan. A notification status displays the scheduled scan.
+1. In the **Actions** column for the site, select **Run Scan**. A notification status displays the scheduled scan.
 
 To review the report:
 
@@ -55,11 +55,11 @@ To review the report:
 
 The report lists issues including Failed Scans, Unidentified Results, and Successful Scans. Each entry provides detailed information for the scan, a list of issues to investigate, and actions to take. Some of these actions may require downloading and installing security patches. You can add those to a development branch on your local workstation.
 
-Scan results include a general label that describes whether a site passed or failed plus detailed information about the checks performed. Failed indicates that the website contains a serious vulnerability, while unidentified suggests that a deeper review is required by your team or hosting provider to determine if further action is required. We also provide suggested remediation steps for each failed security test. Security scan results are protected and viewable only by the registered user, and notifications of scan completion are restricted to the users designated in the site registration process.
+Scan results include a general label that describes whether a site passed or failed, plus detailed information about the checks performed. "Failed" indicates that the website contains a serious vulnerability, while "Unidentified" suggests that a deeper review is required by your team or hosting provider to determine if further action is required. We also provide suggested remediation steps for each failed security test. Security scan results are protected and viewable only by the registered user. Only users designated in the site registration process receive scan completion notifications.
 
 ## Ready to go live {#ready}
 
-You are ready to start go live steps:
+When you are ready to begin the go-live process, see the following steps:
 
 *  [Go live checklist]({{ page.baseurl }}/cloud/live/go-live-checklist.html)
 *  [Launch steps]({{ page.baseurl }}/cloud/live/launch-steps.html)


### PR DESCRIPTION
## Purpose of this pull request

This pull request (PR):

- [X] Adds a note about whitelisting the public IP addresses used by the Magento Security Scanner tool to allow it to scan a site
- [X] Removes obsolete metadata from the topic
- [X] Cleans up some of the older text

See internal staging build 1173 for a preview.

## Affected DevDocs pages

-  https://devdocs.magento.com/guides/v2.3/cloud/live/live.html#security-scan

whatsnew
Added more information about the [Magento Security Scanner](https://devdocs.magento.com/guides/v2.3/cloud/live/live.html#security-scan), including which IP addresses, ports, and user agent strings it uses.