### PR TITLE
Extending setBillingAddressOnCart mutation example in gr…

### DIFF
--- a/src/guides/v2.3/graphql/tutorials/checkout/checkout-billing-address.md
+++ b/src/guides/v2.3/graphql/tutorials/checkout/checkout-billing-address.md
@@ -32,7 +32,7 @@ The following mutation adds a new billing address. `{ CART_ID }` is the unique s
 {:.bs-callout-info}
 For logged-in customers, send the customer's authorization token in the `Authorization` parameter of the header. See ["Get customer authorization token"]({{ page.baseurl }}/graphql/get-customer-authorization-token.html) for more information.
 
-```text
+```graphql
 mutation {
   setBillingAddressOnCart(
     input: {

--- a/src/guides/v2.3/graphql/tutorials/checkout/checkout-billing-address.md
+++ b/src/guides/v2.3/graphql/tutorials/checkout/checkout-billing-address.md
@@ -60,6 +60,10 @@ mutation {
         company
         street
         city
+        region{
+          code
+          label
+        }
         postcode
         telephone
         country {
@@ -88,6 +92,10 @@ mutation {
             "Beverly Hills"
           ],
           "city": "Los Angeles",
+          "region": {
+            "code": "CA",
+            "label": "California"
+          },
           "postcode": "90210",
           "telephone": "123-456-0000",
           "country": {
@@ -136,6 +144,10 @@ mutation {
         company
         street
         city
+        region{
+          code
+          label
+        }
         postcode
         telephone
         country {
@@ -177,6 +189,10 @@ mutation {
             "Beverly Hills"
           ],
           "city": "Los Angeles",
+          "region": {
+            "code": "CA",
+            "label": "California"
+          },
           "postcode": "90210",
           "telephone": "123-456-0000",
           "country": {
@@ -266,6 +282,10 @@ mutation {
         company
         street
         city
+        region{
+          code
+          label
+        }
         postcode
         telephone
         country {
@@ -294,6 +314,10 @@ mutation {
             "Beverly Hills"
           ],
           "city": "Los Angeles",
+          "region": {
+            "code": "CA",
+            "label": "California"
+          },
           "postcode": "90210",
           "telephone": "123-456-0000",
           "country": {


### PR DESCRIPTION
…aphql tutorial

## Purpose of this pull request

This pull request (PR)  adds region field to the request  and response in setBillingInformationOnCart   Mutation.

## Affected DevDocs pages

<!-- REQUIRED List the affected pages on devdocs.magento.com (URLs). Not needed for large numbers of files. -->

-  https://devdocs.magento.com/guides/v2.3/graphql/tutorials/checkout/checkout-billing-address.html

