### PR TITLE
Mae fix queue consumers command name

### DIFF
--- a/src/guides/v2.3/install-gde/install/cli/install-cli-subcommands-maint.md
+++ b/src/guides/v2.3/install-gde/install/cli/install-cli-subcommands-maint.md
@@ -68,7 +68,7 @@ magento maintenance:enable --ip=192.0.2.10 --ip=192.0.2.11
 ```
 
  {:.bs-callout-info}
-  After you place Magento in maintenance mode, you must stop all message queue consumer processes. One way to find these processes is to run the `ps -ef | grep queue:consumer:start` command. Then run the `kill <process_id>` command for each consumer. In a multiple node environment, be sure to repeat this task on each node.
+  After you place Magento in maintenance mode, you must stop all message queue consumer processes. One way to find these processes is to run the `ps -ef | grep queue:consumers:start` command. Then run the `kill <process_id>` command for each consumer. In a multiple node environment, be sure to repeat this task on each node.
 
 ## Maintain the list of exempt IP addresses {#instgde-cli-maint-exempt}
 


### PR DESCRIPTION
## Purpose of this pull request

Fixed CLI command syntax for the queue:consumers CLI command syntax in the Magento Installation Guide:  `queue:consumer:start` -> `queue:consumers:start`

## Affected DevDocs pages

https://devdocs.magento.com/guides/v2.3/install-gde/install/cli/install-cli-install.html
