### PR TITLE
Added missing sub fields for region when setting shipping address by …

### DIFF
--- a/src/guides/v2.3/graphql/tutorials/checkout/checkout-shipping-address.md
+++ b/src/guides/v2.3/graphql/tutorials/checkout/checkout-shipping-address.md
@@ -61,7 +61,10 @@ mutation {
         company
         street
         city
-        region
+        region {
+          code
+          label
+        }
         postcode
         telephone
         country {


### PR DESCRIPTION
…graphql

## Purpose of this pull request

Added missing sub fields for region when setting shipping address by graphql

## Affected DevDocs pages

<!-- REQUIRED List the affected pages on devdocs.magento.com (URLs). Not needed for large numbers of files. -->

-  https://devdocs.magento.com/guides/v2.3/graphql/tutorials/checkout/checkout-shipping-address.html

