### PR TITLE
Added release items for PHP-FPM container

### DIFF
--- a/src/cloud/docker/docker-containers-service.md
+++ b/src/cloud/docker/docker-containers-service.md
@@ -56,13 +56,13 @@ elasticsearch | [magento/magento-cloud-docker-elasticsearch](https://hub.docker.
 
 The Elasticsearch container for {{site.data.var.mcd}} is a standard Elasticsearch container with required plugins and configurations for {{site.data.var.ee}}.
 
-## FPM container
+## PHP-FPM container
 
 Container name |Docker base image | Ports exposed
 -------- | -------- | ---------------
 fpm | [magento/magento-cloud-docker-php][php-cloud], which is based on the [php](https://hub.docker.com/_/php) Docker image | 9000, 9001
 
-The FPM container is based on the [magento/magento-cloud-docker-php][php] image and includes the following volumes:
+The PHP-FPM container is based on the [magento/magento-cloud-docker-php][php] image and includes the following volumes:
 
 -  Read-only volumes:
    -  `/app`

--- a/src/cloud/docker/docker-containers.md
+++ b/src/cloud/docker/docker-containers.md
@@ -22,7 +22,7 @@ Magento Cloud Docker references the `.magento.app.yaml` and `.magento/services.y
 | [deploy] | Deploy Container |   |  |  PHP Container, runs the deploy process
 | [db] | MariaDB     | `--db` | 10.0, 10.1, 10.2 |  Standard database container
 | [elasticsearch] | Elasticsearch | `--es` | 1.7, 2.4, 5.2, 6.5 |
-| [fpm][fpm-container] | PHP FPM | `--php` | 7.0, 7.1, 7.2, 7.3 |  Used for all incoming requests
+| [PHP-FPM][php-fpm-container] | PHP FPM | `--php` | 7.0, 7.1, 7.2, 7.3 |  Used for all incoming requests
 | [node][node-container] | Node | `--node` | 6, 8, 10, 11 |  Used gulp or other NPM based commands
 | [rabbitmq][rabbitmq-container]| RabbitMQ | `--rmq` | 3.5, 3.7, 3.8 |
 | [redis][redis-container] | Redis     | `--redis` | 3.2, 4.0, 5.0 |   Standard redis container
@@ -131,7 +131,7 @@ Now you can see all requests that are passing through the TLS container and chec
 [nginx]: https://hub.docker.com/r/magento/magento-cloud-docker-nginx
 [node-container]: {{site.baseurl}}/cloud/docker/docker-containers-cli.html#node-container
 [rabbitmq-container]: {{site.baseurl}}/cloud/docker/docker-containers-service.html#rabbitmq-container
-[fpm-container]: {{site.baseurl}}/cloud/docker/docker-containers-service.html#fpm-container
+[php-fpm-container]: {{site.baseurl}}/cloud/docker/docker-containers-service.html#php-fpm-container
 [redis-container]: {{site.baseurl}}/cloud/docker/docker-containers-service.html#redis-container
 [selenium-container]: {{site.baseurl}}/cloud/docker/docker-containers-service.html#selenium-container
 [tls-container]: {{site.baseurl}}/cloud/docker/docker-containers-service.html#tls-container

--- a/src/cloud/release-notes/mcd-release-notes.md
+++ b/src/cloud/release-notes/mcd-release-notes.md
@@ -22,11 +22,15 @@ The release notes include:
 
 -  {:.new}**Container updates**–
 
+   -  {:.new}**PHP-FPM container updates**–
+
+      -  {:.new}**Added Node.js support**–Updated the PHP-FPM image to support node, npm, and the grunt-cli capabilities inside the PHP container.<!--MAGECLOUD-3953-->
+
+      -  {:.new}**Added support for [ionCube](https://www.ioncube.com/)**–Updated the default Docker configuration to support ionCube in the local Docker development environment.<!--MAGECLOUD-4354-->
+
    -  {:.new}**New Selenium container**–Added a [Selenium container]({{site.baseurl}}/cloud/docker/docker-containers-service.html#selenium-container) to support {{site.data.var.ee}} application testing using the Magento Functional Testing Framework (MFTF).<!--MAGECLOUD-4040-->
 
    -  {:.new}**RabbitMQ version support**–Updated the RabbitMQ container configuration to support RabbitMQ version 3.8.<!--MAGECLOUD-4674-->
-
-   -  {:.new}**Updated the Magento PHP image to support Node.js**–Updated the PHP image to support node, npm, and the grunt-cli capabilities inside the PHP container.<!--MAGECLOUD-3953-->
 
    -  {:.fix}**Persistent database container**–The `magento-db: /var/lib/mysql` database volume now persists after you stop and remove the Docker configuration and restores when you restart the Docker configuration. Now, you must manually delete the database volume. See [Database containers].<!--MAGECLOUD-3978-->
 
@@ -36,17 +40,19 @@ The release notes include:
 
       -  {:.new}The base image for the [Magento Cloud Varnish container] is now based on the `centos` Docker image.
 
-   -  {:.new}**Improved default timeout configuration for the Magento Cloud TLS and Varnish containers**–[Fix submitted by Mathew Beane of Zilker Technologies](https://github.com/magento/magento-cloud-docker/pull/78)<!--MAGECLOUD-4460-->
+   -  {:.new}**Improved default timeout configuration for the Magento Cloud TLS and Varnish containers**–[Fix submitted by Mathew Beane from Zilker Technologies(https://github.com/magento/magento-cloud-docker/pull/78)<!--MAGECLOUD-4460-->
 
       -  Added `.first_byte_timeout` and `.between_bytes_timeout` configuration to the TLS container. Both timeout values default to `300s` (5 minutes).
 
       -  Increased the timeout value in the Varnish container configuration from 15 to 300 seconds.
 
-   -  {:.new}**Added support for the [Pound TLS Termination Proxy]**[Fix submitted by Sorin Sugar](https://github.com/magento/magento-cloud-docker/pull/37)–<!--MAGECLOUD-4061-->The [Pound configuration file][`pound.cfg`] adds the following ENV variables to customize the Docker configuration for the TLS container:
+   -  {:.new}**Added support for the [Pound TLS Termination Proxy]**–[Fix submitted by Sorin Sugar](https://github.com/magento/magento-cloud-docker/pull/37)<!--MAGECLOUD-4061-->
 
-      -  **`TimeOut` variable**–Sets the Time to First Byte (TTFB) timeout value. The default value is 300 seconds.
+      The [Pound configuration file][`pound.cfg`] adds the following ENV variables to customize the Docker configuration for the TLS container:
 
-      -  **`RewriteLocation` variable**–Determines whether the Pound proxy rewrites the location to the request URL by default. Defaults to `0` to prevent the rewrite from breaking redirects to outside websites like an external SSO site.
+      -  **`TimeOut`**–Sets the Time to First Byte (TTFB) timeout value. The default value is 300 seconds.
+
+      -  **`RewriteLocation`**–Determines whether the Pound proxy rewrites the location to the request URL by default. Defaults to `0` to prevent the rewrite from breaking redirects to outside websites like an external SSO site.
 
 -  {:.new}**Docker configuration changes**–
 
@@ -59,6 +65,10 @@ The release notes include:
 -  {:.new}**Command changes**–
 
    -  {:.fix}Renamed the `./bin/docker` file to `./bin/magento-docker` to fix an issue that caused some Docker environments to break because the `./bin/docker` file overwrites existing Docker binary files. This is a [backward incompatible change] that requires updates to your scripts and commands.<!-- MAGECLOUD-4038 -->
+
+   -  {:.new}**Added an option to expose the database port to the host**–[Updated submitted by Adarsh Manickam](https://github.com/magento/magento-cloud-docker/pull/101).
+
+      Use the `--expose-db-port=<PORT>` option to expose the database port to the host when building the `docker-compose.yml` file: `bin/ece-docker build:compose --expose-db-port=<PORT>`<!--MAGECLOUD-4454-->
 
    -  {:.new}**New `cloud-post-deploy` command**–Previously, the post-deploy hooks defined in the `.magento.app.yaml` file ran automatically after you deployed Magento to a Cloud Docker container using the `cloud-deploy` command. Now, you must issue a separate `cloud-post-deploy` command to run the post-deploy hooks after you deploy. See the updated launch instructions for [developer] and [production] mode.<!--MAGECLOUD-3996-->
 

--- a/src/cloud/release-notes/mcd-release-notes.md
+++ b/src/cloud/release-notes/mcd-release-notes.md
@@ -40,19 +40,19 @@ The release notes include:
 
       -  {:.new}The base image for the [Magento Cloud Varnish container] is now based on the `centos` Docker image.
 
-   -  {:.new}**Improved default timeout configuration for the Magento Cloud TLS and Varnish containers**–[Fix submitted by Mathew Beane from Zilker Technologies](https://github.com/magento/magento-cloud-docker/pull/78)<!--MAGECLOUD-4460-->
+   -  {:.new}**Improved default timeout configuration for the Magento Cloud TLS and Varnish containers**–
 
       -  Added `.first_byte_timeout` and `.between_bytes_timeout` configuration to the TLS container. Both timeout values default to `300s` (5 minutes).
 
       -  Increased the timeout value in the Varnish container configuration from 15 to 300 seconds.
 
-   -  {:.new}**Added support for the [Pound TLS Termination Proxy]**–[Fix submitted by Sorin Sugar](https://github.com/magento/magento-cloud-docker/pull/37)<!--MAGECLOUD-4061-->
+      [Fix submitted by Mathew Beane from Zilker Technologies](https://github.com/magento/magento-cloud-docker/pull/78)<!--MAGECLOUD-4460-->
 
-      The [Pound configuration file][`pound.cfg`] adds the following ENV variables to customize the Docker configuration for the TLS container:
+   -  {:.new}**Added support for the [Pound TLS Termination Proxy]**–The [Pound configuration file][`pound.cfg`] adds the following ENV variables to customize the Docker configuration for the TLS container:
 
       -  **`TimeOut`**–Sets the Time to First Byte (TTFB) timeout value. The default value is 300 seconds.
 
-      -  **`RewriteLocation`**–Determines whether the Pound proxy rewrites the location to the request URL by default. Defaults to `0` to prevent the rewrite from breaking redirects to outside websites like an external SSO site.
+      -  **`RewriteLocation`**–Determines whether the Pound proxy rewrites the location to the request URL by default. Defaults to `0` to prevent the rewrite from breaking redirects to outside websites like an external SSO site. [Fix submitted by Sorin Sugar](https://github.com/magento/magento-cloud-docker/pull/37)<!--MAGECLOUD-4061-->
 
 -  {:.new}**Docker configuration changes**–
 
@@ -66,11 +66,9 @@ The release notes include:
 
    -  {:.fix}Renamed the `./bin/docker` file to `./bin/magento-docker` to fix an issue that caused some Docker environments to break because the `./bin/docker` file overwrites existing Docker binary files. This is a [backward incompatible change] that requires updates to your scripts and commands.<!-- MAGECLOUD-4038 -->
 
-   -  {:.new}**Added an option to expose the database port to the host**–[Fix submitted by Adarsh Manickam](https://github.com/magento/magento-cloud-docker/pull/101).
+   -  {:.new}**Added an option to expose the database port to the host**–Use the `--expose-db-port=<PORT>` option to expose the database port to the host when building the `docker-compose.yml` file: `bin/ece-docker build:compose --expose-db-port=<PORT>`<!--MAGECLOUD-4454--> [Fix submitted by Adarsh Manickam](https://github.com/magento/magento-cloud-docker/pull/101).
 
-      Use the `--expose-db-port=<PORT>` option to expose the database port to the host when building the `docker-compose.yml` file: `bin/ece-docker build:compose --expose-db-port=<PORT>`<!--MAGECLOUD-4454-->
-
-   -  {:.new}**New `cloud-post-deploy` command**–Previously, the post-deploy hooks defined in the `.magento.app.yaml` file ran automatically after you deployed Magento to a Cloud Docker container using the `cloud-deploy` command. Now, you must issue a separate `cloud-post-deploy` command to run the post-deploy hooks after you deploy. See the updated launch instructions for [developer] and [production] mode.<!--MAGECLOUD-3996-->
+   -  {:.new}**New post-deploy command**–Previously, the post-deploy hooks defined in the `.magento.app.yaml` file ran automatically after you deployed Magento to a Cloud Docker container using the `cloud-deploy` command. Now, you must issue a separate `cloud-post-deploy` command to run the post-deploy hooks after you deploy. See the updated launch instructions for [developer] and [production] mode.<!--MAGECLOUD-3996-->
 
    -  {:.new}Added the `--rm` option to `./bin/magento-docker` commands for the build and deploy containers. This removes the container after the task is complete.<!--MAGECLOUD-4205-->
 

--- a/src/cloud/release-notes/mcd-release-notes.md
+++ b/src/cloud/release-notes/mcd-release-notes.md
@@ -40,7 +40,7 @@ The release notes include:
 
       -  {:.new}The base image for the [Magento Cloud Varnish container] is now based on the `centos` Docker image.
 
-   -  {:.new}**Improved default timeout configuration for the Magento Cloud TLS and Varnish containers**–[Fix submitted by Mathew Beane from Zilker Technologies(https://github.com/magento/magento-cloud-docker/pull/78)<!--MAGECLOUD-4460-->
+   -  {:.new}**Improved default timeout configuration for the Magento Cloud TLS and Varnish containers**–[Fix submitted by Mathew Beane from Zilker Technologies](https://github.com/magento/magento-cloud-docker/pull/78)<!--MAGECLOUD-4460-->
 
       -  Added `.first_byte_timeout` and `.between_bytes_timeout` configuration to the TLS container. Both timeout values default to `300s` (5 minutes).
 
@@ -66,7 +66,7 @@ The release notes include:
 
    -  {:.fix}Renamed the `./bin/docker` file to `./bin/magento-docker` to fix an issue that caused some Docker environments to break because the `./bin/docker` file overwrites existing Docker binary files. This is a [backward incompatible change] that requires updates to your scripts and commands.<!-- MAGECLOUD-4038 -->
 
-   -  {:.new}**Added an option to expose the database port to the host**–[Updated submitted by Adarsh Manickam](https://github.com/magento/magento-cloud-docker/pull/101).
+   -  {:.new}**Added an option to expose the database port to the host**–[Fix submitted by Adarsh Manickam](https://github.com/magento/magento-cloud-docker/pull/101).
 
       Use the `--expose-db-port=<PORT>` option to expose the database port to the host when building the `docker-compose.yml` file: `bin/ece-docker build:compose --expose-db-port=<PORT>`<!--MAGECLOUD-4454-->
 


### PR DESCRIPTION
## Purpose of this pull request

Added the following release items to the Docker 1.0.0 release notes:

- PHP-FPM container updates
    -  Node.js support (MAGECLOUD-3953)
    -  ionCube support (MAGECLOUD-4354)
- Docker command update:
   -  `expose db port to host` option for `ece-docker build:compose` command (MAGECLOUD-4544)

## Affected DevDocs pages

https://devdocs.magento.com/cloud/release-notes/mcd-release-notes.html