### PR TITLE
Removed JS file extension in the require function

### DIFF
--- a/src/guides/v2.2/javascript-dev-guide/javascript/js-resources.md
+++ b/src/guides/v2.2/javascript-dev-guide/javascript/js-resources.md
@@ -53,7 +53,7 @@ JS resources are accessed using relative paths.
 *  Called in script:
 
    ```javascript
-   require(["js/theme.js"], function(){
+   require(["js/theme"], function(){
    });
    ```
 

--- a/src/guides/v2.2/javascript-dev-guide/javascript/js-resources.md
+++ b/src/guides/v2.2/javascript-dev-guide/javascript/js-resources.md
@@ -53,7 +53,7 @@ JS resources are accessed using relative paths.
 *  Called in script:
 
    ```javascript
-   require(["js/theme"], function(){
+   require(["js/theme.js"], function(){
    });
    ```
 

--- a/src/guides/v2.3/javascript-dev-guide/javascript/js-resources.md
+++ b/src/guides/v2.3/javascript-dev-guide/javascript/js-resources.md
@@ -52,7 +52,7 @@ JS resources are accessed using relative paths.
 *  Called in script:
 
    ```javascript
-   require(["js/theme.js"], function(){
+   require(["js/theme"], function(){
    });
    ```
 


### PR DESCRIPTION
## Purpose of this pull request

In RequireJS, all code is wrapped in require() or define() functions. The first parameter of these functions specifies dependencies. Note that the file extension has been omitted. This is because RequireJS considers .js files.

## Affected DevDocs pages

https://devdocs.magento.com/guides/v2.2/javascript-dev-guide/javascript/js-resources.html
https://devdocs.magento.com/guides/v2.3/javascript-dev-guide/javascript/js-resources.html