### PR TITLE
Update project-conf-files_services-mysql.md

### DIFF
--- a/src/cloud/project/project-conf-files_services-mysql.md
+++ b/src/cloud/project/project-conf-files_services-mysql.md
@@ -153,5 +153,5 @@ Accessing the MariaDB database directly requires you to use a SSH to log in to t
    -  For Pro, use the following command with db, username, and password retrieved from the `$MAGENTO_CLOUD_RELATIONSHIPS` variable.
 
    ```bash
-   mysql -h<db> -p<number> -u<username> -p<password>
+   mysql -h<db> -P<number> -u<username> -p<password>
    ```

--- a/src/cloud/project/project-conf-files_services-mysql.md
+++ b/src/cloud/project/project-conf-files_services-mysql.md
@@ -146,12 +146,12 @@ Accessing the MariaDB database directly requires you to use a SSH to log in to t
 
    -  For Starter, use the following command:
 
-   ```bash
-   mysql -h database.internal -u <username>
-   ```
+      ```bash
+      mysql -h database.internal -u <username>
+      ```
 
    -  For Pro, use the following command with db, username, and password retrieved from the `$MAGENTO_CLOUD_RELATIONSHIPS` variable.
 
-   ```bash
-   mysql -h<db> -P<number> -u<username> -p<password>
-   ```
+     ```bash
+     mysql -h<db> -P<number> -u<username> -p<password>
+     ```


### PR DESCRIPTION


## Purpose of this pull request

Fixed the mysql command syntax for setting the port number.

Change from:
   "mysql -h<db> -p<number> -u<username> -p<password>"
to:
   "mysql -h<db> -P<number> -u<username> -p<password>"

That is, change the first lowercase "-p" to an uppercase "-P". The lowercase "-p" is for the password (as seen in the second instance of "-p"). The first instance is supposed to be the option to set the port, which should be an uppercase "-P".

## Affected DevDocs pages

- https://devdocs.magento.com/cloud/project/project-conf-files_services-mysql.html
