### PR TITLE
Improve the example of declaring the command name

### DIFF
--- a/src/guides/v2.2/extension-dev-guide/cli-cmds/cli-howto.md
+++ b/src/guides/v2.2/extension-dev-guide/cli-cmds/cli-howto.md
@@ -70,7 +70,7 @@ Following is a summary of the process:
 
            /**
             * Execute the command
-            * 
+            *
             * @param InputInterface $input
             * @param OutputInterface $output
             *
@@ -92,7 +92,7 @@ Following is a summary of the process:
    {:.bs-callout-info}
    Style the output text by using `<error>`, `<info>`, or `<comment>` tags. See [Symfony](https://symfony.com/doc/master/console/coloring.html){:target="_blank"} docummentation for more information about styling.
 
-2. Declare your Command class in `Magento\Framework\Console\CommandListInterface` and configure the command name using dependency injection (`<your component root dir>/etc/di.xml`):
+1. Declare your Command class in `Magento\Framework\Console\CommandListInterface` and configure the command name using dependency injection (`<your component root dir>/etc/di.xml`):
 
    ```xml
    <config xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="urn:magento:framework:ObjectManager/etc/config.xsd">
@@ -114,7 +114,7 @@ Following is a summary of the process:
    </config>
    ```
 
-3. Clean the [cache](https://glossary.magento.com/cache) and compiled code directories:
+1. Clean the [cache](https://glossary.magento.com/cache) and compiled code directories:
 
    ```bash
    rm -rf var/cache/* var/page_cache/* generated/*

--- a/src/guides/v2.2/extension-dev-guide/cli-cmds/cli-howto.md
+++ b/src/guides/v2.2/extension-dev-guide/cli-cmds/cli-howto.md
@@ -62,7 +62,6 @@ Following is a summary of the process:
                         'Name'
                     )
                ];
-               $this->setName('my:first:command');
                $this->setDescription('This is my first console command.');
                $this->setDefinition($options);
 
@@ -70,6 +69,8 @@ Following is a summary of the process:
            }
 
            /**
+            * Execute the command
+            * 
             * @param InputInterface $input
             * @param OutputInterface $output
             *
@@ -91,11 +92,17 @@ Following is a summary of the process:
    {:.bs-callout-info}
    Style the output text by using `<error>`, `<info>`, or `<comment>` tags. See [Symfony](https://symfony.com/doc/master/console/coloring.html){:target="_blank"} docummentation for more information about styling.
 
-1. Declare your Command class in `Magento\Framework\Console\CommandListInterface` using dependency injection (`<your component root dir>/etc/di.xml`):
+2. Declare your Command class in `Magento\Framework\Console\CommandListInterface` and configure the command name using dependency injection (`<your component root dir>/etc/di.xml`):
 
    ```xml
    <config xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="urn:magento:framework:ObjectManager/etc/config.xsd">
        ...
+       <type name=" Magento\CommandExample\Console\Command\SomeCommand">
+           <arguments>
+               <!-- configure the command name via constructor $name argument -->
+               <argument name="name" xsi:type="string">my:first:command</argument>
+           </arguments>
+       </type>
        <type name="Magento\Framework\Console\CommandList">
            <arguments>
                <argument name="commands" xsi:type="array">
@@ -107,7 +114,7 @@ Following is a summary of the process:
    </config>
    ```
 
-1. Clean the [cache](https://glossary.magento.com/cache) and compiled code directories:
+3. Clean the [cache](https://glossary.magento.com/cache) and compiled code directories:
 
    ```bash
    rm -rf var/cache/* var/page_cache/* generated/*


### PR DESCRIPTION
## Purpose of this pull request

This pull request (PR) improves an example of declaring the command name.

## Affected DevDocs pages

-  https://devdocs.magento.com/guides/v2.2/extension-dev-guide/cli-cmds/cli-howto.html
-  https://devdocs.magento.com/guides/v2.3/extension-dev-guide/cli-cmds/cli-howto.html

## Links to Magento source code

The Magento uses the **symfony/console** package to create a console command.
The Magento gives us an ability to use the DI arguments (https://devdocs.magento.com/guides/v2.3/extension-dev-guide/build/di-xml-file.html#argument-types) to configure arguments for a class's constructor.
In case if we create a new command and inherits the https://github.com/symfony/console/blob/master/Command/Command.php class, we are able to configure the $name argument for a new command via ID argument.
It makes the command name extendable from another module.
There is no example in the Magento of using this way, but I've tested it and it works well.

-  https://github.com/symfony/console/blob/master/Command/Command.php#L74
