### PR TITLE
Include link to Elasticsuite documentation in the Cloud Guide

### DIFF
--- a/src/cloud/env/variables-deploy.md
+++ b/src/cloud/env/variables-deploy.md
@@ -240,7 +240,7 @@ stage:
 -  Removing the ElasticSearch service causes a deploy failure accompanied by an appropriate validation error
 
 {:.bs-callout-info}
-Magento does not support the ElasticSuite third-party plugin.
+For details on using or troubleshooting the Elasticsuite plugin with Magento, see the [Elasticsuite documentation](https://github.com/Smile-SA/elasticsuite).
 
 ### `ENABLE_GOOGLE_ANALYTICS`
 


### PR DESCRIPTION
## Purpose of this pull request

Added link to [Elasticsuite for Magento 2](https://github.com/Smile-SA/elasticsuite) documentation for troubleshooting.

## Affected DevDocs pages

https://devdocs.magento.com/cloud/env/variables-deploy.html