### PR TITLE
Note added for foreign keys in declarative schema

### DIFF
--- a/src/guides/v2.3/extension-dev-guide/declarative-schema/db-schema.md
+++ b/src/guides/v2.3/extension-dev-guide/declarative-schema/db-schema.md
@@ -416,8 +416,8 @@ In the following example, the selected `constraint` node defines the characteris
 </schema>
 ```
 
- {:.bs-callout-info}
-Foreign keys can only be added to tables where both the tables are created by using declarative schema (`db_schema.xml`) only.
+{:.bs-callout-info}
+Foreign keys can only be added to tables when both tables were created using a declarative schema (`db_schema.xml`).
 
 ### Drop a foreign key
 

--- a/src/guides/v2.3/extension-dev-guide/declarative-schema/db-schema.md
+++ b/src/guides/v2.3/extension-dev-guide/declarative-schema/db-schema.md
@@ -416,6 +416,9 @@ In the following example, the selected `constraint` node defines the characteris
 </schema>
 ```
 
+ {:.bs-callout-info}
+Foreign keys can only be added to tables where both the tables are created by using declarative schema (`db_schema.xml`) only.
+
 ### Drop a foreign key
 
 The following example removes the  `FL_ALLOWED_SEVERITIES` foreign key by deleting its `constraint` node. To drop a constraint declared in another module, redeclare it with the `disabled` attribute set to `true`.


### PR DESCRIPTION
## Purpose of this pull request

This pull request (PR) has added a note for the declarative schema foreign key behavior.

## Affected DevDocs pages

<!-- REQUIRED List the affected pages on devdocs.magento.com (URLs). Not needed for large numbers of files. -->

-  https://devdocs.magento.com/guides/v2.3/extension-dev-guide/declarative-schema/db-schema.html

<!--
If you are fixing a GitHub issue, note it using GitHub keyword format (https://help.github.com/en/articles/closing-issues-using-keywords#closing-an-issue-in-a-different-repository) to close the issue when this pull request is merged. Example: `Fixes #1234`

`master` is the default branch. Merged pull requests to `master` go live on the site automatically. Any requested changes to content on the `master` branch must be related to the released codebase. Any content related to future releases goes in the `develop` branch.

See Contribution guidelines (https://github.com/magento/devdocs/blob/master/.github/CONTRIBUTING.md) for more information.
-->
