### PR TITLE
magento/devdocs#: Add createBraintreeClientToken mutation API error

### DIFF
--- a/src/guides/v2.3/graphql/mutations/create-braintree-client-token.md
+++ b/src/guides/v2.3/graphql/mutations/create-braintree-client-token.md
@@ -31,3 +31,8 @@ mutation {
 }
 ```
 
+## Errors
+
+Error | Description
+--- | ---
+`The Braintree payment method is not active.` | The [Braintree](https://docs.magento.com/m2/ee/user_guide/payment/braintree.html) payment method is disabled in admin. 


### PR DESCRIPTION

## Purpose of this pull request

This pull request (PR) adds information about the API errors of `createBraintreeClientToken` mutation.

## Affected DevDocs pages

<!-- REQUIRED List the affected pages on devdocs.magento.com (URLs). Not needed for large numbers of files. -->

- https://devdocs.magento.com/guides/v2.3/graphql/mutations/create-braintree-client-token.html

## Links to Magento source code

<!--  OPTIONAL - REMOVE THIS SECTION IF NOT USED. If this pull request references a file in a Magento codebase repository, add it here. -->

-  [The Braintree payment method is not active.](https://github.com/magento/magento2/blob/2.3.3/dev/tests/api-functional/testsuite/Magento/GraphQl/Braintree/CreateBraintreeClientTokenTest.php#L38)

<!--
If you are fixing a GitHub issue, note it using GitHub keyword format (https://help.github.com/en/articles/closing-issues-using-keywords#closing-an-issue-in-a-different-repository) to close the issue when this pull request is merged. Example: `Fixes #1234`

`master` is the default branch. Merged pull requests to `master` go live on the site automatically. Any requested changes to content on the `master` branch must be related to the released codebase. Any content related to future releases goes in the `develop` branch.

See Contribution guidelines (https://github.com/magento/devdocs/blob/master/.github/CONTRIBUTING.md) for more information.
-->

Thank you!