### PR TITLE
Update widget_modal.md

### DIFF
--- a/src/guides/v2.3/javascript-dev-guide/widgets/widget_modal.md
+++ b/src/guides/v2.3/javascript-dev-guide/widgets/widget_modal.md
@@ -288,9 +288,17 @@ The modal widget has the following methods:
 
 Open the modal window.
 
+```javascript
+$('#css-selector').modal('openModal');
+```
+
 ### `closeModal()` {#modal_close}
 
 Close the modal window.
+
+```javascript
+$('#css-selector').modal('closeModal');
+```
 
 ### `keyEventSwitcher()` {#modal_keyEventSwitcher}
 


### PR DESCRIPTION
## Purpose of this pull request

This pull request (PR) adda an example of how use methods to open/close modals, i.e. to avoid mistake of $('#css-selector').openModal();

## Affected DevDocs pages

- https://devdocs.magento.com/guides/v2.3/javascript-dev-guide/widgets/widget_modal.html#modal_open
