### PR TITLE
Fix cloud MySQL topic formatting

### DIFF
--- a/src/cloud/project/project-conf-files_services-mysql.md
+++ b/src/cloud/project/project-conf-files_services-mysql.md
@@ -120,7 +120,6 @@ Accessing the MariaDB database directly requires you to use a SSH to log in to t
    In the response, find the MySQL information. For example:
 
    ```json
-   {
    "database" : [
       {
          "password" : "",

--- a/src/cloud/project/project-conf-files_services-mysql.md
+++ b/src/cloud/project/project-conf-files_services-mysql.md
@@ -96,7 +96,7 @@ relationships:
     databaseimporter: "mysql:importer"
 ```
 
- {:.bs-callout-info}
+{:.bs-callout-info}
 If you configure one MySQL user, you cannot use the [`DEFINER`](http://dev.mysql.com/doc/refman/5.6/en/show-grants.html) access control mechanism for stored procedures and views.
 
 ## Connect to the database
@@ -111,13 +111,13 @@ Accessing the MariaDB database directly requires you to use a SSH to log in to t
    echo $MAGENTO_CLOUD_RELATIONSHIPS | base64 -d | json_pp
    ```
 
-      or
+   or
 
    ```bash
    php -r 'print_r(json_decode(base64_decode($_ENV["MAGENTO_CLOUD_RELATIONSHIPS"])));'
    ```
 
-   In the response, find the MySQL information, for example:
+   In the response, find the MySQL information. For example:
 
    ```json
    {
@@ -152,6 +152,6 @@ Accessing the MariaDB database directly requires you to use a SSH to log in to t
 
    -  For Pro, use the following command with db, username, and password retrieved from the `$MAGENTO_CLOUD_RELATIONSHIPS` variable.
 
-     ```bash
-     mysql -h<db> -P<number> -u<username> -p<password>
-     ```
+      ```bash
+      mysql -h<db> -P<number> -u<username> -p<password>
+      ```


### PR DESCRIPTION
## Purpose of this pull request

There was a recent update to the MySQL services topic in the Cloud guide that looked sketchy. This PR fixes some formatting issues plaguing that topic.

## Affected DevDocs pages

https://devdocs.magento.com/cloud/project/project-conf-files_services-mysql.html
