### PR TITLE
Correct caption default value for ui-select component

### DIFF
--- a/src/guides/v2.3/ui_comp_guide/components/ui-select.md
+++ b/src/guides/v2.3/ui_comp_guide/components/ui-select.md
@@ -9,7 +9,7 @@ The Select component provides the interface for a list or a data set. With this 
 
 | Option | Description | Type | Default |
 | --- | --- | --- | --- |
-| `caption` | Caption for DOM select element. | String | `''` |
+| `caption` | Caption for DOM select element. | String | `-` |
 | `elementTmpl` | The path to the `.html` template of the particular type of field (select). | String | `ui/form/element/select` |
 | `options` | The array of the options to be displayed in the list for selection. | Array | `[]` |
 | `component` | The path to the component’s `.js` file in terms of RequireJS. | String | `Magento_Ui/js/form/element/select` |


### PR DESCRIPTION
## Purpose of this pull request

This pull request (PR) corrects the default value for the caption configuration option of the ui-select component. 

The caption configuration option is required, and does not have a default value. Omitting it causes errors on the category form, and possibly other places as well.

## Affected DevDocs pages

-  https://devdocs.magento.com/guides/v2.3/ui_comp_guide/components/ui-secondary-uiselect.html