### PR TITLE
Fixed a formatting issue in 2.2.11 release notes

### DIFF
--- a/src/guides/v2.2/release-notes/release-notes-2-2-11-commerce.md
+++ b/src/guides/v2.2/release-notes/release-notes-2-2-11-commerce.md
@@ -14,7 +14,7 @@ Magento 2.2.11 has not been tested with PHP 7.1. PHP 7.1 reached EOL (End of Lif
 
 Twenty-three security enhancements that help close cross-site scripting (XSS) and remote code execution (RCE) vulnerabilities as well as other security issues. No confirmed attacks related to these issues have occurred to date. However, certain vulnerabilities can potentially be exploited to access customer information or take over administrator sessions. Most of these issues require that an attacker first obtains access to the Admin. As a result, we remind you to take all necessary steps to protect your Admin, including but not limited to these efforts: IP whitelisting, two-factor authentication, use of a VPN, the use of a unique location rather than /admin, and good password hygiene.
 
-With this quarterly release, we’ve changed how we describe these security issues. Individual issues are no longer described in the Magento Security Center. Instead, these issues are documented in an Adobe Security bulletin. Please see [Security updates available for Magento | APSB20-02](https://helpx.adobe.com/security/products/magento/apsb20-02.html) for more information.
+With this quarterly release, we’ve changed how we describe these security issues. Individual issues are no longer described in the Magento Security Center. Instead, these issues are documented in an Adobe Security bulletin. Please see [Security updates available for Magento (APSB20-02)](https://helpx.adobe.com/security/products/magento/apsb20-02.html) for more information.
 
 ## Functional fixes
 


### PR DESCRIPTION
## Purpose of this pull request

This pull request (PR) fixes the issue that @hguthrie caught in #6470. 

### Bad formatting
<img width="1178" alt="Screen Shot 2020-01-27 at 5 05 31 PM" src="https://user-images.githubusercontent.com/13662379/73222766-aa9b7200-4129-11ea-9655-b67ef090f362.png">


### Fixed formatting
<img width="1155" alt="Screen Shot 2020-01-27 at 5 22 34 PM" src="https://user-images.githubusercontent.com/13662379/73222770-ae2ef900-4129-11ea-8b64-2e1479474063.png">