### PR TITLE
Updates to Magento Cloud Docker CLI commands

### DIFF
--- a/src/cloud/docker/docker-containers.md
+++ b/src/cloud/docker/docker-containers.md
@@ -54,6 +54,32 @@ Note that you can remove Varnish from the configuration, in which case the traff
 
 You can share files easily between your machine and a Docker container by placing the files in the `.docker/mnt` directory. You can find the files in the `/mnt` directory the next time you build and start the Docker environment using the `docker-compose up` command.
 
+## Sharing Magento Cloud project data
+
+When you launch the {{site.data.var.ece}} project locally in a Docker environment, the default project configuration sets up the following volumes:
+
+```text
+magento-var
+magento-app-etc
+magento-pub-media
+magento-pub-static
+```
+
+You can use these volumes to interact with the shared writeable mount directories for your Magento Cloud project which are configured by default in the `.magento.app.yaml` file.
+
+```yaml
+ # The mounts that will be performed when the package is deployed.
+mounts:
+    "var": "shared:files/var"
+    "app/etc": "shared:files/etc"
+    "pub/media": "shared:files/media"
+    "pub/static": "shared:files/static"
+```
+
+You can customize this configuration by updating the [`mounts`][mount-configuration] section in the `magento.app.yaml` file.
+
+### File synchronization
+
 Additionally, you can share data into the containers using file synchronization. See the [File synchronization] and [Developer Mode] documentation.
 
 ## Container Volumes
@@ -111,3 +137,4 @@ Now you can see all requests that are passing through the TLS container and chec
 [tls-container]: {{site.baseurl}}/cloud/docker/docker-containers-service.html#tls-container
 [varnish-container]: {{site.baseurl}}/cloud/docker/docker-containers-service.html#varnish-container
 [web-container]: {{site.baseurl}}/cloud/docker/docker-containers-service.html#web-container
+[mount-configuration]: {{site.baseurl}}/cloud/project/project-conf-files_magento-app.html#mounts

--- a/src/cloud/docker/docker-containers.md
+++ b/src/cloud/docker/docker-containers.md
@@ -65,7 +65,7 @@ magento-pub-media
 magento-pub-static
 ```
 
-You can use these volumes to interact with the shared writeable mount directories for your Magento Cloud project which are configured by default in the `.magento.app.yaml` file.
+You can use these volumes to interact with the shared writeable mount directories for your Magento Cloud project, which are configured by default in the `.magento.app.yaml` file.
 
 ```yaml
  # The mounts that will be performed when the package is deployed.

--- a/src/cloud/docker/docker-containers.md
+++ b/src/cloud/docker/docker-containers.md
@@ -56,7 +56,7 @@ You can share files easily between your machine and a Docker container by placin
 
 ## Sharing Magento Cloud project data
 
-When you launch the {{site.data.var.ece}} project locally in a Docker environment, the default project configuration sets up the following volumes:
+When you launch the {{site.data.var.ece}} project locally in a Docker environment, the default project configuration creates the following volumes:
 
 ```text
 magento-var

--- a/src/cloud/docker/docker-containers.md
+++ b/src/cloud/docker/docker-containers.md
@@ -99,7 +99,7 @@ The `docker-compose down -v` command removes all components of your local Docker
 You can use the following command to remove _all_ data and rebuild a clean environment:
 
 ```bash
- bin/docker down
+ bin/magento-docker down
 ```
 
 The `magento-sync` volume is an external volume that you must create or delete manually. If the `magento-sync` volume does not exist, the following error message displays:

--- a/src/cloud/docker/docker-mode-developer.md
+++ b/src/cloud/docker/docker-mode-developer.md
@@ -93,15 +93,23 @@ To launch the Docker environment in developer mode:
    {:.bs-callout-info}
    If you host your Docker environment on Windows and the session start fails, update the `mutagen.sh` file to change the value for the `--symlink-mode` option to `portable`.
 
-1. Deploy Magento in the Docker container.
+1. Install Magento in your Docker environment.
 
-   ```bash
-   docker-compose run deploy cloud-deploy && \
-   docker-compose run deploy magento-command deploy:mode:set developer
-   ```
+   -  Deploy Magento in the Docker container.
 
-   {: .bs-callout-info }
-   Developer mode does not require the `build` operation.
+      ```bash
+      docker-compose run deploy cloud-deploy && \
+      docker-compose run deploy magento-command deploy:mode:set developer
+      ```
+
+   -  Run post-deploy hooks.
+
+       ```bash
+       docker-compose run deploy cloud-post-deploy
+       ```
+
+      {: .bs-callout-info }
+      Developer mode does not require the `build` operation.
 
 1. Configure and connect Varnish.
 

--- a/src/cloud/docker/docker-mode-production.md
+++ b/src/cloud/docker/docker-mode-production.md
@@ -44,20 +44,23 @@ To launch the Docker environment in developer mode:
 
 1. Install Magento in your Docker environment.
 
-   -  Build Magento in the Docker container:
+   -  Build Magento in the Docker container.
 
       ```bash
       docker-compose run build cloud-build
       ```
 
-   -  Deploy Magento in the Docker container:
+   -  Deploy Magento in the Docker container.
 
       ```bash
       docker-compose run deploy cloud-deploy
       ```
 
-   {: .bs-callout-info }
-   For `{{site.data.var.ct}}` v2002.0.12, install Magento with the `docker-compose run cli magento-installer` command.
+   -  Run post-deploy hooks.
+
+      ```bash
+      docker-compose run deploy cloud-post-deploy
+      ```
 
 1. Configure and connect Varnish.
 

--- a/src/cloud/docker/docker-quick-reference.md
+++ b/src/cloud/docker/docker-quick-reference.md
@@ -13,6 +13,7 @@ Action | Command
 Build and start Docker environment | `docker-compose up -d`
 Build environment | `docker-compose run build cloud-build`
 Deploy environment | `docker-compose run deploy cloud-deploy`
+Run post-deploy hooks | `docker-compose run deploy cloud-post-deploy`
 Connect to CLI container | `docker-compose run deploy bash`
 Use `{{site.data.var.ct}}` command | `docker-compose run deploy ece-command <command>`
 Use Magento command | `docker-compose run deploy magento-command <command>`
@@ -39,20 +40,20 @@ docker-compose -f docker-compose.yml -f docker-compose-custom.yml [-f more-custo
 | Option       | Key              | Available values
 | ------------ | ---------------- | ------------------
 | [Mode]({{site.baseurl}}/cloud/docker/docker-config.html#launch-modes)         | `--mode`, `-m`   | production, developer
-| [File synchronization engine]({{site.baseurl}}/cloud/docker/docker-config.html#launch-modes) | `--sync-engine` | docker-sync, mutagen, native
+| [File synchronization engine]({{site.baseurl}}/cloud/docker/docker-config.html#launch-modes) | `--sync-engine` | native (default), docker-sync, mutagen
 
-## bin/docker
+## bin/magento-docker
 
-Run `bin/docker` commands using the following format:
+Run `bin/magento-docker` commands using the following format:
 
 ```bash
-./bin/docker <command>
+./bin/magento-docker <command>
 ```
 
 For example, to connect to the bash shell:
 
 ```terminal
-$ ./bin/docker bash
+$ ./bin/magento-docker bash
 Starting project_redis_1 ... done
 Starting project_db_1    ... done
 Starting project_elasticsearch_1 ... done
@@ -67,6 +68,7 @@ Connect to bash shell | `bash`
 Pull the latest images | `pull`
 Build application | `ece-build`
 Deploy application | `ece-deploy`
+Run post-deploy hooks | `ece-post-deploy`
 Re-build and re-deploy application | `ece-redeploy`
 Stop containers | `stop`
 Start containers | `start`

--- a/src/cloud/release-notes/mcd-release-notes.md
+++ b/src/cloud/release-notes/mcd-release-notes.md
@@ -22,7 +22,7 @@ The release notes include:
 
 -  {:.new}**Support for Magento application testing**–Added a [Selenium container]({{site.baseurl}}/cloud/docker/docker-containers-service.html#selenium-container) to support {{site.data.var.ee}} application testing using the Magento Functional Testing Framework (MFTF).<!--MAGECLOUD-4040-->
 
--  {:.new}<!--MAGECLOUD-3248-->**Manage mounts and volumes for your project–**Added the ability manage mounts and volumes when launching a Docker environment for local developments. See [Sharing Magento Cloud project data].
+-  {:.new}<!--MAGECLOUD-3248-->**Manage mounts and volumes for your project–**Added the ability manage mounts and volumes when launching a Docker environment for local development. See [Sharing Magento Cloud project data].
 
 -  {:.new}Added a container health check to the Elasticsearch service to ensure that the service is ready before continuing with build and deploy processing. If the health check returns an error, the container restarts automatically.<!--MAGECLOUD-4456-->
 

--- a/src/cloud/release-notes/mcd-release-notes.md
+++ b/src/cloud/release-notes/mcd-release-notes.md
@@ -18,27 +18,46 @@ The release notes include:
 
 ## v1.0.0
 
--  {:.new}**Added a stand-alone Magento Cloud Docker package**—Moved the Docker package to the [new `magento-cloud-docker` repository](https://github.com/magento/magento-cloud-docker) to maintain code quality and provide independent releases.<!--MAGECLOUD-3986-->
+-  {:.new}**Added a stand-alone Magento Cloud Docker package**–Moved the Docker package to the [new `magento-cloud-docker` repository](https://github.com/magento/magento-cloud-docker) to maintain code quality and provide independent releases.<!--MAGECLOUD-3986-->
 
--  {:.new}**Support for Magento application testing**–Added a [Selenium container]({{site.baseurl}}/cloud/docker/docker-containers-service.html#selenium-container) to support {{site.data.var.ee}} application testing using the Magento Functional Testing Framework (MFTF).<!--MAGECLOUD-4040-->
+-  {:.new}**Container updates**–
 
--  {:.new}**Manage mounts and volumes for your project**—Added the ability manage mounts and volumes when launching a Docker environment for local development. See [Sharing Magento Cloud project data].<!--MAGECLOUD-3248-->
+   -  {:.new}**New Selenium container**–Added a [Selenium container]({{site.baseurl}}/cloud/docker/docker-containers-service.html#selenium-container) to support {{site.data.var.ee}} application testing using the Magento Functional Testing Framework (MFTF).<!--MAGECLOUD-4040-->
 
--  {:.new}Added a container health check to the Elasticsearch service to ensure that the service is ready before continuing with build and deploy processing. If the health check returns an error, the container restarts automatically.<!--MAGECLOUD-4456-->
+   -  {:.new}**RabbitMQ version support**–Updated the RabbitMQ container configuration to support RabbitMQ version 3.8.<!--MAGECLOUD-4674-->
 
--  {:.new}Added support for RabbitMQ version 3.8.<!--MAGECLOUD-4674-->
+   -  {:.new}**Updated the Magento PHP image to support Node.js**–Updated the PHP image to support node, npm, and the grunt-cli capabilities inside the PHP container.<!--MAGECLOUD-3953-->
 
--  {:.fix}The `magento-db: /var/lib/mysql` database volume now persists after you stop and remove the Docker configuration and restores when you restart the Docker configuration. Now, you must manually delete the database volume. See [Database containers].<!--MAGECLOUD-3978-->
+   -  {:.fix}**Persistent database container**–The `magento-db: /var/lib/mysql` database volume now persists after you stop and remove the Docker configuration and restores when you restart the Docker configuration. Now, you must manually delete the database volume. See [Database containers].<!--MAGECLOUD-3978-->
 
--  {:.new}Added DB dumps and archive files—ZIP, SQL, GZ, and BZ2—to the exclusion list in the `dist/docker-sync.yml` and `dist/mutagen.sh` files. Large files (>1 GB) can cause a period of inactivity and are not necessary to sync.<!--MAGECLOUD-3979-->
+-  {:.new}**Docker configuration changes**–
 
--  {:.new}Added the `--rm` option to `./bin/magento-docker` commands for the build and deploy containers. This removes the container after the task is complete.<!--MAGECLOUD-4205-->
+   -  {:.new}**Manage mounts and volumes for your project**–Added the ability manage mounts and volumes when launching a Docker environment for local development. See [Sharing Magento Cloud project data].<!--MAGECLOUD-3248-->
 
--  {:.new}Added the `--sync-engine="native"` option to the `docker-build` command to disable file synchronization when you generate the Docker Compose configuration file in developer mode. Use this option when developing on Linux systems, which do not require file synchronization for local Docker development.<!--MAGECLOUD-4351-->
+   -  {:.new}**Support for network bridge mode**–Added support for network bridge mode to enable connections between Docker containers over the local network.<!--MAGECLOUD-4165-->
 
--  {:.new}Added validation to the deployment process for local Docker development environments to verify that the Cloud environment configuration includes the encryption key required to decrypt the database.  Now, you get an error message in the log if the envirionment configuration does not specify a value for the encryption key.<!--MAGECLOUD-4423-->
+   -  {:.new}**Stop synchronizing large backup files**–Added DB dumps and archive files—ZIP, SQL, GZ, and BZ2—to the exclusion list in the `dist/docker-sync.yml` and `dist/mutagen.sh` files. Synchronizing large files (>1 GB) can cause a period of inactivity and backup files do normally require synchronization.<!--MAGECLOUD-3979-->
 
--  {:.fix}The `./bin/docker` file overwrites existing Docker binary files, which caused some Docker environments to break. Renamed the `./bin/docker` file to `./bin/magento-docker` to avoid any conflicts.<!-- MAGECLOUD-4038 -->
+-  {:.new}**Command changes**–
+
+   -  {:.fix}Renamed the `./bin/docker` file to `./bin/magento-docker` to fix an issue that caused some Docker environments to break because the `./bin/docker` file overwrites existing Docker binary files. This is a [backward incompatible change] that requires updates to your scripts and commands.<!-- MAGECLOUD-4038 -->
+
+   -  {:.new}**New `cloud-post-deploy` command**–Previously, the post-deploy hooks defined in the `.magento.app.yaml` file ran automatically after you deployed Magento to a Cloud Docker container using the `cloud-deploy` command. Now, you must issue a separate `cloud-post-deploy` command to run the post-deploy hooks after you deploy. See the updated launch instructions for [developer] and [production] mode.<!--MAGECLOUD-3996-->
+
+   -  {:.new}Added the `--rm` option to `./bin/magento-docker` commands for the build and deploy containers. This removes the container after the task is complete.<!--MAGECLOUD-4205-->
+
+   -  {:.new}Added the `--sync-engine="native"` option to the `docker-build` command to disable file synchronization when you generate the Docker Compose configuration file in developer mode. Use this option when developing on Linux systems, which do not require file synchronization for local Docker development.<!--MAGECLOUD-4351-->
+
+   -  {:.new}**Stop synchronizing large backup files**–Added DB dumps and archive files—ZIP, SQL, GZ, and BZ2—to the exclusion list in the `dist/docker-sync.yml` and `dist/mutagen.sh` files. Synchronizing large files (>1 GB) can cause a period of inactivity and backup files do normally require synchronization.<!--MAGECLOUD-3979-->
+
+-  {:.new}**Validation improvements**–
+
+   -  {:.new}Added validation to the deployment process for local Docker development environments to verify that the Cloud environment configuration includes the encryption key required to decrypt the database.  Now, you get an error message in the log if the environment configuration does not specify a value for the encryption key.<!--MAGECLOUD-4423-->
+
+   -  {:.new}Added a container health check to the Elasticsearch service to ensure that the service is ready before continuing with build and deploy processing. If the health check returns an error, the container restarts automatically.<!--MAGECLOUD-4456-->
 
 [Sharing Magento Cloud project data]: {{site.baseurl}}/cloud/docker/docker-containers.html#sharing-magento-cloud-project-data
 [Database containers]: {{site.baseurl}}/cloud/docker/docker-containers-service.html#database-container
+[developer]: {{site.baseurl}}/cloud/docker/docker-mode-developer.html
+[production]: {{site.baseurl}}/cloud/docker/docker-mode-production.html
+[backward incompatible change]: {{site.baseurl}}/cloud/release-notes/backware-incompatible-changes.html#docker-updates

--- a/src/cloud/release-notes/mcd-release-notes.md
+++ b/src/cloud/release-notes/mcd-release-notes.md
@@ -18,15 +18,17 @@ The release notes include:
 
 ## v1.0.0
 
--  {:.new}Moved the Docker package to the [new `magento-cloud-docker` repository](https://github.com/magento/magento-cloud-docker) to maintain code quality and provide independent releases.<!--MAGECLOUD-3986-->
+-  {:.new}**Added a stand-alone Magento Cloud Docker package–**Moved the Docker package to the [new `magento-cloud-docker` repository](https://github.com/magento/magento-cloud-docker) to maintain code quality and provide independent releases.<!--MAGECLOUD-3986-->
 
 -  {:.new}**Support for Magento application testing**–Added a [Selenium container]({{site.baseurl}}/cloud/docker/docker-containers-service.html#selenium-container) to support {{site.data.var.ee}} application testing using the Magento Functional Testing Framework (MFTF).<!--MAGECLOUD-4040-->
+
+-  {:.new}<!--MAGECLOUD-3248-->**Manage mounts and volumes for your project–**Added the ability manage mounts and volumes when launching a Docker environment for local developments. See [Sharing Magento Cloud project data].
 
 -  {:.new}Added a container health check to the Elasticsearch service to ensure that the service is ready before continuing with build and deploy processing. If the health check returns an error, the container restarts automatically.<!--MAGECLOUD-4456-->
 
 -  {:.new}Added support for RabbitMQ version 3.8.<!--MAGECLOUD-4674-->
 
--  {:.fix}The `magento-db: /var/lib/mysql` database volume now persists after you stop and remove the Docker configuration and restores when you restart the Docker configuration. Now, you must manually delete the database volume. See [Database containers]({{site.baseurl}}/cloud/docker/docker-containers-service.html#database-container).<!--MAGECLOUD-3978-->
+-  {:.fix}The `magento-db: /var/lib/mysql` database volume now persists after you stop and remove the Docker configuration and restores when you restart the Docker configuration. Now, you must manually delete the database volume. See [Database containers].<!--MAGECLOUD-3978-->
 
 -  {:.new}Added DB dumps and archive files—ZIP, SQL, GZ, and BZ2—to the exclusion list in the `dist/docker-sync.yml` and `dist/mutagen.sh` files. Large files (>1 GB) can cause a period of inactivity and are not necessary to sync.<!--MAGECLOUD-3979-->
 
@@ -37,3 +39,6 @@ The release notes include:
 -  {:.new}Added validation to the deployment process for local Docker development environments to verify that the Cloud environment configuration includes the encryption key required to decrypt the database.  Now, you get an error message in the log if the envirionment configuration does not specify a value for the encryption key.<!--MAGECLOUD-4423-->
 
 -  {:.fix}The `./bin/docker` file overwrites existing Docker binary files, which caused some Docker environments to break. Renamed the `./bin/docker` file to `./bin/magento-docker` to avoid any conflicts.<!-- MAGECLOUD-4038 -->
+
+[Sharing Magento Cloud project data]: {{site.baseurl}}/cloud/docker/docker-containers.html#sharing-magento-cloud-project-data
+[Database containers]: {{site.baseurl}}/cloud/docker/docker-containers-service.html#database-container

--- a/src/cloud/release-notes/mcd-release-notes.md
+++ b/src/cloud/release-notes/mcd-release-notes.md
@@ -18,11 +18,11 @@ The release notes include:
 
 ## v1.0.0
 
--  {:.new}**Added a stand-alone Magento Cloud Docker package–**Moved the Docker package to the [new `magento-cloud-docker` repository](https://github.com/magento/magento-cloud-docker) to maintain code quality and provide independent releases.<!--MAGECLOUD-3986-->
+-  {:.new}**Added a stand-alone Magento Cloud Docker package**—Moved the Docker package to the [new `magento-cloud-docker` repository](https://github.com/magento/magento-cloud-docker) to maintain code quality and provide independent releases.<!--MAGECLOUD-3986-->
 
 -  {:.new}**Support for Magento application testing**–Added a [Selenium container]({{site.baseurl}}/cloud/docker/docker-containers-service.html#selenium-container) to support {{site.data.var.ee}} application testing using the Magento Functional Testing Framework (MFTF).<!--MAGECLOUD-4040-->
 
--  {:.new}<!--MAGECLOUD-3248-->**Manage mounts and volumes for your project–**Added the ability manage mounts and volumes when launching a Docker environment for local development. See [Sharing Magento Cloud project data].
+-  {:.new}**Manage mounts and volumes for your project**—Added the ability manage mounts and volumes when launching a Docker environment for local development. See [Sharing Magento Cloud project data].<!--MAGECLOUD-3248-->
 
 -  {:.new}Added a container health check to the Elasticsearch service to ensure that the service is ready before continuing with build and deploy processing. If the health check returns an error, the container restarts automatically.<!--MAGECLOUD-4456-->
 


### PR DESCRIPTION
## Purpose of this pull request
Updated Magento Cloud Docker command documentation and Docker release notes:

- Updated launch Docker instructions to run post-deploy hooks as a separate operation using the new `cloud-post-deploy` command (MAGECLOUD-3996)
- Updated the Docker command quick reference to update modified command
names and add the cloud-post-deploy command
- Added release notes for cloud-post-deploy command update
- Updated .bin/docker references to .bin/magento-docker (MAGECLOUD-4038)
- Re-organized release notes to group by category

## Affected DevDocs pages

- https://devdocs.magento.com/cloud/release-notes/mcd-release-notes.html
- https://devdocs.magento.com/cloud/docker/docker-quick-reference.html
- https://devdocs.magento.com/cloud/docker/docker-mode-developer.html
- https://devdocs.magento.com/cloud/docker/docker-mode-production.html

whatsnew
Updated Magento Cloud Docker command documentation:
- Updated Docker quick reference to add new commands and change the Docker command file path from `.bin/docker` to the new `.bin/magento-docker` path.
- Added documentation for new `cloud-post-deploy`  command and updated launch instructions