### PR TITLE
MAGECLOUD-4738: Document All Backward-incompatible Changes in ECE-Tools 2002.1.0

### DIFF
--- a/src/cloud/release-notes/backward-incompatible-changes.md
+++ b/src/cloud/release-notes/backward-incompatible-changes.md
@@ -42,4 +42,4 @@ In earlier releases of {{ site.data.var.ct }}, you could use the `m2-ece-build` 
 
 ### Patches changes
 
-- Cloud patches bundled all patches provided by [Magento Technical resources](https://magento.com/tech-resources/download). Patches which were copied from there to your project should be removed to avoid conflicts.
+- Cloud patches bundled all patches provided by [Magento Technical resources](https://magento.com/tech-resources/download). If you have copied any Magento-supplied patches downloaded from the Technical Resources page into your Magento project, remove them to prevent conflicts.

--- a/src/cloud/release-notes/backward-incompatible-changes.md
+++ b/src/cloud/release-notes/backward-incompatible-changes.md
@@ -39,3 +39,7 @@ In earlier releases of {{ site.data.var.ct }}, you could use the `m2-ece-build` 
 -  **New magento/magento-cloud-patches package**–We moved {{ site.data.var.ece }} patches and related functionality to a separate package, `magento/magento-cloud-patches` in {{ site.data.var.ct }} version 2002.1.0. See [Release notes for magento/magento-cloud-patches]({{site.baseurl}}/cloud/release-notes/mcp-release-notes.html).
 
 -  **New magento/magento-cloud-docker package**–We moved Docker development functionality to a separate package in {{ site.data.var.ct }} v2002.1.0. See [Release notes for magento/magento-cloud-docker]({{ site.baseurl }}/cloud/release-notes/mcd-release-notes.html).
+
+### Patches changes
+
+- Cloud patches bundled all patches provided by [Magento Technical resources](https://magento.com/tech-resources/download). Patches which were copied from there to your project should be removed to avoid conflicts.

--- a/src/cloud/release-notes/mcp-release-notes.md
+++ b/src/cloud/release-notes/mcp-release-notes.md
@@ -29,7 +29,7 @@ This release includes the following patches and critical fixes:
 
 ## v1.0.1
 
-All Magento Open Source 2.x patches form [Magento Technical resources](https://magento.com/tech-resources/download) were included in this release. If any of them were copied to your project before, they should be removed to avoid possible conflicts.
+All Magento Open Source 2.x patches from the [Magento Technical resources](https://magento.com/tech-resources/download) are included in this release. If you copied any patches into your project previously, remove them to avoid conflicts.
 
 This release includes the following patches and critical fixes:
 

--- a/src/cloud/release-notes/mcp-release-notes.md
+++ b/src/cloud/release-notes/mcp-release-notes.md
@@ -35,6 +35,6 @@ This release includes the following patches and critical fixes:
 
 -  {:.fix}<!--MAGECLOUD-4606-->**Review Hotfixes List and Add All Missing for 2.1.4+**–Updated the magento-cloud-patches package to include all Magento Open Source 2.x patches available on the [Magento Download page](https://magento.com/tech-resources/download).
 
--  {:.fix}<!--MAGECLOUD-4847-->**Issues caused by MC-21696 hot fix from ece-tools patches**–Patch from MC-21696 was replaced with more accurate fix.
+-  {:.fix}<!--MAGECLOUD-4847-->**Fixed issues caused by the MC-21696 hot fix from `ece-tools` patches**–Replaced the patch for MC-21696 with a more accurate fix.
 
 -  {:.fix}<!--MAGECLOUD-4884-->**Update PageBuilder Patches for RCE**–Update PageBuilder Patches which were bundled for 2.3.1 and 2.3.2 in MAGECLOUD-4649 before + add few more patches..

--- a/src/cloud/release-notes/mcp-release-notes.md
+++ b/src/cloud/release-notes/mcp-release-notes.md
@@ -26,3 +26,15 @@ This release includes the following patches and critical fixes:
 -  {:.fix}<!--MAGECLOUD-4422-->**Backward Compatibility of new Mail Interfaces**-Fixes a backward incompatibility issue caused by the `Magento\Framework\Mail\EmailMessageInterface` PHP interface introduced in {{ site.data.var.ee }} v2.3.3. In the scope of this patch, the new `EmailMessageInterface` inherits from the old `MessageInterface`, and {{ site.data.var.ee }} core modules are reverted to depend on `MessageInterface`.
 
 -  {:.fix}<!--MAGECLOUD-4448-->**Catalog pagination does not work on Elasticsearch 6.x**–Fixes a critical issue with search result pagination that affects customers using Elasticsearch 6.x as the catalog search engine.
+
+## v1.0.1
+
+All Magento Open Source 2.x patches form [Magento Technical resources](https://magento.com/tech-resources/download) were included in this release. If any of them were copied to your project before, they should be removed to avoid possible conflicts.
+
+This release includes the following patches and critical fixes:
+
+-  {:.fix}<!--MAGECLOUD-4606-->**Review Hotfixes List and Add All Missing for 2.1.4+**–Updated the magento-cloud-patches package to include all Magento Open Source 2.x patches available on the [Magento Download page](https://magento.com/tech-resources/download).
+
+-  {:.fix}<!--MAGECLOUD-4847-->**Issues caused by MC-21696 hot fix from ece-tools patches**–Patch from MC-21696 was replaced with more accurate fix.
+
+-  {:.fix}<!--MAGECLOUD-4884-->**Update PageBuilder Patches for RCE**–Update PageBuilder Patches which were bundled for 2.3.1 and 2.3.2 in MAGECLOUD-4649 before + add few more patches..


### PR DESCRIPTION
## Purpose of this pull request

This pull request (PR) describes incompatible changes in the ece-patches package.

## Affected DevDocs pages

-  https://devdocs.magento.com/cloud/release-notes/backward-incompatible-changes.html
- https://devdocs.magento.com//cloud/release-notes/mcp-release-notes.html

whatsnew
Added information about backward incompatible changes that affect the Magento Cloud patches component in the Magento Cloud Suite. 