### PR TITLE
Added `downloadable domain` node description

### DIFF
--- a/src/guides/v2.3/config-guide/prod/config-reference-envphp.md
+++ b/src/guides/v2.3/config-guide/prod/config-reference-envphp.md
@@ -15,6 +15,7 @@ The `env.php` file contains the following sections:
 | `cache_types`         | Cache storage settings                         |
 | `crypt`               | The encryption key for cryptographic functions |
 | `db`                  | Database connection settings                   |
+| `downloadable_domains`| List of downloadable domains                   |
 | `install`             | The installation date                          |
 | `lock`                | Lock provider settings                         |
 | `MAGE_MODE`           | The [Magento mode][magento-mode]               |
@@ -22,7 +23,7 @@ The `env.php` file contains the following sections:
 | `resource`            | Mapping of resource name to a connection       |
 | `session`             | Session storage data                           |
 | `x-frame-options`     | Setting for [x-frame-options][x-frame-options] |
-| `downloadable_domains`| List of downloadable domains                   |
+
 ## backend
 
 Configure the **frontName** for the Magento admin url using the `backend` node in env.php.
@@ -92,6 +93,18 @@ All database configurations are availble in this node.
   ]
 ]
 ```
+
+## downloadable_domains
+
+A list of downloadable domains available in this node. Additional domains can be added, removed, or listed using CLI commands.
+
+```conf
+'downloadable_domains' => [
+    'local.vanilla.com'
+]
+```
+
+Learn more about [downloadable-domains][downloadable_domains] commands.
 
 ## install
 
@@ -165,17 +178,6 @@ x-frame-options header can be configured using this node.
 ```
 
 Learn more about session in [x-frame-options][x-frame-options].
-
-## downloadable_domains
-List of downloadable domains are available in this node. Additional domains can be added, removed or listed through CLI commands.
-
-```conf
-'downloadable_domains' => [
-    'local.vanilla.com'
-]
-```
-
-Learn more about [downloadable-domains][downloadable_domains] commands.
 
 <!-- Link definitions -->
 [lock-provider-config]: {{ page.baseurl }}/install-gde/install/cli/install-cli-subcommands-lock.html

--- a/src/guides/v2.3/config-guide/prod/config-reference-envphp.md
+++ b/src/guides/v2.3/config-guide/prod/config-reference-envphp.md
@@ -9,20 +9,20 @@ functional_areas:
 
 The `env.php` file contains the following sections:
 
-| Name              | Description                                    |
-| ----------------- | ---------------------------------------------- |
-| `backend`         | Settings for the Admin area                    |
-| `cache_types`     | Cache storage settings                         |
-| `crypt`           | The encryption key for cryptographic functions |
-| `db`              | Database connection settings                   |
-| `install`         | The installation date                          |
-| `lock`            | Lock provider settings                         |
-| `MAGE_MODE`       | The [Magento mode][magento-mode]               |
-| `queue`           | [Message queues][message-queues] settings      |
-| `resource`        | Mapping of resource name to a connection       |
-| `session`         | Session storage data                           |
-| `x-frame-options` | Setting for [x-frame-options][x-frame-options] |
-
+| Name                  | Description                                    |
+| --------------------- | ---------------------------------------------- |
+| `backend`             | Settings for the Admin area                    |
+| `cache_types`         | Cache storage settings                         |
+| `crypt`               | The encryption key for cryptographic functions |
+| `db`                  | Database connection settings                   |
+| `install`             | The installation date                          |
+| `lock`                | Lock provider settings                         |
+| `MAGE_MODE`           | The [Magento mode][magento-mode]               |
+| `queue`               | [Message queues][message-queues] settings      |
+| `resource`            | Mapping of resource name to a connection       |
+| `session`             | Session storage data                           |
+| `x-frame-options`     | Setting for [x-frame-options][x-frame-options] |
+| `downloadable_domains`| List of downloadable domains                   |
 ## backend
 
 Configure the **frontName** for the Magento admin url using the `backend` node in env.php.
@@ -166,6 +166,17 @@ x-frame-options header can be configured using this node.
 
 Learn more about session in [x-frame-options][x-frame-options].
 
+## downloadable_domains
+List of downloadable domains are available in this node. Additional domains can be added, removed or listed through CLI commands.
+
+```conf
+'downloadable_domains' => [
+    'local.vanilla.com'
+]
+```
+
+Learn more about [downloadable-domains][downloadable_domains] commands.
+
 <!-- Link definitions -->
 [lock-provider-config]: {{ page.baseurl }}/install-gde/install/cli/install-cli-subcommands-lock.html
 [encryption-key]: https://docs.magento.com/m2/ce/user_guide/system/encryption-key.html
@@ -176,3 +187,4 @@ Learn more about session in [x-frame-options][x-frame-options].
 [x-frame-options]: {{ page.baseurl }}/config-guide/secy/secy-xframe.html
 [magento-mode]: {{ page.baseurl }}/config-guide/bootstrap/magento-modes.html
 [message-queues]: {{ page.baseurl }}/config-guide/mq/rabbitmq-overview.html
+[downloadable-domains]: {{ page.baseurl }}/reference/cli/magento.html#downloadabledomainsadd


### PR DESCRIPTION
## Purpose of this pull request

Added downloadable domain node description in the env.php reference page and also provides page links to update the downloadable domain via CLI.

## Affected DevDocs pages

<!-- REQUIRED List the affected pages on devdocs.magento.com (URLs). Not needed for large numbers of files. -->

-  https://devdocs.magento.com/guides/v2.3/config-guide/prod/config-reference-envphp.html
