### PR TITLE
Add global "Commerce-only" designation to Page Builder content

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -89,6 +89,7 @@ defaults:
       group: page-builder
       github_link: false
       feedback_link: false
+      ee_only: true
 
   - 
       scope:
@@ -97,6 +98,7 @@ defaults:
         group: page-builder
         github_link: false
         feedback_link: false
+        ee_only: true
 
   -
     scope:


### PR DESCRIPTION
## Purpose of this pull request

This pull request (PR) adds metadata to the Page Builder scope configuration so that the following icon displays at the top of all Page Builder pages on devdocs:

<img width="978" alt="Screen Shot 2020-01-21 at 3 13 02 PM" src="https://user-images.githubusercontent.com/13662379/72843761-d36ec380-3c60-11ea-8662-1668ff251b84.png">

## Affected DevDocs pages

- **Page Builder:** https://devdocs.magento.com/page-builder/docs/index.html
- **Page Builder Migration:** https://devdocs.magento.com/page-builder-migration/docs/
