### PR TITLE
MAGECLOUD-4672: Connection to DB doesn't work

### DIFF
--- a/src/cloud/docker/docker-manage-database.md
+++ b/src/cloud/docker/docker-manage-database.md
@@ -80,7 +80,7 @@ To connect to the database port:
 1. Connect to the database with port information from the previous step.
 
    ```bash
-   mysql -h127.0.0.1 -p32769 -umagento2 -pmagento2
+   mysql -h127.0.0.1 -P32769 -umagento2 -pmagento2
    ```
 
 1. Verify the version of the database service.


### PR DESCRIPTION
## Purpose of this pull request

This pull request (PR) to fix a typo in the CLI command for connection to the database in the Docker container through port forwarding

## Affected DevDocs pages

<!-- REQUIRED List the affected pages on devdocs.magento.com (URLs). Not needed for large numbers of files. -->

-  https://devdocs.magento.com/cloud/docker/docker-database.html

## Links to Magento source code

<!--  OPTIONAL - REMOVE THIS SECTION IF NOT USED. If this pull request references a file in a Magento codebase repository, add it here. -->

-  ...

<!--
If you are fixing a GitHub issue, note it using GitHub keyword format (https://help.github.com/en/articles/closing-issues-using-keywords#closing-an-issue-in-a-different-repository) to close the issue when this pull request is merged. Example: `Fixes #1234`

`master` is the default branch. Merged pull requests to `master` go live on the site automatically. Any requested changes to content on the `master` branch must be related to the released codebase. Any content related to future releases goes in the `develop` branch.

See Contribution guidelines (https://github.com/magento/devdocs/blob/master/.github/CONTRIBUTING.md) for more information.
-->
