### PR TITLE
MAGECLOUD-5181: Disable cron container by default

### DIFF
--- a/src/cloud/docker/docker-manage-cron-jobs.md
+++ b/src/cloud/docker/docker-manage-cron-jobs.md
@@ -19,9 +19,7 @@ The Magento cron implementation has the following limitations:
 -  The `setup:cron:run` and `cron:update` commands are not available on Cloud and Docker for Cloud environments
 -  In the Docker environment, cron works only with the CLI container to run the `./bin/magento cron:run` command
 
-By default, cron container is not present in your Docker development environment to improve overall performance.
-
-## Add the cron container
+To improve the overall performance in the Docker development environment, the cron container is not present by default. You can add the cron container as needed using the `--with-cron` option.
 
 ```bash
 ./vendor/bin/ece-docker build:compose --mode="developer" --with-cron --sync-engine="mutagen"
@@ -37,15 +35,6 @@ docker-compose run deploy bash -c "cat /app/var/cron.log"
 
 ```bash
 docker-compose run cron /usr/local/bin/php bin/magento cron:run
-```
-
-## Disable the Cron container
-
-If cron runs cause a performance problem, you can prevent the Cron container from running automatically by adding the following snippet to your `docker-compose.override.yml` file.
-
-```yaml
-cron:
-  entrypoint: "bash -c"
 ```
 
 [Cron container]: {{site.baseurl}}/cloud/docker/docker-containers-cli.html

--- a/src/cloud/docker/docker-manage-cron-jobs.md
+++ b/src/cloud/docker/docker-manage-cron-jobs.md
@@ -19,6 +19,14 @@ The Magento cron implementation has the following limitations:
 -  The `setup:cron:run` and `cron:update` commands are not available on Cloud and Docker for Cloud environments
 -  In the Docker environment, cron works only with the CLI container to run the `./bin/magento cron:run` command
 
+By default, cron container is not present in your Docker development environment to improve overall performance.
+
+## Add the cron container
+
+```bash
+./vendor/bin/ece-docker build:compose --mode="developer" --with-cron --sync-engine="mutagen"
+```
+
 **To view the cron log:**
 
 ```bash
@@ -38,16 +46,6 @@ If cron runs cause a performance problem, you can prevent the Cron container fro
 ```yaml
 cron:
   entrypoint: "bash -c"
-```
-
-After disabling the Cron container, use `docker-compose` to run cron jobs manually.
-
-## Remove the cron container
-
-Improve performance in your Docker development environment by build the Cloud Docker environment without a Cron container.
-
-```bash
-./vendor/bin/ece-docker build:compose --mode="developer" `--no-cron` --sync-engine="mutagen"
 ```
 
 [Cron container]: {{site.baseurl}}/cloud/docker/docker-containers-cli.html

--- a/src/cloud/docker/docker-manage-cron-jobs.md
+++ b/src/cloud/docker/docker-manage-cron-jobs.md
@@ -19,7 +19,7 @@ The Magento cron implementation has the following limitations:
 -  The `setup:cron:run` and `cron:update` commands are not available on Cloud and Docker for Cloud environments
 -  In the Docker environment, cron works only with the CLI container to run the `./bin/magento cron:run` command
 
-To improve the overall performance in the Docker development environment, the cron container is not present by default. You can add the cron container as needed using the `--with-cron` option.
+To improve the overall performance in the Docker development and production environments, the Cron container is not present by default. You can add the cron container as needed by adding the `--with-cron` option to the Docker build command.
 
 ```bash
 ./vendor/bin/ece-docker build:compose --mode="developer" --with-cron --sync-engine="mutagen"

--- a/src/cloud/docker/docker-mftf.md
+++ b/src/cloud/docker/docker-mftf.md
@@ -34,7 +34,7 @@ To set up and run MFTF tests in a Cloud Docker environment:
 1. Generate the `docker-compose.yml` file.
 
     ```bash
-    ./vendor/bin/ece-docker build:compose --with-selenium --no-cron
+    ./vendor/bin/ece-docker build:compose --with-selenium
     ```
 
 1. Start the {{site.data.var.mcd-prod}} environment. Optionally, you can set up {{site.data.var.mcd-prod}} to work in [Developer Mode].


### PR DESCRIPTION
## Purpose of this pull request

Updated the Magento Cloud Docker Cron container configuration information with instructions for adding the Cron container to Magento Cloud Docker development and production environments. 
By default, the Cron container is not included in the Magento Cloud Docker configuration file.

https://magento2.atlassian.net/browse/MAGECLOUD-5181

## Affected DevDocs pages

https://devdocs.magento.com/cloud/docker/src/cloud/docker/docker-manage-cron-jobs.html


## Links to Magento source code

https://github.com/magento/magento-cloud-docker/pull/144