### PR TITLE
Extra colon removed

### DIFF
--- a/src/guides/v2.2/coding-standards/code-standard-less.md
+++ b/src/guides/v2.2/coding-standards/code-standard-less.md
@@ -346,7 +346,7 @@ Helper class names should be lowercase and start with underscore ("_").
 
 Some parts of Magento code might not comply with this standard yet. You might still find helper names with no underscores. We are working to gradually remove the inconsistency.
 
-**Example:**:
+**Example:**
 
 ```css
 ._active {


### PR DESCRIPTION
## Purpose of this pull request

This pull request (PR) 
Extra colon(":") removed after Example title of Helper classes section


## Affected DevDocs pages

https://devdocs.magento.com/guides/v2.3/coding-standards/code-standard-less.html
