### PR TITLE
corrected the grunt file path for Magento2.3.x

### DIFF
--- a/src/guides/v2.3/frontend-dev-guide/css-topics/css_debug.md
+++ b/src/guides/v2.3/frontend-dev-guide/css-topics/css_debug.md
@@ -14,7 +14,7 @@ The topic describes how to install, configure, and use [Grunt JavaScript task ru
 
 ## Adding themes to Grunt configuration {#add_theme}
 
-To compile `.less` files, add your theme to `module.exports` in the Grunt configuration, either in the default `dev/tools/grunt/configs/local-themes.js` or in the [custom configuration file]({{ page.baseurl }}/frontend-dev-guide/tools/using_grunt.html#grunt_config). For example:
+To compile `.less` files, add your theme to `module.exports` in the Grunt configuration, either in the default `dev/tools/grunt/configs/themes.js` or in the [custom configuration file]({{ page.baseurl }}/frontend-dev-guide/tools/using_grunt.html#grunt_config). For example:
 
 1. Install [node.js] to any location on your machine.
 


### PR DESCRIPTION
`dev/tools/grunt/configs/local-themes.js' is not existing in Magento 2.3.x The correct one is `dev/tools/grunt/configs/themes.js'

## Purpose of this pull request

This pull request (PR)  contains the updated file path

## Affected DevDocs pages

https://devdocs.magento.com/guides/v2.3/frontend-dev-guide/css-topics/css_debug.html