### PR TITLE
magento/devdocs#:6443 Align Magento PHP prerequisites in different topics

### DIFF
--- a/src/guides/v2.3/install-gde/prereq/php-settings.md
+++ b/src/guides/v2.3/install-gde/prereq/php-settings.md
@@ -18,8 +18,6 @@ If you are interested in participating in Magento Community projects we welcome 
 <!--{% assign supported_php_versions = site.data.codebase.v2_3.open-source.composer_lock.platform.php | split: "||" %}-->
 {% include install/php-versions-template.md %}
 
-Magento 2.3.3 supports PHP 7.3.
-
 ## Verify PHP is installed {#centos-verify-php}
 
 Most flavors of Linux have PHP installed by default.
@@ -45,19 +43,8 @@ On CentOS, [additional steps may be required][].
 
 Magento requires a set of extensions to be installed:
 
--  bcmath
--  devel
--  gd
--  iconv
--  intl
--  json
--  mbstring
--  mysql
--  mysqlnd
--  opcache
--  pdo
--  soap
--  xml
+<!--{% assign platform-req = site.data.codebase.v2_3.open-source.composer_lock.platform %}-->
+{% include install/php-extensions-template.md %}
 
 In the command line, type:
 

--- a/src/guides/v2.3/install-gde/system-requirements-tech.md
+++ b/src/guides/v2.3/install-gde/system-requirements-tech.md
@@ -51,8 +51,6 @@ Magento recommends using PHP 7.3
 <!--{% assign supported_php_versions = site.data.codebase.v2_3.open-source.composer_lock.platform.php | split: "||" %}-->
 {% include install/php-versions-template.md %}
 
-Magento 2.3.3 adds support for PHP 7.3.
-
 ### Required PHP extensions
 
 {:.bs-callout-info}

--- a/src/guides/v2.3/performance-best-practices/software.md
+++ b/src/guides/v2.3/performance-best-practices/software.md
@@ -43,20 +43,8 @@ Magento fully supports PHP 7.2.11. There are several factors to account for when
 
 We recommend limiting the list of active PHP extensions to those that are required for Magento functionality:
 
-*  `php-bcmath`
-*  `php-cli`
-*  `php-common`
-*  `php-curl`
-*  `php-gd`
-*  `php-intl`
-*  `php-mbstring`
-*  `php-opcache`
-*  `php-openssl`
-*  `php-pdo`
-*  `php-soap`
-*  `php-xml`
-*  `php-xsl`
-*  `php-zip`
+<!--{% assign platform-req = site.data.codebase.v2_3.open-source.composer_lock.platform %}-->
+{% include install/php-extensions-template.md %}
 
 Adding more extensions increases library load times.
 


### PR DESCRIPTION
## Purpose of this pull request

This pull request (PR) fix the hardcoded PHP requirements in different topicks

## Affected DevDocs pages
- https://devdocs.magento.com/guides/v2.3/install-gde/system-requirements-tech.html
- https://devdocs.magento.com/guides/v2.3/install-gde/prereq/php-settings.html
- https://devdocs.magento.com/guides/v2.3/performance-best-practices/software.html

## Links to Magento source code
- https://github.com/magento/devdocs/blob/master/src/guides/v2.3/install-gde/system-requirements-tech.md
- https://github.com/magento/devdocs/blob/master/src/guides/v2.3/install-gde/prereq/php-settings.md
- https://github.com/magento/devdocs/blob/master/src/guides/v2.3/performance-best-practices/software.md