### PR TITLE
Add missing command in cache clean

### DIFF
--- a/src/guides/v2.3/frontend-dev-guide/cache_for_frontdevs.md
+++ b/src/guides/v2.3/frontend-dev-guide/cache_for_frontdevs.md
@@ -26,7 +26,7 @@ The full list of cache types can be found in the [Overview of cache types]({{ pa
 To clean cache, run
 
 ```bash
-magento cache:clean <type> ... <type>
+bin/magento cache:clean <type> ... <type>
 ```
 
 To view the status of the cache, run:


### PR DESCRIPTION
## Purpose of this pull request

This pull request (PR)
Add missing command for cache clean command

## Affected DevDocs pages

https://devdocs.magento.com/guides/v2.3/frontend-dev-guide/cache_for_frontdevs.html#clean_cache