### PR TITLE
Fix the link to the Code of conduct

### DIFF
--- a/.github/ISSUE_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE.md
@@ -17,7 +17,7 @@ Thank you for taking the time to report this issue!
 GitHub Issues should only be created for problems/topics related to this project's codebase.
 
 Before submitting this issue, please make sure you are complying with our Code of Conduct:
-https://github.com/magento/devdocs/blob/develop/.github/CODE_OF_CONDUCT.md
+https://github.com/magento/devdocs/blob/master/.github/CODE_OF_CONDUCT.md
 
 Issues that do not comply with our Code of Conduct or do not contain enough information may be closed at the maintainers' discretion.
 

--- a/.github/ISSUE_TEMPLATE/BUG.md
+++ b/.github/ISSUE_TEMPLATE/BUG.md
@@ -34,7 +34,7 @@ Thank you for taking the time to report this issue!
 GitHub Issues should only be created for problems/topics related to this project's codebase.
 
 Before submitting this issue, please make sure you are complying with our Code of Conduct:
-https://github.com/magento/devdocs/blob/develop/.github/CODE_OF_CONDUCT.md
+https://github.com/magento/devdocs/blob/master/.github/CODE_OF_CONDUCT.md
 
 Issues that do not comply with our Code of Conduct or do not contain enough information may be closed at the maintainers' discretion.
 

--- a/.github/ISSUE_TEMPLATE/COMMUNITY_ISSUE_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE/COMMUNITY_ISSUE_TEMPLATE.md
@@ -45,7 +45,7 @@ Thank you for taking the time to request updates for your Community Engineering 
 GitHub Issues should only be created for problems/topics related to this project's codebase.
 
 Before submitting this issue, please make sure you are complying with our Code of Conduct:
-https://github.com/magento/devdocs/blob/develop/.github/CODE_OF_CONDUCT.md
+https://github.com/magento/devdocs/blob/master/.github/CODE_OF_CONDUCT.md
 
 Issues that do not comply with our Code of Conduct or do not contain enough information may be closed at the maintainers' discretion.
 

--- a/.github/ISSUE_TEMPLATE/NEW_FEATURE.md
+++ b/.github/ISSUE_TEMPLATE/NEW_FEATURE.md
@@ -30,7 +30,7 @@ Thank you for taking the time to report this issue!
 GitHub Issues should only be created for problems/topics related to this project's codebase.
 
 Before submitting this issue, please make sure you are complying with our Code of Conduct:
-https://github.com/magento/devdocs/blob/develop/.github/CODE_OF_CONDUCT.md
+https://github.com/magento/devdocs/blob/master/.github/CODE_OF_CONDUCT.md
 
 Issues that do not comply with our Code of Conduct or do not contain enough information may be closed at the maintainers' discretion.
 

--- a/.github/ISSUE_TEMPLATE/NEW_TOPIC.md
+++ b/.github/ISSUE_TEMPLATE/NEW_TOPIC.md
@@ -29,7 +29,7 @@ Thank you for taking the time to report this issue!
 GitHub Issues should only be created for problems/topics related to this project's codebase.
 
 Before submitting this issue, please make sure you are complying with our Code of Conduct:
-https://github.com/magento/devdocs/blob/develop/.github/CODE_OF_CONDUCT.md
+https://github.com/magento/devdocs/blob/master/.github/CODE_OF_CONDUCT.md
 
 Issues that do not comply with our Code of Conduct or do not contain enough information may be closed at the maintainers' discretion.
 

--- a/.github/ISSUE_TEMPLATE/TOPIC_CLARIFICATION.md
+++ b/.github/ISSUE_TEMPLATE/TOPIC_CLARIFICATION.md
@@ -26,7 +26,7 @@ Thank you for taking the time to report this issue!
 GitHub Issues should only be created for problems/topics related to this project's codebase.
 
 Before submitting this issue, please make sure you are complying with our Code of Conduct:
-https://github.com/magento/devdocs/blob/develop/.github/CODE_OF_CONDUCT.md
+https://github.com/magento/devdocs/blob/master/.github/CODE_OF_CONDUCT.md
 
 Issues that do not comply with our Code of Conduct or do not contain enough information may be closed at the maintainers' discretion.
 


### PR DESCRIPTION
## Purpose of this pull request

This pull request (PR) fixes link to the Code of Conduct in Github templates.

Fixes #6467 