### PR TITLE
Word "Differences" changed to "Relationship"

### DIFF
--- a/src/guides/v2.2/frontend-dev-guide/themes/theme-inherit.md
+++ b/src/guides/v2.2/frontend-dev-guide/themes/theme-inherit.md
@@ -38,7 +38,7 @@ The Orange theme by OrangeCo inherits from the Magento Blank theme. The inherita
 {:.bs-callout-info}
 A parent and a child theme can belong to different vendors. For example, your custom theme can inherit from the Magento Blank theme.
 
-## Differences between parent and child themes
+## Relationship between parent and child themes
 
 *  A child theme inherits view configuration, templates, layouts, and static file from its parents.
 


### PR DESCRIPTION
## Purpose of this pull request

This pull request (PR) 

will change Word "Differences" to "Relationship" in the title "Differences between parent and child themes"

The section says about the relationship between Parent and child theme not difference.

## Affected DevDocs pages
https://devdocs.magento.com/guides/v2.3/frontend-dev-guide/themes/theme-inherit.html