### PR TITLE
Update GraphQL tutorial to use customerCart query

### DIFF
--- a/src/guides/v2.3/graphql/tutorials/checkout/checkout-customer.md
+++ b/src/guides/v2.3/graphql/tutorials/checkout/checkout-customer.md
@@ -62,7 +62,7 @@ mutation {
 }
 ```
 
-[`createCustomer`]({{ page.baseurl }}/graphql/mutations/create-customer.html) mutation describes additional parameters.
+The [`createCustomer`]({{ page.baseurl }}/graphql/mutations/create-customer.html) mutation describes additional parameters.
 
 ## Generate an authentication token for the customer
 

--- a/src/guides/v2.3/graphql/tutorials/checkout/checkout-customer.md
+++ b/src/guides/v2.3/graphql/tutorials/checkout/checkout-customer.md
@@ -14,15 +14,11 @@ contributor_name: Atwix
 contributor_link: https://www.atwix.com/
 ---
 
-Customers can make purchases in two ways:
+This step creates a customer account and generates an authentication token for that customer.  You can skip this step if you want to perform this tutorial as a guest user.
 
-*  As a logged-in user
-*  As a guest user who does not create an account
+## Create a customer
 
-To place order as a new customer, use the `createCustomer` mutation to register the new customer account in the store.
-
-{:.bs-callout-info}
-Skip this step if you want to place order as a guest user.
+Use the `createCustomer` mutation to register the new customer account in the store.
 
 **Request:**
 
@@ -66,9 +62,11 @@ mutation {
 }
 ```
 
-["Customer endpoint"]({{ page.baseurl }}/graphql/mutations/create-customer.html) describes additional `createCustomer` parameters.
+[`createCustomer`]({{ page.baseurl }}/graphql/mutations/create-customer.html) mutation describes additional parameters.
 
-To place an order as a new customer, you must get the customer's authorization token. Use the `generateCustomerToken` mutation for that.
+## Generate an authentication token for the customer
+
+To place an order as a customer, you must obtain an authorization token by calling the `generateCustomerToken` mutation. You must include the customer's email and password as input.
 
 **Request:**
 

--- a/src/guides/v2.3/graphql/tutorials/checkout/checkout-shopping-cart.md
+++ b/src/guides/v2.3/graphql/tutorials/checkout/checkout-shopping-cart.md
@@ -14,16 +14,19 @@ contributor_name: Atwix
 contributor_link: https://www.atwix.com/
 ---
 
-The `customerCart` query returns the active cart for the logged-in customer. If the cart does not exist, the query creates one. The customer’s authorization token must be specified in the headers. ["Get customer authorization token"]({{ page.baseurl }}/graphql/get-customer-authorization-token.html) describes describes these tokens.
+The procedure for creating a cart depends on whether the cart is for a logged-in customer or a guest.
 
-{:.bs-callout-info}
-Use the [`createEmptyCart`]({{page.baseurl}}/graphql/mutations/create-empty-cart.html) mutation to create an empty shopping cart and generate a cart ID for a guest user. If the guest later logs in as a customer, use the [`mergeCarts`]({{page.baseurl}}/graphql/mutations/merge-carts.html) mutation to transfer the contents of the guest cart into the customer's cart.
+The `customerCart` query returns the active cart for the logged-in customer. If the cart does not exist, the query creates one. You must specify the customer’s authorization token in the headers. Otherwise, the query fails. ["Get customer authorization token"]({{ page.baseurl }}/graphql/get-customer-authorization-token.html) describes describes these tokens.
+
+For guests, use the [`createEmptyCart`]({{page.baseurl}}/graphql/mutations/create-empty-cart.html) mutation to create an empty shopping cart and generate a cart ID for a guest user. If the guest later logs in as a customer, use the [`mergeCarts`]({{page.baseurl}}/graphql/mutations/merge-carts.html) mutation to transfer the contents of the guest cart into the customer's cart.
+
+## Create a customer cart
+
+The customer created in the previous step does not have an active cart. The following query creates an empty cart and returns the cart ID. You must specify the customer’s authorization token in the headers of the call.
 
 **Request:**
 
-The customer created in the previous step does not have an active cart. The following query creates an empty cart and returns the cart ID:
-
-```text
+```graphql
 {
   customerCart{
     id
@@ -37,8 +40,32 @@ The customer created in the previous step does not have an active cart. The foll
 {
   "data": {
     "customerCart": {
-      "id": "A7jCcOmUjjCh7MxDIzu1SeqdqETqEa5h"
+      "id": "pXVxnNg4PFcK1lD60O5evqF7f4SkiRR1"
     }
+  }
+}
+```
+
+In the subsequent tutorial steps, the unique shopping cart identifier `pXVxnNg4PFcK1lD60O5evqF7f4SkiRR1` will be listed as `{ CART_ID }`.
+
+## Create a guest cart
+
+The following example creates an empty cart for a guest. Do not include an authorization token on any call made on behalf of a guest.
+
+**Request:**
+
+```graphql
+mutation {
+  createEmptyCart
+}
+```
+
+**Response:**
+
+```json
+{
+  "data": {
+    "createEmptyCart": "A7jCcOmUjjCh7MxDIzu1SeqdqETqEa5h"
   }
 }
 ```

--- a/src/guides/v2.3/graphql/tutorials/checkout/checkout-shopping-cart.md
+++ b/src/guides/v2.3/graphql/tutorials/checkout/checkout-shopping-cart.md
@@ -14,18 +14,20 @@ contributor_name: Atwix
 contributor_link: https://www.atwix.com/
 ---
 
-The `createEmptyCart` mutation creates an empty shopping cart and generates a cart ID.
+The `customerCart` query returns the active cart for the logged-in customer. If the cart does not exist, the query creates one. The customer’s authorization token must be specified in the headers. ["Get customer authorization token"]({{ page.baseurl }}/graphql/get-customer-authorization-token.html) describes describes these tokens.
 
 {:.bs-callout-info}
-For logged-in customers, send the customer's authorization token in the Authorization parameter of the header. See ["Get customer authorization token"]({{ page.baseurl }}/graphql/get-customer-authorization-token.html) for more information.
+Use the [`createEmptyCart`]({{page.baseurl}}/graphql/mutations/create-empty-cart.html) mutation to create an empty shopping cart and generate a cart ID for a guest user. If the guest later logs in as a customer, use the [`mergeCarts`]({{page.baseurl}}/graphql/mutations/merge-carts.html) mutation to transfer the contents of the guest cart into the customer's cart.
 
 **Request:**
 
-The following mutation creates an empty cart:
+The customer created in the previous step does not have an active cart. The following query creates an empty cart and returns the cart ID:
 
 ```text
-mutation {
-  createEmptyCart
+{
+  customerCart{
+    id
+  }
 }
 ```
 
@@ -34,7 +36,9 @@ mutation {
 ```json
 {
   "data": {
-    "createEmptyCart": "A7jCcOmUjjCh7MxDIzu1SeqdqETqEa5h"
+    "customerCart": {
+      "id": "A7jCcOmUjjCh7MxDIzu1SeqdqETqEa5h"
+    }
   }
 }
 ```
@@ -43,4 +47,4 @@ In the subsequent tutorial steps, the unique shopping cart identifier `A7jCcOmUj
 
 ## Verify this step {#verify-step}
 
-There are no additional verification steps. The values of `quote` and `entity_id` value are  not displayed on the website or in the Magento Admin.
+There are no additional verification steps. The value of `id` value is not displayed on the website or in the Magento Admin.

--- a/src/guides/v2.3/graphql/tutorials/checkout/checkout-shopping-cart.md
+++ b/src/guides/v2.3/graphql/tutorials/checkout/checkout-shopping-cart.md
@@ -47,4 +47,4 @@ In the subsequent tutorial steps, the unique shopping cart identifier `A7jCcOmUj
 
 ## Verify this step {#verify-step}
 
-There are no additional verification steps. The value of `id` value is not displayed on the website or in the Magento Admin.
+There are no additional verification steps. The value of `id` is not displayed on the website or in the Magento Admin.

--- a/src/guides/v2.3/graphql/tutorials/checkout/checkout-shopping-cart.md
+++ b/src/guides/v2.3/graphql/tutorials/checkout/checkout-shopping-cart.md
@@ -14,7 +14,7 @@ contributor_name: Atwix
 contributor_link: https://www.atwix.com/
 ---
 
-The procedure for creating a cart depends on whether the cart is for a logged-in customer or a guest.
+The procedure for creating a cart varies for logged-in customers and guests.
 
 The `customerCart` query returns the active cart for the logged-in customer. If the cart does not exist, the query creates one. You must specify the customer’s authorization token in the headers. Otherwise, the query fails. ["Get customer authorization token"]({{ page.baseurl }}/graphql/get-customer-authorization-token.html) describes describes these tokens.
 


### PR DESCRIPTION
## Purpose of this pull request

This pull request (PR) updates step 2 of the GraphQL tutorial (Step 2. Create an empty cart0 to use the `customerCart` query.

## Affected DevDocs pages

-  https://devdocs.magento.com/guides/v2.3/graphql/tutorials/checkout/checkout-shopping-cart.html
