### PR TITLE
Add redirect based on HotJar broken link report

### DIFF
--- a/src/cloud/project/user-admin.md
+++ b/src/cloud/project/user-admin.md
@@ -4,6 +4,8 @@ title: Create and manage users
 functional_areas:
   - Cloud
   - Configuration
+redirect_from:
+  - /cloud/admin/admin-user-admin.html
 ---
 
 You can manage user access to {{ site.data.var.ece }} projects by assigning users one or more roles. You can add and manage user accounts for the entire project and permissions per available environment.


### PR DESCRIPTION
## Purpose of this pull request

Feedback from HotJar noting a link that returns 404:
“ https://devdocs.magento.com/cloud/admin/admin-user-admin.html cant get to where I need to go ”
This link is likely from an outdated reference to an older version of the _Cloud Guide_.  Added a redirect so that this link opens the [Create and manage users](https://devdocs.magento.com/cloud/project/user-admin.html) topic.


## Affected DevDocs pages

- https://devdocs.magento.com/cloud/project/user-admin.html

<!-- REQUIRED List the affected pages on devdocs.magento.com (URLs). Not needed for large numbers of files. -->

