### PR TITLE
Add the example of using the childDefaults property of uiCollection UI component

### DIFF
--- a/src/guides/v2.3/ui_comp_guide/concepts/ui_comp_uicollection_concept.md
+++ b/src/guides/v2.3/ui_comp_guide/concepts/ui_comp_uicollection_concept.md
@@ -64,7 +64,7 @@ The `uiCollection` class implements the following methods:
 
 *  `childDefaults` can be used to set the children defaults: properties from `childDefaults` are set into child elements' [`defaults` property]({{ page.baseurl }}/ui_comp_guide/concepts/ui_comp_uiclass_concept.html#uiclass_properties).
 
-   Example of configuring the provider property by default for all child elements of the [Columns]({{ page.baseurl }}/ui_comp_guide/components/ui-columns.html) component.
+   This is an example of configuring the provider property by default for all child elements of the [Columns]({{ page.baseurl }}/ui_comp_guide/components/ui-columns.html) component.
 
    ```xml
    <listing>

--- a/src/guides/v2.3/ui_comp_guide/concepts/ui_comp_uicollection_concept.md
+++ b/src/guides/v2.3/ui_comp_guide/concepts/ui_comp_uicollection_concept.md
@@ -64,6 +64,22 @@ The `uiCollection` class implements the following methods:
 
 *  `childDefaults` can be used to set the children defaults: properties from `childDefaults` are set into child elements' [`defaults` property]({{ page.baseurl }}/ui_comp_guide/concepts/ui_comp_uiclass_concept.html#uiclass_properties).
 
+   Example of configuring the provider property by default for all child elements of the [Columns]({{ page.baseurl }}/ui_comp_guide/components/ui-columns.html) component.
+
+   ```xml
+   <listing>
+       ...
+       <columns>
+           <settings>
+               <childDefaults>
+                   <param name="provider" xsi:type="string">ui_registry.path.to.provider.component</param>
+               </childDefaults>
+           </settings>
+           ...
+       </columns>
+   </listing>
+   ```
+
 ## uiCollection template {#uicollection_template}
 
 The `uiCollection` template is `<UI_Module_dir>/view/base/web/templates/collection.html`, in the {{site.data.var.ce}} GitHub repository: [`app/code/Magento/Ui/view/base/web/templates/collection.html`]({{ site.mage2bloburl }}/{{ page.guide_version }}/app/code/Magento/Ui/view/base/web/templates/collection.html).


### PR DESCRIPTION
## Purpose of this pull request

This pull request (PR) adds the example of using the `childDefaults` property of the uiCollection UI component.

## Affected DevDocs pages

-  https://devdocs.magento.com/guides/v2.3/ui_comp_guide/concepts/ui_comp_uicollection_concept.html#commonly-used-uicollection-properties

## Links to Magento source code

-  https://github.com/magento/magento2/blob/2.3/app/code/Magento/Cms/view/adminhtml/ui_component/cms_page_listing.xml#L127-L136
-  https://github.com/magento/magento2/blob/2.3/app/code/Magento/Customer/view/adminhtml/ui_component/customer_address_listing.xml#L48-L53
