### PR TITLE
Update xss-protection.md

### DIFF
--- a/src/guides/v2.2/extension-dev-guide/xss-protection.md
+++ b/src/guides/v2.2/extension-dev-guide/xss-protection.md
@@ -74,10 +74,10 @@ When using the Escaper:
 **When to use Escaper methods:**
 
 **Case**: JSON inside an HTML attribute
-**Escaper method**: escapeHtmlAttribute
+**Escaper method**: escapeHtmlAttr
 
 ```php
-<div data-bind='settings: <?= $block->escapeHtmlAttribute($myJson) ?>'></div>
+<div data-bind='settings: <?= $block->escapeHtmlAttr($myJson) ?>'></div>
 ```
 
 **Case**: JSON inside script tag


### PR DESCRIPTION

## Purpose of this pull request

This pull request (PR) fixes escapeHtmlAttr reference (escapeHtmlAttribute method does not exist; it is escapeHtmlAttr).

## Affected DevDocs pages


<!-- REQUIRED List the affected pages on devdocs.magento.com (URLs). Not needed for large numbers of files. -->

- https://devdocs.magento.com/guides/v2.2/extension-dev-guide/xss-protection.html
- https://devdocs.magento.com/guides/v2.3/extension-dev-guide/xss-protection.html

## Links to Magento source code

- https://github.com/magento/magento2/blob/cef605f171d616d33976ebfcc53874aaf40a2339/lib/internal/Magento/Framework/View/Element/AbstractBlock.php#L924


<!--
If you are fixing a GitHub issue, note it using GitHub keyword format (https://help.github.com/en/articles/closing-issues-using-keywords#closing-an-issue-in-a-different-repository) to close the issue when this pull request is merged. Example: `Fixes #1234`

`master` is the default branch. Merged pull requests to `master` go live on the site automatically. Any requested changes to content on the `master` branch must be related to the released codebase. Any content related to future releases goes in the `develop` branch.

See Contribution guidelines (https://github.com/magento/devdocs/blob/master/.github/CONTRIBUTING.md) for more information.
-->
