### PR TITLE
Fix the inheritance of alert widget

### DIFF
--- a/src/guides/v2.3/javascript-dev-guide/widgets/widget_alert.md
+++ b/src/guides/v2.3/javascript-dev-guide/widgets/widget_alert.md
@@ -31,7 +31,8 @@ $('#init_element').alert({
 ```javascript
 require([
     'Magento_Ui/js/modal/alert'
-], function(alert) { // Variable that represents the `alert` function
+    'jquery'
+], function(alert, $) { // Variable that represents the `alert` function
 
     alert({
         title: $.mage.__('Some title'),

--- a/src/guides/v2.3/javascript-dev-guide/widgets/widget_alert.md
+++ b/src/guides/v2.3/javascript-dev-guide/widgets/widget_alert.md
@@ -4,7 +4,7 @@ subgroup: 3_Widgets
 title: Alert widget
 ---
 
-The Magento alert widget implements a modal pop-up window with a confirmation button. It extends the [Magento modal widget].
+The Magento alert widget implements a modal pop-up window with a confirmation button. It extends the [Magento confirmation widget] which in turn extends the [Magento modal widget].
 
 The alert widget source is [`<Magento_Ui_module_dir>/view/base/web/js/modal/alert.js`].
 
@@ -249,6 +249,7 @@ require([
 
 ![Alert Widget]({{ site.baseurl }}/common/images/widget/alert-widget-result.png)
 
+[Magento confirmation widget]: {{ page.baseurl }}/javascript-dev-guide/widgets/widget_confirm.html
 [Magento modal widget]: {{ page.baseurl }}/javascript-dev-guide/widgets/widget_modal.html
 [`<Magento_Ui_module_dir>/view/base/web/js/modal/alert.js`]: {{ site.mage2bloburl }}/{{ page.guide_version }}/app/code/Magento/Ui/view/base/web/js/modal/alert.js
 [Magento Admin Pattern Library, the Slide-out Panels, Modal Windows, and Overlays topic.]: {{ page.baseurl }}/pattern-library/containers/slideouts-modals-overlays/slideouts-modals-overalys.html#modals


### PR DESCRIPTION
## Purpose of this pull request

This pull request (PR) fixes the inheritance of alert widget and the standalone example 2

## Affected DevDocs pages
https://devdocs.magento.com/guides/v2.3/javascript-dev-guide/widgets/widget_alert.html
-  ...

## Links to Magento source code
https://github.com/magento/magento2/blob/2.3/app/code/Magento/Ui/view/base/web/js/modal/alert.js
https://github.com/magento/magento2/blob/2.3/app/code/Magento/Ui/view/base/web/js/modal/confirm.js
