### PR TITLE
Added link to ElasticSuite documentation

### DIFF
--- a/src/cloud/project/project-conf-files_services-elastic.md
+++ b/src/cloud/project/project-conf-files_services-elastic.md
@@ -190,3 +190,6 @@ elasticsearch:
 ```
 
 If you use the ElasticSuite third-party plugin, you must [update the `{{site.data.var.ct}}` package]({{ site.baseurl }}/cloud/project/ece-tools-update.html) to version 2002.0.19 or later.
+
+{:.bs-callout-tip}
+For details on using or troubleshooting the Elasticsuite plugin with Magento, see the [Elasticsuite documentation](https://github.com/Smile-SA/elasticsuite).


### PR DESCRIPTION
## Purpose of this pull request

Adds a tip to use the Smile Elasticsuite documentation for details on using and troubleshooting the Elasticsuite plugin from Magento.

## Affected DevDocs pages

- https://devdocs.magento.com/cloud/project/project-conf-files_services-elastic.html#elasticsearch-plugins