### PR TITLE
magento/devdocs#: Extend “Customize the 503 error page” topic name

### DIFF
--- a/src/_data/toc/cloud-guide.yml
+++ b/src/_data/toc/cloud-guide.yml
@@ -205,7 +205,7 @@ pages:
           url: /cloud/cdn/configure-fastly.html
           versionless: true
           children:
-            - label: Customize error pages
+            - label: Customize error and maintenance pages
               url: /cloud/cdn/cloud-fastly-custom-response.html
               versionless: true
 

--- a/src/cloud/cdn/cloud-fastly-custom-response.md
+++ b/src/cloud/cdn/cloud-fastly-custom-response.md
@@ -1,6 +1,6 @@
 ---
 group: cloud-guide
-title: Customize error pages
+title: Customize error and maintenance pages
 redirect_from:
    - /cloud/configure/fastly-vcl-extend-timeout.html
 functional_areas:


### PR DESCRIPTION
## Purpose of this pull request

This pull request (PR) has appeared from the question in cloud channel:

<img width="606" alt="6396" src="https://user-images.githubusercontent.com/13585327/72429660-2a742480-3799-11ea-9fea-54a16866b920.png">

and adds a "Maintenance" world into "Customize the 503 error page" section of the [Customize error pages](https://devdocs.magento.com/cloud/cdn/cloud-fastly-custom-response.html) page.

## Affected DevDocs pages

<!-- REQUIRED List the affected pages on devdocs.magento.com (URLs). Not needed for large numbers of files. -->

-  https://devdocs.magento.com/cloud/cdn/cloud-fastly-custom-response.html

## Links to Magento source code

<!--  OPTIONAL - REMOVE THIS SECTION IF NOT USED. If this pull request references a file in a Magento codebase repository, add it here. -->

-  ["Set Error / Maintenance page guide" by Fastly](https://github.com/fastly/fastly-magento2/blob/master/Documentation/Guides/ERROR-MAINTENANCE-PAGE.md)

<!--
If you are fixing a GitHub issue, note it using GitHub keyword format (https://help.github.com/en/articles/closing-issues-using-keywords#closing-an-issue-in-a-different-repository) to close the issue when this pull request is merged. Example: `Fixes #1234`

`master` is the default branch. Merged pull requests to `master` go live on the site automatically. Any requested changes to content on the `master` branch must be related to the released codebase. Any content related to future releases goes in the `develop` branch.

See Contribution guidelines (https://github.com/magento/devdocs/blob/master/.github/CONTRIBUTING.md) for more information.
-->
