### PR TITLE
Add support for DELETE async calls

### DIFF
--- a/src/guides/v2.3/rest/asynchronous-web-endpoints.md
+++ b/src/guides/v2.3/rest/asynchronous-web-endpoints.md
@@ -16,10 +16,11 @@ Magento supports the following types of asynchronous requests:
 
 *  POST
 *  PUT
+*  DELETE
 *  PATCH
 
 {:.bs-callout-info}
-GET and DELETE requests are not supported. Although Magento does not currently implement any PATCH requests, they are supported in custom extensions.
+GET requests are not supported. Although Magento does not currently implement any PATCH requests, they are supported in custom extensions.
 
 The route to all asynchronous calls contains the prefix `/async`, added before `/V1` of a standard synchronous endpoint. For example:
 

--- a/src/guides/v2.3/rest/bulk-endpoints.md
+++ b/src/guides/v2.3/rest/bulk-endpoints.md
@@ -12,7 +12,7 @@ Bulk API endpoints differ from other REST endpoints in that they combine multipl
 {:.bs-callout-info}
 Use the [`bin/magento queue:consumers:start async.operations.all`]({{ page.baseurl }}/config-guide/cli/config-cli-subcommands-queue.html) command to start the consumer that handles asynchronous and bulk API messages. Also, before using the Bulk API to process messages, you must install and configure RabbitMQ, which is the default message broker. See [RabbitMQ]({{ page.baseurl }}/install-gde/prereq/install-rabbitmq.html).
 
-### Routes
+## Routes
 
 To call a bulk endpoint, add the prefix `/async/bulk` before the `/V1` of a synchronous endpoint route. For example:
 
@@ -33,7 +33,7 @@ Synchronous route | Bulk route
 {:.bs-callout-info}
 GET requests are not supported.
 
-### Payloads
+## Payloads
 
 The payload of a bulk request contains an array of request bodies. For example, the minimal payload for creating four customers with `POST /async/bulk/V1/customers` would be structured as follows:
 
@@ -76,7 +76,7 @@ The payload of a bulk request contains an array of request bodies. For example, 
 {:.bs-callout-tip}
 The second and third requests are duplicates.
 
-### Responses
+## Responses
 
 The response contains an array that indicates whether the call successfully added each request to the message queue. Although the duplicated request to create a customer will fail, Magento added it to the message queue successfully.
 
@@ -109,9 +109,9 @@ The response contains an array that indicates whether the call successfully adde
 }
 ```
 
-### Sample usage of DELETE requests
+## DELETE requests
 
-The following call asynchronously delete from Magento CMS blocks with IDs `1` and `2`:
+The following call asynchronously deletes CMS blocks with IDs `1` and `2`:
 
 ```http
 DELETE <host>/rest/async/bulk/V1/cmsPage/byPageId
@@ -148,7 +148,7 @@ POST /all/async/bulk/V1/products
 PUT /all/async/bulk/V1/products/bySku
 ```
 
-### Fallback and creating/updating objects when setting store scopes
+## Fallback and creating/updating objects when setting store scopes
 
 The following rules apply when you create or update an object, such as a product.
 

--- a/src/guides/v2.3/rest/bulk-endpoints.md
+++ b/src/guides/v2.3/rest/bulk-endpoints.md
@@ -109,13 +109,34 @@ The response contains an array that indicates whether the call successfully adde
 }
 ```
 
+### Sample usage of DELETE requests
+
+The following call asynchronously delete from Magento CMS blocks with IDs `1` and `2`:
+
+```http
+DELETE <host>/rest/async/bulk/V1/cmsPage/byPageId
+```
+
+### DELETE Request Payload
+
+```json
+[
+    {
+        "page_id": "1"
+    },
+    {
+        "page_id": "2"
+    }
+]
+```
+
 ## Store scopes
 
 You can specify a store code in the route of an asynchronous endpoint so that it operates on a specific store, as shown below:
 
 ```http
 POST /<store_code>/async/bulk/V1/products
-PUT /<store_code>/async/bulk/V1/products/:sku
+PUT /<store_code>/async/bulk/V1/products/bySku
 ```
 
 As a result, the asynchronous calls update the products on the specific store, instead of the default store.
@@ -124,7 +145,7 @@ You can specify the `all` store code to perform operations on all existing store
 
 ```http
 POST /all/async/bulk/V1/products
-PUT /all/async/bulk/V1/products/:sku
+PUT /all/async/bulk/V1/products/bySku
 ```
 
 ### Fallback and creating/updating objects when setting store scopes

--- a/src/guides/v2.3/rest/bulk-endpoints.md
+++ b/src/guides/v2.3/rest/bulk-endpoints.md
@@ -31,7 +31,7 @@ Synchronous route | Bulk route
 `POST /V1/carts/:quoteId/items` | `POST async/bulk/V1/carts/byQuoteId/items`
 
 {:.bs-callout-info}
-GET and DELETE requests are not supported.
+GET requests are not supported.
 
 ### Payloads
 

--- a/src/guides/v2.3/rest/bulk-endpoints.md
+++ b/src/guides/v2.3/rest/bulk-endpoints.md
@@ -117,7 +117,7 @@ The following call asynchronously deletes CMS blocks with IDs `1` and `2`:
 DELETE <host>/rest/async/bulk/V1/cmsPage/byPageId
 ```
 
-### DELETE Request Payload
+### DELETE request payload
 
 ```json
 [


### PR DESCRIPTION
## Purpose of this pull request

DELETE support for Async/Bulk calls was added from 2.3.2, so I adding it to the list

## Affected DevDocs pages

https://devdocs.magento.com/guides/v2.3/rest/bulk-endpoints.html
https://devdocs.magento.com/guides/v2.3/rest/asynchronous-web-endpoints.html

