### PR TITLE
Note added for the object property convertors behaviour

### DIFF
--- a/src/guides/v2.3/extension-dev-guide/service-contracts/design-patterns.md
+++ b/src/guides/v2.3/extension-dev-guide/service-contracts/design-patterns.md
@@ -10,7 +10,7 @@ In the programming community, a _design pattern_ is a recommended way of writing
 
 Design patterns for service contracts tell you which types of interfaces to define, and how and where to define and implement those interfaces.
 
- {:.bs-callout-info}
+{:.bs-callout-info}
 Service contract data interfaces are now mutable.
 
 ## Interface types and locations {#top-level-msc}
@@ -33,9 +33,9 @@ Define data interfaces in the `Api/Data` subdirectory for a module.
 
 For example, the data interfaces for the Customer module are in the `/app/code/Magento/Customer/Api/Data` subdirectory.
 
- {:.bs-callout-info}
-Magento Framework's [SimpleDataObjectConverter]({{ site.mage2bloburl }}/{{ page.guide_version }}/lib/internal/Magento/Framework/Api/SimpleDataObjectConverter.php) follows strict camel case to snake case conversion of data keys (table columns), so it's recommended not to use `underscore (_)` between numbers and alphabets in column names.
- For example, use `default_shipping1` instead of `default_shipping_1`, as the Data Interface method `defaultShipping1` will be converted into `default_shipping1`.
+{:.bs-callout-info}
+Magento Framework's [SimpleDataObjectConverter]({{ site.mage2bloburl }}/{{ page.guide_version }}/lib/internal/Magento/Framework/Api/SimpleDataObjectConverter.php) follows a strict 'camel case' to 'snake case' conversion of data keys (table columns). It is recommended to not use `underscore (_)` between numbers and alphabets in column names.
+For example, use `default_shipping1` instead of `default_shipping_1`, as the Data Interface method `defaultShipping1` will be converted into `default_shipping1`.
 
 ### Data search results interfaces {#search-results-interfaces}
 

--- a/src/guides/v2.3/extension-dev-guide/service-contracts/design-patterns.md
+++ b/src/guides/v2.3/extension-dev-guide/service-contracts/design-patterns.md
@@ -33,6 +33,10 @@ Define data interfaces in the `Api/Data` subdirectory for a module.
 
 For example, the data interfaces for the Customer module are in the `/app/code/Magento/Customer/Api/Data` subdirectory.
 
+ {:.bs-callout-info}
+Magento Framework's [SimpleDataObjectConverter]({{ site.mage2bloburl }}/{{ page.guide_version }}/lib/internal/Magento/Framework/Api/SimpleDataObjectConverter.php) follows strict camel case to snake case conversion of data keys (table columns), so it's recommended not to use `underscore (_)` between numbers and alphabets in column names.
+ For example, use `default_shipping1` instead of `default_shipping_1`, as the Data Interface method `defaultShipping1` will be converted into `default_shipping1`.
+
 ### Data search results interfaces {#search-results-interfaces}
 
 When you pass search criteria to a `getList()` call, a search results interface is returned with the search results.


### PR DESCRIPTION
## Purpose of this pull request

This pull request (PR) is to add a note for Object methods  to property convertors behaveiour.

## Affected DevDocs pages

<!-- REQUIRED List the affected pages on devdocs.magento.com (URLs). Not needed for large numbers of files. -->

-  https://devdocs.magento.com/guides/v2.3/extension-dev-guide/service-contracts/design-patterns.html

## Links to Magento source code

<!--  OPTIONAL - REMOVE THIS SECTION IF NOT USED. If this pull request references a file in a Magento codebase repository, add it here. -->

-  https://github.com/magento/magento2/blob/2.4-develop/lib/internal/Magento/Framework/Api/SimpleDataObjectConverter.php

<!--
If you are fixing a GitHub issue, note it using GitHub keyword format (https://help.github.com/en/articles/closing-issues-using-keywords#closing-an-issue-in-a-different-repository) to close the issue when this pull request is merged. Example: `Fixes #1234`

`master` is the default branch. Merged pull requests to `master` go live on the site automatically. Any requested changes to content on the `master` branch must be related to the released codebase. Any content related to future releases goes in the `develop` branch.

See Contribution guidelines (https://github.com/magento/devdocs/blob/master/.github/CONTRIBUTING.md) for more information.
-->

## Issues
https://github.com/magento/magento2/issues/25490