### PR TITLE
Updated Cloud Guide to add latest info for RabbitMQ version support

### DIFF
--- a/src/cloud/project/project-conf-files_services.md
+++ b/src/cloud/project/project-conf-files_services.md
@@ -166,7 +166,7 @@ Service   |  Magento 2.3  | Magento 2.2
 `nginx`   | 1.9           | 1.9
 `node`    | 6, 8, 10, 11  | 6, 8, 10, 11
 `php`     | Magento 2.3.3 and later—7.1, 7.2, 7.3<br>Magento 2.3.0 to 2.3.2—7.1, 7.2 | Magento 2.2.10 and later—7.1, 7.2<br>Magento 2.2.5 to 2.2.9—7.0, 7.1<br>Magento 2.2.4 and earlier—7.0.2, 7.0.4, ~7.0.6, 7.1<br><br>**Note:** Beginning with {{ site.data.var.ct }} v2002.1.0, you must use PHP version 7.1.3 or later for both Magento 2.2 and 2.3.
-`rabbitmq`| 3.5, 3.7      | 3.5
+`rabbitmq`| 3.5, 3.7, 3.8      | 3.5
 `redis`   | 3.2, 4.0, 5.0 | 3.2, 4.0, 5.0
 `varnish` | Magento 2.3.3 and later—4.0, 5.0, 6.2<br>Magento 2.3.0 to 2.3.2—4.0, 5.0 | 4.0, 5.0
 

--- a/src/cloud/release-notes/ece-release-notes.md
+++ b/src/cloud/release-notes/ece-release-notes.md
@@ -96,6 +96,8 @@ The `{{site.data.var.ct}}` 2002.0.22 release changes the structure of the `{{sit
 
 -  {:.new}<!-- MAGECLOUD-3535 -->Improved version compatibility validation and warning notifications for compatibility issues between Magento version and installed services, such as Elasticsearch, RabbitMq, Redis, and DB.
 
+-  {:.new}<!-- MAGECLOUD-4674-->Added support for RabitMQ version 3.8.
+
 -  {:.new}<!-- MAGECLOUD-4018 -->Updated interactive validations for service compatibility to reflect supported versions for the new {{ site.data.var.ee }} 2.3.3 and 2.2.10 releases. See [Service versions]({{ site.baseurl }}/cloud/project/project-conf-files_services.html#service-versions).
 
 -  {:.fix}<!-- MAGECLOUD-3653-->Improved the log message returned when the cron job management process in the deploy phase tries to stop a cron job that has already finished to clarify that this issue is not an error.  Changed the log level from `INFO` to `DEBUG`.


### PR DESCRIPTION
## Purpose of this pull request

- Updated the Service versions table to add support for RabbitMQ version 3.8 on Magento 2.3.
- Updated release notes.

## Affected DevDocs pages

- https://devdocs.magento.com/cloud/project/project-conf-files_services.html
