### PR TITLE
Remove duplicated </a> tag.

### DIFF
--- a/src/guides/v2.3/coding-standards/code-standard-demarcation.md
+++ b/src/guides/v2.3/coding-standards/code-standard-demarcation.md
@@ -37,7 +37,7 @@ Use [RFC 2119](http://www.ietf.org/rfc/rfc2119.txt) to interpret the "MUST," "MU
    <p> ... </p>
    <p> ... </p>
 </section>
-<a href="#information-dialog-tree">Scroll to text</a></a>
+<a href="#information-dialog-tree">Scroll to text</a>
 ```
 
 **Unacceptable:**


### PR DESCRIPTION
## Purpose of this pull request
Remove duplicated `</a>` tag.

This pull request (PR) 
Semantics section Acceptable example remove duplicated `</a>` tag.

## Affected DevDocs pages
https://devdocs.magento.com/guides/v2.3/coding-standards/code-standard-demarcation.html
