### PR TITLE
Docker update RabbitMQ v3.8 support

### DIFF
--- a/src/cloud/docker/docker-containers.md
+++ b/src/cloud/docker/docker-containers.md
@@ -24,7 +24,7 @@ All customized Docker containers are stored in the [Magento Cloud Docker reposit
 | [elasticsearch]({{site.baseurl}}/cloud/docker/docker-containers-service.html#elasticsearch-container) | Elasticsearch | --es | 1.7, 2.4, 5.2, 6.5 |
 | [fpm]({{site.baseurl}}/cloud/docker/docker-containers-service.html#fpm-container) | PHP FPM | --php | 7.0, 7.1, 7.2 |  Used for all incoming requests
 | [node]({{site.baseurl}}/cloud/docker/docker-containers-cli.html#node-container) | Node | --node | 6, 8, 10, 11 |  Used gulp or other NPM based commands
-| [rabbitmq]({{site.baseurl}}/cloud/docker/docker-containers-service.html#rabbitmq-container) | RabbitMQ | --rmq | 3.5, 3.7 |
+| [rabbitmq]({{site.baseurl}}/cloud/docker/docker-containers-service.html#rabbitmq-container) | RabbitMQ | --rmq | 3.5, 3.7, 3.8 |
 | [redis]({{site.baseurl}}/cloud/docker/docker-containers-service.html#redis-container) | Redis     | --redis | 3.2, 4.0, 5.0 |   Standard redis container
 | [tls]({{site.baseurl}}/cloud/docker/docker-containers-service.html#tls-container) | SSL Endpoint |  |   |  Terminates SSL, can be configured to pass to varnish or nginx
 | [varnish]({{site.baseurl}}/cloud/docker/docker-containers-service.html#varnish-container) | Varnish | --varnish | 4,6 |

--- a/src/cloud/release-notes/mcd-release-notes.md
+++ b/src/cloud/release-notes/mcd-release-notes.md
@@ -34,3 +34,6 @@ The release notes include:
 
 -  {:.new}Added a container health check to the Elasticsearch service to ensure that the service is ready before continuing with build and deploy processing. If the health check returns an error, the container restarts automatically.<!--MAGECLOUD-4456-->
 
+- {:.new}Added support for RabbitMQ version 3.8.<!--MAGECLOUD-4674-->
+
+


### PR DESCRIPTION
## Purpose of this pull request

Added release note for updated support for RabbitMQ version 3.8

## Affected DevDocs pages

https://devdocs.magento.com/cloud/release-notes/release-notes-mcd.html