### PR TITLE
magento/devdocs#: Editorial. GraphQl. Fix mutation query.

### DIFF
--- a/src/guides/v2.3/graphql/mutations/remove-item.md
+++ b/src/guides/v2.3/graphql/mutations/remove-item.md
@@ -24,7 +24,8 @@ mutation {
       cart_id: "IeTUiU0oCXjm0uRqGCOuhQ2AuQatogjG",
       cart_item_id: 14
     }
-  ){
+  ) 
+ {
   cart {
     items {
       id
@@ -37,9 +38,10 @@ mutation {
       grand_total{
         value
         currency
-        }
+      }
     }
   }
+ }
 }
 ```
 


### PR DESCRIPTION

## Purpose of this pull request

This pull request (PR) adds a missed `}` char and fixes a mutation request query in the "`Example usage`" section.

## Affected DevDocs pages

<!-- REQUIRED List the affected pages on devdocs.magento.com (URLs). Not needed for large numbers of files. -->

-  https://devdocs.magento.com/guides/v2.3/graphql/mutations/remove-item.html

## Links to Magento source code

<!--  OPTIONAL - REMOVE THIS SECTION IF NOT USED. If this pull request references a file in a Magento codebase repository, add it here. -->

-  ...

<!--
If you are fixing a GitHub issue, note it using GitHub keyword format (https://help.github.com/en/articles/closing-issues-using-keywords#closing-an-issue-in-a-different-repository) to close the issue when this pull request is merged. Example: `Fixes #1234`

`master` is the default branch. Merged pull requests to `master` go live on the site automatically. Any requested changes to content on the `master` branch must be related to the released codebase. Any content related to future releases goes in the `develop` branch.

See Contribution guidelines (https://github.com/magento/devdocs/blob/master/.github/CONTRIBUTING.md) for more information.
-->

Thank you!