### PR TITLE
Removing obsolete Fastly installation and configuration info

### DIFF
--- a/src/cloud/cdn/cloud-fastly.md
+++ b/src/cloud/cdn/cloud-fastly.md
@@ -154,16 +154,3 @@ Fastly provides a GeoIP service and supports some GeoIP functionality. GeoIP
 handling manages visitor redirection (automatically) and store matching
 (select from list) based on their obtained country code. For more information,
 see the Fastly [GeoIP documentation](https://github.com/fastly/fastly-magento2/blob/21b61c8189971275589219d418332798efc7db41/Documentation/CONFIGURATION.md#geoip-handling).
-
-## Installation and configuration {#install-configure}
-
-The installation and configuration process is:
-
--  Install the Fastly module in an Integration branch, without configuring settings or entering credentials.
--  Deploy the code to `integration` then to Staging and Production
--  Configure Fastly in Staging and Production, not in Integration or your local
--  Test Fastly for caching
-
-For instructions, see [Set up Fastly]({{ site.baseurl }}/cloud/cdn/configure-fastly.html).
-After you have configured it, you can continue with advanced options including
-custom VCL snippets.


### PR DESCRIPTION
## Purpose of this pull request

Remove outdated and incorrect Fastly installation and configuration section from the Fastly intro topic.  Fastly set up information is covered in the [Set up Fastly](https://devdocs.magento.com/cloud/cdn/configure-fastly.html) topic.

## Affected DevDocs pages

- https://devdocs.magento.com/cloud/cdn/cloud-fastly.html