### PR TITLE
Indexer reset command added with examples

### DIFF
--- a/src/guides/v2.3/config-guide/cli/config-cli-subcommands-index.md
+++ b/src/guides/v2.3/config-guide/cli/config-cli-subcommands-index.md
@@ -123,6 +123,40 @@ Catalog Search index has been rebuilt successfully in <time>
 {:.bs-callout-info}
 Reindexing all indexers can take a long time for stores with large numbers of products, customers, categories, and promotional rules.
 
+## Reset Indexer
+
+Use this command to reset the indexer status to invalid for all indexers or specific indexers.
+
+Command options:
+
+```bash
+bin/magento indexer:reset [indexer]
+```
+
+Where ```[indexer]``` is a space-separated list of indexers. Omit ```[indexer]``` to reset all indexers.
+
+A sample follows:
+
+```bash
+bin/magento indexer:reset
+```
+
+Sample result:
+
+```terminal
+Design Config Grid indexer has been invalidated.
+Customer Grid indexer has been invalidated.
+Category Products indexer has been invalidated.
+Product Categories indexer has been invalidated.
+Catalog Rule Product indexer has been invalidated.
+Product EAV indexer has been invalidated.
+Inventory indexer has been invalidated.
+Catalog Product Rule indexer has been invalidated.
+Stock indexer has been invalidated.
+Product Price indexer has been invalidated.
+Catalog Search indexer has been invalidated.
+```
+
 ## Configure indexers
 
 Use this command to set the following indexer options:

--- a/src/guides/v2.3/config-guide/cli/config-cli-subcommands-index.md
+++ b/src/guides/v2.3/config-guide/cli/config-cli-subcommands-index.md
@@ -123,9 +123,9 @@ Catalog Search index has been rebuilt successfully in <time>
 {:.bs-callout-info}
 Reindexing all indexers can take a long time for stores with large numbers of products, customers, categories, and promotional rules.
 
-## Reset Indexer
+## Reset indexer
 
-Use this command to reset the indexer status to invalid for all indexers or specific indexers.
+Use this command to invalidate the status of all indexers or specific indexers.
 
 Command options:
 
@@ -133,7 +133,7 @@ Command options:
 bin/magento indexer:reset [indexer]
 ```
 
-Where ```[indexer]``` is a space-separated list of indexers. Omit ```[indexer]``` to reset all indexers.
+Where ```[indexer]``` is a space-separated list of indexers. Omit `[indexer]` to invalidate all indexers.
 
 A sample follows:
 


### PR DESCRIPTION
## Purpose of this pull request

Added command for Indexer reset. 

## Affected DevDocs pages

<!-- REQUIRED List the affected pages on devdocs.magento.com (URLs). Not needed for large numbers of files. -->

-  https://devdocs.magento.com/guides/v2.3/config-guide/cli/config-cli-subcommands-index.html

whatsnew
Added the "Reset indexer" section to [Manage the indexers](https://devdocs.magento.com/guides/v2.3/config-guide/cli/config-cli-subcommands-index.html) in the _Configuration Guide_.
