### PR TITLE
#6151 - Fix Schema location in queue.xml example for message queue co…

### DIFF
--- a/src/guides/v2.3/extension-dev-guide/message-queues/config-mq.md
+++ b/src/guides/v2.3/extension-dev-guide/message-queues/config-mq.md
@@ -36,7 +36,7 @@ The `queue.xml` file defines the broker that processes topics. It also specifies
 {:.no_toc}
 
 ```xml
-<config xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="urn:magento:framework:Communication/etc/communication.xsd">
+<config xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="urn:magento:framework-message-queue:etc/queue.xsd">
     <broker topic="product_action_attribute.update" exchange="magento-db" type="db">
         <queue name="product_action_attribute.update"
                consumer="product_action_attribute.update"


### PR DESCRIPTION
## Purpose of this pull request

Fixes #6151 

Where incorrect `xsi:noNamespaceSchemaLocation` config node attribute is used in queue.xml example

## Affected DevDocs pages

- https://devdocs.magento.com/guides/v2.3/extension-dev-guide/message-queues/config-mq.html



<!--
If you are fixing a GitHub issue, note it using GitHub keyword format (https://help.github.com/en/articles/closing-issues-using-keywords#closing-an-issue-in-a-different-repository) to close the issue when this pull request is merged. Example: `Fixes #1234`

`master` is the default branch. Merged pull requests to `master` go live on the site automatically. Any requested changes to content on the `master` branch must be related to the released codebase. Any content related to future releases goes in the `develop` branch.

See Contribution guidelines (https://github.com/magento/devdocs/blob/master/.github/CONTRIBUTING.md) for more information.
-->
