### PR TITLE
Changed minimun Magento version to 2.2 since 2.1 is not suported anym…

### DIFF
--- a/src/cloud/basic-information/starter-architecture.md
+++ b/src/cloud/basic-information/starter-architecture.md
@@ -66,11 +66,11 @@ The Production and Staging environments include the following technologies. You 
 -  Fastly for HTTP caching and CDN
 -  Nginx web server speaking to PHP-FPM, one instance with multiple workers
 -  Redis server
--  Elasticsearch for searching for {{site.data.var.ece}} 2.1 and later
+-  Elasticsearch for searching for {{site.data.var.ece}} 2.2 and later
 
 ### Services {#cloud-arch-services}
 
-{{site.data.var.ece}} currently supports the following services: PHP, MySQL (MariaDB), Elasticsearch (Magento 2.1.x and later), Redis, and RabbitMQ.
+{{site.data.var.ece}} currently supports the following services: PHP, MySQL (MariaDB), Elasticsearch (Magento 2.2.x and later), Redis, and RabbitMQ.
 
 Each service runs in its own secure container. Containers are managed together in the project. Some services are built-in, such as the following:
 


### PR DESCRIPTION
…ore.

## Purpose of this pull request

The cloud documentation mentions version 2.1 as minimum used version. Upgraded to 2.2 since 2.1 isn't supported anymore.

## Affected DevDocs pages

- [/cloud/basic-information/starter-architecture.html](https://devdocs.magento.com/cloud/basic-information/starter-architecture.html)


<!--
If you are fixing a GitHub issue, note it using GitHub keyword format (https://help.github.com/en/articles/closing-issues-using-keywords#closing-an-issue-in-a-different-repository) to close the issue when this pull request is merged. Example: `Fixes #1234`

`master` is the default branch. Merged pull requests to `master` go live on the site automatically. Any requested changes to content on the `master` branch must be related to the released codebase. Any content related to future releases goes in the `develop` branch.

See Contribution guidelines (https://github.com/magento/devdocs/blob/master/.github/CONTRIBUTING.md) for more information.
-->
