### PR TITLE
Fixes class name in CLI command code sample

### DIFF
--- a/src/guides/v2.3/extension-dev-guide/cli-cmds/cli-howto.md
+++ b/src/guides/v2.3/extension-dev-guide/cli-cmds/cli-howto.md
@@ -103,7 +103,7 @@ Following is a summary of the process:
                <argument name="name" xsi:type="string">my:first:command</argument>
            </arguments>
        </type>
-       <type name="Magento\Framework\Console\CommandList">
+       <type name="Magento\Framework\Console\CommandListInterface">
            <arguments>
                <argument name="commands" xsi:type="array">
                    <item name="commandexample_somecommand" xsi:type="object">Magento\CommandExample\Console\Command\SomeCommand</item>


### PR DESCRIPTION
## Purpose of this pull request

This pull request (PR) updates a class name in the code sample.

## Affected DevDocs pages

- https://devdocs.magento.com/guides/v2.3/extension-dev-guide/cli-cmds/cli-howto.html