### PR TITLE
magento/devdocs#: Restore missed PR about CRON options

### DIFF
--- a/src/_includes/config/setup-cron_2.3_how-to.md
+++ b/src/_includes/config/setup-cron_2.3_how-to.md
@@ -15,9 +15,8 @@ To create the Magento crontab:
    ```
 
 Use `--force` to rewrite an existing Magento crontab.
-
- {:.bs-callout-info}
-
+ 
+{:.bs-callout-info}
 *  `magento cron:install` does not rewrite an existing crontab inside `#~ MAGENTO START` and `#~ MAGENTO END` comments in your crontab.
 *  `magento cron:install --force` has no effect on any cron jobs outside the Magento comments.
 
@@ -44,3 +43,17 @@ content='The `update/cron.php` file exists in [Composer](https://glossary.magent
 
 In [Composer-based installations](https://glossary.magento.com/composer), Magento creates the `update/` directory when you run `composer create-project`. Running `composer install` does not create the `update/` directory (if it did not exist before). See [Recreate the Magento updater](https://devdocs.magento.com/guides/v2.3/comp-mgr/cli/cli-upgrade.html#recreate-magento-updater).'
 %}
+
+As of Magento 2.3.4, mentioned crons have been grouped to `all` (`cron:run`, `update/cron.php`, `setup:cron:run` crons) and `non-optional` (`cron:run` cron only) groups.
+
+Use `--non-optional` (or `-d`) to install a non-optional CRON job:
+
+```bash
+bin/magento cron:install --non-optional
+```
+
+```terminal
+#~ MAGENTO START
+* * * * * /usr/bin/php /var/www/html/magento2/bin/magento cron:run | grep -v Ran jobs by schedule >> /var/www/html/magento2/var/log/magento.cron.log
+#~ MAGENTO END
+```

--- a/src/_includes/config/setup-cron_2.3_how-to.md
+++ b/src/_includes/config/setup-cron_2.3_how-to.md
@@ -15,8 +15,9 @@ To create the Magento crontab:
    ```
 
 Use `--force` to rewrite an existing Magento crontab.
- 
+
 {:.bs-callout-info}
+
 *  `magento cron:install` does not rewrite an existing crontab inside `#~ MAGENTO START` and `#~ MAGENTO END` comments in your crontab.
 *  `magento cron:install --force` has no effect on any cron jobs outside the Magento comments.
 


### PR DESCRIPTION

## Purpose of this pull request

This pull request (PR) recovers info from https://github.com/magento/devdocs/pull/5298. Looks like, somehow , we lost it.

## Affected DevDocs pages

<!-- REQUIRED List the affected pages on devdocs.magento.com (URLs). Not needed for large numbers of files. -->

-  https://devdocs.magento.com/guides/v2.3/config-guide/cli/config-cli-subcommands-cron.html

## Links to Magento source code

<!--  OPTIONAL - REMOVE THIS SECTION IF NOT USED. If this pull request references a file in a Magento codebase repository, add it here. -->

- https://github.com/magento/magento2/pull/24187

<!--
If you are fixing a GitHub issue, note it using GitHub keyword format (https://help.github.com/en/articles/closing-issues-using-keywords#closing-an-issue-in-a-different-repository) to close the issue when this pull request is merged. Example: `Fixes #1234`

`master` is the default branch. Merged pull requests to `master` go live on the site automatically. Any requested changes to content on the `master` branch must be related to the released codebase. Any content related to future releases goes in the `develop` branch.

See Contribution guidelines (https://github.com/magento/devdocs/blob/master/.github/CONTRIBUTING.md) for more information.
-->

CC: @hostep @lbajsarowicz 