### PR TITLE
make link clickable

### DIFF
--- a/src/recommendations/configure.md
+++ b/src/recommendations/configure.md
@@ -14,7 +14,7 @@ The Catalog SaaS Export module is a requirement to successfully use the [Product
 
 ### Provide API key {#apikeys}
 
-1. Log in to your Magento account at `https://account.magento.com`.
+1. Log in to your Magento account at [account.magento.com](https://account.magento.com).
 
 1. Under the **Magento** tab, select **API Portal** on the sidebar.
 


### PR DESCRIPTION
## Purpose of this pull request

This pull request (PR) makes clickable the account.magento.com link so users do not have to copy-paste the URL into their browser.

## Affected DevDocs pages

-  https://devdocs.magento.com/recommendations/configure.html
