### PR TITLE
Fixed incorrect syntax to use jQuery in mageInit options

### DIFF
--- a/src/guides/v2.3/javascript-dev-guide/widgets/widget_modal.md
+++ b/src/guides/v2.3/javascript-dev-guide/widgets/widget_modal.md
@@ -358,7 +358,7 @@ The following example shows how to initialize the modal widget and pass options 
             'trigger': '[data-trigger=trigger]',
             'responsive': true,
             'buttons': [{
-                text: $.mage.__('Submit'),
+                text: jQuery.mage.__('Submit'),
                 class: 'action'
             }]
         }}">


### PR DESCRIPTION
## Purpose of this pull request

This pull request (PR) fixes an error thrown due to incorrect syntax reported by the issue #6588. 

## Affected DevDocs pages

-  https://devdocs.magento.com/guides/v2.3/javascript-dev-guide/widgets/widget_modal.html