### PR TITLE
Italic style removed from the word "is"

### DIFF
--- a/src/guides/v2.2/frontend-dev-guide/themes/js-bundling.md
+++ b/src/guides/v2.2/frontend-dev-guide/themes/js-bundling.md
@@ -47,7 +47,7 @@ JavaScript bundling does not work unless Magento is in [production mode][product
 
 ## How bundling works in Magento
 
-When you enable bundling, Magento combines hundreds of JavaScript files into just a few JavaScript bundles and downloads those bundles for each page. Because the browser downloads the bundles synchronously, page rendering *is* blocked until all bundles finish downloading. But the time saved from reducing server requests from hundreds to just a few, usually offsets the cost of downloading the bundles synchronously.
+When you enable bundling, Magento combines hundreds of JavaScript files into just a few JavaScript bundles and downloads those bundles for each page. Because the browser downloads the bundles synchronously, page rendering is blocked until all bundles finish downloading. But the time saved from reducing server requests from hundreds to just a few, usually offsets the cost of downloading the bundles synchronously.
 
 ### Excluding files
 


### PR DESCRIPTION
## Purpose of this pull request

This pull request (PR) 
will remove the italic style for the word "is" under the "How bundling works in Magento"


## Affected DevDocs pages
https://devdocs.magento.com/guides/v2.3/frontend-dev-guide/themes/js-bundling.html