### PR TITLE
remove dead link pictos.cc from both references I found

### DIFF
--- a/guides/v2.1/design-styleguide/iconography/iconography.md
+++ b/guides/v2.1/design-styleguide/iconography/iconography.md
@@ -120,5 +120,3 @@ Icons should be very descriptive, especially if they stand on their own. Add des
 ## Learn More
 
 * yatil.: [The best way to use icon fonts](https://yatil.net/the-best-way-to-use-icon-fonts/)
-
-* Pictos: [Using Icon Fonts](http://pictos.cc/articles/using-icon-fonts/)

--- a/guides/v2.1/pattern-library/graphics/iconography/iconography.md
+++ b/guides/v2.1/pattern-library/graphics/iconography/iconography.md
@@ -89,4 +89,3 @@ From: [http://modernwebaccessibility.com/en/blog/demystify-speak-none](http://mo
 ## Additional resources
 
 * [https://yatil.net/the-best-way-to-use-icon-fonts/](https://yatil.net/the-best-way-to-use-icon-fonts/){:target="_blank"}
-* [http://pictos.cc/articles/using-icon-fonts/](http://pictos.cc/articles/using-icon-fonts/){:target="_blank"}


### PR DESCRIPTION
## Purpose of this pull request

This PR removes 2 deadlinks from the references. domain name is not registered any more.

## Affected DevDocs pages

https://devdocs.magento.com/guides/v2.2/pattern-library/graphics/iconography/iconography.html#creating-icons

