### PR TITLE
magento/devdocs#: Add link to “Applying patches > Custom patches” from “Apply custom patches”

### DIFF
--- a/src/cloud/project/project-patch.md
+++ b/src/cloud/project/project-patch.md
@@ -5,7 +5,7 @@ functional_areas:
   - Cloud
   - Upgrade
 ---
-Sometimes we provide a custom patch to address a specific issue. Also, third-party extension developers can provide a custom patch. Copy the custom patch to the `/m2-hotfixes` directory and test it on your local workstation.
+Sometimes we provide a [custom patch]({{ page.baseurl }}/comp-mgr/patching.html#custom-patches) to address a specific issue. Also, third-party extension developers can provide a custom patch. Copy the custom patch to the `/m2-hotfixes` directory and test it on your local workstation.
 
 {% include cloud/note-upgrade.md %}
 


### PR DESCRIPTION

## Purpose of this pull request

There is a page about [Applying patches](https://devdocs.magento.com/guides/v2.3/comp-mgr/patching.html). It describes how to create a custom patch.

There is a [Apply custom patches](https://devdocs.magento.com/cloud/project/project-patch.html) page which describe how to implement a custom patch. 

This pull request (PR) links [Apply custom patches](https://devdocs.magento.com/cloud/project/project-patch.html) page with [Applying patches](https://devdocs.magento.com/guides/v2.3/comp-mgr/patching.html).

## Affected DevDocs pages

<!-- REQUIRED List the affected pages on devdocs.magento.com (URLs). Not needed for large numbers of files. -->

- https://devdocs.magento.com/cloud/project/project-patch.html

## Links to Magento source code

<!--  OPTIONAL - REMOVE THIS SECTION IF NOT USED. If this pull request references a file in a Magento codebase repository, add it here. -->

-  ...

<!--
If you are fixing a GitHub issue, note it using GitHub keyword format (https://help.github.com/en/articles/closing-issues-using-keywords#closing-an-issue-in-a-different-repository) to close the issue when this pull request is merged. Example: `Fixes #1234`

`master` is the default branch. Merged pull requests to `master` go live on the site automatically. Any requested changes to content on the `master` branch must be related to the released codebase. Any content related to future releases goes in the `develop` branch.

See Contribution guidelines (https://github.com/magento/devdocs/blob/master/.github/CONTRIBUTING.md) for more information.
-->

Thank you!
