### PR TITLE
Corrected the Docker compose override file name

### DIFF
--- a/src/guides/v2.2/cloud/docker/docker-quick-reference.md
+++ b/src/guides/v2.2/cloud/docker/docker-quick-reference.md
@@ -26,7 +26,7 @@ List containers and ports | `docker-compose ps` or `docker ps`
 
 Because the `docker:build` command in the `{{site.data.var.ct}}` package overwrites the base configuration, we recommend saving your customizations in an override configuration file. You can use this method to merge multiple custom configurations. See [Docker Docs: Multiple Compose files](https://docs.docker.com/compose/extends/#multiple-compose-files).
 
-The `docker-compose up` command considers the base `docker-compose.yml` configuration by default. If the `docker-compose-override.yml` file is present, then the override configuration merges with the base configuration.
+The `docker-compose up` command considers the base `docker-compose.yml` configuration by default. If the `docker-compose.override.yml` file is present, then the override configuration merges with the base configuration.
 
 Use the `-f` argument to specify an alternate configuration file. The following example uses the default configuration and merges each custom configuration sequentially:
 


### PR DESCRIPTION
## Purpose of this pull request

Fixes the default Docker override filename according to https://docs.docker.com/compose/extends/#multiple-compose-files

<!--
If you are fixing a GitHub issue, note it using GitHub keyword format (https://help.github.com/en/articles/closing-issues-using-keywords#closing-an-issue-in-a-different-repository) to close the issue when this pull request is merged. Example: `Fixes #1234`

`master` is the default branch. Merged pull requests to `master` go live on the site automatically. Any requested changes to content on the `master` branch must be related to the released codebase. Any content related to future releases goes in the `develop` branch.

See Contribution guidelines (https://github.com/magento/devdocs/blob/master/.github/CONTRIBUTING.md) for more information.
-->
