### PR TITLE
Fixed ObjectManager Test Class

### DIFF
--- a/src/guides/v2.3/extension-dev-guide/test/test_object-mgr.md
+++ b/src/guides/v2.3/extension-dev-guide/test/test_object-mgr.md
@@ -22,7 +22,7 @@ The ObjectManager public interface methods are:
 -  [getCollectionMock method](#getCollectionMock). Lists mocked constructor arguments.
 -  [getConstructArguments method](#getConstructArguments). Creates collection instances that contain specified elements.
 
-### getObject method {#getobject}
+### getObject {#getobject}
 
 Creates mocks for all constructor dependencies and applies any specified custom mocks from `$arguments` array.
 <p>Also, instantiates the required `$className` by using constructor with already existing mocks.
@@ -49,7 +49,7 @@ $scopePool = $objectManagerHelper->getObject('\Magento\App\Config\ScopePool',
      $arguments);
 ```
 
-### getCollectionMock method {#getCollectionMock}
+### getCollectionMock {#getCollectionMock}
 
 Retrieves a collection instance with mocked getIterator method.
 
@@ -79,7 +79,7 @@ $optionCollection =
           array($options));
 ```
 
-### getConstructArguments method {#getConstructArguments}
+### getConstructArguments {#getConstructArguments}
 
 Lists dependency mocks for a specified class.
 

--- a/src/guides/v2.3/extension-dev-guide/test/test_object-mgr.md
+++ b/src/guides/v2.3/extension-dev-guide/test/test_object-mgr.md
@@ -11,7 +11,7 @@ To unit test such classes, you must manually create mocks for all constructor pa
 Use the `\Magento\Framework\TestFramework\Unit\Helper\ObjectManager` helper class to simplify this task. Its methods automatically create mocks for all required dependencies. You can then instantiate a testing object by passing these mocks to a class constructor.
 You can still create your custom mocks, if needed.
 
- {:.bs-callout-info}
+{:.bs-callout-info}
 Do not use the ObjectManager helper class for classes with a small number of dependencies.
 
 ## ObjectManager methods {#help}
@@ -25,7 +25,8 @@ The ObjectManager public interface methods are:
 ### getObject {#getobject}
 
 Creates mocks for all constructor dependencies and applies any specified custom mocks from `$arguments` array.
-<p>Also, instantiates the required `$className` by using constructor with already existing mocks.
+Also, instantiates the required `$className` by using constructor with already existing mocks.
+
 **Syntax**:
 
 ```php

--- a/src/guides/v2.3/extension-dev-guide/test/test_object-mgr.md
+++ b/src/guides/v2.3/extension-dev-guide/test/test_object-mgr.md
@@ -6,10 +6,11 @@ menu_title: Object Manager helper
 menu_order: 3
 ---
 
-<p>Block and model class constructors declare many dependencies. The Magento system uses constructor [dependency injection](https://glossary.magento.com/dependency-injection).</p>
-<p>To unit test such classes, you must manually create mocks for all constructor parameters before you can instantiate the class objects. If the number of dependencies is ten or greater, this task is time-consuming.</p>
-<p>Use the <code>\Magento\Framework\TestFramework\Unit\Helper\ObjectManager</code> helper class to simplify this task. Its methods automatically create mocks for all required dependencies. You can then instantiate a testing object by passing these mocks to a class constructor.</p>
-<p>You can still create your custom mocks, if needed.</p>
+Block and model class constructors declare many dependencies. The Magento system uses constructor [dependency injection](https://glossary.magento.com/dependency-injection).
+To unit test such classes, you must manually create mocks for all constructor parameters before you can instantiate the class objects. If the number of dependencies is ten or greater, this task is time-consuming.
+Use the `\Magento\Framework\TestFramework\Unit\Helper\ObjectManager` helper class to simplify this task. Its methods automatically create mocks for all required dependencies. You can then instantiate a testing object by passing these mocks to a class constructor.
+You can still create your custom mocks, if needed.
+
  {:.bs-callout-info}
 Do not use the ObjectManager helper class for classes with a small number of dependencies.
 
@@ -23,15 +24,18 @@ The ObjectManager public interface methods are:
 
 ### getObject method {#getobject}
 
-<p>Creates mocks for all constructor dependencies and applies any specified custom mocks from <code>$arguments</code> array.</p>
-<p>Also, instantiates the required <code>$className</code> by using constructor with already existing mocks.</p>
-<p><b>Syntax:</b></p>
-<pre>
+Creates mocks for all constructor dependencies and applies any specified custom mocks from `$arguments` array.
+<p>Also, instantiates the required `$className` by using constructor with already existing mocks.
+**Syntax**:
+
+```php
 public function getObject($className,
      array $arguments = []);
-</pre>
-<p><b>Example:</b></p>
-<pre>
+```
+
+**Example**:
+
+```php
 $objectManagerHelper = new \Magento\TestFramework\Helper\ObjectManager($this);
 
 // default constructor arguments
@@ -43,19 +47,24 @@ $cacheMock = $this->getMock('\Magento\Cache\FrontendInterface');
 $arguments = array('cache' => $cacheMock);
 $scopePool = $objectManagerHelper->getObject('\Magento\App\Config\ScopePool',
      $arguments);
-</pre>
+```
 
 ### getCollectionMock method {#getCollectionMock}
 
-<p>Retrieves a collection instance with mocked getIterator method.</p>
-<p><b>Syntax:</b></p>
-<pre>
+Retrieves a collection instance with mocked getIterator method.
+
+**Syntax**:
+
+```php
 public function getCollectionMock($className,
      array $data);
-</pre>
-<p>The collection contains elements from the $data array.</p>
-<p><b>Example:</b></p>
-<pre>
+```
+
+The collection contains elements from the `$data` array.
+
+**Example**:
+
+```php
 $objectManagerHelper = new \Magento\TestFramework\Helper\ObjectManager($this);
 // Prepare mock for collection elements
 $option = $this->getMock(
@@ -68,19 +77,24 @@ $option = $this->getMock(
 $optionCollection =
      $this->objectManagerHelper->getCollectionMock('Magento\Bundle\Model\Resource\Option\Collection',
           array($options));
-</pre>
+```
 
 ### getConstructArguments method {#getConstructArguments}
 
-<p>Lists dependency mocks for a specified class.</p>
-<p><b>Syntax:</b></p>
-<pre>
+Lists dependency mocks for a specified class.
+
+**Syntax**:
+
+```php
 public function getConstructArguments($className,
      array $arguments = []);
-</pre>
-<p>In the Magento system, several tests introduced mocks for abstract models and blocks.</p>
-<p><b>Example:</b></p>
-<pre>
+```
+
+In the Magento system, several tests introduced mocks for abstract models and blocks.
+
+**Example**:
+
+```php
 $attributeData = array(
     'store_label' => 'Test',
     'attribute_code' => 'test',
@@ -105,4 +119,4 @@ $arguments = $objectManagerHelper->getConstructArguments(
 /** @var $attribute \Magento\Eav\Model\Entity\Attribute\AbstractAttribute|\PHPUnit\Framework\MockObject\MockObject */
 $attribute = $this->getMockForAbstractClass($attributeClass,
     $arguments);
-</pre>
+```

--- a/src/guides/v2.3/extension-dev-guide/test/test_object-mgr.md
+++ b/src/guides/v2.3/extension-dev-guide/test/test_object-mgr.md
@@ -8,7 +8,7 @@ menu_order: 3
 
 <p>Block and model class constructors declare many dependencies. The Magento system uses constructor [dependency injection](https://glossary.magento.com/dependency-injection).</p>
 <p>To unit test such classes, you must manually create mocks for all constructor parameters before you can instantiate the class objects. If the number of dependencies is ten or greater, this task is time-consuming.</p>
-<p>Use the <code>\Magento\TestFramework\Helper\ObjectManager</code> helper class to simplify this task. Its methods automatically create mocks for all required dependencies. You can then instantiate a testing object by passing these mocks to a class constructor.</p>
+<p>Use the <code>\Magento\Framework\TestFramework\Unit\Helper\ObjectManager</code> helper class to simplify this task. Its methods automatically create mocks for all required dependencies. You can then instantiate a testing object by passing these mocks to a class constructor.</p>
 <p>You can still create your custom mocks, if needed.</p>
  {:.bs-callout-info}
 Do not use the ObjectManager helper class for classes with a small number of dependencies.


### PR DESCRIPTION
## Purpose of this pull request

This pull request fix a wrong information about ObjectManager test class

## Affected DevDocs pages

<!-- REQUIRED List the affected pages on devdocs.magento.com (URLs). Not needed for large numbers of files. -->

-  https://devdocs.magento.com/guides/v2.3/extension-dev-guide/test/test_object-mgr.html

## Links to Magento source code

<!--  OPTIONAL - REMOVE THIS SECTION IF NOT USED. If this pull request references a file in a Magento codebase repository, add it here. -->

-  An example of use https://github.com/magento/magento2/blob/2.4-develop/app/code/Magento/MysqlMq/Test/Unit/Model/Driver/Bulk/ExchangeTest.php

<!--
If you are fixing a GitHub issue, note it using GitHub keyword format (https://help.github.com/en/articles/closing-issues-using-keywords#closing-an-issue-in-a-different-repository) to close the issue when this pull request is merged. Example: `Fixes #1234`

`master` is the default branch. Merged pull requests to `master` go live on the site automatically. Any requested changes to content on the `master` branch must be related to the released codebase. Any content related to future releases goes in the `develop` branch.

See Contribution guidelines (https://github.com/magento/devdocs/blob/master/.github/CONTRIBUTING.md) for more information.
-->
