### PR TITLE
Period(".") added.

### DIFF
--- a/src/guides/v2.2/frontend-dev-guide/css-topics/css-themes.md
+++ b/src/guides/v2.2/frontend-dev-guide/css-topics/css-themes.md
@@ -31,7 +31,7 @@ In a [theme directory][], stylesheets are stored in the following locations:
 <tr>
 <td> <code>/&lt;Namespace&gt;_&lt;Module&gt;/web/css</code>
 </td>
-<td> Module-specific styles
+<td> Module-specific styles.
 </td>
 </tr>
 <tr>
@@ -45,11 +45,11 @@ Contains the following:
 </li>
 <li><code>_styles.less</code> - a composite file, which includes all Less files used in the <a href="https://glossary.magento.com/theme">theme</a>. The underscore sign ("_") in a file name conventionally means that a file is not used independently, but is included in other files.
 </li>
-<li><code>styles-m.less</code>: used to generate mobile-specific styles, includes <code>_styles.less</code>
+<li><code>styles-m.less</code>: used to generate mobile-specific styles, includes <code>_styles.less</code>.
 </li>
 <li><code>styles-l.less</code>: used to generate desktop-specific styles, includes <code>_styles.less</code>.
 </li>
-<li><code>/source</code>: this subdirectory contains Less configuration files that invoke mixins from the Magento UI <a href="https://glossary.magento.com/library">library</a>
+<li><code>/source</code>: this subdirectory contains Less configuration files that invoke mixins from the Magento UI <a href="https://glossary.magento.com/library">library</a>.
 </li>
 <li>
 <code>/source/_theme.less</code>: overrides the default Magento UI library variables values.


### PR DESCRIPTION
## Purpose of this pull request

This pull request (PR) 

1. How Magento stylesheet files are organized section /<Namespace>_<Module>/web/css description Period(".") added at the end of file.
2. How Magento stylesheet files are organized section /web/css description Period(".") added at the end of file.

## Affected DevDocs pages

https://devdocs.magento.com/guides/v2.3/frontend-dev-guide/css-topics/css-themes.html