### PR TITLE
Add Cron container configuration change to Magento Cloud Docker  BIC topic

### DIFF
--- a/src/_data/main-nav.yml
+++ b/src/_data/main-nav.yml
@@ -29,7 +29,7 @@
           url: /cloud/docker/docker-development.html
           versionless: true
 
-        - label: Launch Docker
+        - label: Configure and launch Docker
           url: /cloud/docker/docker-config.html
           versionless: true
 

--- a/src/_data/toc/cloud-guide.yml
+++ b/src/_data/toc/cloud-guide.yml
@@ -144,17 +144,19 @@ pages:
             - label: Manage cron jobs
               url: /cloud/docker/docker-manage-cron-jobs.html
               versionless: true
+  
+            - label: Extend Docker
+              url: /cloud/docker/docker-extend.html
+              versionless: true
 
+        - label: Launch Docker
+          children: 
             - label: Developer mode
               url: /cloud/docker/docker-mode-developer.html
               versionless: true
 
             - label: Production mode
               url: /cloud/docker/docker-mode-production.html
-              versionless: true
-  
-            - label: Extend Docker
-              url: /cloud/docker/docker-extend.html
               versionless: true
 
         - label: Functional Testing

--- a/src/_includes/cloud/note-docker-config-reference-link.md
+++ b/src/_includes/cloud/note-docker-config-reference-link.md
@@ -1,0 +1,2 @@
+{:.bs-callout-info}
+See [Configure Docker]({{site.baseurl}}/cloud/docker/docker-config.html) for additional information about Docker prerequisites and using the Magento Cloud Docker environment.

--- a/src/cloud/docker/docker-config.md
+++ b/src/cloud/docker/docker-config.md
@@ -51,7 +51,7 @@ The `ece-docker build:compose` command overwrites the existing `docker-compose.y
 
 1. Optionally, [enable Xdebug].
 
-## Launch modes
+## Launch modes for configuring the Docker environment
 
 _Mode_ is an additional configuration option for the Docker configuration generator (the `ece-docker build:compose` command). This mode option does not affect the Magento mode. It determines the {{site.data.var.ece}} file system installation and read-only or read-write behavior.
 

--- a/src/cloud/docker/docker-development.md
+++ b/src/cloud/docker/docker-development.md
@@ -9,6 +9,8 @@ functional_areas:
 
 {{site.data.var.ece}} provides a Docker environment option for those who use their local environment for development, test, or automation tasks. The {{site.data.var.ece}} Docker environment requires three, essential components: a {{site.data.var.ee}} v2 template, Docker Compose, and the {{site.data.var.ece}} `{{site.data.var.ct}}` package.
 
+{%include cloud/note-docker-config-reference-link.md%}
+
 ## Host Operating Systems
 
 The Cloud Docker environment supports Linux, macOS, and Windows operating systems. The containers should run on any Docker host, but some of the set up scripts require you to install PHP and Composer.

--- a/src/cloud/docker/docker-mode-production.md
+++ b/src/cloud/docker/docker-mode-production.md
@@ -9,6 +9,8 @@ functional_areas:
 
 Production mode is the default configuration setting for launching the Docker environment with read-only filesystem permissions. This option builds the Docker environment in production mode and verifies configured service versions.
 
+{%include cloud/note-docker-config-reference-link.md%}
+
 {:.procedure}
 To launch the Docker environment in developer mode:
 

--- a/src/cloud/docker/docker-quick-reference.md
+++ b/src/cloud/docker/docker-quick-reference.md
@@ -6,6 +6,9 @@ functional_areas:
   - Docker
 ---
 
+{:.bs-callout-info}
+See [Configure Docker] for details on configuring and launching a {{site.data.var.mcd-prod}} environment.
+
 ## docker-compose
 
 Action | Command
@@ -39,8 +42,8 @@ docker-compose -f docker-compose.yml -f docker-compose-custom.yml [-f more-custo
 
 | Option       | Key              | Available values
 | ------------ | ---------------- | ------------------
-| [Mode]({{site.baseurl}}/cloud/docker/docker-config.html#launch-modes)         | `--mode`, `-m`   | production, developer
-| [File synchronization engine]({{site.baseurl}}/cloud/docker/docker-config.html#launch-modes) | `--sync-engine` | native (default), docker-sync, mutagen
+| [Mode]({{site.baseurl}}/cloud/docker/docker-config.html#launch-modes-for-configuring-the-docker-environment)         | `--mode`, `-m`   | production, developer
+| [File synchronization engine]({{site.baseurl}}/cloud/docker/docker-config.html#launch-modes-for-configuring-the-docker-environment) | `--sync-engine` | native (default), docker-sync, mutagen
 
 {:.bs-callout-info}
 See [Service versions] for a list of the options to configure the software service version when building your {{site.data.var.mcd-prod}} environment.
@@ -80,3 +83,4 @@ Destroy containers | `down`
 Destroy, re-create, and start containers | `up`
 
 [Service versions]: {{site.baseurl}}/cloud/docker/docker-containers.html#service-containers
+[Configure Docker]: {{site.baseurl}}/cloud/docker/docker-config.html

--- a/src/cloud/reference/ece-tools-reference.md
+++ b/src/cloud/reference/ece-tools-reference.md
@@ -127,7 +127,7 @@ Ideal state is configured
 The `{{site.data.var.ct}}` package includes a dependency for the [magento/magento-cloud-patches] package, which delivers Magento patches and hot fixes that improve the integration of all {{site.data.var.ee}} versions with Cloud environments and supports quick delivery of critical fixes. The `{{site.data.var.mcp}}` also delivers custom patches that you add to your {{site.data.var.ece}} project. See [Apply patches].
 
 <!-- link definitions -->
-[mode]: {{site.baseurl}}/cloud/docker/docker-config.html#launch-modes
+[mode]: {{site.baseurl}}/cloud/docker/docker-config.html#launch-modes-for-configuring-the-docker-environment
 [hooks]: {{site.baseurl}}/cloud/project/project-conf-files_magento-app.html#hooks
 [cloudvar]: {{site.baseurl}}/cloud/env/variables-cloud.html
 [wizard]: {{site.baseurl}}/cloud/deploy/smart-wizards.html

--- a/src/cloud/release-notes/backward-incompatible-changes.md
+++ b/src/cloud/release-notes/backward-incompatible-changes.md
@@ -73,6 +73,10 @@ In earlier {{ site.data.var.ct }} releases, you could use the `m2-ece-build` and
 
    -  **Updating the Magento Cloud docker-compose commands**–We renamed the path to the command file from `./bin/docker` to `./bin/magento-docker`.  Update your scripts and commands to use the new path.
 
+   -  **Cron container no longer included in default Docker configuration**–Now, you must add the `--with-cron` option to the `ece-docker build:compose` command to include the Cron container in the Docker environment configuration. See [Manage cron jobs]({{site.baseurl}}/cloud/docker/docker-manage-cron-jobs.html).
+
+    Any scripts that previously generated containers with crons will now be lacking crons.
+
    -  **Using temporary containers**–In previous versions, the containers created by `bin/magento-docker` command operations were not removed, so you could use them for other operations.  Now, the `magento-docker` commands remove any containers they create after the command completes.
 
       If you want to keep a container created by a docker-compose operation, use the `docker-compose run` command instead of the `bin/magento-docker` command.

--- a/src/cloud/release-notes/cloud-release-archive.md
+++ b/src/cloud/release-notes/cloud-release-archive.md
@@ -139,7 +139,7 @@ The `{{site.data.var.ct}}` 2002.0.22 release changes the structure of the `{{sit
 
    -  {:.new}<!-- MAGECLOUD-3345 -->**New Docker Image**—Added a Node.js image to support Gulp and other capabilities, such as Jasmine JS Unit Testing.
 
-   -  {:.new}<!-- MAGECLOUD-3152/3511 -->**Docker build modes**—Now you can choose to launch the Docker environment in [Production mode or Developer mode]({{ site.baseurl }}/cloud/docker/docker-config.html#launch-modes). Developer mode supports active development with full, writable filesystem permissions.
+   -  {:.new}<!-- MAGECLOUD-3152/3511 -->**Docker build modes**—Now you can choose to launch the Docker environment in [Production mode or Developer mode]({{ site.baseurl }}/cloud/docker/docker-config.html#launch-modes-for-configuring-the-docker-environment). Developer mode supports active development with full, writable filesystem permissions.
 
    -  {:.fix}<!-- MAGECLOUD-3369 -->Fixed an issue that caused Docker deploy to fail with a `Name or service not known` error if the cache is configured for a service that is not available. Now, you can remove a service from the [`.magento/services.yaml` file]({{ site.baseurl }}/cloud/project/project-conf-files_services.html). The Docker configuration generator updates the service in the `docker/config.php.dist` file automatically.
 


### PR DESCRIPTION
## Purpose of this pull request

Added information about Cron container changes in the default Magento Cloud Docker environment to the [Backward incompatible changes](topic in the _Cloud Guide_

## Affected DevDocs pages

https://devdocs.magento.com/cloud/release-notes/backward-incompatible-changes.html
