### PR TITLE
Update adding-attributes.md

### DIFF
--- a/src/guides/v2.3/extension-dev-guide/extension_attributes/adding-attributes.md
+++ b/src/guides/v2.3/extension-dev-guide/extension_attributes/adding-attributes.md
@@ -180,7 +180,7 @@ For scalar attributes we can use next configuration:
 ```xml
 <config xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="urn:magento:framework:Api/etc/extension_attributes.xsd">
     <extension_attributes for="Magento\Catalog\Api\Data\ProductInterface">
-        <attribute code="first_custom_attribute" type="number" />
+        <attribute code="first_custom_attribute" type="int" />
         <attribute code="second_custom_attribute" type="string" />
     </extension_attributes>
 </config>


### PR DESCRIPTION
## Purpose of this pull request
This pull request (PR) changes the `number` scalar example to `int`.

Copying/pasting existing example would generate an interface with `$firstCustomAttribute` parameter type hinted as `\number` that would lead to a PHP Fatal error.

## Affected DevDocs pages
- [Adding extension attributes to entity](https://devdocs.magento.com/guides/v2.3/extension-dev-guide/extension_attributes/adding-attributes.html)
