### PR TITLE
Small typo in code example

### DIFF
--- a/src/guides/v2.2/extension-dev-guide/proxies.md
+++ b/src/guides/v2.2/extension-dev-guide/proxies.md
@@ -35,7 +35,7 @@ class FastLoading
     public function __construct(
         SlowLoading $slowLoading
     ){
-        $this->slowLoading = slowLoading;
+        $this->slowLoading = $slowLoading;
     }
 
     public function getFastValue()


### PR DESCRIPTION
There is small typo with using variable in code example.

## Purpose of this pull request

This pull request (PR) ...

## Affected DevDocs pages

<!-- REQUIRED List the affected pages on devdocs.magento.com (URLs). Not needed for large numbers of files. -->

- https://devdocs.magento.com/guides/v2.3/extension-dev-guide/proxies.html

## Links to Magento source code

<!--  OPTIONAL - REMOVE THIS SECTION IF NOT USED. If this pull request references a file in a Magento codebase repository, add it here. -->

- src/guides/v2.2/extension-dev-guide/proxies.md
<!--
If you are fixing a GitHub issue, note it using GitHub keyword format (https://help.github.com/en/articles/closing-issues-using-keywords#closing-an-issue-in-a-different-repository) to close the issue when this pull request is merged. Example: `Fixes #1234`

`master` is the default branch. Merged pull requests to `master` go live on the site automatically. Any requested changes to content on the `master` branch must be related to the released codebase. Any content related to future releases goes in the `develop` branch.

See Contribution guidelines (https://github.com/magento/devdocs/blob/master/.github/CONTRIBUTING.md) for more information.
-->
