### PR TITLE
Fixes for Docker 1.0.0 topics

### DIFF
--- a/src/cloud/docker/docker-containers-service.md
+++ b/src/cloud/docker/docker-containers-service.md
@@ -169,7 +169,7 @@ To mount custom NGINX configuration file using volumes:
 
 1. On your local host, create a `./.docker/nginx/etc/` directory.
 
-1. Copy the `nginx.conf` and `vhost.conf` [configuration files][configs] to the new directory.
+1. Copy the `nginx.conf` and `vhost.conf` [configuration files][nginx configs] to the new directory.
 
 1. In the `vhost.conf` file, customize the values for variables like `!UPLOAD_MAX_FILESIZE!;` as needed.
 

--- a/src/cloud/docker/docker-containers.md
+++ b/src/cloud/docker/docker-containers.md
@@ -36,7 +36,7 @@ The `docker:build` command runs in interactive mode and verifies the configured 
 For example, the following command starts the Docker configuration generator in developer mode and specifies PHP version 7.2:
 
 ```bash
-./vendor/bin/ece-tools docker:build --mode="developer" --php 7.2
+./vendor/bin/ece-docker build:compose --mode="developer" --php 7.2
 ```
 
 ## Request Flow

--- a/src/cloud/docker/docker-mode-production.md
+++ b/src/cloud/docker/docker-mode-production.md
@@ -25,7 +25,7 @@ To launch the Docker environment in developer mode:
 1. In your local environment, start the Docker configuration generator. You can use the service keys, such as `--php`, to [specify a version][services].
 
    ```bash
-   ./vendor/bin/ece-tools docker:build
+   ./vendor/bin/ece-docker build:compose
    ```
 
 1. _Optional_: If you have a custom PHP configuration file, copy the default configuration DIST file to your custom configuration file and make any necessary changes.

--- a/src/cloud/docker/docker-quick-reference.md
+++ b/src/cloud/docker/docker-quick-reference.md
@@ -42,6 +42,9 @@ docker-compose -f docker-compose.yml -f docker-compose-custom.yml [-f more-custo
 | [Mode]({{site.baseurl}}/cloud/docker/docker-config.html#launch-modes)         | `--mode`, `-m`   | production, developer
 | [File synchronization engine]({{site.baseurl}}/cloud/docker/docker-config.html#launch-modes) | `--sync-engine` | native (default), docker-sync, mutagen
 
+{:.bs-callout-info}
+See [Service versions] for a list of the options to configure the software service version when building your Magento Cloud Docker environment.
+
 ## bin/magento-docker
 
 Run `bin/magento-docker` commands using the following format:
@@ -75,3 +78,5 @@ Start containers | `start`
 Restart containers | restart
 Destroy containers | `down`
 Destroy, re-create, and start containers | `up`
+
+[Service versions]: {{site.baseurl}}/cloud/docker/docker-containers.html#service-versions

--- a/src/cloud/release-notes/mcd-release-notes.md
+++ b/src/cloud/release-notes/mcd-release-notes.md
@@ -20,6 +20,8 @@ The release notes include:
 
 -  {:.new}**Added a stand-alone Magento Cloud Docker package**–Moved the Docker package to the [new `magento-cloud-docker` repository](https://github.com/magento/magento-cloud-docker) to maintain code quality and provide independent releases.<!--MAGECLOUD-3986-->
 
+-  {:.new}**Added versioning to the Docker images**–You must now update the {{site.data.var.mcd}} package to get the updated images.
+
 -  {:.new}**Container updates**–
 
    -  {:.new}**PHP-FPM container updates**–
@@ -30,7 +32,7 @@ The release notes include:
 
    -  {:.new}**Web container updates**–
 
-      -  {:.new}**Customize NGINX configuration**–Added the capability to mount a custom `nginx.conf` file to the Magento Cloud Docker environment. See [Web container]({{site.baseurl}}/cloud/docker/dockr-containers-service.html#web-container).
+      -  {:.new}**Customize NGINX configuration**–Added the capability to mount a custom `nginx.conf` file to the Magento Cloud Docker environment. See [Web container]({{site.baseurl}}/cloud/docker/docker-containers-service.html#web-container).<!--MAGECLOUD-4204-->
 
       -  {:.new}**Auto-generated NGINX certificates**–The Docker configuration file now includes the configuration to auto-generate NGINX certificates for the Web container.<!--MAGECLOUD-4258-->
 


### PR DESCRIPTION
## Purpose of this pull request

Updates and fixes for Cloud Docker 1.0.0 topics.
- Updated renamed commands
- Fixed broken links
- Updated Docker Quick ref with link to service version page
with config options

## Affected DevDocs pages

https://magento.devdocs.com/cloud/docker/docker-containers-service.html
https://magento.devdocs.com/cloud/docker/docker-containers.html
https://magento.devdocs.com/cloud/docker/docker-mode-production.html
https://magento.devdocs.com/cloud/docker/docker-quick-reference.html
https://magento.devdocs.com/cloud/release-notes/mcd-release-notes.html




