### PR TITLE
MAGECLOUD-4925:  Ability to support custom database parameters in docker image

### DIFF
--- a/src/cloud/docker/docker-containers-service.md
+++ b/src/cloud/docker/docker-containers-service.md
@@ -40,7 +40,7 @@ Add a custom `my.cnf` file to the `services` section in the  `docker-compose.ove
 
 Add a custom `custom.cnf` file to the `.docker/mysql/mariadb.conf.d` directory:
 
-```sh
+```shell
 cp custom.cnf .docker/mysql/mariadb.conf.d
 ```
 

--- a/src/cloud/docker/docker-containers-service.md
+++ b/src/cloud/docker/docker-containers-service.md
@@ -28,7 +28,7 @@ When a database container initializes, it creates a new database with the specif
 
 To prevent accidental data loss, the database is stored in a persistent **`magento-db`** volume after you stop and remove the Docker configuration. The next time you use the `docker-compose up` command, the Docker environment restores your database from the persistent volume. You must manually destroy the database volume using the `docker volume rm <volume_name>` command.
 
-You can inject a MySQL configuration into the database container at creation by adding the configuration to the `docker-compose-override.yml` file. Add the custom values using an included `my.cnf` file like new mount or copy the custom configuration file to the directory `.docker/mysql/mariadb.conf.d`. Also, you can add the correct variables directly to the override file as shown in the following examples.
+You can inject a MySQL configuration into the database container at creation by adding the configuration to the `docker-compose-override.yml` file. Add the custom values by including a `my.cnf` file using a mount, or by copying the custom configuration file to the directory `.docker/mysql/mariadb.conf.d`. Also, you can add the correct variables directly to the override file as shown in the following examples.
 
 Add a custom `my.cnf` file to the `services` section in the  `docker-compose.override.yml` file:
 

--- a/src/cloud/docker/docker-containers-service.md
+++ b/src/cloud/docker/docker-containers-service.md
@@ -28,7 +28,7 @@ When a database container initializes, it creates a new database with the specif
 
 To prevent accidental data loss, the database is stored in a persistent **`magento-db`** volume after you stop and remove the Docker configuration. The next time you use the `docker-compose up` command, the Docker environment restores your database from the persistent volume. You must manually destroy the database volume using the `docker volume rm <volume_name>` command.
 
-You can inject a MySQL configuration into the database container at creation by adding the configuration to the `docker-compose-override.yml` file. Add the custom values using an included `my.cnf` file, or add the correct variables directly to the override file as shown in the following examples.
+You can inject a MySQL configuration into the database container at creation by adding the configuration to the `docker-compose-override.yml` file. Add the custom values using an included `my.cnf` file like new mount or copy the custom configuration file to the directory `.docker/mysql/mariadb.conf.d`. Also, you can add the correct variables directly to the override file as shown in the following examples.
 
 Add a custom `my.cnf` file to the `services` section in the  `docker-compose.override.yml` file:
 
@@ -36,6 +36,12 @@ Add a custom `my.cnf` file to the `services` section in the  `docker-compose.ove
   db:
     volumes:
       - path/to/custom.my.cnf:/etc/mysql/conf.d/custom.my.cnf
+```
+
+Add a custom `custom.cnf` file to the `.docker/mysql/mariadb.conf.d` directory:
+
+```sh
+cp custom.cnf .docker/mysql/mariadb.conf.d
 ```
 
 Add configuration values to the `docker-compose.override.yml` file:


### PR DESCRIPTION
## Purpose of this pull request

This pull request (PR) adds a description about customizing MariaDB settings

## Affected DevDocs pages

<!-- REQUIRED List the affected pages on devdocs.magento.com (URLs). Not needed for large numbers of files. -->

- https://devdocs.magento.com/cloud/docker/docker-containers-service.html#database-container

## Links to Magento source code

<!--  OPTIONAL - REMOVE THIS SECTION IF NOT USED. If this pull request references a file in a Magento codebase repository, add it here. -->

<!--
If you are fixing a GitHub issue, note it using GitHub keyword format (https://help.github.com/en/articles/closing-issues-using-keywords#closing-an-issue-in-a-different-repository) to close the issue when this pull request is merged. Example: `Fixes #1234`

`master` is the default branch. Merged pull requests to `master` go live on the site automatically. Any requested changes to content on the `master` branch must be related to the released codebase. Any content related to future releases goes in the `develop` branch.

See Contribution guidelines (https://github.com/magento/devdocs/blob/master/.github/CONTRIBUTING.md) for more information.
-->
