### PR TITLE
Update Code Standard Demarcation - Fix Incorrect Code

### DIFF
--- a/guides/v2.2/coding-standards/code-standard-demarcation.md
+++ b/guides/v2.2/coding-standards/code-standard-demarcation.md
@@ -407,8 +407,8 @@ jQuery('#{$htmlId}-suggest').treeSuggest({$selectorOptions});
 ```php?start_inline=1
 ...
 $fieldset->addField('new_category_parent', 'text', array(
-    'label'    => Mage::helper('Mage_Catalog_Helper_Data')->__('Parent Category'),
-    'title'    => Mage::helper('Mage_Catalog_Helper_Data')->__('Parent Category'),
+    'label'    => __('Parent Category'),
+    'title'    => __('Parent Category'),
     'required' => true,
     'class'    => 'parent category',
 ));
@@ -420,8 +420,8 @@ $fieldset->addField('new_category_parent', 'text', array(
 ```php?start_inline=1
 ...
 $fieldset->addField('new_category_parent', 'text', array(
-    'label'    => Mage::helper('Mage_Catalog_Helper_Data')->__('Parent Category'),
-    'title'    => Mage::helper('Mage_Catalog_Helper_Data')->__('Parent Category'),
+    'label'    => __('Parent Category'),
+    'title'    => __('Parent Category'),
     'required' => true,
     'style'    => 'border: 1px solid #ccc;',
 ));
@@ -501,7 +501,7 @@ public function getAttributeId($element)
    <input type="checkbox"
       <?php echo ($this->getAttributeName($element)) ? ' name="' . $this->getAttributeName($element) . '"' : NULL; ?>
       data-mage-init="{customToggleWidget: [elementSelector: "input[name='someCustomName']"]}" />
-   <?php echo Mage::helper('Mage_Catalog_Helper_Data')->__('Change'); ?>
+   <?php echo __('Change'); ?>
 </label>
 </span>
 <!-- jQuery.hide() code can be either located in the widget itself OR can ask PHP Block class whether or not 'weight_and_type_switcher' should be visible. Based on this condition CSS can be applied to hide/show those elements. -->
@@ -525,7 +525,7 @@ public function getCheckbox($elementName){
 <span class="attribute-change-checkbox">
 	<label>
 		<?php echo $this->getCheckbox($element)?>
-		<?php echo Mage::helper('Mage_Catalog_Helper_Data')->__('Change'); ?>
+		<?php echo __('Change'); ?>
 	</label>
 </span>
 <!-- jQuery.hide() code can be either located in the widget itself OR can ask PHP Block class whether or not 'weight_and_type_switcher' should be visible. Based on this condition CSS can be applied to hide/show those elements. -->

--- a/guides/v2.3/coding-standards/code-standard-demarcation.md
+++ b/guides/v2.3/coding-standards/code-standard-demarcation.md
@@ -398,8 +398,8 @@ jQuery('#{$htmlId}-suggest').treeSuggest({$selectorOptions});
 ```php
 ...
 $fieldset->addField('new_category_parent', 'text', array(
-    'label'    => Mage::helper('Mage_Catalog_Helper_Data')->__('Parent Category'),
-    'title'    => Mage::helper('Mage_Catalog_Helper_Data')->__('Parent Category'),
+    'label'    => __('Parent Category'),
+    'title'    => __('Parent Category'),
     'required' => true,
     'class'    => 'parent category',
 ));
@@ -411,8 +411,8 @@ $fieldset->addField('new_category_parent', 'text', array(
 ```php
 ...
 $fieldset->addField('new_category_parent', 'text', array(
-    'label'    => Mage::helper('Mage_Catalog_Helper_Data')->__('Parent Category'),
-    'title'    => Mage::helper('Mage_Catalog_Helper_Data')->__('Parent Category'),
+    'label'    => __('Parent Category'),
+    'title'    => __('Parent Category'),
     'required' => true,
     'style'    => 'border: 1px solid #ccc;',
 ));
@@ -491,7 +491,7 @@ public function getAttributeId($element)
    <input type="checkbox"
       <?php echo ($this->getAttributeName($element)) ? ' name="' . $this->getAttributeName($element) . '"' : NULL; ?>
       data-mage-init="{customToggleWidget: [elementSelector: "input[name='someCustomName']"]}" />
-   <?php echo Mage::helper('Mage_Catalog_Helper_Data')->__('Change'); ?>
+   <?php echo __('Change'); ?>
 </label>
 </span>
 <!-- jQuery.hide() code can be either located in the widget itself OR can ask PHP Block class whether or not 'weight_and_type_switcher' should be visible. Based on this condition CSS can be applied to hide/show those elements. -->
@@ -515,7 +515,7 @@ public function getCheckbox($elementName){
 <span class="attribute-change-checkbox">
 	<label>
 		<?php echo $this->getCheckbox($element)?>
-		<?php echo Mage::helper('Mage_Catalog_Helper_Data')->__('Change'); ?>
+		<?php echo __('Change'); ?>
 	</label>
 </span>
 <!-- jQuery.hide() code can be either located in the widget itself OR can ask PHP Block class whether or not 'weight_and_type_switcher' should be visible. Based on this condition CSS can be applied to hide/show those elements. -->


### PR DESCRIPTION
## Purpose of this pull request

This pull request (PR) will remove the Old Magento 1 code in the Page
Update to Magento 2 code.

## Affected DevDocs pages

<!-- REQUIRED List the affected pages on devdocs.magento.com (URLs). Not needed for large numbers of files. -->

- https://devdocs.magento.com/guides/v2.2/coding-standards/code-standard-demarcation.html
- https://devdocs.magento.com/guides/v2.3/coding-standards/code-standard-demarcation.html

<!--
If you are fixing a GitHub issue, note it using GitHub keyword format (https://help.github.com/en/articles/closing-issues-using-keywords#closing-an-issue-in-a-different-repository) to close the issue when this pull request is merged. Example: `Fixes #1234`

`master` is the default branch. Merged pull requests to `master` go live on the site automatically. Any requested changes to content on the `master` branch must be related to the released codebase. Any content related to future releases goes in the `develop` branch.

See Contribution guidelines (https://github.com/magento/devdocs/blob/master/.github/CONTRIBUTING.md) for more information.
-->
