### PR TITLE
magento/devdocs#: Extend setShippingAddressesOnCart example

### DIFF
--- a/src/guides/v2.3/graphql/mutations/set-shipping-address.md
+++ b/src/guides/v2.3/graphql/mutations/set-shipping-address.md
@@ -48,8 +48,16 @@ mutation {
         company
         street
         city
+        region {
+          code
+          label
+        }
         postcode
         telephone
+        country {
+          code
+          label
+        }
       }
     }
   }
@@ -73,8 +81,16 @@ mutation {
               "Main Street"
             ],
             "city": "Austin",
+            "region": {
+              "code": "TX",
+              "label": "Texas"
+            },
             "postcode": "78758",
-            "telephone": "8675309"
+            "telephone": "8675309",
+            "country": {
+              "code": "US",
+              "label": "US"
+            }
           }
         ]
       }


### PR DESCRIPTION
## Purpose of this pull request

This pull request (PR) extends example of `setShippingAddressesOnCart` mutation usage. Current example a bit confused because we specify `region` and `country_code` attributes but do not retrieve them in the response.

## Affected DevDocs pages

<!-- REQUIRED List the affected pages on devdocs.magento.com (URLs). Not needed for large numbers of files. -->

- https://devdocs.magento.com/guides/v2.3/graphql/tutorials/checkout/checkout-shipping-address.html


## Links to Magento source code

<!--  OPTIONAL - REMOVE THIS SECTION IF NOT USED. If this pull request references a file in a Magento codebase repository, add it here. -->

- [region](https://github.com/magento/magento2/blob/2.3.4/app/code/Magento/QuoteGraphQl/etc/schema.graphqls#L217)
- [country](https://github.com/magento/magento2/blob/2.3.4/app/code/Magento/QuoteGraphQl/etc/schema.graphqls#L219)

<!--
If you are fixing a GitHub issue, note it using GitHub keyword format (https://help.github.com/en/articles/closing-issues-using-keywords#closing-an-issue-in-a-different-repository) to close the issue when this pull request is merged. Example: `Fixes #1234`

`master` is the default branch. Merged pull requests to `master` go live on the site automatically. Any requested changes to content on the `master` branch must be related to the released codebase. Any content related to future releases goes in the `develop` branch.

See Contribution guidelines (https://github.com/magento/devdocs/blob/master/.github/CONTRIBUTING.md) for more information.
-->

Thank you!
