### PR TITLE
MAGECLOUD-5139: Add possibility to edit index.php in production mode

### DIFF
--- a/src/cloud/docker/docker-containers-service.md
+++ b/src/cloud/docker/docker-containers-service.md
@@ -160,7 +160,7 @@ The Web container uses NGINX to handle web requests after TLS and Varnish. This 
 The NGINX configuration for this container is the standard Magento [nginx config], which includes the configuration to auto-generate NGINX certificates for the container. You can customize the NGINX configuration by mounting a new configuration file using a volume.
 
 {:.procedure}
-To mount custom NGINX configuration file using volumes:
+To mount the custom NGINX configuration file using volumes:
 
 1. On your local host, create a `./.docker/nginx/etc/` directory.
 
@@ -179,7 +179,7 @@ To mount custom NGINX configuration file using volumes:
    ```
 
 {:.procedure}
-To mount custom index.php file using volumes:
+To mount the custom index.php file using volumes:
 
 1. To mount the custom index.php file to the Web container, add the volume configuration to the `docker-compose.override.yml` file.
 

--- a/src/cloud/docker/docker-containers-service.md
+++ b/src/cloud/docker/docker-containers-service.md
@@ -181,7 +181,7 @@ To mount custom NGINX configuration file using volumes:
 {:.procedure}
 To mount custom index.php file using volumes:
 
-1. To mount the custom NGINX file to the Web container, add the volume configuration to the `docker-compose.override.yml` file.
+1. To mount the custom index.php file to the Web container, add the volume configuration to the `docker-compose.override.yml` file.
 
 ```yaml
   services:

--- a/src/cloud/docker/docker-containers-service.md
+++ b/src/cloud/docker/docker-containers-service.md
@@ -170,9 +170,9 @@ To mount custom NGINX configuration file using volumes:
 
 1. To mount the custom NGINX configuration to the Web container, add the volume configuration to the `docker-compose.override.yml` file.
 
-   ```yaml
-   services:
-     web:
+```yaml
+  services:
+    web:
       volumes:
         - ./.docker/nginx/etc/nginx.conf:/etc/nginx/nginx.conf
         - ./.docker/nginx/etc/vhost.conf:/etc/nginx/conf.d/default.conf
@@ -183,12 +183,12 @@ To mount custom index.php file using volumes:
 
 1. To mount the custom NGINX file to the Web container, add the volume configuration to the `docker-compose.override.yml` file.
 
-    ```yaml
-    services:
-     web:
-       volumes:
-         - ./pub/index.php:/app/pub/index.php:ro
-    ```
+```yaml
+  services:
+    web:
+      volumes:
+        - ./pub/index.php:/app/pub/index.php:ro
+```
 
 [mariadb]: https://hub.docker.com/_/mariadb
 [mariadb Docker documentation]: https://hub.docker.com/_/mariadb

--- a/src/cloud/docker/docker-containers-service.md
+++ b/src/cloud/docker/docker-containers-service.md
@@ -170,12 +170,25 @@ To mount custom NGINX configuration file using volumes:
 
 1. To mount the custom NGINX configuration to the Web container, add the volume configuration to the `docker-compose.override.yml` file.
 
-   ```conf
-   web:
-    volumes:
-      ./.docker/nginx/etc/nginx.conf:/etc/nginx/nginx.conf
-      ./.docker/nginx/etc/vhost.conf:/etc/nginx/conf.d/default.conf
+   ```yaml
+   services:
+     web:
+      volumes:
+        - ./.docker/nginx/etc/nginx.conf:/etc/nginx/nginx.conf
+        - ./.docker/nginx/etc/vhost.conf:/etc/nginx/conf.d/default.conf
    ```
+
+{:.procedure}
+To mount custom index.php file using volumes:
+
+1. To mount the custom NGINX file to the Web container, add the volume configuration to the `docker-compose.override.yml` file.
+
+    ```yaml
+    services:
+     web:
+       volumes:
+         - ./pub/index.php:/app/pub/index.php:ro
+    ```
 
 [mariadb]: https://hub.docker.com/_/mariadb
 [mariadb Docker documentation]: https://hub.docker.com/_/mariadb


### PR DESCRIPTION
## Purpose of this pull request

Adds instruction on how to mount custom `index.php` file on Cloud Docker

- https://magento2.atlassian.net/browse/MAGECLOUD-5139

## Affected DevDocs pages

<!-- REQUIRED List the affected pages on devdocs.magento.com (URLs). Not needed for large numbers of files. -->

-  https://devdocs.magento.com/cloud/docker/docker-containers-service.html

<!--
If you are fixing a GitHub issue, note it using GitHub keyword format (https://help.github.com/en/articles/closing-issues-using-keywords#closing-an-issue-in-a-different-repository) to close the issue when this pull request is merged. Example: `Fixes #1234`

`master` is the default branch. Merged pull requests to `master` go live on the site automatically. Any requested changes to content on the `master` branch must be related to the released codebase. Any content related to future releases goes in the `develop` branch.

See Contribution guidelines (https://github.com/magento/devdocs/blob/master/.github/CONTRIBUTING.md) for more information.
-->
