### PR TITLE
DO NOT MERGE: Updates to Cloud Docker Varnish container default config and install options

### DIFF
--- a/src/cloud/docker/docker-containers.md
+++ b/src/cloud/docker/docker-containers.md
@@ -38,7 +38,7 @@ You can share files easily between your machine and a Docker container by placin
 The `docker:build` command runs in interactive mode and verifies the configured service versions. To skip the interactive mode, use the `-n, --no-interaction` option.
 
 **Varnish** service is installed by default and right after the deployment Magento is configured to use Varnish for FPC.
-You may avoid installation of Varnish using `--no-varnish` option.
+You can skip installation of the Varnish container by adding the `--no-varnish` option to the `docker:build` command when you are creating a Cloud Docker environment.
 
  {:.bs-callout-info}
 If you have Magento 2.2.0 and higher it will be configured to use Varnish as FPC during the deployment.

--- a/src/cloud/docker/docker-containers.md
+++ b/src/cloud/docker/docker-containers.md
@@ -37,14 +37,9 @@ You can share files easily between your machine and a Docker container by placin
 
 The `docker:build` command runs in interactive mode and verifies the configured service versions. To skip the interactive mode, use the `-n, --no-interaction` option.
 
-**Varnish** service is installed by default and right after the deployment Magento is configured to use Varnish for full page cacheing (FPC).
-You can skip installation of the Varnish container by adding the `--no-varnish` option to the `docker:build` command when you are creating a Cloud Docker environment.
+The **Varnish** service is installed by default, and when deployment completes Magento is configured to use Varnish for full page cacheing (FPC) for Magento version 2.2.0 or later. The configuration process preserves any custom FPC configurations that you have already configure.
 
- {:.bs-callout-info}
-If you have Magento 2.2.0 and higher it will be configured to use Varnish as FPC during the deployment.
-if you have custom configurations for FPC in app/etc/env.php - they won't be overwritten.
-
-For example, the following command starts the Docker configuration generator for the developer mode and specifies the PHP version 7.2 without installation of Varnish:
+You can skip installation of the Varnish container by adding the `--no-varnish` option to the `docker:build` command when you are creating a Cloud Docker environment. For example, the following command starts the Docker configuration generator for developer mode with options to specify PHP version 7.2 and skip the Varnish installation:
 
 ```bash
 ./vendor/bin/ece-tools docker:build --mode="developer" --php 7.2 --no-varnish

--- a/src/cloud/docker/docker-containers.md
+++ b/src/cloud/docker/docker-containers.md
@@ -37,11 +37,19 @@ You can share files easily between your machine and a Docker container by placin
 
 The `docker:build` command runs in interactive mode and verifies the configured service versions. To skip the interactive mode, use the `-n, --no-interaction` option.
 
-For example, the following command starts the Docker configuration generator for the developer mode and specifies the PHP version 7.2:
+**Varnish** service is installed by default and right after the deployment Magento is configured to use Varnish for FPC.
+You may avoid installation of Varnish using `--no-varnish` option.
+
+ {:.bs-callout-info}
+If you have Magento less than 2.2.0 you need to configure Magento manually to use Varnish for FPC
+
+For example, the following command starts the Docker configuration generator for the developer mode and specifies the PHP version 7.2 without installation of Varnish:
 
 ```bash
-./vendor/bin/ece-tools docker:build --mode="developer" --php 7.2
+./vendor/bin/ece-tools docker:build --mode="developer" --php 7.2 --no-varnish
 ```
+
+In addition some services are installed by default with latest version
 
 [Docker architecture]: {{ site.baseurl }}/common/images/cloud/docker-topology.png
 [Database container]: {{site.baseurl}}/cloud/docker/docker-database.html

--- a/src/cloud/docker/docker-containers.md
+++ b/src/cloud/docker/docker-containers.md
@@ -37,7 +37,7 @@ You can share files easily between your machine and a Docker container by placin
 
 The `docker:build` command runs in interactive mode and verifies the configured service versions. To skip the interactive mode, use the `-n, --no-interaction` option.
 
-The **Varnish** service is installed by default, and when deployment completes Magento is configured to use Varnish for full page cacheing (FPC) for Magento version 2.2.0 or later. The configuration process preserves any custom FPC configurations that you have already configure.
+The **Varnish** service is installed by default, and when deployment completes Magento is configured to use Varnish for full page cacheing (FPC) for Magento version 2.2.0 or later. The configuration process preserves any custom FPC configuration settings that already exist.
 
 You can skip installation of the Varnish container by adding the `--no-varnish` option to the `docker:build` command when you are creating a Cloud Docker environment. For example, the following command starts the Docker configuration generator for developer mode with options to specify PHP version 7.2 and skip the Varnish installation:
 

--- a/src/cloud/docker/docker-containers.md
+++ b/src/cloud/docker/docker-containers.md
@@ -37,7 +37,7 @@ You can share files easily between your machine and a Docker container by placin
 
 The `docker:build` command runs in interactive mode and verifies the configured service versions. To skip the interactive mode, use the `-n, --no-interaction` option.
 
-**Varnish** service is installed by default and right after the deployment Magento is configured to use Varnish for FPC.
+**Varnish** service is installed by default and right after the deployment Magento is configured to use Varnish for full page cacheing (FPC).
 You can skip installation of the Varnish container by adding the `--no-varnish` option to the `docker:build` command when you are creating a Cloud Docker environment.
 
  {:.bs-callout-info}

--- a/src/cloud/docker/docker-containers.md
+++ b/src/cloud/docker/docker-containers.md
@@ -41,7 +41,8 @@ The `docker:build` command runs in interactive mode and verifies the configured 
 You may avoid installation of Varnish using `--no-varnish` option.
 
  {:.bs-callout-info}
-If you have Magento less than 2.2.0 you need to configure Magento manually to use Varnish for FPC
+If you have Magento 2.2.0 and higher it will be configured to use Varnish as FPC during the deployment.
+if you have custom configurations for FPC in app/etc/env.php - they won't be overwritten.
 
 For example, the following command starts the Docker configuration generator for the developer mode and specifies the PHP version 7.2 without installation of Varnish:
 

--- a/src/cloud/docker/docker-containers.md
+++ b/src/cloud/docker/docker-containers.md
@@ -50,8 +50,6 @@ For example, the following command starts the Docker configuration generator for
 ./vendor/bin/ece-tools docker:build --mode="developer" --php 7.2 --no-varnish
 ```
 
-In addition some services are installed by default with latest version
-
 [Docker architecture]: {{ site.baseurl }}/common/images/cloud/docker-topology.png
 [Database container]: {{site.baseurl}}/cloud/docker/docker-database.html
 [CLI containers]: {{site.baseurl}}/cloud/docker/docker-cli.html


### PR DESCRIPTION
## Purpose

Add information about changes to Varnish container configuration in Cloud Docker environments effective for Magento Cloud Docker v1.0.1 release.

- New `docker-build` option `--no-varnish` to skip Varnish installation and remove varnish as a service from resulting docker-compose

- In Magento Cloud Docker environments using Magento v2.2.0 or later, Varnish is installed by default. After deployment, Varnish is configured as the FPC for the Magento instance. Any custom FPC configuration that already exists is preserved.

## Affected pages

https://devdocs.magento.com/cloud/docker/docker-containers.html
