### PR TITLE
magento/devdocs#: Add removeCouponFromCart mutation API errors

### DIFF
--- a/src/guides/v2.3/graphql/mutations/remove-coupon.md
+++ b/src/guides/v2.3/graphql/mutations/remove-coupon.md
@@ -5,7 +5,7 @@ redirect from:
   - /guides/v2.3/graphql/reference/quote-remove-coupon.html
 ---
 
-The `removeCouponFromCart` mutation removes a previously-applied coupon from the cart.
+The `removeCouponFromCart` mutation removes a previously-applied coupon from the cart. The cart must contain at least one item in order to remove the coupon.
 
 ## Syntax
 

--- a/src/guides/v2.3/graphql/mutations/remove-coupon.md
+++ b/src/guides/v2.3/graphql/mutations/remove-coupon.md
@@ -99,3 +99,15 @@ Attribute |  Data Type | Description
 {% include graphql/cart-object.md %}
 
 [Cart query output]({{page.baseurl}}/graphql/queries/cart.html#cart-output) provides more information about the `Cart` object.
+
+## Errors
+
+Error | Description
+--- | ---
+`Cart does not contain products.` | The coupon cannot be removed from the empty cart.
+`Could not find a cart with ID "XXX"` | The specified `cart_id` value does not exist in the `quote_id_mask` table.
+`Current user does not have an active cart.` | User can not perform this mutation on the inactive cart. 
+`Required parameter "cart_id" is missing` | The required `cart_id` attribute contains an empty value.
+`The coupon code couldn't be deleted. Verify the coupon code and try again.` | Coupon has been not removed from the cart. Check the existing shopping cart price rules for details.
+`The current user cannot perform operations on cart XXX` | An unauthorized user (guest) tried to add the product into a customer's cart, or an authorized user (customer) tried to add the product into the cart of another customer.
+`Wrong store code specified for cart` | The specified `cart_id` does not exist in specified store.

--- a/src/guides/v2.3/graphql/mutations/remove-coupon.md
+++ b/src/guides/v2.3/graphql/mutations/remove-coupon.md
@@ -106,8 +106,8 @@ Error | Description
 --- | ---
 `Cart does not contain products.` | The coupon cannot be removed from the empty cart.
 `Could not find a cart with ID "XXX"` | The specified `cart_id` value does not exist in the `quote_id_mask` table.
-`Current user does not have an active cart.` | User can not perform this mutation on the inactive cart. 
+`Current user does not have an active cart.` | The user cannot perform this mutation on the inactive cart.
 `Required parameter "cart_id" is missing` | The required `cart_id` attribute contains an empty value.
-`The coupon code couldn't be deleted. Verify the coupon code and try again.` | Coupon has been not removed from the cart. Check the existing shopping cart price rules for details.
+`The coupon code couldn't be deleted. Verify the coupon code and try again.` | The coupon was not removed from the cart. Check the existing shopping cart price rules for details.
 `The current user cannot perform operations on cart XXX` | An unauthorized user (guest) tried to add the product into a customer's cart, or an authorized user (customer) tried to add the product into the cart of another customer.
 `Wrong store code specified for cart` | The specified `cart_id` does not exist in specified store.


### PR DESCRIPTION

## Purpose of this pull request

This pull request (PR) adds information about the API errors of `removeCouponFromCart` mutation.

## Affected DevDocs pages

<!-- REQUIRED List the affected pages on devdocs.magento.com (URLs). Not needed for large numbers of files. -->

-  https://devdocs.magento.com/guides/v2.3/graphql/mutations/remove-coupon.html

## Links to Magento source code

<!--  OPTIONAL - REMOVE THIS SECTION IF NOT USED. If this pull request references a file in a Magento codebase repository, add it here. -->

- [Cart does not contain products.](https://github.com/magento/magento2/blob/2.3.3/app/code/Magento/QuoteGraphQl/Model/Resolver/RemoveCouponFromCart.php#L68)
- [Could not find a cart with ID "XXX"](https://github.com/magento/magento2/blob/2.3.3/app/code/Magento/QuoteGraphQl/Model/Cart/GetCartForUser.php#L61)
- [Current user does not have an active cart.](https://github.com/magento/magento2/blob/2.3.3/app/code/Magento/QuoteGraphQl/Model/Cart/GetCartForUser.php#L76)
- [Required parameter "cart_id" is missing](https://github.com/magento/magento2/blob/2.3.3/app/code/Magento/QuoteGraphQl/Model/Resolver/RemoveCouponFromCart.php#L54)
- [The coupon code couldn't be deleted. Verify the coupon code and try again.]()
- [The current user cannot perform operations on cart XXX](https://github.com/magento/magento2/blob/2.3.3/app/code/Magento/QuoteGraphQl/Model/Cart/GetCartForUser.php#L99)
- [Wrong store code specified for cart](https://github.com/magento/magento2/blob/2.3.3/app/code/Magento/QuoteGraphQl/Model/Cart/GetCartForUser.php#L83)

<!--
If you are fixing a GitHub issue, note it using GitHub keyword format (https://help.github.com/en/articles/closing-issues-using-keywords#closing-an-issue-in-a-different-repository) to close the issue when this pull request is merged. Example: `Fixes #1234`

`master` is the default branch. Merged pull requests to `master` go live on the site automatically. Any requested changes to content on the `master` branch must be related to the released codebase. Any content related to future releases goes in the `develop` branch.

See Contribution guidelines (https://github.com/magento/devdocs/blob/master/.github/CONTRIBUTING.md) for more information.
-->

Thank you!