### PR TITLE
Added example response for sample query for grouped product data types

### DIFF
--- a/src/guides/v2.3/graphql/product/grouped-product.md
+++ b/src/guides/v2.3/graphql/product/grouped-product.md
@@ -56,3 +56,57 @@ The following query returns information about downloadable product `24-WG085_Gro
   }
 }
 ```
+
+{% collapsible Response %}
+
+``` text
+{
+  "data": {
+    "products": {
+      "items": [
+        {
+          "id": 45,
+          "name": "Set of Sprite Yoga Straps",
+          "sku": "24-WG085_Group",
+          "type_id": "grouped",
+          "items": [
+            {
+              "qty": 0,
+              "position": 0,
+              "product": {
+                "sku": "24-WG085",
+                "name": "Sprite Yoga Strap 6 foot",
+                "type_id": "simple",
+                "url_key": "sprite-yoga-strap-6-foot"
+              }
+            },
+            {
+              "qty": 0,
+              "position": 1,
+              "product": {
+                "sku": "24-WG086",
+                "name": "Sprite Yoga Strap 8 foot",
+                "type_id": "simple",
+                "url_key": "sprite-yoga-strap-8-foot"
+              }
+            },
+            {
+              "qty": 0,
+              "position": 2,
+              "product": {
+                "sku": "24-WG087",
+                "name": "Sprite Yoga Strap 10 foot",
+                "type_id": "simple",
+                "url_key": "sprite-yoga-strap-10-foot"
+              }
+            }
+          ]
+        }
+      ]
+    }
+  }
+}
+```
+
+{% endcollapsible %}
+

--- a/src/guides/v2.3/graphql/product/grouped-product.md
+++ b/src/guides/v2.3/graphql/product/grouped-product.md
@@ -29,7 +29,7 @@ Attribute | Type | Description
 
 The following query returns information about downloadable product `24-WG085_Group`, which is defined in the sample data.
 
-``` text
+```graphql
 {
   products(filter:
     {sku: {eq: "24-WG085_Group"}}
@@ -59,7 +59,7 @@ The following query returns information about downloadable product `24-WG085_Gro
 
 {% collapsible Response %}
 
-``` text
+```json
 {
   "data": {
     "products": {


### PR DESCRIPTION
## Purpose of this pull request

Added example response for sample query for grouped product data types

## Affected DevDocs pages

<!-- REQUIRED List the affected pages on devdocs.magento.com (URLs). Not needed for large numbers of files. -->

- https://devdocs.magento.com/guides/v2.3/graphql/product/grouped-product.html

