### PR TITLE
MAGECLOUD-4736: Document Changes to Magento-Cloud-Patches

### DIFF
--- a/src/_data/toc/cloud-guide.yml
+++ b/src/_data/toc/cloud-guide.yml
@@ -516,7 +516,7 @@ pages:
           url: /cloud/project/ece-tools-update.html
           versionless: true
 
-        - label: Apply custom patches
+        - label: Apply patches
           url: /cloud/project/project-patch.html
           versionless: true
 

--- a/src/cloud/project/project-patch.md
+++ b/src/cloud/project/project-patch.md
@@ -17,7 +17,7 @@ You can also use {{site.data.var.mcp}} to apply [custom patches]({{ site.baseurl
 {:.procedure}
 To use {{ site.data.var.mcp }} as a stand-alone package: 
 
-1. Add the Magento Cloud Patches package to your `composer.json`
+1. Add the {{site.data.var.mcp}} package to your `composer.json` file.
 
     ```bash
     composer require magento/magento-cloud-patches

--- a/src/cloud/project/project-patch.md
+++ b/src/cloud/project/project-patch.md
@@ -15,7 +15,7 @@ You can also use {{site.data.var.mcp}} to apply [custom patches]({{ site.baseurl
 {% include cloud/note-upgrade.md %}
 
 {:.procedure}
-To implement Magento Cloud Patches:
+To use {{ site.data.var.mcp }} as a stand-alone package: 
 
 1. Add the Magento Cloud Patches package to your `composer.json`
 

--- a/src/cloud/project/project-patch.md
+++ b/src/cloud/project/project-patch.md
@@ -24,7 +24,7 @@ To use {{ site.data.var.mcp }} as a stand-alone package:
     ```
     
 {:.procedure}
-To apply patches for testing:
+To apply {{site.data.var.ece}} patches manually:
 
 1. From the project root, apply the patches.
 

--- a/src/cloud/project/project-patch.md
+++ b/src/cloud/project/project-patch.md
@@ -10,7 +10,7 @@ provides Magento Cloud patches which improve the integration of all {{site.data.
 
 The {{ site.data.var.mcp }} package is a dependency for the {{site.data.var.ct}} package and is installed or updated when you install or update the {{ site.data.var.ct }} package version. You can also use and manage the {{ site.data.var.mcp }} as a stand-alone package for an existing {{ site.data.var.ece }} project.
 
-Magento Cloud Patches can also apply [custom patches]({{ site.baseurl }}/guides/v2.3/comp-mgr/patching.html#custom-patches) provided by support or third-party extension developers. Copy the custom patch to a directory called `/m2-hotfixes` in the project root and test it on your local workstation.
+You can also use {{site.data.var.mcp}} to apply [custom patches]({{ site.baseurl }}/guides/v2.3/comp-mgr/patching.html#custom-patches) provided by support or third-party extension developers.  To use this feature,  copy the custom patch to the `/m2-hotfixes` directory in the {{ site.data.var.ee }} project root directory. Then, test the patch on your local workstation.
 
 {% include cloud/note-upgrade.md %}
 
@@ -55,4 +55,3 @@ To apply and test a custom patch:
 
     {:.bs-callout-info}
     Make sure to test all patches in a pre-production environment.  For Magento Cloud, new branches can be created with `magento-cloud environment:branch <branch-name>`
-

--- a/src/cloud/project/project-patch.md
+++ b/src/cloud/project/project-patch.md
@@ -5,7 +5,10 @@ functional_areas:
   - Cloud
   - Upgrade
 ---
-The [Magento Cloud Patches](https://github.com/magento/magento-cloud-patches) package is a set of patches, previously used within the ece-tools package to improve the integration of all Magento versions with Cloud environments and to deliver critical fixes quickly. This can also be integrated to an existing Magento project as a standalone package.
+The [Magento Cloud Patches](https://github.com/magento/magento-cloud-patches) package
+provides Magento Cloud patches which improve the integration of all {{site.data.var.ee}} versions with Cloud environments and supports quick delivery of critical fixes. You can also add and apply custom patches using {{ site.data.var.mcp }}.
+
+The {{ site.data.var.mcp }} package is a dependency for the {{site.data.var.ct}} package and is installed or updated when you install or update the {{ site.data.var.ct }} package version. You can also use and manage the {{ site.data.var.mcp }} as a stand-alone package for an existing {{ site.data.var.ece }} project.
 
 Magento Cloud Patches can also apply [custom patches]({{ site.baseurl }}/guides/v2.3/comp-mgr/patching.html#custom-patches) provided by support or third-party extension developers. Copy the custom patch to a directory called `/m2-hotfixes` in the project root and test it on your local workstation.
 
@@ -52,5 +55,4 @@ To apply and test a custom patch:
 
     {:.bs-callout-info}
     Make sure to test all patches in a pre-production environment.  For Magento Cloud, new branches can be created with `magento-cloud environment:branch <branch-name>`
-
 

--- a/src/cloud/project/project-patch.md
+++ b/src/cloud/project/project-patch.md
@@ -1,43 +1,32 @@
 ---
 group: cloud-guide
-title: Apply custom patches
+title: Apply patches
 functional_areas:
   - Cloud
   - Upgrade
 ---
+The [Magento Cloud Patches](https://github.com/magento/magento-cloud-patches) package is a set of patches, previously used within the ece-tools package to improve the integration of all Magento versions with Cloud environments and to deliver critical fixes quickly. This can also be integrated to an existing Magento project as a standalone package.
 
-Sometimes we provide a [custom patch]({{ site.baseurl }}/guides/v2.3/comp-mgr/patching.html#custom-patches) to address a specific issue. Also, third-party extension developers can provide a custom patch. Copy the custom patch to the `/m2-hotfixes` directory and test it on your local workstation.
+Magento Cloud Patches can also apply [custom patches]({{ site.baseurl }}/guides/v2.3/comp-mgr/patching.html#custom-patches) provided by support or third-party extension developers. Copy the custom patch to a directory called `/m2-hotfixes` in the project root and test it on your local workstation.
 
 {% include cloud/note-upgrade.md %}
 
 {:.procedure}
-To apply and test a custom patch:
+To implement Magento Cloud Patches:
 
-You can only apply patches during the build phase of redeployment.
-
-1. On your local workstation, create a branch based on the `integration` branch.
+1. Add the Magento Cloud Patches package to your `composer.json`
 
     ```bash
-    magento-cloud environment:branch <branch-name>
+    composer require magento/magento-cloud-patches
     ```
-
-1. Copy the patch file to the `/m2-hotfixes` directory.
-
-1. Add, commit, and push your code changes.
-
-    ```bash
-    git add -A && git commit -m "Apply patch" && git push origin <branch name>
-    ```
-
-1. After test validation, merge this branch with the `integration` branch.
-
+    
 {:.procedure}
-To test if a patch can be applied using your local workstation:
+To apply patches for testing:
 
-1. From the project root, apply the patch.
+1. From the project root, apply the patches.
 
     ```bash
-    git apply ./m2-hotfixes/<patch-file-name>
+     php ./vendor/bin/ece-patches apply
     ```
 
 1. Clear the Magento cache.
@@ -48,4 +37,20 @@ To test if a patch can be applied using your local workstation:
 
     You can also clean the cache using the [Magento Admin Cache Management](http://docs.magento.com/m2/ee/user_guide/system/cache-management.html).
 
-1. Test the patch, make any necessary changes.
+1. Test the patches, make any necessary changes to custom patches.
+
+{:.procedure}
+To apply and test a custom patch:
+
+1. In the project root, create a directory called `m2-hotfixes` if it does not exist
+
+    ```bash
+    mkdir m2-hotfixes
+    ```
+
+1. Copy the patch file to the `/m2-hotfixes` directory.
+
+    {:.bs-callout-info}
+    Make sure to test all patches in a pre-production environment.  For Magento Cloud, new branches can be created with `magento-cloud environment:branch <branch-name>`
+
+

--- a/src/cloud/release-notes/mcp-release-notes.md
+++ b/src/cloud/release-notes/mcp-release-notes.md
@@ -7,7 +7,10 @@ functional_areas:
   - Configuration
 ---
 
-The [Magento Cloud Patches](https://github.com/magento/magento-cloud-patches) package is a set of patches, previously used within the ece-tools package to improve the integration of all Magento versions with Cloud environments and to deliver critical fixes quickly. This package can be integrated to an existing Magento project as a standalone package. Information about integrating Magento Cloud Patches can be found at [Apply patches]({{ site.baseurl }}/cloud/project/project-patch.html). These release notes describe the latest improvements to this package.
+The [Magento Cloud Patches](https://github.com/magento/magento-cloud-patches) package provides a set of patches which improve the integration of all Magento versions with Cloud environments and supports quick delivery of critical fixes.
+
+The {{ site.data.var.mcp }} package is a dependency for the {{site.data.var.ct}} package and is installed and updated when you install or update the {{ site.data.var.ct }} package. You can also use and manage the {{ site.data.var.mcp }} as a stand-alone package to apply patches to a {{ site.data.var.ee }} project that is not on the Cloud platform. These release notes describe the latest improvements to this package.
+
 
 The `{{site.data.var.mcp}}` package uses the following version sequence: `<major>.<minor>.<patch>`.
 

--- a/src/cloud/release-notes/mcp-release-notes.md
+++ b/src/cloud/release-notes/mcp-release-notes.md
@@ -7,7 +7,7 @@ functional_areas:
   - Configuration
 ---
 
-The [Magento Cloud Patches](https://github.com/magento/magento-cloud-patches) package provides a set of patches which improve the integration of all Magento versions with Cloud environments and supports quick delivery of critical fixes. These release notes describe the latest improvements to this package, which is a component of [{{ site.data.var.csuite }}]({{ page.baseurl }}/cloud/release-notes/cloud-tools.html).
+The [Magento Cloud Patches](https://github.com/magento/magento-cloud-patches) package is a set of patches, previously used within the ece-tools package to improve the integration of all Magento versions with Cloud environments and to deliver critical fixes quickly. This package can be integrated to an existing Magento project as a standalone package. Information about integrating Magento Cloud Patches can be found at [Apply patches]({{ site.baseurl }}/cloud/project/project-patch.html). These release notes describe the latest improvements to this package.
 
 The `{{site.data.var.mcp}}` package uses the following version sequence: `<major>.<minor>.<patch>`.
 


### PR DESCRIPTION
## Purpose of this pull request

This pull request (PR) updates DevDocs to reflect de-composing Magento Cloud Patches from ECE-Tools

## Affected DevDocs pages

<!-- REQUIRED List the affected pages on devdocs.magento.com (URLs). Not needed for large numbers of files. -->

- cloud/project/project-patch
- cloud/release-notes/mcp-release-notes
