### PR TITLE
Updated note about Page Builder patches improvement

### DIFF
--- a/src/cloud/release-notes/mcp-release-notes.md
+++ b/src/cloud/release-notes/mcp-release-notes.md
@@ -27,7 +27,7 @@ Catalog pagination does not work on Elasticsearch 6.x
 
 -  {:.fix}<!--MAGECLOUD-4884-->**Updated the Magento Page Builder patches**–In {{site.data.var.mcp-prod}} 1.0.0, we bundled patches for Page Builder to address known remote code execution (RCE) issues, with the initial fix based on Magento 2.3.3. We have updated these patches with a more stable implementation based on Magento 2.3.4., which includes multiple optimizations for fixing the issue.
 
-If you have an older version of the {{site.data.var.mcp}} package, you are still protected from the RCE vulnerability issues. If you update to {{site.data.var.mcp}} 1.0.1 or later, you have a better implementation of the same fix.
+   If you have an older version of the {{site.data.var.mcp}} package, you are still protected from the RCE vulnerability issues. If you update to {{site.data.var.mcp}} 1.0.1 or later, you have a better implementation of the same fix.
 
 ## v1.0.0
 

--- a/src/cloud/release-notes/mcp-release-notes.md
+++ b/src/cloud/release-notes/mcp-release-notes.md
@@ -25,9 +25,9 @@ This release includes the following updates:
 
 Catalog pagination does not work on Elasticsearch 6.x
 
--  {:.fix}<!--MAGECLOUD-4884-->**Updated the Magento Page Builder patches**–In {{site.data.var.mcp-prod}} 1.0.0, we bundled patches for Page Builder to address known remote code execution (RCE) issues, with the initial fix based on Magento 2.3.3. We have updated these patches with a more stable implementation based on Magento 2.3.4., which includes multiple optimizations for fixing the issue.
+-  {:.fix}<!--MAGECLOUD-4884-->**Updated the Magento Page Builder patches**–In {{site.data.var.mcp-prod}} 1.0.0, we bundled Page Builder patches to address a known remote code execution (RCE) vulnerability, with the initial fix based on Magento 2.3.3. We have updated these patches with a more stable implementation based on Magento 2.3.4., which includes multiple optimizations for fixing the issue.
 
-   If you have an older version of the {{site.data.var.mcp}} package, you are still protected from the RCE vulnerability issues. If you update to {{site.data.var.mcp}} 1.0.1 or later, you have a better implementation of the same fix.
+   If you have the {{site.data.var.mcp}} 1.0.0 package, you are still protected from the Page Builder RCE vulnerability issues. If you update to {{site.data.var.mcp}} 1.0.1 or later, you have a better implementation of the same fix.
 
 ## v1.0.0
 

--- a/src/cloud/release-notes/mcp-release-notes.md
+++ b/src/cloud/release-notes/mcp-release-notes.md
@@ -25,7 +25,7 @@ This release includes the following updates:
 
 Catalog pagination does not work on Elasticsearch 6.x
 
--  {:.fix}<!--MAGECLOUD-4884-->**Updated the Magento Page Builder patches**–In {{site.data.var.mcp-prod}} 1.0.0, we bundled Page Builder patches to address a known remote code execution (RCE) vulnerability, with the initial fix based on Magento 2.3.3. We have updated these patches with a more stable implementation based on Magento 2.3.4., which includes multiple optimizations for fixing the issue.
+-  {:.fix}<!--MAGECLOUD-4884-->**Updated the Magento Page Builder patches**–In {{site.data.var.mcp-prod}} 1.0.0, we bundled Page Builder patches to address a known Page Builder remote code execution (RCE) vulnerability, with the initial fix based on Magento 2.3.3. We have updated these patches with a more stable implementation based on Magento 2.3.4., which includes multiple optimizations for fixing the issue.
 
    If you have the {{site.data.var.mcp}} 1.0.0 package, you are still protected from the Page Builder RCE vulnerability issues. If you update to {{site.data.var.mcp}} 1.0.1 or later, you have a better implementation of the same fix.
 

--- a/src/cloud/release-notes/mcp-release-notes.md
+++ b/src/cloud/release-notes/mcp-release-notes.md
@@ -27,7 +27,7 @@ Catalog pagination does not work on Elasticsearch 6.x
 
 -  {:.fix}<!--MAGECLOUD-4884-->**Updated the Magento Page Builder patches**–In {{site.data.var.mcp-prod}} 1.0.0, we bundled patches for Page Builder to address known remote code execution (RCE) issues, with the initial fix based on Magento 2.3.3. We have updated these patches with a more stable implementation based on Magento 2.3.4., which includes multiple optimizations for fixing the issue.
 
-If you have an older version of the {{site.data.var.mcp}} package, you are still protected from the RCE vulnerability issues. If you update to {{site.data.var.mcp}} 1.0.1 or later, you will have a better implementation of the same fix.
+If you have an older version of the {{site.data.var.mcp}} package, you are still protected from the RCE vulnerability issues. If you update to {{site.data.var.mcp}} 1.0.1 or later, you have a better implementation of the same fix.
 
 
 ## v1.0.0

--- a/src/cloud/release-notes/mcp-release-notes.md
+++ b/src/cloud/release-notes/mcp-release-notes.md
@@ -25,7 +25,10 @@ This release includes the following updates:
 
 Catalog pagination does not work on Elasticsearch 6.x
 
--  {:.fix}<!--MAGECLOUD-4884-->**Updated the Magento Page Builder patches**–Update previously released Page Builder security patches for Magento versions 2.3.1 and 2.3.2 to address an issue in Page Builder preview that allows unauthenticated users to use some templating methods, which can lead to remote code execution (RCE) and global information leak. These patches were initially released in {{site.data.var.mcp}} v1.0.0.
+-  {:.fix}<!--MAGECLOUD-4884-->**Updated the Magento Page Builder patches**–In {{site.data.var.mcp-prod}} 1.0.0, we bundled patches for Page Builder to address known remote code execution (RCE) issues, with the initial fix based on Magento 2.3.3. We have updated these patches with a more stable implementation based on Magento 2.3.4., which includes multiple optimizations for fixing the issue.
+
+If you have an older version of the {{site.data.var.mcp}} package, you are still protected from the RCE vulnerability issues. If you update to {{site.data.var.mcp}} 1.0.1 or later, you will have a better implementation of the same fix.
+
 
 ## v1.0.0
 

--- a/src/cloud/release-notes/mcp-release-notes.md
+++ b/src/cloud/release-notes/mcp-release-notes.md
@@ -29,7 +29,6 @@ Catalog pagination does not work on Elasticsearch 6.x
 
 If you have an older version of the {{site.data.var.mcp}} package, you are still protected from the RCE vulnerability issues. If you update to {{site.data.var.mcp}} 1.0.1 or later, you have a better implementation of the same fix.
 
-
 ## v1.0.0
 
 This is the first release of the [`magento/magento-cloud-patches`](https://github.com/magento/magento-cloud-patches) package, which is a new dependency for the `{{ site.data.var.ct }}` package version 2002.0.22 or later releases.


### PR DESCRIPTION
## Purpose of this pull request

Updated release note about Page Builder patches to clarify that patches delivered in 1.0.0 and 1.0.1 both protect Magento sites from the known RCE issue.

## Affected DevDocs pages

https://devdocs.magento.com/cloud/release-notes/mcp-release-notes.html
