### PR TITLE
Need to modify config.php before running docker:build

### DIFF
--- a/src/cloud/docker/docker-config.md
+++ b/src/cloud/docker/docker-config.md
@@ -107,16 +107,16 @@ For example, the following command starts the Docker configuration generator for
 
 Continue launching your Docker environment in the default _production_ mode.
 
-1. In your local environment, start the Docker configuration generator. You can use the service keys, such as `--php`, to [specify a version](#service-versions).
-
-   ```bash
-   ./vendor/bin/ece-tools docker:build
-   ```
-
 1. _Optional_: If you have a custom PHP configuration file, copy the default configuration DIST file to your custom configuration file and make any necessary changes.
 
    ```bash
    cp ./docker/config.php.dist ./docker/config.php
+   ```
+
+1. In your local environment, start the Docker configuration generator. You can use the service keys, such as `--php`, to [specify a version](#service-versions).
+
+   ```bash
+   ./vendor/bin/ece-tools docker:build
    ```
 
 1. _Optional_: Configure the Docker global variables in the `docker-compose.yml` file. For example, you can [configure Xdebug]({{ site.baseurl }}/cloud/docker/docker-development-debug.html#configure-xdebug).
@@ -178,6 +178,12 @@ The `{{site.data.var.ct}}` version 2002.0.18 and later supports developer mode.
    Optionally, you can install the `mutagen.io` tool using the [Installation instructions](https://mutagen.io/documentation/introduction/installation/).
 
    If you have it installed, continue to the next step.
+
+1. _Optional_: If you have a custom PHP configuration file, copy the default configuration DIST file to your custom configuration file and make any necessary changes.
+
+   ```bash
+   cp ./docker/config.php.dist ./docker/config.php
+   ```
 
 1. In your local environment, start the Docker configuration generator. You can use the service keys, such as `--php`, to [specify a version](#service-versions).
 


### PR DESCRIPTION
## Purpose of this pull request

Recent changes to Docker configuration require the config.php file to exist before running the docker:build command in order for customizations to be effective. A couple steps in the setup doc need to be reversed.

## Affected DevDocs pages

https://devdocs.magento.com/cloud/docker/docker-config.html
