### PR TITLE
Update code reference to view_model

### DIFF
--- a/src/guides/v2.3/extension-dev-guide/view-models.md
+++ b/src/guides/v2.3/extension-dev-guide/view-models.md
@@ -65,4 +65,4 @@ $viewModel = $block->getViewModel();
 
 ## Examples of View models in Magento
 
--  [Magento Theme](https://github.com/magento/magento2/blob/2.2.9/app/code/Magento/Theme/view/frontend/layout/default.xml#L43-L47 "view_model definition"). This `view_model` is injected into a template to return the target store redirect url.
+-  [Magento Theme](https://github.com/magento/magento2/blob/2.3.3/app/code/Magento/Theme/view/frontend/layout/default.xml#L43-L45 "view_model definition"). This `view_model` is injected into a template to return the target store redirect url.


### PR DESCRIPTION
## Purpose of this pull request
This PR is intended to fix a wrong code reference that points to a non-existing `view_model` argument mentioned in the docs.

## Affected DevDocs pages

- https://devdocs.magento.com/guides/v2.3/extension-dev-guide/view-models.html

## Links to Magento source code
- https://github.com/magento/magento2/blob/2.3.3/app/code/Magento/Theme/view/frontend/layout/default.xml#L43-L45