### PR TITLE
Extra Spacing removed from Template-specific non-inline styles's example block

### DIFF
--- a/src/guides/v2.3/frontend-dev-guide/templates/template-email.md
+++ b/src/guides/v2.3/frontend-dev-guide/templates/template-email.md
@@ -136,9 +136,9 @@ The value of that variable comes from any of the following:
 *  Any styles you add to any `html` email template inside a comment block, like in the following example, are included in the `template_styles` variable:
 
 ```html
-      <!--@styles
-      .example-style { color: green; }
-      @-->
+ <!--@styles
+   .example-style { color: green; }
+ @-->
 ```
 
 *  If you customize transactional emails using the Magento Admin, you can add CSS styles to the **Template Styles** field to include those styles in the `template_styles` variable.


### PR DESCRIPTION
## Purpose of this pull request

This pull request (PR) will remove extra spacing from the example block

## Affected DevDocs pages
https://devdocs.magento.com/guides/v2.3/frontend-dev-guide/templates/template-email.html