### PR TITLE
Updated Docker database container with info about setting CRYPT_KEY o…

### DIFF
--- a/src/cloud/docker/docker-database.md
+++ b/src/cloud/docker/docker-database.md
@@ -24,7 +24,7 @@ To import a database dump into the Docker environment:
    magento-cloud db:dump
    ```
 
-   {: .bs-callout-info }
+   {: .bs-callout-note }
    The `magento-cloud db:dump` command runs the [mysqldump](https://dev.mysql.com/doc/refman/8.0/en/mysqldump.html) command with the `--single-transaction` flag, which allows you to back up your database without locking the tables.
 
 1. Place the resulting SQL file into the `.docker/mysql/docker-entrypoint-initdb.d` folder.
@@ -32,6 +32,9 @@ To import a database dump into the Docker environment:
    The `{{site.data.var.ct}}` package imports and processes the SQL file the next time you build and start the Docker environment using the `docker-compose up` command.
 
 Although it is a more complex approach, you can use GZIP by _sharing_ the `.sql.gz` file using the `.docker/mnt` directory and importing it inside the Docker container.
+
+{:.bs-callout-info}
+When you import a database from an existing Magento installation into a new Magento Commerce Cloud environment, you must add the encryption key from the remote environment to the new environment, and then deploy the changes. See [Add the Magento encryption key]({{ site.baseurl}}/cloud/setup/first-time-setup-import-import.html#encryption-key).
 
 ## Connect to the database
 

--- a/src/cloud/docker/docker-database.md
+++ b/src/cloud/docker/docker-database.md
@@ -34,7 +34,7 @@ To import a database dump into the Docker environment:
 Although it is a more complex approach, you can use GZIP by _sharing_ the `.sql.gz` file using the `.docker/mnt` directory and importing it inside the Docker container.
 
 {:.bs-callout-info}
-When you import a database from an existing Magento installation into a new Magento Commerce Cloud environment, you must add the encryption key from the remote environment to the new environment, and then deploy the changes. See [Add the Magento encryption key]({{ site.baseurl}}/cloud/setup/first-time-setup-import-import.html#encryption-key).
+When you import a database from an existing Magento installation into a new {{ site.data.var.ece }} environment, you must add the encryption key from the remote environment to the new environment, and then deploy the changes. See [Add the Magento encryption key]({{ site.baseurl}}/cloud/setup/first-time-setup-import-import.html#encryption-key).
 
 ## Connect to the database
 

--- a/src/cloud/env/variables-deploy.md
+++ b/src/cloud/env/variables-deploy.md
@@ -132,7 +132,7 @@ stage:
 {:.bs-callout-warning}
 You must set the `CRYPT_KEY` value through the Project Web UI instead of the `.magento.env.yaml` file to avoid exposing the key in the source code repository for your environment. See [Set environment and project variables]({{ site.baseurl }}/cloud/project/project-webint-basic.html#project-conf-env-var).
 
-When you move the database from one environment to another without an installation process, you need the corresponding cryptographic information. Magento uses the encryption key value set in the Web UI as the `crypt/key` value in the `env.php` file. This does not overwrite an existing encryption key value in the `env.php` file.
+When you move the database from one environment to another without an installation process, you need the corresponding cryptographic information. Magento uses the encryption key value set in the Web UI as the `crypt/key` value in the `env.php` file.
 
 ### `DATABASE_CONFIGURATION`
 

--- a/src/cloud/release-notes/mcd-release-notes.md
+++ b/src/cloud/release-notes/mcd-release-notes.md
@@ -30,3 +30,5 @@ The release notes include:
 -  {:.new}Added the `--rm` option to `./bin/magento-docker` commands for the build and deploy containers. This removes the container after the task is complete.<!--MAGECLOUD-4205-->
 
 -  {:.new}Added the `--sync-engine="native"` option to the `docker-build` command to disable file synchronization when you generate the Docker Compose configuration file in developer mode. Use this option when developing on Linux systems, which do not require file synchronization for local Docker development.<!--MAGECLOUD-4351-->
+
+-  {:.new}Added validation to the deployment process for local Docker development environments to verify that the Cloud environment configuration includes the encryption key required to decrypt the database.  Now, you get an error message in the log if the envirionment configuration does not specify a value for the encryption key.<!--MAGECLOUD-4423-->

--- a/src/cloud/setup/first-time-setup-import-import.md
+++ b/src/cloud/setup/first-time-setup-import-import.md
@@ -27,51 +27,51 @@ Create a remote Git reference from your Cloud Git repository to the repository c
 
 1. Copy `composer.json` to a _non-tracked directory_ so it does not get overwritten.
 
-    ```
-    cp composer.json ../composer.json.cloud
-    ```
+   ```bash
+   cp composer.json ../composer.json.cloud
+   ```
 
 1. Rename your Cloud Git remote from `origin` to `cloud-project` to make it clear which repository is which:
 
-    ```
-    git remote rename origin cloud-project
-    ```
+   ```bash
+   git remote rename origin cloud-project
+   ```
 
 1. Add a remote upstream for your existing {{site.data.var.ee}} installation:
 
-    ```
-    git remote add prev-project <git url>
-    ```
+   ```bash
+   git remote add prev-project <git url>
+   ```
 
 1. Review the remote branch configuration.
 
-    ```
-    git remote -v
-    ```
+   ```bash
+   git remote -v
+   ```
 
-    Verify that the remote branch configuration matches the following sample configuration, with your project name instead of `ikyyrqvlgnrai`.
+   Verify that the remote branch configuration matches the following sample configuration, with your project name instead of `ikyyrqvlgnrai`.
 
-    ```
-    cloud-project   ikyyrqvlgnrai@git.us.magento.cloud:ikyykimjgnrao.git (fetch)
-    cloud-project   ikyyrqvlgnrai@git.us.magento.cloud:ikyykimjgnrao.git (push)
-    magento ikyyrqvlgnrai@git.us.magento.cloud:ikyykimjgnrao.git (fetch)
-    magento ikyyrqvlgnrai@git.us.magento.cloud:ikyykimjgnrao.git (push)
-    prev-project    git@github.com:mygitusername/myeereponame.git (fetch)
-    prev-project    git@github.com:mygitusername/myeereponame.git (push)
-    ```
+   ```bash
+   cloud-project   ikyyrqvlgnrai@git.us.magento.cloud:ikyykimjgnrao.git (fetch)
+   cloud-project   ikyyrqvlgnrai@git.us.magento.cloud:ikyykimjgnrao.git (push)
+   magento ikyyrqvlgnrai@git.us.magento.cloud:ikyykimjgnrao.git (fetch)
+   magento ikyyrqvlgnrai@git.us.magento.cloud:ikyykimjgnrao.git (push)
+   prev-project    git@github.com:mygitusername/myeereponame.git (fetch)
+   prev-project    git@github.com:mygitusername/myeereponame.git (push)
+   ```
 
 1. Checkout the Cloud project `master` branch.
 
-    ```
-    magento-cloud environment:checkout master
-    ```
+   ```bash
+   magento-cloud environment:checkout master
+   ```
 
 1. Set the `cloud-project` branch as an upstream tracking branch for `master`.
 
-    ```
-    git fetch cloud-project
-    git branch -u cloud-project/master
-    ```
+   ```bash
+   git fetch cloud-project
+   git branch -u cloud-project/master
+   ```
 
 ## Import your {{site.data.var.ee}} code to your Cloud project {#cloud-import-imp}
 
@@ -79,36 +79,35 @@ After you have completed the git reference configuration, you can import the {{s
 
 1. Fetch the {{site.data.var.ee}} branch.
 
-    ```
-    git fetch prev-project
-    ```
+   ```bash
+   git fetch prev-project
+   ```
 
 1. Reset your Cloud `master` branch to contain the code and the commit history of your {{site.data.var.ee}} branch.
 
-    ```
-    git reset --hard prev-project/<branch name>
-    ```
+   ```bash
+   git reset --hard prev-project/<branch name>
+   ```
 
 1. Push code from your {{site.data.var.ee}} project to your {{site.data.var.ece}} project, overwriting the previous contents and commit history with that of your project.
 
-    ```
-    git push -f cloud-project master
-    ```
+   ```bash
+   git push -f cloud-project master
+   ```
 
-    If the import succeeds, the {{site.data.var.ece}} environment redeploys.
+   If the import succeeds, the {{site.data.var.ece}} environment redeploys.
 
-    ```
-    Re-deploying environment 43biovskhelhy-master-l5ut8gq.
-       Environment configuration:
-         mymagento (type: php:7.0, size: S, disk: 2048)
-         mysql (type: mysql:10.0, size: S, disk: 2048)
-         redis (type: redis:3.0, size: S)
-         solr (type: solr:4.10, size: S, disk: 1024)
-
-    Environment routes:
-       http://master-o9gv6gq-43biovskhelhy.us.magentosite.cloud/ is served by application `mymagento`
-       https://master-o9gv6gq-43biovskhelhy.us.magentosite.cloud/ is served by application `mymagento`
-    ```
+   ```bash
+   Re-deploying environment 43biovskhelhy-master-l5ut8gq.
+      Environment configuration:
+        mymagento (type: php:7.0, size: S, disk: 2048)
+        mysql (type: mysql:10.0, size: S, disk: 2048)
+        redis (type: redis:3.0, size: S)
+        solr (type: solr:4.10, size: S, disk: 1024)
+   Environment routes:
+      http://master-o9gv6gq-43biovskhelhy.us.magentosite.cloud/ is served by application `mymagento`
+      https://master-o9gv6gq-43biovskhelhy.us.magentosite.cloud/ is served by application `mymagento`
+   ```
 
 ## Import the Magento database {#cloud-import-db}
 
@@ -124,45 +123,46 @@ This topic discusses how to import the Integration environment database. The dat
 
 When importing data, you will need to drop and create a new database. If you have done any data you want to keep, [create a backup]({{ site.baseurl }}/cloud/project/project-webint-snap.html) of the database.
 
+{:.procedure}
 To drop and re-create the Cloud database:
 
 1. SSH to the Integration environment.
 
-    ```
-    magento-cloud ssh
-    ```
+   ```bash
+   magento-cloud ssh
+   ```
 
 1. Connect to the database.
 
-    ```
-    mysql -h <db-host> -P <db-port> -p -u <db-user> <db-name>
-    ```
+   ```bash
+   mysql -h <db-host> -P <db-port> -p -u <db-user> <db-name>
+   ```
 
 1. Drop the database. At the `MariaDB [main]>` prompt, enter:
 
-    ```
-    drop database main;
-    ```
+   ```bash
+   drop database main;
+   ```
 
 1. Re-create the database:
 
-    ```
-    create database main;
-    ```
+   ```bash
+   create database main;
+   ```
 
 1. At the `MariaDB [main]>` prompt, enter `exit`.
 
 1. At the shell command prompt, enter the following command to re-create the database.
 
-    ```
-    zcat var/db.sql.tgz | sed -e 's/DEFINER[ ]*=[ ]*[^*]*\*/\*/' | mysql -h <db-host> -P <db-port> -p -u <db-user> <db-name>
-    ```
+   ```bash
+   zcat var/db.sql.tgz | sed -e 's/DEFINER[ ]*=[ ]*[^*]*\*/\*/' | mysql -h <db-host> -P <db-port> -p -u   <db-user> <db-name>
+   ```
 
-    For example,
+   For example,
 
-    ```
-    zcat var/db.sql.tgz | sed -e 's/DEFINER[ ]*=[ ]*[^*]*\*/\*/' | mysql -h database.internal -p -u user main
-    ```
+   ```bash
+   zcat var/db.sql.tgz | sed -e 's/DEFINER[ ]*=[ ]*[^*]*\*/\*/' | mysql -h database.internal -p -u user main
+   ```
 
 ### Update base URLs {#baseurl}
 
@@ -170,42 +170,43 @@ Before you can access Magento from your local Cloud development system, you must
 
 The following example shows how to change _only_ the insecure URL but you can use the same procedure to change secure URLs as well.
 
+{:.procedure}
 To update the unsecure base URL:
 
 1. If you haven't already done so, SSH to the Cloud integration server.
 
-    ```
-    magento-cloud ssh
-    ```
+   ```bash
+   magento-cloud ssh
+   ```
 
 1. Connect to the database.
 
-    ```
-    mysql -h <db-host> -P <db-port> -p -u <db-user> <db-name>
-    ```
+   ```bash
+   mysql -h <db-host> -P <db-port> -p -u <db-user> <db-name>
+   ```
 
 1. Show the contents of the `core_config_data` table.
 
-    ```
-    SELECT * from core_config_data;
-    ```
+   ```bash
+   SELECT * from core_config_data;
+   ```
 
     Note the `path` of `web/unsecure/base_url`; this is the value you'll change.
 
 1. Enter the following command to change the value of `path` to your integration server's unsecure base URL:
 
-    ```
-    UPDATE core_config_data SET value='<Cloud unsecure base URL>' WHERE path='web/unsecure/base_url';
-    ```
+   ```bash
+   UPDATE core_config_data SET value='<Cloud unsecure base URL>' WHERE path='web/unsecure/base_url';
+   ```
 
     {:.bs-callout-warning}
     The base URL _must_ end with a `/` character.
 
 1. Confirm the change by entering the following command:
 
-    ```
-    SELECT * from core_config_data;
-    ```
+   ```bash
+   SELECT * from core_config_data;
+   ```
 
 1. If the change was successful, enter `exit` to exit the `[Maria DB]` prompt.
 1. Continue with the next section.
@@ -219,30 +220,43 @@ The {{site.data.var.ee}} encryption key is required as an environment variable i
 
 You copied the key in a [previous step]({{ site.baseurl }}/cloud/setup/first-time-setup-import-prepare.html#encryption-key).
 
-To add your {{site.data.var.ee}} encryption key:
+{:.procedure}
+To add your {{site.data.var.ee}} encryption key using the `CRYPT_KEY` environment variable:
 
-1. If you haven't done so already, SSH to the Cloud environment.
+1. Log in to your Cloud project as an Admin user from the Project Web UI, or from the command line.
 
-    ```
-    magento-cloud environment:ssh
-    ```
+1. Set the `CRYPT_KEY` environment variable to the encryption key value that you copied from the remote environment:
 
-1. Open `app/etc/env.php` in a text editor.
+   -  From the Project Web UI, select your environment, then select the *Variables* tab to set the `CRYPT_KEY` value. See [Set environment and project variables]({{site.baseurl}}/cloud/project/project-webint-basic.html#project-conf-env-var).
+
+   -  From the command line, use the `project:variable:set` command to add the encryption key to the `CRYPT_KEY` environment variable. See [Working with environment variables]({{ site.baseurl }}/cloud/env/working-with-variables.html).
+
+{:.procedure}
+To add your {{site.data.var.ee}} encryption key to the `env.php` file for each environment:
+
+1. If you have not done so already, use SSH to connect to the Cloud environment.
+
+   ```bash
+   magento-cloud environment:ssh
+   ```
+
+1. Open the `app/etc/env.php` file in a text editor.
+
 1. Replace the existing value of `key` with your [{{site.data.var.ee}} key]({{ site.baseurl }}/cloud/setup/first-time-setup-import-prepare.html#encryption-key).
 
-    ```php
-    return array (
-      'crypt' =>
-      array (
-        'key' => '<your encryption key>',
-      ),
-    );
-    ```
+   ```php
+   return array (
+     'crypt' =>
+     array (
+       'key' => '<your encryption key>',
+     ),
+   );
+   ```
 
 1. Save your changes to `env.php` and exit the text editor.
 
-    {:.bs-callout-info}
-    You must add this key to the `env.php` file for all environments: Integration, Staging, and Production.
+   {:.bs-callout-info}
+   You must add this key to the `env.php` file for all environments: Integration, Staging, and Production.
 
 ## Import media {#media}
 
@@ -250,21 +264,21 @@ To import media files into your Cloud environment:
 
 1. If you haven't done so already, SSH to the Cloud environment.
 
-    ```
-    magento-cloud ssh -p <project ID> -e <environment ID>
-    ```
+   ```bash
+   magento-cloud ssh -p <project ID> -e <environment ID>
+   ```
 
 1. Enter the following command to clear existing media files:
 
-    ```
-    rm -rf pub/media/*
-    ```
+   ```bash
+   rm -rf pub/media/*
+   ```
 
 1. Enter the following command to extract the media files to the `pub/media` directory:
 
-    ```
-    tar -xzf var/media.tgz pub/media
-    ```
+   ```bash
+   tar -xzf var/media.tgz pub/media
+   ```
 
 ## Clear the cache {#cache}
 
@@ -290,9 +304,9 @@ To verify everything imported properly, perform the following tasks in your loca
 
 1. On your Cloud environment, enter the following commands to find the information to log in to the [Magento Admin](https://glossary.magento.com/magento-admin) and to view the storefront:
 
-    ```
-    magento-cloud environment:url
-    ```
+   ```bash
+   magento-cloud environment:url
+   ```
 
 1. Log in to the Magento [Admin](https://glossary.magento.com/admin) using the username and password of your {{site.data.var.ee}} system.
 1. Verify that the settings in the Admin are the same as your {{site.data.var.ee}} system.

--- a/src/cloud/setup/first-time-setup-import-import.md
+++ b/src/cloud/setup/first-time-setup-import-import.md
@@ -97,7 +97,7 @@ After you have completed the git reference configuration, you can import the {{s
 
    If the import succeeds, the {{site.data.var.ece}} environment redeploys.
 
-   ```bash
+   ```terminal
    Re-deploying environment 43biovskhelhy-master-l5ut8gq.
       Environment configuration:
         mymagento (type: php:7.0, size: S, disk: 2048)
@@ -121,12 +121,12 @@ You need the following information to complete this task:
 {:.bs-callout-info}
 This topic discusses how to import the Integration environment database. The database connection information is different for Staging and Production environments.
 
-When importing data, you will need to drop and create a new database. If you have done any data you want to keep, [create a backup]({{ site.baseurl }}/cloud/project/project-webint-snap.html) of the database.
+When importing data, you need to drop and create a new database. If you have data you want to keep, [create a backup]({{ site.baseurl }}/cloud/project/project-webint-snap.html) of the database.
 
 {:.procedure}
 To drop and re-create the Cloud database:
 
-1. SSH to the Integration environment.
+1. Use SSH to log in to the Integration environment.
 
    ```bash
    magento-cloud ssh
@@ -154,13 +154,13 @@ To drop and re-create the Cloud database:
 
 1. At the shell command prompt, enter the following command to re-create the database.
 
-   ```bash
+   ```shell
    zcat var/db.sql.tgz | sed -e 's/DEFINER[ ]*=[ ]*[^*]*\*/\*/' | mysql -h <db-host> -P <db-port> -p -u   <db-user> <db-name>
    ```
 
    For example,
 
-   ```bash
+   ```shell
    zcat var/db.sql.tgz | sed -e 's/DEFINER[ ]*=[ ]*[^*]*\*/\*/' | mysql -h database.internal -p -u user main
    ```
 
@@ -173,7 +173,7 @@ The following example shows how to change _only_ the insecure URL but you can us
 {:.procedure}
 To update the unsecure base URL:
 
-1. If you haven't already done so, SSH to the Cloud integration server.
+1. If you have not already done so, use SSH to connect to the Cloud integration server.
 
    ```bash
    magento-cloud ssh
@@ -187,15 +187,15 @@ To update the unsecure base URL:
 
 1. Show the contents of the `core_config_data` table.
 
-   ```bash
+   ```shell
    SELECT * from core_config_data;
    ```
 
-    Note the `path` of `web/unsecure/base_url`; this is the value you'll change.
+    Note the `path` of `web/unsecure/base_url`; this is the value to change.
 
 1. Enter the following command to change the value of `path` to your integration server's unsecure base URL:
 
-   ```bash
+   ```shell
    UPDATE core_config_data SET value='<Cloud unsecure base URL>' WHERE path='web/unsecure/base_url';
    ```
 
@@ -204,7 +204,7 @@ To update the unsecure base URL:
 
 1. Confirm the change by entering the following command:
 
-   ```bash
+   ```shell
    SELECT * from core_config_data;
    ```
 
@@ -227,7 +227,7 @@ To add your {{site.data.var.ee}} encryption key using the `CRYPT_KEY` environmen
 
 1. Set the `CRYPT_KEY` environment variable to the encryption key value that you copied from the remote environment:
 
-   -  From the Project Web UI, select your environment, then select the *Variables* tab to set the `CRYPT_KEY` value. See [Set environment and project variables]({{site.baseurl}}/cloud/project/project-webint-basic.html#project-conf-env-var).
+   -  From the Project Web UI, select your environment, then select the _Variables_ tab to set the `CRYPT_KEY` value. See [Set environment and project variables]({{site.baseurl}}/cloud/project/project-webint-basic.html#project-conf-env-var).
 
    -  From the command line, use the `project:variable:set` command to add the encryption key to the `CRYPT_KEY` environment variable. See [Working with environment variables]({{ site.baseurl }}/cloud/env/working-with-variables.html).
 
@@ -244,7 +244,7 @@ To add your {{site.data.var.ee}} encryption key to the `env.php` file for each e
 
 1. Replace the existing value of `key` with your [{{site.data.var.ee}} key]({{ site.baseurl }}/cloud/setup/first-time-setup-import-prepare.html#encryption-key).
 
-   ```php
+   ```php?start_inline=1
    return array (
      'crypt' =>
      array (
@@ -262,7 +262,7 @@ To add your {{site.data.var.ee}} encryption key to the `env.php` file for each e
 
 To import media files into your Cloud environment:
 
-1. If you haven't done so already, SSH to the Cloud environment.
+1. If you have not done so already, use SSH to connect to the Cloud environment.
 
    ```bash
    magento-cloud ssh -p <project ID> -e <environment ID>

--- a/src/guides/v2.2/release-notes/ReleaseNotes2.2.2EE.md
+++ b/src/guides/v2.2/release-notes/ReleaseNotes2.2.2EE.md
@@ -691,7 +691,7 @@ You can find Magento Shipping-specific release notes in [Magento Shipping Releas
 
 **Issue**: In Swagger, the text area that contains the payload structure of some POST and PUT operations is not displayed. If a fraction of the text area is displayed, you can click on it to display the payload structure in a text area in the center of the page. If the text area is not displayed at all, then you cannot access the payload structure.
 
-**Workaround**: Use the [static Swagger site]({{ site.baseurl }}/swagger) to navigate to the REST call you want to use, then copy the payload structure to your Swagger instance.
+**Workaround**: Use the [static Swagger site]({{ site.baseurl }}/swagger/index_22.html) to navigate to the REST call you want to use, then copy the payload structure to your Swagger instance.
 
 ### Magento Shipping issues
 

--- a/src/guides/v2.2/release-notes/ReleaseNotes2.2.2EE.md
+++ b/src/guides/v2.2/release-notes/ReleaseNotes2.2.2EE.md
@@ -691,7 +691,7 @@ You can find Magento Shipping-specific release notes in [Magento Shipping Releas
 
 **Issue**: In Swagger, the text area that contains the payload structure of some POST and PUT operations is not displayed. If a fraction of the text area is displayed, you can click on it to display the payload structure in a text area in the center of the page. If the text area is not displayed at all, then you cannot access the payload structure.
 
-**Workaround**: Use the [static Swagger site]({{ site.baseurl }}/swagger/index_22.html) to navigate to the REST call you want to use, then copy the payload structure to your Swagger instance.
+**Workaround**: Use the [static Swagger site]({{ site.baseurl }}/swagger/index_22.html) to navigate to the REST call, then copy the payload structure to your Swagger instance.
 
 ### Magento Shipping issues
 


### PR DESCRIPTION
## Purpose of this pull request

- Updated the Docker database container topic with information about setting the encryption key for an imported database using the CRYPT_KEY deploy variable.
- Updated the "Add Magento encryption key" with instructions for setting key using CRYPT_KEY environment variable
- Added release note about new validation that checks the Cloud environment for encryption key when deploying to local Docker environments
- Cleanup markdown syntax

## Affected DevDocs pages

- https://devdocs.magento.com/cloud/docker/docker-database.html
- https://devdocs.magento.com/cloud/env/variables-deploy.html
- https://devdocs.magento.com/cloud/docker/docker-database.html
- https://devdocs.magento.com/cloud/setup/first-time-setup-import-import.html
- https://devdocs.magento.com/cloud/release-notes/mcd-release-notes.html