### PR TITLE
Added a point for Theme development best practices

### DIFF
--- a/src/guides/v2.3/frontend-dev-guide/theme-best-practice.md
+++ b/src/guides/v2.3/frontend-dev-guide/theme-best-practice.md
@@ -13,6 +13,7 @@ We recommend using the following best practices when developing themes:
 
 1. When [inheriting]({{ page.baseurl }}/frontend-dev-guide/themes/theme-inherit.html) from a default Magento theme, extend the default styles instead of overriding them.  Whenever possible, put your customizations in the `_extend.less` or `_theme.less` file, instead of overriding a `.less` file from a parent theme.
 1. Customize, or create new, `.xml` layout files instead of customizing and overriding `.phtml` templates. For example, if you need to create a new container, it is better to add an `.xml` file than override an existing template. Some other customizations that can be performed using layout instructions include:
+
     *  Change the position of a block or container using `<move>`.
     *  Add or remove a block or container by setting the `remove` or `display` attribute to `true` or `false` within the `<referenceBlock>/<referenceContainer>`.
     *  Change the HTML tag or CSS class for the existing container using the `<referenceContainer>` element.
@@ -24,9 +25,10 @@ We recommend using the following best practices when developing themes:
 1. Use `<theme_dir>/etc/view.xml` to change image types or sizes, or add your own types. See [Configure images properties]({{ page.baseurl }}/frontend-dev-guide/themes/theme-images.html) for details. Use this file to also [customize the product gallery widget]({{ page.baseurl }}/javascript-dev-guide/widgets/widget_gallery.html).
 1. If you need to change the wording in the user interface, [add custom CSV dictionary files]({{ page.baseurl }}/frontend-dev-guide/translations/theme_dictionary.html) instead of overriding `.phtml` templates.
 1. Use [the CSS critical path]({{ page.baseurl }}/frontend-dev-guide/css-topics/css-critical-path.html) to render the page much faster.
-1. Always keep the text translatable. To ensure text used within your Magento templates can be translated, simply wrap it within the translate function:
-Example:
-```xml
-<a href="#"><?= __('Click to download'); ?></a>
-```
+1. Always keep the text translatable. To ensure text used within your Magento templates can be translated, wrap it within the translate function:
+   Example:
+   ```xml
+   <a href="#"><?= __('Click to download'); ?></a>
+   ```
+
 After updating or upgrading Magento instances, check for changes in any files that are overridden by your theme. If there were changes to default templates, layouts, or styles, copy those changes to your templates, layouts, and styles.

--- a/src/guides/v2.3/frontend-dev-guide/theme-best-practice.md
+++ b/src/guides/v2.3/frontend-dev-guide/theme-best-practice.md
@@ -24,5 +24,9 @@ We recommend using the following best practices when developing themes:
 1. Use `<theme_dir>/etc/view.xml` to change image types or sizes, or add your own types. See [Configure images properties]({{ page.baseurl }}/frontend-dev-guide/themes/theme-images.html) for details. Use this file to also [customize the product gallery widget]({{ page.baseurl }}/javascript-dev-guide/widgets/widget_gallery.html).
 1. If you need to change the wording in the user interface, [add custom CSV dictionary files]({{ page.baseurl }}/frontend-dev-guide/translations/theme_dictionary.html) instead of overriding `.phtml` templates.
 1. Use [the CSS critical path]({{ page.baseurl }}/frontend-dev-guide/css-topics/css-critical-path.html) to render the page much faster.
-
+1. Always keep the text translatable. To ensure text used within your Magento templates can be translated, simply wrap it within the translate function:
+Example:
+```xml
+<a href="#"><?= __('Click to download'); ?></a>
+```
 After updating or upgrading Magento instances, check for changes in any files that are overridden by your theme. If there were changes to default templates, layouts, or styles, copy those changes to your templates, layouts, and styles.


### PR DESCRIPTION
Added a point mentioning to make texts translatable with an example

This pull request (PR) ...

## Affected DevDocs pages

https://devdocs.magento.com/guides/v2.3/frontend-dev-guide/theme-best-practice.html