### PR TITLE
Fixed the broken link in env docs

### DIFF
--- a/src/guides/v2.3/config-guide/prod/config-reference-envphp.md
+++ b/src/guides/v2.3/config-guide/prod/config-reference-envphp.md
@@ -104,7 +104,7 @@ A list of downloadable domains available in this node. Additional domains can be
 ]
 ```
 
-Learn more about [downloadable-domains][downloadable_domains] commands.
+Learn more about [Downloadable Domains][downloadable-domains] commands.
 
 ## install
 


### PR DESCRIPTION
## Purpose of this pull request

Found that Downloadable Domains Link has been broken in the env docs page. Fixed the link issue and committed the code changes.

## Affected DevDocs pages

<!-- REQUIRED List the affected pages on devdocs.magento.com (URLs). Not needed for large numbers of files. -->

-  https://devdocs.magento.com/guides/v2.3/config-guide/prod/config-reference-envphp.html


<!--  OPTIONAL - REMOVE THIS SECTION IF NOT USED. If this pull request references a file in a Magento codebase repository, add it here. -->

<!--
If you are fixing a GitHub issue, note it using GitHub keyword format (https://help.github.com/en/articles/closing-issues-using-keywords#closing-an-issue-in-a-different-repository) to close the issue when this pull request is merged. Example: `Fixes #1234`

`master` is the default branch. Merged pull requests to `master` go live on the site automatically. Any requested changes to content on the `master` branch must be related to the released codebase. Any content related to future releases goes in the `develop` branch.

See Contribution guidelines (https://github.com/magento/devdocs/blob/master/.github/CONTRIBUTING.md) for more information.
-->
