### PR TITLE
Doc updates for Cloud Docker default Varnish configuration

### DIFF
--- a/src/cloud/docker/docker-containers-service.md
+++ b/src/cloud/docker/docker-containers-service.md
@@ -28,29 +28,30 @@ When a database container initializes, it creates a new database with the specif
 
 To prevent accidental data loss, the database is stored in a persistent **`magento-db`** volume after you stop and remove the Docker configuration. The next time you use the `docker-compose up` command, the Docker environment restores your database from the persistent volume. You must manually destroy the database volume using the `docker volume rm <volume_name>` command.
 
-You can inject a MySQL configuration into the database container at creation by adding the configuration to the `docker-compose-override.yml` file. Add the custom values by including a `my.cnf` file using a mount, or by copying the custom configuration file to the directory `.docker/mysql/mariadb.conf.d`. Also, you can add the correct variables directly to the override file as shown in the following examples.
+You can inject a MySQL configuration into the database container at creation by adding the configuration to the `docker-compose-override.yml` file using any of the following methods:
 
-Add a custom `my.cnf` file to the `services` section in the  `docker-compose.override.yml` file:
+-  Use a mount to add a custom `my.cnf` file to the `services` section in the  `docker-compose.override.yml` file:
 
-```yaml
-  db:
-    volumes:
-      - path/to/custom.my.cnf:/etc/mysql/conf.d/custom.my.cnf
-```
+   ```yaml
+     db:
+       volumes:
+         - path/to/custom.my.cnf:/etc/mysql/conf.d/custom.my.cnf
+   ```
 
-Add a custom `custom.cnf` file to the `.docker/mysql/mariadb.conf.d` directory:
+-  Add a custom `custom.cnf` file to the `.docker/mysql/mariadb.conf.d` directory:
 
-```shell
-cp custom.cnf .docker/mysql/mariadb.conf.d
-```
+   ```bash
+   cp custom.cnf .docker/mysql/mariadb.conf.d
+   ```
 
-Add configuration values to the `docker-compose.override.yml` file:
+-  Add configuration values directly to the `docker-compose.override.yml` file:
 
-```yaml
-  db:
-    environment:
-      - innodb-buffer-pool-size=134217728
-```
+   ```yaml
+   services:
+     db:
+       environment:
+         - innodb-buffer-pool-size=134217728
+   ```
 
 See [Manage the database] for details about using the database.
 
@@ -141,13 +142,15 @@ To increase the timeout on this container, add the following code to the  `docke
 
 The Varnish container simulates Fastly and is useful for testing VCL snippets.
 
-You can specify `VARNISHD_PARAMS` and other environment variables using ENV to specify custom values for required parameters. This is usually done by adding the configuration to the `docker-compose.override.yml` file.
+The **Varnish** service is installed by default. When deployment completes, Magento is configured to use Varnish for full page caching (FPC) for Magento version 2.2.0 or later. The configuration process preserves any custom FPC configuration settings that already exist.
 
-```yaml
-varnish:
-  environment:
-    - VARNISHD_PARAMS="-p default_ttl=3600 -p default_grace=3600 -p feature=+esi_ignore_https -p feature=+esi_disable_xml_check"
+To skip the Varnish installation, add the `--no-varnish` option to the `ece-docker build:compose` command.
+
+```bash
+./vendor/bin/ece-docker build:compose --mode="developer" --php 7.2 --no-varnish
 ```
+
+You can specify `VARNISHD_PARAMS` and other environment variables using ENV to specify custom values for required parameters. This is usually done by adding the configuration to the `docker-compose.override.yml` file.
 
 To clear the Varnish cache:
 

--- a/src/cloud/release-notes/mcd-release-notes.md
+++ b/src/cloud/release-notes/mcd-release-notes.md
@@ -16,6 +16,18 @@ The release notes include:
 -  {:.new}New features
 -  {:.fix}Fixes and improvements
 
+## v1.0.1
+
+-  {:.new}**Container updates**–
+
+   -  {:.new}**Varnish container**–
+
+      -  {:.new}The Varnish service is now provisioned by default when you deploy a Magento Cloud Docker environment using a supported version of the Magento Cloud application template.<!--MAGECLOUD-3598-->
+
+-  {:.new}**Command changes**–
+
+   -  {:.new}Added the `--no-varnish` option to the `ece-tools build:compose` command to skip Varnish service installation when you generate the configuration for a Magento Cloud Docker environment.<!--MAGECLOUD-3598-->
+
 ## v1.0.0
 
 -  {:.new}**Created a separate package to deliver `{{site.data.var.mcd-prod}}`**–Moved the source code to deliver {{site.data.var.mcd-prod}} from the `{{site.data.var.ct}}` repository to the [new `magento-cloud-docker` repository](https://github.com/magento/magento-cloud-docker) to maintain code quality and provide independent releases.  The new package is a dependency for {{site.data.var.ct}} v2002.1.0 and later.


### PR DESCRIPTION
## Purpose

Add information about changes to Varnish container configuration in Cloud Docker environments effective for Magento Cloud Docker v1.0.1 release.

- New `docker-build` option `--no-varnish` to skip Varnish installation and remove varnish as a service from resulting docker-compose

- In Magento Cloud Docker environments using Magento v2.2.0 or later, Varnish is installed by default. After deployment, Varnish is configured as the FPC for the Magento instance. Any custom FPC configuration that already exists is preserved.

## Affected pages

https://devdocs.magento.com/cloud/docker/docker-containers-service.html
https://devdocs.magento.com/cloud/release-notes/mcd-release-notes.html

## Links to Magento source code

https://github.com/magento/magento-cloud-docker/pull/97

whatsnew
Added information about the default Varnish container configuration to the [Docker services containers](https://devdocs.magento.com/cloud/docker/docker-containers-service.html) topic in the _Cloud Guide_.