### PR TITLE
Add Cron container config change to Cloud Docker BIC

### DIFF
--- a/src/cloud/release-notes/backward-incompatible-changes.md
+++ b/src/cloud/release-notes/backward-incompatible-changes.md
@@ -73,6 +73,10 @@ In earlier {{ site.data.var.ct }} releases, you could use the `m2-ece-build` and
 
    -  **Updating the Magento Cloud docker-compose commands**–We renamed the path to the command file from `./bin/docker` to `./bin/magento-docker`.  Update your scripts and commands to use the new path.
 
+   -  **Cron container no longer included in default Docker configuration**–Now, you must add the `--with-cron` option to the `ece-docker build:compose` command to include the Cron container in the Docker environment configuration. See [Manage cron jobs]({{site.baseurl}}/cloud/docker/docker-manage-cron-jobs.html).
+
+    Any scripts that previously generated containers with crons will now be lacking crons.
+
    -  **Using temporary containers**–In previous versions, the containers created by `bin/magento-docker` command operations were not removed, so you could use them for other operations.  Now, the `magento-docker` commands remove any containers they create after the command completes.
 
       If you want to keep a container created by a docker-compose operation, use the `docker-compose run` command instead of the `bin/magento-docker` command.


### PR DESCRIPTION
## Purpose of this pull request

Added information about Cron container changes in the default Magento Cloud Docker environment to the [Backward incompatible changes](https://devdocs.magento.com/cloud/release-notes/backward-incompatible-changes.html) topic.

## Affected DevDocs pages

https://devdocs.magento.com/cloud/release-notes/backward-incompatible-changes.html

## Links to Magento source code

https://github.com/magento/magento-cloud-docker/pull/144