### PR TITLE
magento/devdocs#: Fix visual bug on the “Create an integration” page

### DIFF
--- a/src/guides/v2.2/get-started/create-integration.md
+++ b/src/guides/v2.2/get-started/create-integration.md
@@ -172,7 +172,7 @@ To develop a module, you must:
 
     `testIntegration` must refer to your `etc/integration/config.xml` file, and the integration name value must be the same.
 
-    The following example demonstrates a minimal 'config.xml' file.
+    The following example demonstrates a minimal `config.xml` file.
 
     ```xml
     <integrations>
@@ -182,7 +182,7 @@ To develop a module, you must:
          <identity_link_url>https://example.com/identity_link_url</identity_link_url>
       </integration>
     </integrations>
-    ``
+    ```
 
     Also, be sure to change the path after `namespace` for your vendor and module names.
 


### PR DESCRIPTION
## Purpose of this pull request

This pull request (PR) fixes a visual bug on the [Create an integration](https://devdocs.magento.com/guides/v2.2/get-started/create-integration.html) page.

**Actual state:**

<img width="1015" alt="6187_actual" src="https://user-images.githubusercontent.com/13585327/70627582-294a5780-1c2f-11ea-816b-377d3a25b714.png">


**Expected result:**

<img width="982" alt="6187_expected" src="https://user-images.githubusercontent.com/13585327/70627601-2f403880-1c2f-11ea-9b2e-fa61cd3d27a3.png">


## Affected DevDocs pages

<!-- REQUIRED List the affected pages on devdocs.magento.com (URLs). Not needed for large numbers of files. -->

-  https://devdocs.magento.com/guides/v2.2/get-started/create-integration.html

## Links to Magento source code

<!--  OPTIONAL - REMOVE THIS SECTION IF NOT USED. If this pull request references a file in a Magento codebase repository, add it here. -->

-  ...

<!--
If you are fixing a GitHub issue, note it using GitHub keyword format (https://help.github.com/en/articles/closing-issues-using-keywords#closing-an-issue-in-a-different-repository) to close the issue when this pull request is merged. Example: `Fixes #1234`

`master` is the default branch. Merged pull requests to `master` go live on the site automatically. Any requested changes to content on the `master` branch must be related to the released codebase. Any content related to future releases goes in the `develop` branch.

See Contribution guidelines (https://github.com/magento/devdocs/blob/master/.github/CONTRIBUTING.md) for more information.
-->

Thank you!