### PR TITLE
Removed Empty Lines from the Example Block

### DIFF
--- a/src/guides/v2.3/frontend-dev-guide/templates/template-email.md
+++ b/src/guides/v2.3/frontend-dev-guide/templates/template-email.md
@@ -371,9 +371,7 @@ The `trans` directive will translate strings into whatever locale is configured 
 The directive supports multiple named parameters, separated by spaces. For example:
 
 ```html
-{% raw %}
-{{trans "Dear %first_name %last_name," first_name=$first_name last_name=$last_name}}
-{% endraw %}
+{% raw %}{{trans "Dear %first_name %last_name," first_name=$first_name last_name=$last_name}}{% endraw %}
 ```
 
 Please note, that variable assignment must not contain spaces.
@@ -381,17 +379,13 @@ Please note, that variable assignment must not contain spaces.
 Correct:
 
 ```html
-{% raw %}
-{{trans "Thank you for your order from %store_name." store_name=$store.getFrontendName()}}
-{% endraw %}
+{% raw %}{{trans "Thank you for your order from %store_name." store_name=$store.getFrontendName()}}{% endraw %}
 ```
 
 Incorrect:
 
 ```html
-{% raw %}
-{{trans "Thank you for your order from %store_name." store_name = $store.getFrontendName()}}
-{% endraw %}
+{% raw %}{{trans "Thank you for your order from %store_name." store_name = $store.getFrontendName()}}{% endraw %}
 ```
 
 {:.bs-callout .bs-callout-info}


### PR DESCRIPTION
## Purpose of this pull request
This pull request (PR) will remove the empty lines from the example blocks.

## Affected DevDocs pages
https://devdocs.magento.com/guides/v2.3/frontend-dev-guide/templates/template-email.html