### PR TITLE
Update on include an external CSS code

### DIFF
--- a/src/guides/v2.3/frontend-dev-guide/css-topics/css-themes.md
+++ b/src/guides/v2.3/frontend-dev-guide/css-topics/css-themes.md
@@ -74,7 +74,7 @@ Your custom `default_head_blocks.xml` should be located as follows:
 
 To include a CSS file, add the `<css src="<path>/<file>" media="print|<option>"/>` block in `<head>` section in a layout file. `<path>` is specified relative to the theme web directory (`<theme_dir>/web`)
 
-For example, the following illustrates how stylesheets are included in the default Blank theme:
+The following illustrates how stylesheets are included in the default Blank theme:
 
 [`/Magento_Theme/layout/default_head_blocks.xml`]
 
@@ -88,14 +88,11 @@ For example, the following illustrates how stylesheets are included in the defau
 </page>
 ```
 
-To include an external CSS file, add `<css src="URL to External Source" src_type="url" rel="stylesheet" type="text/css" />` to the list.
+To include an external CSS file, add `<css src="URL to External Source" src_type="url" rel="stylesheet" type="text/css" />`.
 
 ```xml
 <page xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="urn:magento:framework:View/Layout/etc/page_configuration.xsd">
     <head>
-        <css src="css/styles-m.css" />
-        <css src="css/styles-l.css" media="screen and (min-width: 768px)"/>
-        <css src="css/print.css" media="print" />
         <css src="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.4/css/bootstrap-theme.min.css"  src_type="url" rel="stylesheet" type="text/css"  />
     </head>
 </page>


### PR DESCRIPTION
We do not need to add the Blank theme's CSS files again in our theme, since we are extending the file default_head_blocks.xml and to include a external css file the updated code is enough.
## Purpose of this pull request
This pull request (PR) will update the include external CSS code section.

## Affected DevDocs pages
https://devdocs.magento.com/guides/v2.3/frontend-dev-guide/css-topics/css-themes.html