### PR TITLE
Introduced a space between "Translate" and "Inline"

### DIFF
--- a/src/guides/v2.2/ui_comp_guide/concepts/knockout-bindings.md
+++ b/src/guides/v2.2/ui_comp_guide/concepts/knockout-bindings.md
@@ -231,7 +231,7 @@ Defines whether the element is visible (`true`) or hidden (`false`).
 
 ### `i18n`
 
-The `i18n` binding is used to translate a string according to the currently enabled locale. Additionally, it creates the necessary elements for the TranslateInline jQuery widget, if it's enabled on the page.
+The `i18n` binding is used to translate a string according to the currently enabled locale. Additionally, it creates the necessary elements for the Translate Inline jQuery widget, if it's enabled on the page.
 
 **Source**: `<Magento_Ui_module_dir>/view/base/web/js/lib/knockout/bindings/i18n.js`. [See on GitHub]({{ site.mage2bloburl }}/{{ page.guide_version }}/app/code/Magento/Ui/view/base/web/js/lib/knockout/bindings/i18n.js).
 


### PR DESCRIPTION
## Purpose of this pull request 

Introduced a space between "Translate" and "Inline"

This pull request (PR) 

Introduced a space between "Translate" and "Inline"

## Affected DevDocs pages

https://devdocs.magento.com/guides/v2.3/ui_comp_guide/concepts/knockout-bindings.html#i18n


