### PR TITLE
Added Specify Docker Build Sources section to Extending Docker Page

### DIFF
--- a/src/cloud/docker/docker-extend.md
+++ b/src/cloud/docker/docker-extend.md
@@ -39,7 +39,6 @@ services:
    build:
      context: ./vendor/magento/magento-cloud-docker/images/nginx/1.9/
 ```
-This example defines the build context for the web container, however this can be done with any of the images in `vendor/magento/magento-cloud-docker` or any image, including locally resourced outside of the project.
 
 If you want to update the container configuration and test iteratively, run the following command to refresh the container build.
 

--- a/src/cloud/docker/docker-extend.md
+++ b/src/cloud/docker/docker-extend.md
@@ -41,7 +41,7 @@ services:
 ```
 This example defines the build context for the web container, however this can be done with any of the images in `vendor/magento/magento-cloud-docker` or any image, including locally resourced outside of the project.
 
-When using this to make changes that require testing you can refresh the build of the container by running the following command:
+If you want to update the container configuration and test iteratively, you can run the following command to refresh the container build.
 
 ```bash
 docker-compose up -d --force-recreate --build

--- a/src/cloud/docker/docker-extend.md
+++ b/src/cloud/docker/docker-extend.md
@@ -41,7 +41,7 @@ services:
 ```
 This example defines the build context for the web container, however this can be done with any of the images in `vendor/magento/magento-cloud-docker` or any image, including locally resourced outside of the project.
 
-If you want to update the container configuration and test iteratively, you can run the following command to refresh the container build.
+If you want to update the container configuration and test iteratively, run the following command to refresh the container build.
 
 ```bash
 docker-compose up -d --force-recreate --build

--- a/src/cloud/docker/docker-extend.md
+++ b/src/cloud/docker/docker-extend.md
@@ -27,4 +27,23 @@ You can use the built-in extension mechanism of Docker to specify [multiple comp
    docker-compose -f docker-compose.yml -f docker-compose-dev.yml run deploy bash
    ```
 
+## Specify Docker Build Sources
+To be able to locally test changes to images or if there is a requirement to make more extensive changes to the containers you will need to build them from source. This is accomplished by adding build context to the `docker-compose.override.yml`.
+
+```yaml
+version: '2.1'
+services:
+ web:
+   build:
+     context: ./vendor/magento/magento-cloud-docker/images/nginx/1.9/
+```
+This example defines the build context for the web container, however this can be done with any of the images in `vendor/magento/magento-cloud-docker` or any image, including locally resourced outside of the project.
+
+When using this to make changes that require testing you can refresh the build of the container by running the following command:
+
+```bash
+docker-compose up -d --force-recreate --build
+```
+
+
 [multiple compose files]: https://docs.docker.com/compose/reference/overview/#specifying-multiple-compose-files

--- a/src/cloud/docker/docker-extend.md
+++ b/src/cloud/docker/docker-extend.md
@@ -45,5 +45,4 @@ When using this to make changes that require testing you can refresh the build o
 docker-compose up -d --force-recreate --build
 ```
 
-
 [multiple compose files]: https://docs.docker.com/compose/reference/overview/#specifying-multiple-compose-files

--- a/src/cloud/docker/docker-extend.md
+++ b/src/cloud/docker/docker-extend.md
@@ -27,7 +27,7 @@ You can use the built-in extension mechanism of Docker to specify [multiple comp
    docker-compose -f docker-compose.yml -f docker-compose-dev.yml run deploy bash
    ```
 
-## Specify Docker Build Sources
+## Specify Docker build sources
 To locally test changes to images or make more extensive changes to the containers, you must build them from source.
 
 The following example shows how to build from source by adding `build:context` configuration  to the `docker-compose.override.yml` file. This example defines the build context for the web container. You can use the same technique to build from any of the images in `vendor/magento/magento-cloud-docker` or any other Docker image, including images locally resourced outside the project.

--- a/src/cloud/docker/docker-extend.md
+++ b/src/cloud/docker/docker-extend.md
@@ -28,7 +28,9 @@ You can use the built-in extension mechanism of Docker to specify [multiple comp
    ```
 
 ## Specify Docker Build Sources
-To be able to locally test changes to images or if there is a requirement to make more extensive changes to the containers you will need to build them from source. This is accomplished by adding build context to the `docker-compose.override.yml`.
+To locally test changes to images or make more extensive changes to the containers, you must build them from source.
+
+The following example shows how to build from source by adding `build:context` configuration  to the `docker-compose.override.yml` file. This example defines the build context for the web container. You can use the same technique to build from any of the images in `vendor/magento/magento-cloud-docker` or any other Docker image, including images locally resourced outside the project.
 
 ```yaml
 version: '2.1'


### PR DESCRIPTION
## Purpose of this pull request

This pull request (PR) adds a section to Extending Docker documentation. This solves an issue in the cloud-docker project: https://github.com/magento/magento-cloud-docker/issues/93

## Affected DevDocs pages
-  cloud/docker/docker-extend.html


whatnew
Added instructions to build Docker containers from source for local testing.
