### PR TITLE
Extra Colon removed after the text "Extends"

### DIFF
--- a/src/guides/v2.3/ui_comp_guide/components/ui-actiondelete.md
+++ b/src/guides/v2.3/ui_comp_guide/components/ui-actiondelete.md
@@ -17,7 +17,7 @@ The ActionDelete component provides a user interface for deleting records of the
 
 ## Source files
 
-Extends [`Abstract`]({{ site.mage2bloburl }}/{{ page.guide_version }}/app/code/Magento/Ui/view/base/web/js/form/element/abstract.js)::
+Extends [`Abstract`]({{ site.mage2bloburl }}/{{ page.guide_version }}/app/code/Magento/Ui/view/base/web/js/form/element/abstract.js):
 
 -  [`app/code/Magento/Ui/view/base/web/js/dynamic-rows/action-delete.js`]({{ site.mage2bloburl }}/{{ page.guide_version }}/app/code/Magento/Ui/view/base/web/js/dynamic-rows/action-delete.js)
 -  [`app/code/Magento/Ui/view/base/web/templates/dynamic-rows/cells/action-delete.html`]({{ site.mage2bloburl }}/{{ page.guide_version }}/app/code/Magento/Ui/view/base/web/templates/dynamic-rows/cells/action-delete.html)

--- a/src/guides/v2.3/ui_comp_guide/components/ui-date.md
+++ b/src/guides/v2.3/ui_comp_guide/components/ui-date.md
@@ -22,7 +22,7 @@ The Date component implements a custom date input field. It uses a date picker i
 
 ## Source files
 
-Extends [`Abstract`]({{ site.mage2bloburl }}/{{ page.guide_version }}/app/code/Magento/Ui/view/base/web/js/form/element/abstract.js)::
+Extends [`Abstract`]({{ site.mage2bloburl }}/{{ page.guide_version }}/app/code/Magento/Ui/view/base/web/js/form/element/abstract.js):
 
 -  [`app/code/Magento/Ui/view/base/web/js/form/element/date.js`]({{ site.mage2bloburl }}/{{ page.guide_version }}/app/code/Magento/Ui/view/base/web/js/form/element/date.js)
 


### PR DESCRIPTION
## Purpose of this pull request
This pull request (PR) will remove the extra colon.

## Affected DevDocs pages
https://devdocs.magento.com/guides/v2.3/ui_comp_guide/components/ui-actiondelete.html