### PR TITLE
Magento file system owner doesn't need sudo previlage.

### DIFF
--- a/src/_includes/install/file-system-perms-twouser_22.md
+++ b/src/_includes/install/file-system-perms-twouser_22.md
@@ -136,7 +136,7 @@ find var generated vendor pub/static pub/media app/etc -type d -exec chmod g+ws 
 ```
 
 ```bash
-sudo chown -R :<web server group> .
+chown -R :<web server group> .
 ```
 
 ```bash


### PR DESCRIPTION
## Purpose of this pull request

Set ownership and permissions for two users:

In this document, we would like to remove this sudo word, because Magento file system owner doesn't need sudo previlage to perform the `chown -R :<web server group> .` if user properly created. 

Also, you can see there is no sudo in this bellow line:
{% include install/file-system-perms-twouser_cmds-only_22.md %}


src\_includes\install\file-system-perms-twouser_cmds-only_22.md


## Affected DevDocs pages

https://devdocs.magento.com/guides/v2.3/install-gde/prereq/file-system-perms.html

-  ...


