### PR TITLE
Invalid file reference

### DIFF
--- a/src/guides/v2.2/frontend-dev-guide/css-topics/css_debug.md
+++ b/src/guides/v2.2/frontend-dev-guide/css-topics/css_debug.md
@@ -14,7 +14,7 @@ The topic describes how to install, configure, and use [Grunt JavaScript task ru
 
 ## Adding themes to Grunt configuration {#add_theme}
 
-To compile `.less` files, add your theme to `module.exports` in the Grunt configuration, either in the default `dev/tools/grunt/configs/local-themes.js` or in the [custom configuration file]({{ page.baseurl }}/frontend-dev-guide/tools/using_grunt.html#grunt_config). For example:
+To compile `.less` files, add your theme to `module.exports` in the Grunt configuration, either in the default `dev/tools/grunt/configs/themes.js` or in the [custom configuration file]({{ page.baseurl }}/frontend-dev-guide/tools/using_grunt.html#grunt_config). For example:
 
 1. Install [node.js] to any location on your machine.
 


### PR DESCRIPTION
local-themes.js to themes.js issue during less compilation

## Purpose of this pull request

This pull request will prevent errors during compilation of less using grunt compiler 

## Affected DevDocs pages

<!-- REQUIRED List the affected pages on devdocs.magento.com (URLs). Not needed for large numbers of files. -->

-  https://devdocs.magento.com/guides/v2.3/frontend-dev-guide/css-topics/css_debug.html

## Links to Magento source code

<!--  OPTIONAL - REMOVE THIS SECTION IF NOT USED. If this pull request references a file in a Magento codebase repository, add it here. -->

-  ...

<!--
If you are fixing a GitHub issue, note it using GitHub keyword format (https://help.github.com/en/articles/closing-issues-using-keywords#closing-an-issue-in-a-different-repository) to close the issue when this pull request is merged. Example: `Fixes #1234`

`master` is the default branch. Merged pull requests to `master` go live on the site automatically. Any requested changes to content on the `master` branch must be related to the released codebase. Any content related to future releases goes in the `develop` branch.

See Contribution guidelines (https://github.com/magento/devdocs/blob/master/.github/CONTRIBUTING.md) for more information.
-->
