### PR TITLE
Adding cli commands in custom payment method page

### DIFF
--- a/src/guides/v2.3/howdoi/checkout/checkout_payment.md
+++ b/src/guides/v2.3/howdoi/checkout/checkout_payment.md
@@ -313,21 +313,22 @@ In your custom module directory, create a new `<your_module_dir>/view/frontend/l
 
 These steps are required in production mode only, not while in development mode.
 
-1.Compile the code:
+1. Compile the code:
 
-```bash
-bin/magento setup:di:compile
-```
+   ```bash
+   bin/magento setup:di:compile
+   ```
 
 1. Deploy the static contents:
 
-```bash
-bin/magento setup:static-content:deploy
-```
+   ```bash
+   bin/magento setup:static-content:deploy
+   ```
+
 1. Clean the cache:
 
-```bash
-bin/magento cache:clean
-```
+   ```bash
+   bin/magento cache:clean
+   ```
 
 For an illustration of `checkout_index_index.xml` where a new payment method is declared, view [app/code/Magento/Authorizenet/view/frontend/layout/checkout_index_index.xml]({{ site.mage2bloburl }}/{{ page.guide_version }}/app/code/Magento/Authorizenet/view/frontend/layout/checkout_index_index.xml)

--- a/src/guides/v2.3/howdoi/checkout/checkout_payment.md
+++ b/src/guides/v2.3/howdoi/checkout/checkout_payment.md
@@ -308,7 +308,10 @@ In your custom module directory, create a new `<your_module_dir>/view/frontend/l
     </body>
 </page>
 ```
-## Step 5:Run the CLI Commands {#compile-code-deploy-contents-and-clean-the-cache}
+
+## Step 5:Run CLI Commands {#compile-code-deploy-contents-and-clean-the-cache}
+
+These steps are required in production mode only, not while in development mode.
 
 1.Compile the code:
 
@@ -316,16 +319,15 @@ In your custom module directory, create a new `<your_module_dir>/view/frontend/l
 bin/magento setup:di:compile
 ```
 
-2.deploy the static contents:
+1. Deploy the static contents:
 
 ```bash
 bin/magento setup:static-content:deploy
 ```
-3.clean the cache:
+1. Clean the cache:
 
 ```bash
 bin/magento cache:clean
 ```
-
 
 For an illustration of `checkout_index_index.xml` where a new payment method is declared, view [app/code/Magento/Authorizenet/view/frontend/layout/checkout_index_index.xml]({{ site.mage2bloburl }}/{{ page.guide_version }}/app/code/Magento/Authorizenet/view/frontend/layout/checkout_index_index.xml)

--- a/src/guides/v2.3/howdoi/checkout/checkout_payment.md
+++ b/src/guides/v2.3/howdoi/checkout/checkout_payment.md
@@ -308,5 +308,24 @@ In your custom module directory, create a new `<your_module_dir>/view/frontend/l
     </body>
 </page>
 ```
+## Step 5:Run the CLI Commands {#compile-code-deploy-contents-and-clean-the-cache}
+
+1.Compile the code:
+
+```bash
+bin/magento setup:di:compile
+```
+
+2.deploy the static contents:
+
+```bash
+bin/magento setup:static-content:deploy
+```
+3.clean the cache:
+
+```bash
+bin/magento cache:clean
+```
+
 
 For an illustration of `checkout_index_index.xml` where a new payment method is declared, view [app/code/Magento/Authorizenet/view/frontend/layout/checkout_index_index.xml]({{ site.mage2bloburl }}/{{ page.guide_version }}/app/code/Magento/Authorizenet/view/frontend/layout/checkout_index_index.xml)


### PR DESCRIPTION
## Purpose of this pull request

Adding cli commands in custom payment method page

## Affected DevDocs pages

<!-- REQUIRED List the affected pages on devdocs.magento.com (URLs). Not needed for large numbers of files. -->

-  https://devdocs.magento.com/guides/v2.3/howdoi/checkout/checkout_payment.html
