### PR TITLE
Update placement-and-design.md minor typo issue

### DIFF
--- a/src/guides/v2.3/ext-best-practices/admin/placement-and-design.md
+++ b/src/guides/v2.3/ext-best-practices/admin/placement-and-design.md
@@ -62,7 +62,7 @@ settings displayed under specific entries in the **Store** > **Settings** > **Co
 
 **Placement:**
 
-The settings for these extensions should be displayed under its respective parent section under the **Store** > **Settings > **Configuration** section.
+The settings for these extensions should be displayed under its respective parent section under the **Store** > **Settings** > **Configuration** section.
 
 For example, if the extension is for Shipping, then you can place it under **Store** > **Settings** > **Configuration** > **Sales** > **Shipping Settings**.
 

--- a/src/guides/v2.3/ext-best-practices/admin/placement-and-design.md
+++ b/src/guides/v2.3/ext-best-practices/admin/placement-and-design.md
@@ -44,7 +44,7 @@ These extensions provide additional [API](https://glossary.magento.com/api) over
 
 **Placement:**
 
-All required settings for this connector type should appear in the **Stores** > **Settings** > **Configuration** section. The actual listings for these extension settings should appear after all of Magento's listed settings. All the setting details and configurations should appear in the section to the right.
+All required settings for this connector type should appear in the **Stores** > Settings > **Configuration** section. The actual listings for these extension settings should appear after all of Magento's listed settings. All the setting details and configurations should appear in the section to the right.
 
 ![Connector settings placement]({{ site.baseurl }}/common/images/ext-best-practices/connector-settings-placement.png)
 
@@ -58,13 +58,13 @@ All required settings for this connector type should appear in the **Stores** > 
 ### Store Feature Connector
 
 These extensions are responsible for integrating with different systems and need additional
-settings displayed under specific entries in the **Store** > **Settings** > **Configuration** section.
+settings displayed under specific entries in the **Store** > Settings > **Configuration** section.
 
 **Placement:**
 
-The settings for these extensions should be displayed under its respective parent section under the **Store** > **Settings** > **Configuration** section.
+The settings for these extensions should be displayed under its respective parent section under the **Store** > Settings > **Configuration** section.
 
-For example, if the extension is for Shipping, then you can place it under **Store** > **Settings** > **Configuration** > **Sales** > **Shipping Settings**.
+For example, if the extension is for Shipping, then you can place it under **Store** > Settings > **Configuration** > **Sales** > **Shipping Settings**.
 
 ![Store Feature Connector placement]({{ site.baseurl }}/common/images/ext-best-practices/store-feature-connector-placement.png)
 


### PR DESCRIPTION
Replace "**Store** > **Settings > **Configuration** section." with "**Store** > **Settings** > **Configuration** section."

![image](https://user-images.githubusercontent.com/19387846/72440954-cf115900-37cf-11ea-90bf-794ee0dd027d.png)

## Purpose of this pull request

This pull request (PR) solve minor typo issue.

## Affected DevDocs pages

<!-- REQUIRED List the affected pages on devdocs.magento.com (URLs). Not needed for large numbers of files. -->

-  https://devdocs.magento.com/guides/v2.3/ext-best-practices/admin/placement-and-design.html

## Links to Magento source code

<!--  OPTIONAL - REMOVE THIS SECTION IF NOT USED. If this pull request references a file in a Magento codebase repository, add it here. -->

<!--
If you are fixing a GitHub issue, note it using GitHub keyword format (https://help.github.com/en/articles/closing-issues-using-keywords#closing-an-issue-in-a-different-repository) to close the issue when this pull request is merged. Example: `Fixes #1234`

`master` is the default branch. Merged pull requests to `master` go live on the site automatically. Any requested changes to content on the `master` branch must be related to the released codebase. Any content related to future releases goes in the `develop` branch.

See Contribution guidelines (https://github.com/magento/devdocs/blob/master/.github/CONTRIBUTING.md) for more information.
-->
