### PR TITLE
Issue #6325 Change command which has to be used to configure a lock

### DIFF
--- a/src/guides/v2.3/install-gde/install/cli/install-cli-subcommands-lock.md
+++ b/src/guides/v2.3/install-gde/install/cli/install-cli-subcommands-lock.md
@@ -31,7 +31,7 @@ If you are running Magento Commerce on the cloud infrastructure, you do not need
 > Command usage
 
 ```bash
-magento setup:store-config:set [--<parameter_name>=<value>, ...]
+magento setup:config:set [--<parameter_name>=<value>, ...]
 ```
 
 > Parameter descriptions


### PR DESCRIPTION
## Purpose of this pull request
Change command which has to be used to configure a lock provider (the command that currently specified in docs doesn't have options to configure a lock and it's deprecated).

## Affected DevDocs pages
https://devdocs.magento.com/guides/v2.3/install-gde/install/cli/install-cli-subcommands-lock.html#instgde-cli-lockconfig