### PR TITLE
[Components] Fix typo at insert listing component guide

### DIFF
--- a/src/guides/v2.3/ui_comp_guide/components/ui-insertlisting.md
+++ b/src/guides/v2.3/ui_comp_guide/components/ui-insertlisting.md
@@ -54,7 +54,7 @@ The following example shows how the InsertListing component integrates with the 
             </settings>
         </insertListing>
     </fieldset>
-</listing>
+</form>
 ```
 
 The listing example insert_listing_example.xml:


### PR DESCRIPTION
## Purpose of this pull request

This pull request (PR) fix type at insert listing component guide exampe

## Affected DevDocs pages

<!-- REQUIRED List the affected pages on devdocs.magento.com (URLs). Not needed for large numbers of files. -->

- https://devdocs.magento.com/guides/v2.3/ui_comp_guide/components/ui-insertlisting.html