### PR TITLE
Adding missing information in setBillingAddressOnCart Mutation

### DIFF
--- a/src/guides/v2.3/graphql/mutations/set-billing-address.md
+++ b/src/guides/v2.3/graphql/mutations/set-billing-address.md
@@ -46,8 +46,16 @@ mutation {
         company
         street
         city
+        region{
+          code
+          label
+        }
         postcode
         telephone
+        country{
+          code
+          label
+        }
       }
     }
   }
@@ -70,8 +78,16 @@ mutation {
             "Main Street"
           ],
           "city": "Austin",
+          "region": {
+              "code": "TX",
+              "label": "Texas"
+            },
           "postcode": "78758",
-          "telephone": "8675309"
+          "telephone": "8675309",
+           "country": {
+             "code": "US",
+             "label": "US"
+          }
         }
       }
     }


### PR DESCRIPTION
## Purpose of this pull request

This pull request (PR) is for adding missing information in setBillingAddresOnCart Mutation.The region and country fieds are set in request but didn't showed in response 

## Affected DevDocs pages

<!-- REQUIRED List the affected pages on devdocs.magento.com (URLs). Not needed for large numbers of files. -->

-  https://devdocs.magento.com/guides/v2.3/graphql/mutations/set-billing-address.html

