### PR TITLE
magento/devdocs#: Add deletePaymentToken mutation API errors

### DIFF
--- a/src/guides/v2.3/graphql/mutations/delete-payment-token.md
+++ b/src/guides/v2.3/graphql/mutations/delete-payment-token.md
@@ -74,6 +74,13 @@ Attribute | Data Type | Description
 
 {% include graphql/customer-payment-tokens.md %}
 
+## Errors
+
+Error | Description
+--- | ---
+`Could not find a token using public hash: xxxxxxxx` | The customer token specified in the `public_hash` attribute does not exist in the `vault_payment_token` table.
+`The current customer isn't authorized.` | The current customer is not currently logged in, or the customer's token does not exist in the `oauth_token` table. 
+
 ## Related topics
 
 [customerPaymentTokens query]({{page.baseurl}}/graphql/queries/customer-payment-tokens.html)


### PR DESCRIPTION

## Purpose of this pull request

This pull request (PR) adds information about the API errors of `deletePaymentToken` mutation.

## Affected DevDocs pages

<!-- REQUIRED List the affected pages on devdocs.magento.com (URLs). Not needed for large numbers of files. -->

-  https://devdocs.magento.com/guides/v2.3/graphql/mutations/delete-payment-token.html

## Links to Magento source code

<!--  OPTIONAL - REMOVE THIS SECTION IF NOT USED. If this pull request references a file in a Magento codebase repository, add it here. -->

- [Could not find a token using public hash: xxxxxxxx](https://github.com/magento/magento2/blob/2.3.3/app/code/Magento/VaultGraphQl/Model/Resolver/DeletePaymentToken.php#L69)
- [The current customer isn't authorized.](https://github.com/magento/magento2/blob/2.3.3/app/code/Magento/VaultGraphQl/Model/Resolver/DeletePaymentToken.php#L59)

<!--
If you are fixing a GitHub issue, note it using GitHub keyword format (https://help.github.com/en/articles/closing-issues-using-keywords#closing-an-issue-in-a-different-repository) to close the issue when this pull request is merged. Example: `Fixes #1234`

`master` is the default branch. Merged pull requests to `master` go live on the site automatically. Any requested changes to content on the `master` branch must be related to the released codebase. Any content related to future releases goes in the `develop` branch.

See Contribution guidelines (https://github.com/magento/devdocs/blob/master/.github/CONTRIBUTING.md) for more information.
-->

Thank you!