### PR TITLE
cloud-docker-1.0.0-file-sync-option-updates

### DIFF
--- a/src/cloud/docker/docker-config.md
+++ b/src/cloud/docker/docker-config.md
@@ -63,7 +63,7 @@ You can launch your Docker environment in one of the following modes:
 For example, the following command starts the Docker configuration generator for the developer mode:
 
 ```bash
-./vendor/bin/ece-tools docker:build --mode="developer"
+./vendor/bin/ece-docker build:compose --mode="developer"
 ```
 
 To skip the interactive mode, use the `-n, --no-interaction` option.

--- a/src/cloud/docker/docker-containers-service.md
+++ b/src/cloud/docker/docker-containers-service.md
@@ -56,13 +56,13 @@ elasticsearch | [magento/magento-cloud-docker-elasticsearch](https://hub.docker.
 
 The Elasticsearch container for {{site.data.var.mcd}} is a standard Elasticsearch container with required plugins and configurations for {{site.data.var.ee}}.
 
-## FPM container
+## PHP-FPM container
 
 Container name |Docker base image | Ports exposed
 -------- | -------- | ---------------
 fpm | [magento/magento-cloud-docker-php][php-cloud], which is based on the [php](https://hub.docker.com/_/php) Docker image | 9000, 9001
 
-The FPM container is based on the [magento/magento-cloud-docker-php][php] image and includes the following volumes:
+The PHP-FPM container is based on the [magento/magento-cloud-docker-php][php] image and includes the following volumes:
 
 -  Read-only volumes:
    -  `/app`

--- a/src/cloud/docker/docker-containers.md
+++ b/src/cloud/docker/docker-containers.md
@@ -22,7 +22,7 @@ Magento Cloud Docker references the `.magento.app.yaml` and `.magento/services.y
 | [deploy] | Deploy Container |   |  |  PHP Container, runs the deploy process
 | [db] | MariaDB     | `--db` | 10.0, 10.1, 10.2 |  Standard database container
 | [elasticsearch] | Elasticsearch | `--es` | 1.7, 2.4, 5.2, 6.5 |
-| [fpm][fpm-container] | PHP FPM | `--php` | 7.0, 7.1, 7.2, 7.3 |  Used for all incoming requests
+| [PHP-FPM][php-fpm-container] | PHP FPM | `--php` | 7.0, 7.1, 7.2, 7.3 |  Used for all incoming requests
 | [node][node-container] | Node | `--node` | 6, 8, 10, 11 |  Used gulp or other NPM based commands
 | [rabbitmq][rabbitmq-container]| RabbitMQ | `--rmq` | 3.5, 3.7, 3.8 |
 | [redis][redis-container] | Redis     | `--redis` | 3.2, 4.0, 5.0 |   Standard redis container
@@ -131,7 +131,7 @@ Now you can see all requests that are passing through the TLS container and chec
 [nginx]: https://hub.docker.com/r/magento/magento-cloud-docker-nginx
 [node-container]: {{site.baseurl}}/cloud/docker/docker-containers-cli.html#node-container
 [rabbitmq-container]: {{site.baseurl}}/cloud/docker/docker-containers-service.html#rabbitmq-container
-[fpm-container]: {{site.baseurl}}/cloud/docker/docker-containers-service.html#fpm-container
+[php-fpm-container]: {{site.baseurl}}/cloud/docker/docker-containers-service.html#php-fpm-container
 [redis-container]: {{site.baseurl}}/cloud/docker/docker-containers-service.html#redis-container
 [selenium-container]: {{site.baseurl}}/cloud/docker/docker-containers-service.html#selenium-container
 [tls-container]: {{site.baseurl}}/cloud/docker/docker-containers-service.html#tls-container

--- a/src/cloud/docker/docker-development-testing.md
+++ b/src/cloud/docker/docker-development-testing.md
@@ -97,7 +97,7 @@ Acceptance Tests (1) -----------------------------------------------------------
 --------------------------------------------------------------------------------------------------------------------
 -------------------------------------------------------------------------------
 PostDeployCest: Test post deploy | {"ADMIN_EMAIL":"admin@example.com"}
- [Magento\MagentoCloud\Test\Functional\Robo\Tasks\GenerateDockerCompose] Running ./bin/ece-tools docker:build
+ [Magento\MagentoCloud\Test\Functional\Robo\Tasks\GenerateDockerCompose] Running ./bin/ece-docker build:compose
  --mode=functional --php=7.2
 ...
 ...

--- a/src/cloud/docker/docker-mode-developer.md
+++ b/src/cloud/docker/docker-mode-developer.md
@@ -7,15 +7,13 @@ functional_areas:
   - Docker
 ---
 
-Developer mode supports an active development environment with full, writable filesystem permissions. This option builds the Docker environment in developer mode and verifies configured service versions. System performance is slower in developer mode because of additional file synchronization operations.
+Developer mode supports an active development environment with full, writable filesystem permissions. This option builds the Docker environment in developer mode and verifies configured service versions. System performance is slower in developer mode because of additional file synchronization operations. However, you can use file synchronization tools to improve performance.
+See [Synchronizing data in Docker].
 
 {: .bs-callout-info }
 The `{{site.data.var.ct}}` version 2002.0.18 and later supports developer mode.
 
-When you launch the Docker environment in developer mode, you must select a file synchronization option:
-
--  On Windows or MacOS, use [docker-sync][dsync-install] or [mutagen][mutagen-install], `docker-sync` is the default option
--  On Linux, use the `native` option to disable file synchronization, which is not required for local Docker development
+When you use the Docker environment in developer mode, you can select the file synchronization option when you build the `docker-compose.yml` configuration file.
 
 Large files (>1 GB) can cause a period of inactivity. DB dumps and archive files—ZIP, SQL, GZ, and BZ2—are not necessary to sync. You can find exclusions to these file types in the `docker-sync.yml` and `mutagen.sh` files.
 
@@ -32,7 +30,7 @@ To launch the Docker environment in developer mode:
    composer install
    ```
 
-1. Install the selected file synchronization tool if required:
+1. On macOS or Windows hosts, install the selected file synchronization tool:
 
    -  [Docker-sync Installation instructions][dsync-install]
    -  [Mutagen.io Installation instructions][mutagen-install]
@@ -40,21 +38,13 @@ To launch the Docker environment in developer mode:
 1. In your local environment, generate the Docker Compose configuration file. You can use the service keys, such as `--php`, to [specify a version][services].
 
    ```bash
-   ./vendor/bin/ece-tools docker:build --mode="developer"
+   ./vendor/bin/ece-docker build:compose --mode="developer"
    ```
 
-   By default, the `docker-build` command generates the Docker Compose configuration file using 'docker-sync' for file synchronization. To use 'mutagen.io' for file synchronization on Windows or MacOS, you must run the command with the `--sync-engine="mutagen"` option.
-
-   For example:
+   If required, set the option for [synchronizing data in Docker]. For example:
 
    ```bash
-   ./vendor/bin/ece-tools docker:build --mode="developer" --sync-engine="mutagen"
-   ```
-
-   On Linux, use the `native` option to generate the Docker Compose configuration file:
-
-   ```bash
-   ./vendor/bin/ece-tools docker:build --mode="developer" --sync-engine="native"
+   ./vendor/bin/ece-docker build:compose --mode="developer" --sync-engine="mutagen"
    ```
 
 1. _Optional_: If you have a custom PHP configuration file, copy the default configuration DIST file to your custom configuration file and make any necessary changes.
@@ -65,7 +55,7 @@ To launch the Docker environment in developer mode:
 
 1. _Optional_: Configure the Docker global variables in the `docker-compose.yml` file. For example, you can [enable and configure Xdebug][xdebug].
 
-1. Start the file synchronization.
+1. If you selected `docker-sync` for file synchronization, start the file synchronization.
 
    For the `docker-sync` tool:
 
@@ -75,16 +65,13 @@ To launch the Docker environment in developer mode:
 
    If this is the first installation, expect to wait a few minutes for file synchronization.
 
-   {: .bs-callout-info}
-   If you use the `mutagen.io` or `native` option for file synchronization, skip this step. You start `mutagen.io` _after_ deploying the Docker containers.
-
 1. Build files to containers and run in the background.
 
    ```bash
    docker-compose up -d
    ```
 
-1. Start the file synchronization with `mutagen.io`. If you use the `docker-sync` or `native` options to generate the Docker Compose configuration file, skip this step.
+1. If you selected `mutagen` for file synchronization, start the file synchronization.
 
    ```bash
    bash ./mutagen.sh
@@ -133,6 +120,7 @@ To launch the Docker environment in developer mode:
 
    -  `https://magento2.docker`
 
+[Synchronizing data in Docker]: {{site.baseurl}}/cloud/docker/docker-syncing-data.html
 [cloud-repo]: https://github.com/magento/magento-cloud
 [magento-creds]: {{site.baseurl}}/guides/v2.3/install-gde/prereq/connect-auth.html
 [services]: {{site.baseurl}}/cloud/docker/docker-containers.html#service-versions

--- a/src/cloud/docker/docker-syncing-data.md
+++ b/src/cloud/docker/docker-syncing-data.md
@@ -7,7 +7,7 @@ functional_areas:
   - Configuration
 ---
 
-In a Docker development environment, the {{site.data.var.ee}} application works only if the Docker containers have access to the {{site.data.var.ee}} application data. You can provide access either by directly mapping the current working directory, or by using a file synchronization tool.
+In a Docker development environment, the {{site.data.var.ee}} application works only if the Docker containers have access to the {{site.data.var.ee}} application data. You can provide access either by directly mapping the current working directory or by using a file synchronization tool.
 
 The {{site.data.var.mcd}}  `docker-build` command provides the `--sync-engine <type>` option to select the file synchronization behavior when you build the `docker-compose.yml` configuration file. You can select from the following values:
 

--- a/src/cloud/docker/docker-syncing-data.md
+++ b/src/cloud/docker/docker-syncing-data.md
@@ -1,17 +1,23 @@
 ---
 group: cloud-guide
-title: Synchronizing data in Docker
+title: Synchronizing data in a Docker development environment
 functional_areas:
   - Cloud
   - Setup
   - Configuration
 ---
-In the Docker environment, the {{site.data.var.ee}} application works only if the Docker containers have access to the {{ site.data.var.ee }} application data. You can provide access  either by directly mapping the current working directory or by using a file synchronization tool.
 
-You must use a file synchronization tool if you are using [Docker Desktop](https://www.docker.com/products/docker-desktop) for Windows or macOS. This tool is required because the filesystem for the Docker containers is inside a Virtual Machine that the Docker Desktop is creating. The application files must be local to the containers.
+In a Docker development environment, the {{site.data.var.ee}} application works only if the Docker containers have access to the {{site.data.var.ee}} application data. You can provide access either by directly mapping the current working directory, or by using a file synchronization tool.
 
-## Native
-The Magento Cloud Docker uses the `/app/` directory inside the containers by default. If you are using Linux native, you can add the `--sync-engine="native` option to the `docker:build` command, which maps the current working directory to the `/app/` directory to eliminate the data synchronization requirement.
+The {{site.data.var.mcd}}  `docker-build` command provides the `--sync-engine <type>` option to select the file synchronization behavior when you build the `docker-compose.yml` configuration file. You can select from the following values:
+
+`--sync-engine` value | Description
+--------------------- | ------------
+`native` | Maps the current working directory to the `/app` directory on each volume, which provides direct access to the data without requiring any synchronization. The `native` option is the default and works well on Linux native hosts. On macOS or Windows hosts, this option results in extremely slow performance in the Docker environment.
+`mutagen` | Uses [Mutagen] for file synchronization. When you select Mutagen, you must [install Mutagen] on your host operating system before you [launch Docker in developer mode]. Use this option on macOS or Windows hosts.
+`docker-sync` | Uses [docker-sync] for file synchronization. When you select docker-sync, you must [install docker-sync] on your host operating system before you [launch Docker in developer mode]. Use this option on macOS or Windows hosts.
+
+Launching the Docker development environment using the native file synchronization option maps to the `/app` folder for the following containers:
 
 ```yaml
   fpm:
@@ -31,12 +37,22 @@ The Magento Cloud Docker uses the `/app/` directory inside the containers by def
       - '.:/app'
 ```
 
-This configuration eliminates the requirement to use the `magento-sync` volume. You can bring the application up quickly without using the Mutagen or docker-sync applications.
+If you use a Linux host, this configuration eliminates the requirement to use the `magento-sync` volume. You can bring the application up quickly without installing the `Mutagen` or `docker-sync` applications.
 
-You can configure native file synchronization by specifying the `--sync-engine="native"` on the `docker:build` command.
+## Configure file synchronization
+
+You do not have to configure file synchronization if you use the `native` option since this is the default setting.
+
+On macOS or Windows systems, you can configure file synchronization using Mutagen or docker-sync by adding the `--sync-engine="<type>"` option to the `docker:build` command.
+
+For example:
+
 ```bash
-./vendor/bin/ece-tools docker:build --mode="developer" --sync-engine="native"
+./vendor/bin/ece-docker build:compose --mode="developer" --sync-engine="mutagen"
 ```
 
-## Mutagen
-Mutagen is used to sync the application data into the containers. You must configure Mutagen when you build the Docker environment, and the Mutagen service must be running on your host operating system.
+[Mutagen]: https://mutagen.io/
+[install Mutagen]: https://mutagen.io/documentation/introduction/installation
+[docker-sync]: https://docker-sync.readthedocs.io/en/latest/#
+[dsync-install]: https://docker-sync.readthedocs.io/en/latest/getting-started/installation.html
+[launch Docker in developer mode]: {{site.baseurl}}/cloud/docker/docker-mode-developer.html

--- a/src/cloud/docker/docker-syncing-data.md
+++ b/src/cloud/docker/docker-syncing-data.md
@@ -1,6 +1,6 @@
 ---
 group: cloud-guide
-title: Synchronizing data in a Docker development environment
+title: Synchronizing data in a Docker developer environment
 functional_areas:
   - Cloud
   - Setup

--- a/src/cloud/release-notes/mcd-release-notes.md
+++ b/src/cloud/release-notes/mcd-release-notes.md
@@ -33,7 +33,7 @@ The release notes include:
    -  {:.new}**RabbitMQ version support**–Updated the RabbitMQ container configuration to support RabbitMQ version 3.8.<!--MAGECLOUD-4674-->
 
    -  {:.fix}**Persistent database container**–The `magento-db: /var/lib/mysql` database volume now persists after you stop and remove the Docker configuration and restores when you restart the Docker configuration. Now, you must manually delete the database volume. See [Database containers].<!--MAGECLOUD-3978-->
-      
+
       -  {:.new}**Updated the TLS and Varnish images to use official Docker images**–<!--MAGECLOUD-4163-->
 
       -  {:.new}The base image for the [Magento Cloud TLS container] is now based on the `debian:jessie` Docker image.
@@ -72,7 +72,11 @@ The release notes include:
 
    -  {:.new}Added the `--rm` option to `./bin/magento-docker` commands for the build and deploy containers. This removes the container after the task is complete.<!--MAGECLOUD-4205-->
 
-   -  {:.new}Added the `--sync-engine="native"` option to the `docker-build` command to disable file synchronization when you generate the Docker Compose configuration file in developer mode. Use this option when developing on Linux systems, which do not require file synchronization for local Docker development.<!--MAGECLOUD-4351-->
+   -  {:.new}**Updates to `build:compose` command**–
+
+      -  {:.new}Added the `--sync-engine="native"` option to the `docker-build` command to disable file synchronization when you generate the Docker Compose configuration file in developer mode. Use this option when developing on Linux systems, which do not require file synchronization for local Docker development. See [Synchronizing data in the Docker environment]({{site.baseurl}}/cloud/docker/docker-syncing-data.html).<!--MAGECLOUD-4351, MAGECLOUD-->
+
+   -  {:.new}Changed the default file synchronization setting from `docker-sync` to `native`.<!--MAGECLOUD-5066-->[Fix submitted by Mathew Beane from Zilker Technologies](https://github.com/magento/magento-cloud-docker/pull/124).
 
 -  {:.new}**Validation improvements**–
 

--- a/src/cloud/release-notes/mcd-release-notes.md
+++ b/src/cloud/release-notes/mcd-release-notes.md
@@ -22,11 +22,15 @@ The release notes include:
 
 -  {:.new}**Container updates**–
 
+   -  {:.new}**PHP-FPM container updates**–
+
+      -  {:.new}**Added Node.js support**–Updated the PHP-FPM image to support node, npm, and the grunt-cli capabilities inside the PHP container.<!--MAGECLOUD-3953-->
+
+      -  {:.new}**Added support for [ionCube](https://www.ioncube.com/)**–Updated the default Docker configuration to support ionCube in the local Docker development environment.<!--MAGECLOUD-4354-->
+
    -  {:.new}**New Selenium container**–Added a [Selenium container]({{site.baseurl}}/cloud/docker/docker-containers-service.html#selenium-container) to support {{site.data.var.ee}} application testing using the Magento Functional Testing Framework (MFTF).<!--MAGECLOUD-4040-->
 
    -  {:.new}**RabbitMQ version support**–Updated the RabbitMQ container configuration to support RabbitMQ version 3.8.<!--MAGECLOUD-4674-->
-
-   -  {:.new}**Updated the Magento PHP image to support Node.js**–Updated the PHP image to support node, npm, and the grunt-cli capabilities inside the PHP container.<!--MAGECLOUD-3953-->
 
    -  {:.fix}**Persistent database container**–The `magento-db: /var/lib/mysql` database volume now persists after you stop and remove the Docker configuration and restores when you restart the Docker configuration. Now, you must manually delete the database volume. See [Database containers].<!--MAGECLOUD-3978-->
 


### PR DESCRIPTION
## Purpose of this pull request

Updated documentation about file synchronization options for `ece-docker build:compose` command

- Revised Synchronizing data in Docker topic to include information
about all `--sync-engine` options on `ece-docker build:compose` command
- Updated documentation to change default file synchronization option
from `docker-sync` to `native` (MAGECLOUD-5066)
- Changed `ece-tools`  to use new command syntax `ece-docker`
- Added file synchronization updates to release notes

## Affected DevDocs pages

- https://devdocs.magento.com/cloud/docker/docker-config.html
- https://devdocs.magento.com/cloud/docker/docker-development-testing.html
- https://devdocs.magento.com/cloud/docker/docker-mode-developer.html
- https://devdocs.magento.com/cloud/docker/docker-syncing-data.html
- https://devdocs.magento.com/cloud/docker/mcd-release-notes.html

whatsnew
Updated information related to options for using the `ece-docker build:compose` command to generate the `docker-compose.yml `configuration file for the Magento Cloud Docker environment:
- Added new `--sync-engine="native"` file synchronization option for `ece-docker build:compose` command to the [Developer mode](https://devdocs.magento.com/cloud/docker/docker-mode-developer.html) topic in the _Cloud Guide_.
- Changed `ece-tools` command references to `ece-docker` to reflect new CLI command structure introduced in Magento Cloud Docker version 1.0.0.