### PR TITLE
Updated What's New for the 2.3.4 release

### DIFF
--- a/src/_data/whats-new.yml
+++ b/src/_data/whats-new.yml
@@ -55,6 +55,18 @@ entries:
   type: Major update
   date: November 7, 2019
   link: https://github.com/magento/devdocs/pull/5952
+- description: Added the [`mergeCarts` mutation](https://devdocs.magento.com/guides/v2.3/graphql/mutations/merge-carts.html)
+    topic to the _GraphQL Developer Guide_.
+  versions: 2.3.4
+  type: New topic
+  date: November 4, 2019
+  link: https://github.com/magento/devdocs/pull/5900
+- description: Added the [`customerCart` query](https://devdocs.magento.com/guides/v2.3/graphql/queries/customer-cart.html)
+    to the _GraphQL Developer Guide_.
+  versions: 2.3.4
+  type: New topic
+  date: November 1, 2019
+  link: https://github.com/magento/devdocs/pull/5899
 - description: Added the [categoryList](https://devdocs.magento.com/guides/v2.3/graphql/queries/category.html)
     query to the _GraphQL Developer Guide_.
   versions: 2.3.4

--- a/src/_data/whats-new.yml
+++ b/src/_data/whats-new.yml
@@ -55,6 +55,44 @@ entries:
   type: Major update
   date: November 7, 2019
   link: https://github.com/magento/devdocs/pull/5952
+- description: Added the `store_name` attribute to the [storeConfig](https://devdocs.magento.com/guides/v2.3/graphql/queries/store-config.html)
+    query.
+  versions: 2.3.4
+  type: Technical changes
+  date: October 4, 2019
+  link: https://github.com/magento/devdocs/pull/5448
+- description: Updated the [ProductInterface](https://devdocs.magento.com/guides/v2.3/graphql/product/product-interface.html)
+    documentation in the _GraphQL Developer Guide_ to include new data types and attributes
+    that support tier pricing and price ranges in composite products.
+  versions: 2.3.4
+  type: Major update
+  date: September 30, 2019
+  link: https://github.com/magento/devdocs/pull/5512
+- description: Updated the [Private Content](https://devdocs.magento.com/guides/v2.3/extension-dev-guide/cache/page-caching/private-content.html)
+    topic in the _Extension Developer Guide_ to provide information about support
+    in Magento 2.3.4.
+  versions: 2.3.4
+  type: Major update
+  date: September 24, 2019
+  link: https://github.com/magento/devdocs/pull/5461
+- description: Added support for cart rule discounts in the GraphQL [Cart output object](https://devdocs.magento.com/guides/v2.3/graphql/queries/cart.html#CartItemPrices).
+  versions: 2.3.4
+  type: Major update
+  date: September 20, 2019
+  link: https://github.com/magento/devdocs/pull/5425
+- description: Deprecated the [setPaymentMethodAndPlaceOrder mutation](https://devdocs.magento.com/guides/v2.3/graphql/mutations/set-payment-place-order.html)
+    in the _GraphQL Developer Guide_.
+  versions: 2.3.4
+  type: Major update
+  date: September 18, 2019
+  link: https://github.com/magento/devdocs/pull/5413
+- description: Added the topic [Filtering with custom attributes](https://devdocs.magento.com/guides/v2.3/graphql/custom-filters.html)
+    to the _GraphQL Developer Guide_ and significantly revised the [`products` query](https://devdocs.magento.com/guides/v2.3/graphql/queries/products.html)
+    to reflect changes in how the query works in Magento 2.3.4.
+  versions: 2.3.4
+  type: Major update
+  date: September 16, 2019
+  link: https://github.com/magento/devdocs/pull/5222
 - description: Added `@method` and `@link` information to [Coding Standards](https://devdocs.magento.com/guides/v2.3/coding-standards/docblock-standard-general.html).
   versions: 2.2.x, 2.3.x
   type: Major update

--- a/src/_data/whats-new.yml
+++ b/src/_data/whats-new.yml
@@ -36,6 +36,12 @@ entries:
   type: Major update
   date: January 8, 2020
   link: https://github.com/magento/devdocs/pull/6354
+- description: Added  the [Migrating custom email templates](https://devdocs.magento.com/guides/v2.3/frontend-dev-guide/templates/template-email-migration.html)
+    topic to the _Frontend Developer Guide_.
+  versions: 2.3.4
+  type: New topic
+  date: December 11, 2019
+  link: https://github.com/magento/devdocs/pull/6107
 - description: Added information about bulk [resolvers](https://devdocs.magento.com/guides/v2.3/graphql/develop/resolvers.html)
     in the _GraphQL Developer Guide_.
   versions: 2.3.4

--- a/src/_data/whats-new.yml
+++ b/src/_data/whats-new.yml
@@ -10,112 +10,112 @@ entries:
     with the `products` query.
   versions: 2.3.4
   type: Technical changes
-  date: January 27, 2020
+  date: January 28, 2020
   link: https://github.com/magento/devdocs/pull/6468
 - description: Updated the Magento [system requirements](https://devdocs.magento.com/guides/v2.3/install-gde/system-requirements-tech.html)
     regarding end-of-life for PHP 7.1.
   versions: 2.3.4
   type: Technical changes
-  date: January 27, 2020
+  date: January 28, 2020
   link: https://github.com/magento/devdocs/pull/6469
 - description: Updated information about Magento [cron](https://devdocs.magento.com/guides/v2.3/config-guide/cli/config-cli-subcommands-cron.html)
     jobs.
   versions: 2.3.x
   type: Technical changes
-  date: January 23, 2020
+  date: January 28, 2020
   link: https://github.com/magento/devdocs/pull/6428
 - description: Added an example of adding a grouped product to a cart in the [`addSimpleProductsToCart`](https://devdocs.magento.com/guides/v2.3/graphql/mutations/add-simple-products.html)
     mutation.
   versions: 2.3.4
   type: Technical changes
-  date: January 15, 2020
+  date: January 28, 2020
   link: https://github.com/magento/devdocs/pull/6379
 - description: Updated the [REST schemas](https://devdocs.magento.com/redoc/2.3/)
     for Magento 2.3.4.
   versions: 2.3.4
   type: Major update
-  date: January 8, 2020
+  date: January 28, 2020
   link: https://github.com/magento/devdocs/pull/6354
 - description: Added  the [Migrating custom email templates](https://devdocs.magento.com/guides/v2.3/frontend-dev-guide/templates/template-email-migration.html)
     topic to the _Frontend Developer Guide_.
   versions: 2.3.4
   type: New topic
-  date: December 11, 2019
+  date: January 28, 2020
   link: https://github.com/magento/devdocs/pull/6107
 - description: Added information about bulk [resolvers](https://devdocs.magento.com/guides/v2.3/graphql/develop/resolvers.html)
     in the _GraphQL Developer Guide_.
   versions: 2.3.4
   type: Major update
-  date: November 12, 2019
+  date: January 28, 2020
   link: https://github.com/magento/devdocs/pull/5950
 - description: Added the 'Create cms-page/product/category-specific layouts' section
     to [Common layout customization tasks](https://devdocs.magento.com/guides/v2.2/frontend-dev-guide/layouts/xml-manage.html).
   versions: 2.2.x
   type: Major update
-  date: November 8, 2019
+  date: January 28, 2020
   link: https://github.com/magento/devdocs/pull/5934
 - description: Updated the wish list documentation in the _GraphQL Developer Guide_.
     The `wishlist` query has been deprecated. Wish list information is now returned
     in the [`customer` query](https://devdocs.magento.com/guides/v2.3/graphql/queries/customer.html<br/>).
   versions: 2.3.4
   type: Major update
-  date: November 7, 2019
+  date: January 28, 2020
   link: https://github.com/magento/devdocs/pull/5952
 - description: Added the [`mergeCarts` mutation](https://devdocs.magento.com/guides/v2.3/graphql/mutations/merge-carts.html)
     topic to the _GraphQL Developer Guide_.
   versions: 2.3.4
   type: New topic
-  date: November 4, 2019
+  date: January 28, 2020
   link: https://github.com/magento/devdocs/pull/5900
 - description: Added the [`customerCart` query](https://devdocs.magento.com/guides/v2.3/graphql/queries/customer-cart.html)
     to the _GraphQL Developer Guide_.
   versions: 2.3.4
   type: New topic
-  date: November 1, 2019
+  date: January 28, 2020
   link: https://github.com/magento/devdocs/pull/5899
 - description: Added the [categoryList](https://devdocs.magento.com/guides/v2.3/graphql/queries/category.html)
     query to the _GraphQL Developer Guide_.
   versions: 2.3.4
   type: New topic
-  date: October 7, 2019
+  date: January 28, 2020
   link: https://github.com/magento/devdocs/pull/5562
 - description: Added the `store_name` attribute to the [storeConfig](https://devdocs.magento.com/guides/v2.3/graphql/queries/store-config.html)
     query.
   versions: 2.3.4
   type: Technical changes
-  date: October 4, 2019
+  date: January 28, 2020
   link: https://github.com/magento/devdocs/pull/5448
 - description: Updated the [ProductInterface](https://devdocs.magento.com/guides/v2.3/graphql/product/product-interface.html)
     documentation in the _GraphQL Developer Guide_ to include new data types and attributes
     that support tier pricing and price ranges in composite products.
   versions: 2.3.4
   type: Major update
-  date: September 30, 2019
+  date: January 28, 2020
   link: https://github.com/magento/devdocs/pull/5512
 - description: Updated the [Private Content](https://devdocs.magento.com/guides/v2.3/extension-dev-guide/cache/page-caching/private-content.html)
     topic in the _Extension Developer Guide_ to provide information about support
     in Magento 2.3.4.
   versions: 2.3.4
   type: Major update
-  date: September 24, 2019
+  date: January 28, 2020
   link: https://github.com/magento/devdocs/pull/5461
 - description: Added support for cart rule discounts in the GraphQL [Cart output object](https://devdocs.magento.com/guides/v2.3/graphql/queries/cart.html#CartItemPrices).
   versions: 2.3.4
   type: Major update
-  date: September 20, 2019
+  date: January 28, 2020
   link: https://github.com/magento/devdocs/pull/5425
 - description: Deprecated the [setPaymentMethodAndPlaceOrder mutation](https://devdocs.magento.com/guides/v2.3/graphql/mutations/set-payment-place-order.html)
     in the _GraphQL Developer Guide_.
   versions: 2.3.4
   type: Major update
-  date: September 18, 2019
+  date: January 28, 2020
   link: https://github.com/magento/devdocs/pull/5413
 - description: Added the topic [Filtering with custom attributes](https://devdocs.magento.com/guides/v2.3/graphql/custom-filters.html)
     to the _GraphQL Developer Guide_ and significantly revised the [`products` query](https://devdocs.magento.com/guides/v2.3/graphql/queries/products.html)
     to reflect changes in how the query works in Magento 2.3.4.
   versions: 2.3.4
   type: Major update
-  date: September 16, 2019
+  date: January 28, 2020
   link: https://github.com/magento/devdocs/pull/5222
 - description: Added `@method` and `@link` information to [Coding Standards](https://devdocs.magento.com/guides/v2.3/coding-standards/docblock-standard-general.html).
   versions: 2.2.x, 2.3.x

--- a/src/_data/whats-new.yml
+++ b/src/_data/whats-new.yml
@@ -36,6 +36,25 @@ entries:
   type: Major update
   date: January 8, 2020
   link: https://github.com/magento/devdocs/pull/6354
+- description: Added information about bulk [resolvers](https://devdocs.magento.com/guides/v2.3/graphql/develop/resolvers.html)
+    in the _GraphQL Developer Guide_.
+  versions: 2.3.4
+  type: Major update
+  date: November 12, 2019
+  link: https://github.com/magento/devdocs/pull/5950
+- description: Added the 'Create cms-page/product/category-specific layouts' section
+    to [Common layout customization tasks](https://devdocs.magento.com/guides/v2.2/frontend-dev-guide/layouts/xml-manage.html).
+  versions: 2.2.x
+  type: Major update
+  date: November 8, 2019
+  link: https://github.com/magento/devdocs/pull/5934
+- description: Updated the wish list documentation in the _GraphQL Developer Guide_.
+    The `wishlist` query has been deprecated. Wish list information is now returned
+    in the [`customer` query](https://devdocs.magento.com/guides/v2.3/graphql/queries/customer.html<br/>).
+  versions: 2.3.4
+  type: Major update
+  date: November 7, 2019
+  link: https://github.com/magento/devdocs/pull/5952
 - description: Added `@method` and `@link` information to [Coding Standards](https://devdocs.magento.com/guides/v2.3/coding-standards/docblock-standard-general.html).
   versions: 2.2.x, 2.3.x
   type: Major update

--- a/src/_data/whats-new.yml
+++ b/src/_data/whats-new.yml
@@ -55,6 +55,12 @@ entries:
   type: Major update
   date: November 7, 2019
   link: https://github.com/magento/devdocs/pull/5952
+- description: Added the [categoryList](https://devdocs.magento.com/guides/v2.3/graphql/queries/category.html)
+    query to the _GraphQL Developer Guide_.
+  versions: 2.3.4
+  type: New topic
+  date: October 7, 2019
+  link: https://github.com/magento/devdocs/pull/5562
 - description: Added the `store_name` attribute to the [storeConfig](https://devdocs.magento.com/guides/v2.3/graphql/queries/store-config.html)
     query.
   versions: 2.3.4

--- a/src/_data/whats-new.yml
+++ b/src/_data/whats-new.yml
@@ -56,7 +56,7 @@ entries:
   link: https://github.com/magento/devdocs/pull/5934
 - description: Updated the wish list documentation in the _GraphQL Developer Guide_.
     The `wishlist` query has been deprecated. Wish list information is now returned
-    in the [`customer` query](https://devdocs.magento.com/guides/v2.3/graphql/queries/customer.html<br/>).
+    in the [`customer` query](https://devdocs.magento.com/guides/v2.3/graphql/queries/customer.html).
   versions: 2.3.4
   type: Major update
   date: January 28, 2020

--- a/src/_data/whats-new.yml
+++ b/src/_data/whats-new.yml
@@ -4,8 +4,38 @@ description: |
   We exclude from this list proofreading, spelling checks, and all minor updates.
 link: /whats-new.html
 thread: /whatsnew-feed.xml
-updated: Mon Jan 27 21:17:38 2020
+updated: Tue Jan 28 19:11:00 2020
 entries:
+- description: Added information about using [non-default sort attributes](https://devdocs.magento.com/guides/v2.3/graphql/queries/products.html)
+    with the `products` query.
+  versions: 2.3.4
+  type: Technical changes
+  date: January 27, 2020
+  link: https://github.com/magento/devdocs/pull/6468
+- description: Updated the Magento [system requirements](https://devdocs.magento.com/guides/v2.3/install-gde/system-requirements-tech.html)
+    regarding end-of-life for PHP 7.1.
+  versions: 2.3.4
+  type: Technical changes
+  date: January 27, 2020
+  link: https://github.com/magento/devdocs/pull/6469
+- description: Updated information about Magento [cron](https://devdocs.magento.com/guides/v2.3/config-guide/cli/config-cli-subcommands-cron.html)
+    jobs.
+  versions: 2.3.x
+  type: Technical changes
+  date: January 23, 2020
+  link: https://github.com/magento/devdocs/pull/6428
+- description: Added an example of adding a grouped product to a cart in the [`addSimpleProductsToCart`](https://devdocs.magento.com/guides/v2.3/graphql/mutations/add-simple-products.html)
+    mutation.
+  versions: 2.3.4
+  type: Technical changes
+  date: January 15, 2020
+  link: https://github.com/magento/devdocs/pull/6379
+- description: Updated the [REST schemas](https://devdocs.magento.com/redoc/2.3/)
+    for Magento 2.3.4.
+  versions: 2.3.4
+  type: Major update
+  date: January 8, 2020
+  link: https://github.com/magento/devdocs/pull/6354
 - description: Added `@method` and `@link` information to [Coding Standards](https://devdocs.magento.com/guides/v2.3/coding-standards/docblock-standard-general.html).
   versions: 2.2.x, 2.3.x
   type: Major update


### PR DESCRIPTION
## Purpose of this pull request

This pull request (PR) adds what's new entries pulled from the `2.3.4-develop` release integration branch.

I was able to pull 6 entries only (all `Technical`), which seems to indicate that we're not using labels for all release work.

See this query for a list of PRs to the `2.3.4-develop` branch: https://github.com/magento/devdocs/pulls?q=is%3Apr+base%3A2.3.4-develop+is%3Aclosed 

I wonder if the the revert in #6349 has anything to do with the lack of entries...

Ran the following command to pull entries:

```
rake whatsnew since='dec 11 2019'
```

I'm not seeing an entry for the new topic added in #6107. 

## Affected DevDocs pages

-  https://devdocs.magento.com/whats-new.html