### PR TITLE
magento/devdocs#: Add mergeCarts query API errors

### DIFF
--- a/src/guides/v2.3/graphql/mutations/merge-carts.md
+++ b/src/guides/v2.3/graphql/mutations/merge-carts.md
@@ -83,3 +83,13 @@ Attribute |  Data Type | Description
 {% include graphql/cart-object.md %}
 
 [Cart query output]({{page.baseurl}}/graphql/queries/cart.html#cart-output) provides more information about the `Cart` object.
+
+## Errors
+
+Error | Description
+--- | ---
+`Current user does not have an active cart.` | The `mergeCarts` mutation deactivates the guest cart specified in the `source_cart_id` after merging. The guest cannot make any further operations with it.
+`Required parameter "destination_cart_id" is missing` | The `destination_cart_id` attribute contains an empty value.
+`Required parameter "source_cart_id" is missing` | The `source_cart_id` attribute contains an empty value.
+`The current customer isn't authorized.` | The current customer is not currently logged in, or the customer's token does not exist in the `oauth_token` table, or you tried to merge two guest carts.
+`The current user cannot perform operations on cart` | The authorized customer tried to merge a guest cart into the cart of another customer.


### PR DESCRIPTION

## Purpose of this pull request

This pull request (PR) adds information about the API errors of `mergeCarts` mutation.

## Affected DevDocs pages

<!-- REQUIRED List the affected pages on devdocs.magento.com (URLs). Not needed for large numbers of files. -->

- https://devdocs.magento.com/guides/v2.3/graphql/mutations/merge-carts.html

## Links to Magento source code

<!--  OPTIONAL - REMOVE THIS SECTION IF NOT USED. If this pull request references a file in a Magento codebase repository, add it here. -->

- [Current user does not have an active cart.](https://github.com/magento/magento2/blob/2.3.4/dev/tests/api-functional/testsuite/Magento/GraphQl/Quote/Customer/MergeCartsTest.php#L111)
- [Required parameter "destination_cart_id" is missing](https://github.com/magento/magento2/blob/2.3.4/app/code/Magento/QuoteGraphQl/Model/Resolver/MergeCarts.php#L56)
- [Required parameter "source_cart_id" is missing](https://github.com/magento/magento2/blob/2.3.4/app/code/Magento/QuoteGraphQl/Model/Resolver/MergeCarts.php#L52)
- [The current customer isn't authorized.](https://github.com/magento/magento2/blob/2.3.4/app/code/Magento/QuoteGraphQl/Model/Resolver/MergeCarts.php#L61)
- [The current user cannot perform operations on cart](https://github.com/magento/magento2/blob/2.3.4/dev/tests/api-functional/testsuite/Magento/GraphQl/Quote/Customer/MergeCartsTest.php#L144)

<!--
If you are fixing a GitHub issue, note it using GitHub keyword format (https://help.github.com/en/articles/closing-issues-using-keywords#closing-an-issue-in-a-different-repository) to close the issue when this pull request is merged. Example: `Fixes #1234`

`master` is the default branch. Merged pull requests to `master` go live on the site automatically. Any requested changes to content on the `master` branch must be related to the released codebase. Any content related to future releases goes in the `develop` branch.

See Contribution guidelines (https://github.com/magento/devdocs/blob/master/.github/CONTRIBUTING.md) for more information.
-->
