### PR TITLE
magento/devdocs#: Logging in to a Magento server. Editorial. Remove a redundant colon char.

### DIFF
--- a/src/guides/v2.3/install-gde/basics/basics_login.md
+++ b/src/guides/v2.3/install-gde/basics/basics_login.md
@@ -13,7 +13,7 @@ functional_areas:
 
 To complete almost all of the tasks in this guide, you must remotely log in to your Magento server.
 
-**Prerequisites:**: You must have:
+**Prerequisites:** You must have:
 
 *  A terminal application
 


### PR DESCRIPTION
## Purpose of this pull request

This pull request (PR) removes a redundant colon char on [Logging in to a Magento server](https://devdocs.magento.com/guides/v2.3/install-gde/basics/basics_login.html) page.

<img width="1272" alt="6357" src="https://user-images.githubusercontent.com/13585327/71970580-a3abce80-3211-11ea-80d4-a9069e8ba753.png">


## Affected DevDocs pages

<!-- REQUIRED List the affected pages on devdocs.magento.com (URLs). Not needed for large numbers of files. -->

- https://devdocs.magento.com/guides/v2.3/install-gde/basics/basics_login.html

## Links to Magento source code

<!--  OPTIONAL - REMOVE THIS SECTION IF NOT USED. If this pull request references a file in a Magento codebase repository, add it here. -->

-  ...

<!--
If you are fixing a GitHub issue, note it using GitHub keyword format (https://help.github.com/en/articles/closing-issues-using-keywords#closing-an-issue-in-a-different-repository) to close the issue when this pull request is merged. Example: `Fixes #1234`

`master` is the default branch. Merged pull requests to `master` go live on the site automatically. Any requested changes to content on the `master` branch must be related to the released codebase. Any content related to future releases goes in the `develop` branch.

See Contribution guidelines (https://github.com/magento/devdocs/blob/master/.github/CONTRIBUTING.md) for more information.
-->
