### PR TITLE
Describe docker php image build process

### DIFF
--- a/src/cloud/docker/docker-containers-service.md
+++ b/src/cloud/docker/docker-containers-service.md
@@ -62,7 +62,7 @@ Container name |Docker base image | Ports exposed
 -------- | -------- | ---------------
 fpm | [magento/magento-cloud-docker-php][php-cloud], which is based on the [php](https://hub.docker.com/_/php) Docker image | 9000, 9001
 
-The FPM container is based on the [magento/magento-cloud-docker-php][php] image and includes the following volumes:
+The FPM container is based on the [magento/magento-cloud-docker-php][php-cloud] image and includes the following volumes:
 
 -  Read-only volumes:
    -  `/app`
@@ -84,7 +84,7 @@ You can load custom extensions in the FPM configuration by adding the configurat
      - 'PHP_EXTENSIONS=bcmath bz2 calendar exif gd gettext intl mysqli pcntl pdo_mysql soap sockets sysvmsg sysvsem sysvshm opcache zip redis xsl xdebug'
 ```
 
-For additional information about configuring the php environment, see the [XDebug for Docker] documentation.
+For additional information about configuring the php environment, see the [XDebug for Docker] and [Rebuilding PHP Images] documentation.
 
 ## RabbitMQ container
 
@@ -175,6 +175,7 @@ The NGINX configuration for this container is the standard Magento [nginx config
 [Manage the database]: {{site.baseurl}}/cloud/docker/docker-containers-service.html
 [php-cloud]: https://hub.docker.com/r/magento/magento-cloud-docker-php
 [XDebug for Docker]: {{site.baseurl}}/cloud/docker/docker-development-debug.html
+[Rebuilding PHP Images]: {{site.baseurl}}/cloud/docker/docker-extend.html#building-the-magento-cloud-docker-php-images
 [redis]: https://hub.docker.com/_/redis
 [rabbitmq]: https://hub.docker.com/_/rabbitmq
 [FPM]: https://php-fpm.org

--- a/src/cloud/docker/docker-extend.md
+++ b/src/cloud/docker/docker-extend.md
@@ -46,4 +46,22 @@ If you want to update the container configuration and test iteratively, run the 
 docker-compose up -d --force-recreate --build
 ```
 
+## Building the Magento Cloud Docker PHP Images
+When developing or extending the Magento Cloud Docker you may need to modify the PHP Images. Extensions and configuration can generally be handled using the container configuration. This method gives additional flexibility, and documents how these images are generated and then uploaded to Docker Hub.
+
+This is done by editing in the the following two directories in the magento-cloud-docker source:
+
+-  In `vendor/magento/magento-cloud-docker/`
+   -  `/images/php/cli`
+   -  `/images/php/fpm`
+
+*Do not edit in the the specific versioned directories.*
+
+After which you will need to locally build the other directories in the `images/php` directory.
+```bash
+ docker run -it  -v $(pwd):/app/ -v ~/.composer/:/root/.composer/ magento/magento-cloud-docker-php:7.3-cli-1.1 bash -c "./vendor/bin/ece-docker image:generate:php"
+```
+
+This command utilizes the php container to run this, and assumes you have already run `composer install` on the project.
+
 [multiple compose files]: https://docs.docker.com/compose/reference/overview/#specifying-multiple-compose-files


### PR DESCRIPTION
## Purpose of this pull request

This pull request (PR) adds a section to the extending docker page. This describes how to update and rebuild the PHP images. This is very useful and required for developers who want to contribute changes back to Magento Cloud Docker. Also, this would be required if they wanted to customize these images.

## Affected DevDocs pages
-  cloud/docker/docker-containers-service.html#fpm-container
-  cloud/docker/docker-extend.html#building-the-magento-cloud-docker-php-images


