### PR TITLE
Improving the RequireJS documentation with another available config

### DIFF
--- a/src/guides/v2.3/javascript-dev-guide/javascript/requirejs.md
+++ b/src/guides/v2.3/javascript-dev-guide/javascript/requirejs.md
@@ -110,9 +110,9 @@ The concept of Javascript mixins itself is explained in depth in [Using Javascri
 
 ### text
 
-The `text` configuration is used to set the security request headers via the following JS file: [`text.js`]({{ site.mage2bloburl }}/{{ page.guide_version }}/lib/web/mage/requirejs/text.js)
+The `text` configuration is used to set the security request headers using the [`text.js`]({{ site.mage2bloburl }}/{{ page.guide_version }}/lib/web/mage/requirejs/text.js) file.
 
-Without [Cross Origin Resource Sharing (CORS)](https://en.wikipedia.org/wiki/Cross-origin_resource_sharing) it is not possible to add X-Requested-With header to a cross domain XHR request. So having this header set, the server knows that the request was initiated from the same domain.
+Without [Cross Origin Resource Sharing (CORS)](https://en.wikipedia.org/wiki/Cross-origin_resource_sharing) it is not possible to add the `X-Requested-With` header to a cross domain XHR request. Set this header to tell the server that the request was initiated from the same domain.
 
 ```javascript
 'config': {

--- a/src/guides/v2.3/javascript-dev-guide/javascript/requirejs.md
+++ b/src/guides/v2.3/javascript-dev-guide/javascript/requirejs.md
@@ -16,10 +16,11 @@ All configuration is done in the `requirejs-config.js` file. It has a single roo
 ```javascript
 var config = {
     'map': {...},
-    'paths': {...}
+    'paths': {...},
     'shim': {...},
     'config': {
-        'mixins': {...}
+        'mixins': {...},
+        'text': {...}
     }
 }
 ```
@@ -106,3 +107,19 @@ In this snippet, `Vendor_Module/js/module-mixin` will overwrite the existing com
 ```
 
 The concept of Javascript mixins itself is explained in depth in [Using Javascript Mixins]({{ page.baseurl }}/javascript-dev-guide/javascript/js_mixins.html).
+
+### text
+
+The `text` configuration is used to set the security request headers via the following JS file: [`text.js`]({{ site.mage2bloburl }}/{{ page.guide_version }}/lib/web/mage/requirejs/text.js)
+
+Without [Cross Origin Resource Sharing (CORS)](https://en.wikipedia.org/wiki/Cross-origin_resource_sharing) it is not possible to add X-Requested-With header to a cross domain XHR request. So having this header set, the server knows that the request was initiated from the same domain.
+
+```javascript
+'config': {
+    'text': {
+        'headers': {
+            'X-Requested-With': 'XMLHttpRequest'
+        }
+    }
+}
+```


### PR DESCRIPTION
## Purpose of this pull request

This pull request (PR) is improving the RequireJS documentation, by adding another available `text` config that can be used.

## Affected DevDocs pages

<!-- REQUIRED List the affected pages on devdocs.magento.com (URLs). Not needed for large numbers of files. -->

-  https://devdocs.magento.com/guides/v2.3/javascript-dev-guide/javascript/requirejs.html#requirejs-config-map

## Links to Magento source code

<!--  OPTIONAL - REMOVE THIS SECTION IF NOT USED. If this pull request references a file in a Magento codebase repository, add it here. -->

-  https://github.com/magento/magento2/blob/2.3/app/code/Magento/Theme/view/base/requirejs-config.js#L61

<!--
If you are fixing a GitHub issue, note it using GitHub keyword format (https://help.github.com/en/articles/closing-issues-using-keywords#closing-an-issue-in-a-different-repository) to close the issue when this pull request is merged. Example: `Fixes #1234`

`master` is the default branch. Merged pull requests to `master` go live on the site automatically. Any requested changes to content on the `master` branch must be related to the released codebase. Any content related to future releases goes in the `develop` branch.

See Contribution guidelines (https://github.com/magento/devdocs/blob/master/.github/CONTRIBUTING.md) for more information.
-->
