### PR TITLE
Removing Deprecated customer id from createCustomer Mutation

### DIFF
--- a/src/_includes/graphql/customer-output.md
+++ b/src/_includes/graphql/customer-output.md
@@ -10,7 +10,7 @@ Attribute |  Data Type | Description
 `firstname` | String | The customer's first name
 `gender` | Int | The customer's gender (Male - 1, Female - 2)
 `group_id` | Int | Deprecated. This attribute is not applicable for GraphQL. The group assigned to the user. Default values are 0 (Not logged in), 1 (General), 2 (Wholesale), and 3 (Retailer)
-`id` | Int | Deprecated. This attribute is not applicable for GraphQL.
+`id` | Int | Deprecated. This attribute is not applicable for GraphQL.The ID assigned to the customer
 `is_subscribed` | Boolean | Indicates whether the customer is subscribed to the company's newsletter
 `lastname` | String | The customer's family name
 `middlename` |String | The customer's middle name

--- a/src/_includes/graphql/customer-output.md
+++ b/src/_includes/graphql/customer-output.md
@@ -10,7 +10,7 @@ Attribute |  Data Type | Description
 `firstname` | String | The customer's first name
 `gender` | Int | The customer's gender (Male - 1, Female - 2)
 `group_id` | Int | Deprecated. This attribute is not applicable for GraphQL. The group assigned to the user. Default values are 0 (Not logged in), 1 (General), 2 (Wholesale), and 3 (Retailer)
-`id` | Int | The ID assigned to the customer
+`id` | Int | Deprecated. This attribute is not applicable for GraphQL.
 `is_subscribed` | Boolean | Indicates whether the customer is subscribed to the company's newsletter
 `lastname` | String | The customer's family name
 `middlename` |String | The customer's middle name

--- a/src/guides/v2.3/graphql/mutations/create-customer.md
+++ b/src/guides/v2.3/graphql/mutations/create-customer.md
@@ -29,7 +29,6 @@ mutation {
     }
   ) {
     customer {
-      id
       firstname
       lastname
       email
@@ -46,7 +45,6 @@ mutation {
   "data": {
     "createCustomer": {
       "customer": {
-        "id": 5,
         "firstname": "Bob",
         "lastname": "Loblaw",
         "email": "bobloblaw@example.com",


### PR DESCRIPTION
## Purpose of this pull request

This pull request (PR) deletes the customer id from createCustmer Mutation.As mentioned in the source code( https://github.com/magento/magento2/blob/2.3/app/code/Magento/CustomerGraphQl/etc/schema.graphqls) 
 line number 95   
  id: Int @doc(description: "The ID assigned to the customer") @deprecated(reason: "id is not needed as part of Customer because on server side it can be identified based on customer token used for authentication. There is no need to know customer ID on the client side.")
although the received customer id is null there is no need to show it in the response  

## Affected DevDocs pages

<!-- REQUIRED List the affected pages on devdocs.magento.com (URLs). Not needed for large numbers of files. -->

-  https://devdocs.magento.com/guides/v2.3/graphql/mutations/create-customer.html

## Links to Magento source code

<!--  OPTIONAL - REMOVE THIS SECTION IF NOT USED. If this pull request references a file in a Magento codebase repository, add it here. -->

-  https://github.com/magento/devdocs/blob/master/src/guides/v2.3/graphql/mutations/create-customer.md
-https://github.com/magento/devdocs/blob/master/src/_includes/graphql/customer-output.md