### PR TITLE
MAGECLOUD-4953-Update Cloud Guide with link to magento-cloud CLI command reference

### DIFF
--- a/src/cloud/reference/cli-ref-topic.md
+++ b/src/cloud/reference/cli-ref-topic.md
@@ -20,6 +20,9 @@ The following lists the available `magento-cloud` CLI commands:
 magento-cloud list
 ```
 
+{:bs-callout-tip}
+You can also find information about `magento-cloud` CLI commands in the [Magento command-line tools reference]({{ site.baseurl }}/reference/cli/magento.html).
+
 Magento designed these commands to manage Cloud Integration environments. It is a best practice to run the Magento Cloud CLI from a project directory, because you can omit the `-p <project ID>` parameter.
 
 Action | Command

--- a/src/cloud/reference/cli-ref-topic.md
+++ b/src/cloud/reference/cli-ref-topic.md
@@ -20,7 +20,7 @@ The following lists the available `magento-cloud` CLI commands:
 magento-cloud list
 ```
 
-{:bs-callout-tip}
+{:.bs-callout-tip}
 You can also find information about `magento-cloud` CLI commands in the [Magento command-line tools reference]({{ site.baseurl }}/reference/cli/magento.html).
 
 Magento designed these commands to manage Cloud Integration environments. It is a best practice to run the Magento Cloud CLI from a project directory, because you can omit the `-p <project ID>` parameter.


### PR DESCRIPTION
# Purpose of this pull request

Customer feedback requesting access to information about `magento-cloud` CLI commands without having an installed Cloud project. 

Added a link to the `magento-cloud` CLI command reference guide which provides documentation for all available `magento-cloud` CLI commands.

## Affected DevDocs pages

- https://devdocs.magento.com/cloud/reference/cli-ref-topic.html
