### PR TITLE
Updated Cloud Components release notes for 1.0.2 release

### DIFF
--- a/src/cloud/release-notes/mcc-release-notes.md
+++ b/src/cloud/release-notes/mcc-release-notes.md
@@ -19,8 +19,6 @@ This release includes the following updates:
 
 -  {:.fix}Fixed an issue caused by an invalid store URL that causes the post-deploy hook to fail when using the `WARM_UP_PAGES` functionality to populate the cache. This issue occurred only when URL rewrites were disabled.<!-- MAGECLOUD-4094 -->
 
-
-
 ## v1.0.1
 
 This release includes the following updates:

--- a/src/cloud/release-notes/mcc-release-notes.md
+++ b/src/cloud/release-notes/mcc-release-notes.md
@@ -15,7 +15,11 @@ The `{{site.data.var.mcc}}` package uses the following version sequence: `<major
 
 This release includes the following updates:
 
+- {:.new}Extended the functionality of the WARM_UP_PAGES environment variable to support cache preloading for specific product pages. See the [post-deploy variables]({{site.baseurl}}/cloud/env/variables-post-deploy.html#warm_up_pages) topic for a detailed feature description.<!--MAGECLOUD-4444-->
+
 -  {:.fix}Fixed an issue caused by an invalid store URL that causes the post-deploy hook to fail when using the `WARM_UP_PAGES` functionality to populate the cache. This issue occurred only when URL rewrites were disabled.<!-- MAGECLOUD-4094 -->
+
+
 
 ## v1.0.1
 

--- a/src/cloud/release-notes/mcc-release-notes.md
+++ b/src/cloud/release-notes/mcc-release-notes.md
@@ -13,9 +13,9 @@ The `{{site.data.var.mcc}}` package uses the following version sequence: `<major
 
 ## v1.0.2
 
-- {:.new}Extended the functionality of the WARM_UP_PAGES environment variable to support cache preloading for specific product pages. See the [post-deploy variables]({{site.baseurl}}/cloud/env/variables-post-deploy.html#warm_up_pages) topic for a detailed feature description.<!--MAGECLOUD-4444-->
+- {:.new}Extended the functionality of the `WARM_UP_PAGES` environment variable to support cache preloading for specific product pages. See the [post-deploy variables]({{site.baseurl}}/cloud/env/variables-post-deploy.html#warm_up_pages) topic for a detailed feature description.<!--MAGECLOUD-4444-->
 
--  {:.fix}Fixed an issue caused by an invalid store URL that causes the post-deploy hook to fail when using the `WARM_UP_PAGES` functionality to populate the cache. This issue occurred only when URL rewrites were disabled.<!-- MAGECLOUD-4094 -->
+-  {:.fix}Fixed an issue where an invalid store URL causes the post-deploy hook to fail when using the `WARM_UP_PAGES` functionality to populate the cache. This issue occurred only when URL rewrites were disabled.<!-- MAGECLOUD-4094 -->
 
 ## v1.0.1
 

--- a/src/cloud/release-notes/mcc-release-notes.md
+++ b/src/cloud/release-notes/mcc-release-notes.md
@@ -13,22 +13,16 @@ The `{{site.data.var.mcc}}` package uses the following version sequence: `<major
 
 ## v1.0.2
 
-This release includes the following updates:
-
 - {:.new}Extended the functionality of the WARM_UP_PAGES environment variable to support cache preloading for specific product pages. See the [post-deploy variables]({{site.baseurl}}/cloud/env/variables-post-deploy.html#warm_up_pages) topic for a detailed feature description.<!--MAGECLOUD-4444-->
 
 -  {:.fix}Fixed an issue caused by an invalid store URL that causes the post-deploy hook to fail when using the `WARM_UP_PAGES` functionality to populate the cache. This issue occurred only when URL rewrites were disabled.<!-- MAGECLOUD-4094 -->
 
 ## v1.0.1
 
-This release includes the following updates:
-
 -  {:.fix}Fixed an issue affecting [**WARM_UP_PAGES**]({{ site.baseurl }}/cloud/env/variables-post-deploy.html#warm_up_pages) functionality that uses a default store URL. Now, if the `config:show:default-url` command cannot fetch a base URL, then the URL from the MAGENTO_CLOUD_ROUTES variable is used.<!-- MAGECLOUD-3866 -->
 
 ## v1.0.0
 
 This is the first release of the [`magento/magento-cloud-components`](https://github.com/magento/magento-cloud-components) package, which is a new dependency for `{{ site.data.var.ct }}` package version 2002.0.20 and later.
-
-This release includes the following updates:
 
 -  {:.new}<!--MAGECLOUD-3258-->Added the capability to use regex patterns to configure the **WARM_UP_PAGES** environment variable to cache single pages, multiple domains, and multiple pages. See [Post-deploy variables]({{ site.baseurl }}/cloud/env/variables-post-deploy.html#warm_up_pages).

--- a/src/cloud/release-notes/mcc-release-notes.md
+++ b/src/cloud/release-notes/mcc-release-notes.md
@@ -15,13 +15,13 @@ The `{{site.data.var.mcc}}` package uses the following version sequence: `<major
 
 This release includes the following updates:
 
--  Item 1
+-  {:.fix}Fixed an issue caused by an invalid store URL that causes the post-deploy hook to fail when using the `WARM_UP_PAGES` functionality to populate the cache. This issue occurred only when URL rewrites were disabled.<!-- MAGECLOUD-4094 -->
 
 ## v1.0.1
 
 This release includes the following updates:
 
--  {:.fix}<!-- MAGECLOUD-3866 -->Fixed an issue affecting [**WARM_UP_PAGES**]({{ site.baseurl }}/cloud/env/variables-post-deploy.html#warm_up_pages) functionality that uses a default store URL. Now, if the `config:show:default-url` command cannot fetch a base URL, then the URL from the MAGENTO_CLOUD_ROUTES variable is used.
+-  {:.fix}Fixed an issue affecting [**WARM_UP_PAGES**]({{ site.baseurl }}/cloud/env/variables-post-deploy.html#warm_up_pages) functionality that uses a default store URL. Now, if the `config:show:default-url` command cannot fetch a base URL, then the URL from the MAGENTO_CLOUD_ROUTES variable is used.<!-- MAGECLOUD-3866 -->
 
 ## v1.0.0
 


### PR DESCRIPTION
## Purpose of this pull request

Updated release notes for Magento Cloud Components 1.0.2 release.

## Affected DevDocs pages


https://devdocs.magento.com/cloud/release-notes/mcc-release-notes.html (new topic)

## Links to Magento source code

[Magento Cloud Components 1.0.2 release content](https://github.com/magento/magento-cloud-components/pulls?q=is%3Apr+is%3Aclosed+label%3A%22Release%3A+1.0.2%22)

whatsnew
Added the [Magento Cloud Components release notes]( https://devdocs.magento.com/cloud/release-notes/mcc-release-notes.html) topic to the _Cloud Guide_.