### PR TITLE
magento/devdocs#: GraphQl. API functional tests. Add info about tests location

### DIFF
--- a/src/guides/v2.3/graphql/functional-testing.md
+++ b/src/guides/v2.3/graphql/functional-testing.md
@@ -9,7 +9,7 @@ Magento provides API functional tests that can verify extension points in GraphQ
 
 ## Creating a new GraphQL functional test
 
-All GraphQL functional tests should inherit from the generic test case `Magento\TestFramework\TestCase\GraphQlAbstract`. It defines the `graphQlQuery()` method, which should be used to perform Web API calls from tests.
+All GraphQL functional tests should be located in the `dev/tests/api-functional/testsuite/Magento/GraphQl/` directory and inherit from the generic test case `Magento\TestFramework\TestCase\GraphQlAbstract`. It defines the `graphQlQuery()` and `graphQlMutation()` methods, which should be used to perform Web API calls from tests.
 
 The following test verifies that the schema returns the correct attribute type, given the `attribute_code` and corresponding `entity_type`.
 


### PR DESCRIPTION

## Purpose of this pull request

This pull request (PR) adds information about GraphQl API functional tests location.

## Affected DevDocs pages

<!-- REQUIRED List the affected pages on devdocs.magento.com (URLs). Not needed for large numbers of files. -->

- https://devdocs.magento.com/guides/v2.3/graphql/functional-testing.html

## Links to Magento source code

<!--  OPTIONAL - REMOVE THIS SECTION IF NOT USED. If this pull request references a file in a Magento codebase repository, add it here. -->

-  [dev/tests/api-functional/testsuite/Magento/GraphQl/](https://github.com/magento/magento2/tree/2.3.3/dev/tests/api-functional/testsuite/Magento/GraphQl)

<!--
If you are fixing a GitHub issue, note it using GitHub keyword format (https://help.github.com/en/articles/closing-issues-using-keywords#closing-an-issue-in-a-different-repository) to close the issue when this pull request is merged. Example: `Fixes #1234`

`master` is the default branch. Merged pull requests to `master` go live on the site automatically. Any requested changes to content on the `master` branch must be related to the released codebase. Any content related to future releases goes in the `develop` branch.

See Contribution guidelines (https://github.com/magento/devdocs/blob/master/.github/CONTRIBUTING.md) for more information.
-->

Thank you!