### PR TITLE
Added external reference link for Payflow pro configuration

### DIFF
--- a/src/guides/v2.3/graphql/payment-methods/payflow-pro.md
+++ b/src/guides/v2.3/graphql/payment-methods/payflow-pro.md
@@ -19,6 +19,8 @@ The following diagram shows the workflow for placing an order when Payflow Pro i
 
 {% include graphql/payment-methods/payflow-pro-workflow.md %}
 
+To configure Payflow Pro Please Visit [Payflow Configuration](https://registration.paypal.com/).
+
 ## Additional Payment information
 
 When you set the payment method to Payflow Pro in the [`setPaymentMethodOnCart`]({{page.baseurl}}/graphql/mutations/set-payment-method.html) mutation, the `payment_method` object must contain a `payflowpro` object and a `CreditCardDetailsInput` object.


### PR DESCRIPTION
## Purpose of this pull request

This pull request (PR) : Added external reference link for Payflow pro configuration

## Affected DevDocs pages

<!-- REQUIRED List the affected pages on devdocs.magento.com (URLs). Not needed for large numbers of files. -->

-  https://devdocs.magento.com/guides/v2.3/graphql/payment-methods/payflow-pro.html

