### PR TITLE
Updates for ece-tools 2002.1.0 backwards incompatible changes

### DIFF
--- a/src/_data/toc/cloud-guide.yml
+++ b/src/_data/toc/cloud-guide.yml
@@ -539,3 +539,7 @@ pages:
         - label: magento-cloud-patches
           url: /cloud/release-notes/mcp-release-notes.html
           versionless: true
+
+        - label: Backward incompatible changes
+          url: /cloud/release-notes/backward-incompatible-changes.html
+          versionless: true

--- a/src/cloud/configure/setup-cron-jobs.md
+++ b/src/cloud/configure/setup-cron-jobs.md
@@ -176,7 +176,7 @@ To disable cron jobs:
    ```shell
    ./vendor/bin/ece-tools cron:disable
    ```
-   
+
 1. After you complete any required maintenance tasks, ensure that you enable the cron jobs again.
 
 ```shell

--- a/src/cloud/deploy/static-content-deployment.md
+++ b/src/cloud/deploy/static-content-deployment.md
@@ -27,8 +27,6 @@ Deployment strategies differ based on whether you choose to generate static cont
 
 Generating static content during the build phase with minified HTML is the optimal configuration for [**zero-downtime** deployments]({{ site.baseurl }}/cloud/deploy/reduce-downtime.html), also known as the **ideal state**. Instead of copying files to a mounted drive, it creates a symlink from the `./init/pub/static` directory.
 
-By default, the [STATIC_CONTENT_SYMLINK environment variable]({{ site.baseurl }}/cloud/env/variables-deploy.html#static_content_symlink) is set to `true`. After generating the static content during the build phase, it creates a symlink to the content folder.
-
 Generating static content requires access to themes and locales. Magento stores themes in the file system, which is accessible during the build phase; however, Magento stores locales in the database. The database is _not_ available during the build phase. In order to generate the static content during the build phase, you must use the `config:dump` command in the {{site.data.var.ct}} package to move locales to the file system. It reads the locales and saves them in the `app/etc/config.php` file.
 
 {:.procedure}

--- a/src/cloud/docker/docker-development-testing.md
+++ b/src/cloud/docker/docker-development-testing.md
@@ -17,9 +17,9 @@ Before you run functional tests, you must prepare your environment with the foll
 
 1. Clone the {{site.data.var.ct}} GitHub repository.
 
-    ```bash
-    git clone git@github.com:magento/ece-tools.git
-    ```
+   ```bash
+   git clone git@github.com:magento/ece-tools.git
+   ```
 
 1. Stop all services that use the following ports:
 
@@ -29,35 +29,35 @@ Before you run functional tests, you must prepare your environment with the foll
 
 1. Update the hosts file.
 
-    Before you begin, you must add the following hostname to your `/etc/hosts` file:
+   Before you begin, you must add the following hostname to your `/etc/hosts` file:
 
-    ```
-    127.0.0.1 magento2.docker
-    ```
+   ```bash
+   127.0.0.1 magento2.docker
+   ```
 
-    Alternatively, you can run the following command to add it to the file:
+   Alternatively, you can run the following command to add it to the file:
 
-    ```bash
-    echo "127.0.0.1 magento2.docker" | sudo tee -a /etc/hosts
-    ```
+   ```bash
+   echo "127.0.0.1 magento2.docker" | sudo tee -a /etc/hosts
+   ```
 
 1. Switch to the preferred PHP version for running tests.
 
 1. Update the project dependencies.
 
-    ```bash
-    composer update
-    ```
+   ```bash
+   composer update
+   ```
 
 1. Add credentials to the Docker environment.
 
-    ```bash
-    echo "COMPOSER_MAGENTO_USERNAME=your_public_key" >> ./.docker/composer.env
-    ```
+   ```bash
+   echo "COMPOSER_MAGENTO_USERNAME=your_public_key" >> ./.docker/composer.env
+   ```
 
-    ```bash
-    echo "COMPOSER_MAGENTO_PASSWORD=your_private_key" >> ./.docker/composer.env
-    ```
+   ```bash
+   echo "COMPOSER_MAGENTO_PASSWORD=your_private_key" >> ./.docker/composer.env
+   ```
 
 ## Run tests
 
@@ -110,32 +110,26 @@ PostDeployCest: Test post deploy | {"ADMIN_EMAIL":"admin@example.com"}
 
 The following list provides the commands to run all available tests for each version of PHP.
 
--  **PHP 7.0**
-
-    ```bash
-    ./vendor/bin/codecept run -g php70 --steps
-    ```
-
 -  **PHP 7.1**
 
-    ```bash
-    ./vendor/bin/codecept run -g php71 --steps
-    ```
+   ```bash
+   ./vendor/bin/codecept run -g php71 --steps
+   ```
 
 -  **PHP 7.2**
 
-    ```bash
-    ./tests/travis/prepare_functional_parallel.sh
-    ```
+   ```bash
+   ./tests/travis/prepare_functional_parallel.sh
+   ```
 
-    ```bash
-    ./vendor/bin/codecept run -g php72parallel_1 --steps
-    ```
+   ```bash
+   ./vendor/bin/codecept run -g php72parallel_1 --steps
+   ```
 
-    ```bash
-    ./vendor/bin/codecept run -g php72parallel_2 --steps
-    ```
+   ```bash
+   ./vendor/bin/codecept run -g php72parallel_2 --steps
+   ```
 
-    ```bash
-    ./vendor/bin/codecept run -g php72parallel_3 --steps
-    ```
+   ```bash
+   ./vendor/bin/codecept run -g php72parallel_3 --steps
+   ```

--- a/src/cloud/env/variables-build.md
+++ b/src/cloud/env/variables-build.md
@@ -47,28 +47,12 @@ stage:
     SCD_COMPRESSION_TIMEOUT: 800
 ```
 
-### `SCD_EXCLUDE_THEMES`
-
-{:.bs-callout-warning}
-The `SCD_EXCLUDE_THEMES` environment variable is deprecated in [ece-tools version 2002.0.16]({{ site.baseurl }}/cloud/release-notes/ece-release-notes.html#v2002016). Use the [SCD_MATRIX variable](#scd_matrix) to control theme configuration.
-
--  **Default**—_Not set_
--  **Version**—Magento 2.1.4 and later
-
-Themes include numerous files. Set this variable to `true` if you want to skip copying over theme files during build. This is helpful when static content deployment occurs during the build phase. Use commas to separate multiple theme locations. For example, the Luma theme is included with {{site.data.var.ece}}. You may not need to constantly build this theme with your code updates and deployments. To exclude the `magento/luma` theme:
-
-```yaml
-stage:
-  build:
-    SCD_EXCLUDE_THEMES: "magento/luma, magento/my-theme"
-```
-
 ### `SCD_MATRIX`
 
 -  **Default**—_Not set_
 -  **Version**—Magento 2.1.4 and later
 
-You can configure multiple locales per theme as long as the theme is not excluded using the `SCD_EXCLUDE_THEMES` variable during build. This is ideal if you want to speed up the build process by reducing the amount of unnecessary theme files. For example, you can build the _magento/backend_ theme in English and a custom theme in other languages.
+You can configure multiple locales per theme. This customization helps speed up the build process by reducing the number of unnecessary theme files. For example, you can build the _magento/backend_ theme in English and a custom theme in other languages.
 
 The following example builds the `magento/backend` theme with three locales:
 

--- a/src/cloud/env/variables-deploy.md
+++ b/src/cloud/env/variables-deploy.md
@@ -410,28 +410,12 @@ stage:
     SCD_COMPRESSION_TIMEOUT: 800
 ```
 
-### `SCD_EXCLUDE_THEMES`
-
-{:.bs-callout-warning}
-The `SCD_EXCLUDE_THEMES` environment variable is deprecated in [ece-tools version 2002.0.16]({{ site.baseurl }}/cloud/release-notes/ece-release-notes.html#v2002016). Use the [SCD_MATRIX variable](#scd_matrix) to control theme configuration.
-
--  **Default**—_Not set_
--  **Version**—Magento 2.1.4 and later
-
-Themes can include numerous files. Set this variable to `true` if you want to skip copying over theme files during deployment. For example, the Luma theme is included with {{site.data.var.ece}}. You may not need to constantly deploy this theme with your code updates and deployments. To exclude the `magento/luma` theme:
-
-```yaml
-stage:
-  deploy:
-    SCD_EXCLUDE_THEMES: "magento/luma, magento/my-theme"
-```
-
 ### `SCD_MATRIX`
 
 -  **Default**—_Not set_
 -  **Version**—Magento 2.1.4 and later
 
-You can configure multiple locales per theme as long as the theme is not excluded using the [`SCD_EXCLUDE_THEMES` variable](#scd_exclude_themes) during deployment. This configuration is ideal to speed up the deployment process by reducing the amount of unnecessary theme files. For example, you can deploy the _magento/backend_ theme in English and a custom theme in other languages.
+You can configure multiple locales per theme. This customization speeds up the deployment process by reducing the number of unnecessary theme files. For example, you can deploy the _magento/backend_ theme in English and a custom theme in other languages.
 
 The following example deploys the `Magento/backend` theme with three locales:
 
@@ -586,26 +570,6 @@ stage:
   deploy:
     SKIP_SCD: true
 ```
-
-### `STATIC_CONTENT_SYMLINK`
-
--  **Default**—`true`
--  **Version**—Magento 2.1.4 and later
-
-Generates symlinks for static content. This setting is vital in the Pro Production environment for the three-node cluster. When this variable is set to `false`, it must copy every file during the deployment, which increases deployment time. Setting the [`SCD_ON_DEMAND` variable]({{ site.baseurl }}/cloud/env/variables-global.html#scd_on_demand) to `true` disables this variable.
-
-If you generate static content during the build phase, it creates a symlink to the content folder.
-If you generate static content during the deploy phase, it writes directly to the content folder.
-Generating static content on demand disables this variable.
-
-```yaml
-stage:
-  deploy:
-    STATIC_CONTENT_SYMLINK: false
-```
-
-{:.bs-callout-warning}
-The `STATIC_CONTENT_SYMLINK` environment variable is marked as deprecated and will be removed in future releases. It's not recommended to use it in your deployment configuration. Ece-tools will always generate symlinks for static content.
 
 ### `UPDATE_URLS`
 

--- a/src/cloud/env/variables-global.md
+++ b/src/cloud/env/variables-global.md
@@ -47,7 +47,7 @@ stage:
     SCD_ON_DEMAND: true
 ```
 
-The `SCD_ON_DEMAND` variable skips the SCD and the `STATIC_CONTENT_SYMLINK` in both phases (build and deploy), clears the `pub/static` and `var/view_preprocessed` folders, and writes the following to the `app/etc/env.php` file:
+The `SCD_ON_DEMAND` variable skips the SCD in both phases (build and deploy), clears the `pub/static` and `var/view_preprocessed` folders, and writes the following to the `app/etc/env.php` file:
 
 ```php?start_inline=1
 return array(
@@ -66,6 +66,7 @@ return array(
 Allows you to increase the maximum expected execution time for static content deployment.
 
 By default, Magento Commerce sets the maximum expected execution to 400 seconds, but in some scenarios you might need more time to complete the static content deployment for a Cloud project.
+
 ```yaml
 stage:
   global:

--- a/src/cloud/env/variables-post-deploy.md
+++ b/src/cloud/env/variables-post-deploy.md
@@ -98,14 +98,14 @@ Customize the list of pages used to preload the cache in the `post_deploy` stage
             - "category:|car_.*?\\.html$|:2"
             - "category:|tires_.*|:store_gb"
       ```
-  
+
    The following example caches for the `product` entity type based on these criteria:
-   - all products for all store (programmatically limited to 100 per store to avoid performance issues) 
-   - all products for store `store1`
-   - products with `sku1` for all stores
-   - products with `sku1` for stores with code `store1` and `store2`
-   - products with `sku1`, `sku2` and `sku3` for stores with code `store1` and `store2`
-   
+   -  all products for all store (programmatically limited to 100 per store to avoid performance issues)
+   -  all products for store `store1`
+   -  products with `sku1` for all stores
+   -  products with `sku1` for stores with code `store1` and `store2`
+   -  products with `sku1`, `sku2` and `sku3` for stores with code `store1` and `store2`
+
       ```yaml
       stage:
         post-deploy:
@@ -116,12 +116,12 @@ Customize the list of pages used to preload the cache in the `post_deploy` stage
             - "product:sku1:store1|store2"
             - "product:sku1|sku2|sku3:store1|store2"
       ```
-      
-   The following example caches for the `store-page` entity type based on these criteria: 
-   - page `/contact-us` for all stores
-   - page `/contact-us` for store with ID `1`
-   - page `/contact-us` for stores with code `code1` and `code2`
-   
+
+   The following example caches for the `store-page` entity type based on these criteria:
+   -  page `/contact-us` for all stores
+   -  page `/contact-us` for store with ID `1`
+   -  page `/contact-us` for stores with code `code1` and `code2`
+
    ```yaml
          stage:
            post-deploy:
@@ -129,7 +129,8 @@ Customize the list of pages used to preload the cache in the `post_deploy` stage
                - "store-page:/contact-us:*"
                - "store-page:/contact-us:1"
                - "store-page:/contact-us:code1|code2"
-   ```      
+   ```
+
 [hooks section]: {{site.baseurl}}/cloud/project/project-conf-files_magento-app.html#hooks
 [CMS]: https://glossary.magento.com/cms/
 [Content elements]: https://docs.magento.com/m2/ce/user_guide/cms/content-elements.html

--- a/src/cloud/project/project-conf-files_magento-app.md
+++ b/src/cloud/project/project-conf-files_magento-app.md
@@ -30,7 +30,7 @@ The `type`  and `build` properties provide information about the base container 
 The supported `type` language is [PHP](https://glossary.magento.com/php). Specify the PHP version as follows:
 
 ```yaml
-type: php:7.1
+type: php:<version>
 ```
 
 The `build` property determines what happens by default when building the project. The `flavor` specifies a default set of build tasks to run. The supported flavor is `composer`.
@@ -290,13 +290,13 @@ crons:
         cmd: "php bin/magento cron:run"
 ```
 
-For {{site.data.var.ece}} 2.1.X, you can use only [workers](#workers) and [cron jobs](#crons). For {{site.data.var.ece}} 2.2.X, cron jobs launch consumers to process batches of messages, and do not require additional configuration.
+For {{site.data.var.ece}} 2.1.x, you can use only [workers](#workers) and [cron jobs](#crons). For {{site.data.var.ece}} 2.2.x, cron jobs launch consumers to process batches of messages, and do not require additional configuration.
 
 If your project requires custom cron jobs, you can add them to the default cron configuration. See [Set up cron jobs]({{ site.baseurl }}/cloud/configure/setup-cron-jobs.html).
 
 ## Variables
 
-The following environment variables are included in `.magento.app.yaml`. These are required for {{site.data.var.ece}} 2.2.X.
+The following environment variables are included in `.magento.app.yaml`. These are required for {{site.data.var.ece}} 2.2.x.
 
 ```yaml
 variables:
@@ -312,7 +312,7 @@ You can choose which version of PHP to run in your `.magento.app.yaml` file:
 
 ```yaml
 name: mymagento
-type: php:7.2
+type: php:<version>
 ```
 
 ### PHP extensions
@@ -493,4 +493,4 @@ workers:
 
 This example defines a single worker named queue, with a "small" container, and runs the command `php worker.php` on startup. If `worker.php` exits, it is automatically restarted.
 
-For {{site.data.var.ece}} 2.1.X, you can use only [workers](#workers) and [cron jobs](#crons). For {{site.data.var.ece}} 2.2.X, cron jobs launch consumers to process batches of messages, and does not require additional configuration.
+For {{site.data.var.ece}} 2.1.x, you can use only [workers](#workers) and [cron jobs](#crons). For {{site.data.var.ece}} 2.2.x, cron jobs launch consumers to process batches of messages, and does not require additional configuration.

--- a/src/cloud/project/project-conf-files_services.md
+++ b/src/cloud/project/project-conf-files_services.md
@@ -165,7 +165,7 @@ Service   |  Magento 2.3  | Magento 2.2
 `mariadb` | 10.0 to 10.2  | 10.0 to 10.2
 `nginx`   | 1.9           | 1.9
 `node`    | 6, 8, 10, 11  | 6, 8, 10, 11
-`php`     | Magento 2.3.3 and later—7.1, 7.2, 7.3<br>Magento 2.3.0 to 2.3.2—7.1, 7.2 | Magento 2.2.10 and later—7.1, 7.2<br>Magento 2.2.5 to 2.2.9—7.0, 7.1<br>Magento 2.2.4 and earlier—7.0.2, 7.0.4, ~7.0.6, 7.1
+`php`     | Magento 2.3.3 and later—7.1, 7.2, 7.3<br>Magento 2.3.0 to 2.3.2—7.1, 7.2 | Magento 2.2.10 and later—7.1, 7.2<br>Magento 2.2.5 to 2.2.9—7.0, 7.1<br>Magento 2.2.4 and earlier—7.0.2, 7.0.4, ~7.0.6, 7.1<br><br>**Note:**  If you use {{ site.data.var.ct }} v2002.1.0 or later, you must use php version 7.1.3 or later for both Magento 2.2 and 2.3 releases.
 `rabbitmq`| 3.5, 3.7      | 3.5
 `redis`   | 3.2, 4.0, 5.0 | 3.2, 4.0, 5.0
 `varnish` | Magento 2.3.3 and later—4.0, 5.0, 6.2<br>Magento 2.3.0 to 2.3.2—4.0, 5.0 | 4.0, 5.0

--- a/src/cloud/project/project-conf-files_services.md
+++ b/src/cloud/project/project-conf-files_services.md
@@ -165,7 +165,7 @@ Service   |  Magento 2.3  | Magento 2.2
 `mariadb` | 10.0 to 10.2  | 10.0 to 10.2
 `nginx`   | 1.9           | 1.9
 `node`    | 6, 8, 10, 11  | 6, 8, 10, 11
-`php`     | Magento 2.3.3 and later—7.1, 7.2, 7.3<br>Magento 2.3.0 to 2.3.2—7.1, 7.2 | Magento 2.2.10 and later—7.1, 7.2<br>Magento 2.2.5 to 2.2.9—7.0, 7.1<br>Magento 2.2.4 and earlier—7.0.2, 7.0.4, ~7.0.6, 7.1<br><br>**Note:**  If you use {{ site.data.var.ct }} v2002.1.0 or later, you must use php version 7.1.3 or later for both Magento 2.2 and 2.3 releases.
+`php`     | Magento 2.3.3 and later—7.1, 7.2, 7.3<br>Magento 2.3.0 to 2.3.2—7.1, 7.2 | Magento 2.2.10 and later—7.1, 7.2<br>Magento 2.2.5 to 2.2.9—7.0, 7.1<br>Magento 2.2.4 and earlier—7.0.2, 7.0.4, ~7.0.6, 7.1<br><br>**Note:**  If you use {{ site.data.var.ct }} v2002.1.0 or later, you must use PHP version 7.1.3 or later for both Magento 2.2 and 2.3 releases.
 `rabbitmq`| 3.5, 3.7      | 3.5
 `redis`   | 3.2, 4.0, 5.0 | 3.2, 4.0, 5.0
 `varnish` | Magento 2.3.3 and later—4.0, 5.0, 6.2<br>Magento 2.3.0 to 2.3.2—4.0, 5.0 | 4.0, 5.0

--- a/src/cloud/project/project-conf-files_services.md
+++ b/src/cloud/project/project-conf-files_services.md
@@ -165,7 +165,7 @@ Service   |  Magento 2.3  | Magento 2.2
 `mariadb` | 10.0 to 10.2  | 10.0 to 10.2
 `nginx`   | 1.9           | 1.9
 `node`    | 6, 8, 10, 11  | 6, 8, 10, 11
-`php`     | Magento 2.3.3 and later—7.1, 7.2, 7.3<br>Magento 2.3.0 to 2.3.2—7.1, 7.2 | Magento 2.2.10 and later—7.1, 7.2<br>Magento 2.2.5 to 2.2.9—7.0, 7.1<br>Magento 2.2.4 and earlier—7.0.2, 7.0.4, ~7.0.6, 7.1<br><br>**Note:**  If you use {{ site.data.var.ct }} v2002.1.0 or later, you must use PHP version 7.1.3 or later for both Magento 2.2 and 2.3 releases.
+`php`     | Magento 2.3.3 and later—7.1, 7.2, 7.3<br>Magento 2.3.0 to 2.3.2—7.1, 7.2 | Magento 2.2.10 and later—7.1, 7.2<br>Magento 2.2.5 to 2.2.9—7.0, 7.1<br>Magento 2.2.4 and earlier—7.0.2, 7.0.4, ~7.0.6, 7.1<br><br>**Note:** Beginning with {{ site.data.var.ct }} v2002.1.0, you must use PHP version 7.1.3 or later for both Magento 2.2 and 2.3.
 `rabbitmq`| 3.5, 3.7      | 3.5
 `redis`   | 3.2, 4.0, 5.0 | 3.2, 4.0, 5.0
 `varnish` | Magento 2.3.3 and later—4.0, 5.0, 6.2<br>Magento 2.3.0 to 2.3.2—4.0, 5.0 | 4.0, 5.0

--- a/src/cloud/release-notes/backward-incompatible-changes.md
+++ b/src/cloud/release-notes/backward-incompatible-changes.md
@@ -7,7 +7,7 @@ Use the following information to learn about backward incompatible changes that 
 
 ### Service version requirement changes
 
-We changed the minimum PHP minimum requirement from 7.1.0 to 7.1.3+ in `{{ site.data.var.ct }}` v2002.1.0 and later. If your environment configuration specifies an earlier version, update the [php configuration]({{ site.baseurl }}/cloud/project/project-conf-files_magento-app.html#configure-php-options) in the `.magento.app.yaml` file.
+We changed the minimum PHP version requirement from 7.1.0 to 7.1.3+ for Cloud projects that use `{{ site.data.var.ct }}` v2002.1.0 and later. If your environment configuration specifies an earlier version, update the [php configuration]({{ site.baseurl }}/cloud/project/project-conf-files_magento-app.html#configure-php-options) in the `.magento.app.yaml` file.
 
 ### Environment configuration changes
 

--- a/src/cloud/release-notes/backward-incompatible-changes.md
+++ b/src/cloud/release-notes/backward-incompatible-changes.md
@@ -1,37 +1,36 @@
 ---
-group: release-notes
-title: Backward Incompatible Changes
+group: cloud-guide
+title: Backward incompatible changes
 ---
 
-Use the following information to learn about backward incompatible changes that require you to adjust Cloud configuration and processes for existing Cloud projects when you upgrade to the latest release of the {{site.data.var.ct}} package or other {{site.data.var.csuite}} packages.
+Use the following information to learn about backward incompatible changes that might require you to adjust Cloud configuration and processes for existing Cloud projects when you upgrade to the latest release of the {{site.data.var.ct}} package or other {{site.data.var.csuite}} packages.
 
 ### Service version requirement changes
 
-**PHP minimum version requirement**–In {{ site.data.var.ct }} v2002.1.0 and later, the minimum php version requirement is 7.1.3+. If your environment configuration specifies an earlier version, update the [php configuration]({{ site.baseurl }}/cloud/project/project-conf-files_magento-app.html#configure-php-options) in the `.magento.app.yaml` file. 
+We changed the minimum PHP minimum requirement from 7.1.0 to 7.1.3+ in `{{ site.data.var.ct }}` v2002.1.0 and later. If your environment configuration specifies an earlier version, update the [php configuration]({{ site.baseurl }}/cloud/project/project-conf-files_magento-app.html#configure-php-options) in the `.magento.app.yaml` file.
 
-### Environment variable changes
+### Environment configuration changes
 
-The following environment variables have been removed from the `{{site.var.data.ct}}` package:
-
--  `SCD_EXCLUDE_THEMES`–use the `SCD_MATRIX` variable instead.
--  `STATIC_CONTENT_THREADS`–use the `SCD_THREADS` variable the instead.
--  `DO_DEPLOY_STATIC_CONTENT`–use the `SKIP_SCD` variable instead.
--  `STATIC_CONTENT_SYMLINK`–Now, the `{{site.data.var.ct}}` always generates symlinks for static content in the `pub/static` directory when you generate static content during the build process.
+   Item | Status | Replacement
+   -------- |------- | -------
+   `SCD_EXCLUDE_THEMES` variable | Removed in `{{ site.data.var.ct }}` v2002.1.0 | [`SCD_MATRIX`]({{ site.baseurl}}/cloud/env/variables-build.html#scd_matrix)
+   `STATIC_CONTENT_THREADS` variable| Removed in `{{ site.data.var.ct }}` v2002.1.0 | [`SCD_THREADS`]({{ site.baseurl}}/cloud/env/variables-build.html#scd_threads)
+   `DO_DEPLOY_STATIC_CONTENT` variable | Removed in `{{ site.data.var.ct }}` v2002.1.0 | [`SKIP_SCD`]({{ site.baseurl}}/cloud/env/variables-build.html#skip_scd)
+   `STATIC_CONTENT_SYMLINK` variable | Removed in `{{site.data.var.ct}}` v2002.1.0 | None. Now, the build always creates a symlink to the static content directory `pub/static`.
+   `build_options.ini` file | Removed in `{{site.data.var.ct}}` v2002.1.0 | Use the [`.magento.env.yaml`]({{ site.baseurl }}/cloud/project/magento-env-yaml.html)) file to configure environment variables to manage build and deploy actions across all your environments.<br><br>If you build a Cloud environment that includes the `build_options.ini` file, the build fails.
 
 ### CLI command changes
 
-The {{site.var.data.ct}} package no longer supports the following CLI commands:
+The {{site.data.var.ct}} package no longer supports the following CLI commands in version 2002.1.0 and later:
 
-- `m2-ece-build`–use the `vendor/bin/ece-tools build` instead
-- `m2-ece-deploy`–use the `vendor/bin/ece-tools deploy` instead
-- `m2-ece-scd-dump`–use the `vendor/bin/ece-tools config:dump` instead
-
-### Removed support the `build_options.ini` file
-
-Use the `.magento.env.yaml` file instead. If you build a Cloud environment that includes the `build_options.ini` file, the build fails.
+ Command| Replacement
+ -------- |-------
+`m2-ece-build` | `vendor/bin/ece-tools build`
+`m2-ece-deploy` | `vendor/bin/ece-tools deploy`
+`m2-ece-scd-dump` | `vendor/bin/ece-tools config:dump`
 
 ### Package changes
 
--  **New `magento/magento-cloud-patches` package**–In {{ site.data.var.ct }} v2002.22.0 and later, we moved {{ site.data.var.ece }} patches and related functionality to a separate package,`magento/magento-cloud-patches`. See [Release notes for magento/magento-cloud-patches]({{site.baseurl}}/cloud/release-notes/mcp-release-notes.md).
+-  **New magento/magento-cloud-patches package**–We moved {{ site.data.var.ece }} patches and related functionality to a separate package, `magento/magento-cloud-patches` in {{ site.data.var.ct }} version 2002.1.0. See [Release notes for magento/magento-cloud-patches]({{site.baseurl}}/cloud/release-notes/mcp-release-notes.html).
 
-- **New `magento/magento-cloud-docker` package**–In {{ site.data.var.ct }} v2002.1.0 and later, we moved Docker development functionality to a separate package, `magento-cloud-docker`. See [Release notes for magento/magento-cloud-docker]({{site.baseurl}}/cloud/release-notes/mcd-release-notes.md).
+-  **New magento/magento-cloud-docker package**–We moved Docker development functionality to a separate package in {{ site.data.var.ct }} v2002.1.0. See [Release notes for magento/magento-cloud-docker]({{ site.baseurl }}/cloud/release-notes/mcd-release-notes.html).

--- a/src/cloud/release-notes/backward-incompatible-changes.md
+++ b/src/cloud/release-notes/backward-incompatible-changes.md
@@ -13,8 +13,8 @@ We changed the minimum PHP version requirement from 7.0.x to 7.1.x for Cloud pro
 
 The folllowing table provides information about environment variables and other environment configuration files that were removed or deprecated in `{{ site.data.var.ct }}` v2002.1.0.
 
-   Item | Status | Replacement
-   -------- |------- | -------
+   Item | Replacement
+   -------- | -------
    `SCD_EXCLUDE_THEMES` variable | [`SCD_MATRIX`]({{ site.baseurl}}/cloud/env/variables-build.html#scd_matrix)
    `STATIC_CONTENT_THREADS` variable | [`SCD_THREADS`]({{ site.baseurl}}/cloud/env/variables-build.html#scd_threads)
    `DO_DEPLOY_STATIC_CONTENT` variable | [`SKIP_SCD`]({{ site.baseurl}}/cloud/env/variables-build.html#skip_scd)

--- a/src/cloud/release-notes/backward-incompatible-changes.md
+++ b/src/cloud/release-notes/backward-incompatible-changes.md
@@ -7,27 +7,31 @@ Use the following information to learn about backward incompatible changes that 
 
 ### Service version requirement changes
 
-We changed the minimum PHP version requirement from 7.1.0 to 7.1.3+ for Cloud projects that use `{{ site.data.var.ct }}` v2002.1.0 and later. If your environment configuration specifies an earlier version, update the [php configuration]({{ site.baseurl }}/cloud/project/project-conf-files_magento-app.html#configure-php-options) in the `.magento.app.yaml` file.
+We changed the minimum PHP version requirement from 7.0.x to 7.1.x for Cloud projects that use `{{ site.data.var.ct }}` v2002.1.0 and later. If your environment configuration specifies PHP 7.0, update the [php configuration]({{ site.baseurl }}/cloud/project/project-conf-files_magento-app.html#configure-php-options) in the `.magento.app.yaml` file.
 
 ### Environment configuration changes
 
+The folllowing table provides information about environment variables and other environment configuration files that were removed or deprecated in `{{ site.data.var.ct }}` v2002.1.0.
+
    Item | Status | Replacement
    -------- |------- | -------
-   `SCD_EXCLUDE_THEMES` variable | Removed in `{{ site.data.var.ct }}` v2002.1.0 | [`SCD_MATRIX`]({{ site.baseurl}}/cloud/env/variables-build.html#scd_matrix)
-   `STATIC_CONTENT_THREADS` variable| Removed in `{{ site.data.var.ct }}` v2002.1.0 | [`SCD_THREADS`]({{ site.baseurl}}/cloud/env/variables-build.html#scd_threads)
-   `DO_DEPLOY_STATIC_CONTENT` variable | Removed in `{{ site.data.var.ct }}` v2002.1.0 | [`SKIP_SCD`]({{ site.baseurl}}/cloud/env/variables-build.html#skip_scd)
-   `STATIC_CONTENT_SYMLINK` variable | Removed in `{{site.data.var.ct}}` v2002.1.0 | None. Now, the build always creates a symlink to the static content directory `pub/static`.
-   `build_options.ini` file | Removed in `{{site.data.var.ct}}` v2002.1.0 | Use the [`.magento.env.yaml`]({{ site.baseurl }}/cloud/project/magento-env-yaml.html)) file to configure environment variables to manage build and deploy actions across all your environments.<br><br>If you build a Cloud environment that includes the `build_options.ini` file, the build fails.
+   `SCD_EXCLUDE_THEMES` variable | [`SCD_MATRIX`]({{ site.baseurl}}/cloud/env/variables-build.html#scd_matrix)
+   `STATIC_CONTENT_THREADS` variable | [`SCD_THREADS`]({{ site.baseurl}}/cloud/env/variables-build.html#scd_threads)
+   `DO_DEPLOY_STATIC_CONTENT` variable | [`SKIP_SCD`]({{ site.baseurl}}/cloud/env/variables-build.html#skip_scd)
+   `STATIC_CONTENT_SYMLINK` variable | None. Now, the build always creates a symlink to the static content directory `pub/static`.
+   `build_options.ini` file | Use the [`.magento.env.yaml`]({{ site.baseurl }}/cloud/project/magento-env-yaml.html)) file to configure environment variables to manage build and deploy actions across all your environments.<br><br>If you build a Cloud environment that includes the `build_options.ini` file, the build fails.
 
 ### CLI command changes
 
-The {{site.data.var.ct}} package no longer supports the following CLI commands in version 2002.1.0 and later:
+In {{ site.data.var.ct }} v2002.1.0, we removed support for the following CLI commands.
 
  Command| Replacement
  -------- |-------
 `m2-ece-build` | `vendor/bin/ece-tools build`
 `m2-ece-deploy` | `vendor/bin/ece-tools deploy`
 `m2-ece-scd-dump` | `vendor/bin/ece-tools config:dump`
+
+In earlier releases of {{ site.data.var.ct }}, you could use the `m2-ece-build` and `m2-ece-deploy` commands to configure deployment hooks in the `.magento.app.yaml` file. When you update to v2002.1.0, check the `hooks` configuration in the `.magento.app.yaml` file for the obsolete commands, and replace them if needed.
 
 ### Package changes
 

--- a/src/cloud/release-notes/ece-release-notes.md
+++ b/src/cloud/release-notes/ece-release-notes.md
@@ -33,7 +33,7 @@ The release notes include:
 -  {:.fix}Fixed an issue in the Elastic Suite configuration process so that the default configuration is overwritten as expected when you configure the `ELASTICSUITE_CONFIGURATION` deploy variable without the `_merge` option.<!--MAGECLOUD-4388-->
 
 {:.bs-callout-info}
-Before updating to {{ site.data.var.ct }} version 2002.1.0, review the [backward incompatible changes]({{ site.data.var.ece }}/cloud/release-notes/backward-incompatible-changes.html) to learn about changes that might require you to update the configuration or processes for your {{ site.data.var.ece }} project.
+Before updating to {{ site.data.var.ct }} version 2002.1.0, review the [backward incompatible changes]({{ site.baseurl }}/cloud/release-notes/backward-incompatible-changes.html) to learn about changes that might require you to update the configuration or processes for your {{ site.data.var.ece }} project.
 
 ## v2002.0.22
 

--- a/src/cloud/release-notes/ece-release-notes.md
+++ b/src/cloud/release-notes/ece-release-notes.md
@@ -28,9 +28,12 @@ The release notes include:
 
 -  {:.new}**Improved validation**–Added validation to check installed service versions against the EOL date for each service. Now, customers recieve a notification if a service version is within three months of the EOL date, and a warning if the EOL date is in the past.<!--MAGECLOUD-4076-->
 
-- {:.fix}Fixed an issue that caused the build process to fail if the `config.php` file is empty.<!--MAGECLOUD-4127-->
+-  {:.fix}Fixed an issue that caused the build process to fail if the `config.php` file is empty.<!--MAGECLOUD-4127-->
 
-- {:.fix}Fixed an issue in the Elastic Suite configuration process so that the default configuration is overwritten as expected when you configure the `ELASTICSUITE_CONFIGURATION` deploy variable without the `_merge` option.<!--MAGECLOUD-4388-->
+-  {:.fix}Fixed an issue in the Elastic Suite configuration process so that the default configuration is overwritten as expected when you configure the `ELASTICSUITE_CONFIGURATION` deploy variable without the `_merge` option.<!--MAGECLOUD-4388-->
+
+{:.bs-callout-info}
+Before updating to {{ site.data.var.ct }} version 2002.1.0, review the [backward incompatible changes]({{ site.data.var.ece }}/cloud/release-notes/backward-incompatible-changes.html) to learn about changes that might require you to update the configuration or processes for your {{ site.data.var.ece }} project.
 
 ## v2002.0.22
 
@@ -262,7 +265,7 @@ The `{{site.data.var.ct}}` version 2002.0.17 includes an important security patc
 
    -  <!-- MAGECLOUD-2823 -->**SCD_COMPRESSION_LEVEL**—Updated the documentation and the sample `.magento.env.yaml` file with the correct default values for SCD compression level. See the definitions in the [build variables]({{ site.baseurl }}/cloud/env/variables-build.html#scd_compression_level) and the [deploy variables]({{ site.baseurl }}/cloud/env/variables-deploy.html#scd_compression_level) content.
 
-   -  <!--MAGECLOUD-2882-->**SCD_EXCLUDE_THEMES**——This environment variable is deprecated. Use the SCD_MATRIX variable to control theme configuration. See the definitions in the [build variables]({{ site.baseurl }}/cloud/env/variables-build.html#scd_exclude_themes) and the [deploy variables]({{ site.baseurl }}/cloud/env/variables-deploy.html#scd_exclude_themes) content.
+   -  <!--MAGECLOUD-2882-->**SCD_EXCLUDE_THEMES**——This environment variable is deprecated. Use the [SCD_MATRIX]({{ site.baseurl }}/cloud/env/variables-build.html#scd_matrix) to control theme configuration.
 
    -  <!-- MAGECLOUD-2904 -->**SCD\_MATRIX**—Fixed the validation process to prevent a problem that occurred when the SCD_MATRIX ignored a theme value that contained different character cases. See the definitions in the [build variables]({{ site.baseurl }}/cloud/env/variables-build.html#scd_matrix) and the [deploy variables]({{ site.baseurl }}/cloud/env/variables-deploy.html#scd_matrix) content.
 


### PR DESCRIPTION
## Purpose of this pull request

- Removed references to outdated information related to backward incompatible changes introduced in the ece-tools package version 2002.1.0. 
- Updated the ece-tools release notes for 2002.1.0 with a link to the backward incompatible changes topic
- Streamlined backward incompatible changes information for CLI commands, environment configuration changes, and package updates.

**Quality checks:**
- [x] Preview build
- [x] Technical review
- [x] Editorial review
- [ ]  Updates based on review feedback

## Affected DevDocs pages

- https://devdocs.magento.com/cloud/release-notes/ece-release-notes.html
- https://devdocs.magento.com/cloud/release-notes/backward-incompatible-changes
- https://devdocs.magento.com/cloud/docker/docker-development-testing.html
- https://devdocs.magento.com/cloud/env/variables-build.html
- https://devdocs.magento.com/cloud/env/variables-deploy.html
- https://devdocs.magento.com/cloud/env/variables-global.html 
- https://devdocs.magento.com/cloud/project/project-conf-files_magento-app.html
- https://devdocs.magento.com/cloud/project/project-conf-files_services.html
