### PR TITLE
Add missing documentation step

### DIFF
--- a/guides/v2.1/frontend-dev-guide/css-topics/using-fonts.md
+++ b/guides/v2.1/frontend-dev-guide/css-topics/using-fonts.md
@@ -43,7 +43,10 @@ To ensure the stability of your customizations and prevent upgrades from overwri
         font-weight: 300;
         font-style: normal
     }
-    ```
+    ``` 
+
+3. Also you have to edit app/code/Magento/Theme/view/frontend/layout/default_head_blocks.xml file to declare your fonts, otherwise Magento 2.3 will not be able to create the static/web/fonts/ directory. Read more [here](app/code/Magento/Theme/view/frontend/layout/default_head_blocks.xml)
+  
 ## Overview of Magento's Icon CSS
 
 In addition to including custom fonts in your Magento Blank theme, you also can include custom fonts for any icons in the Blank theme. The icon font files for the Magento Blank theme are located in the `lib/web/fonts/Blank-Theme-Icons` directory. The `lib/web/css/source/lib/variables/_typography.less` file defines the font icon path and name for the icons and the `web/css/source/_icons.less` file uses these files to define the icon font face itself, which should be used in all CSS declarations.


### PR DESCRIPTION
## Purpose of this pull request

I was following the documentation 
https://devdocs.magento.com/guides/v2.3/frontend-dev-guide/css-topics/using-fonts.html
in order to add my custom fonts to the project, but after finishing all steps the steps my fonts were not exported in the static/fonts directory.  So this documentation page is incomplete because important information is missing.

After searching I've found the following step in another page of the DevDocs https://devdocs.magento.com/guides/v2.3/frontend-dev-guide/layouts/xml-manage.html#layout_markup_css
So, after I followed the steps to include my custom fonts, everything worked. 

But there must be a link to that page because it is important for all who might want to include custom fonts in their Magento installations, and load the fonts from their local directories and not via an external call to the cloud. 

## Affected DevDocs pages

<!-- REQUIRED List the affected pages on devdocs.magento.com (URLs). Not needed for large numbers of files. -->

-  https://devdocs.magento.com/guides/v2.3/frontend-dev-guide/layouts/xml-manage.html#layout_markup_css

## Links to Magento source code


<!--
If you are fixing a GitHub issue, note it using GitHub keyword format (https://help.github.com/en/articles/closing-issues-using-keywords#closing-an-issue-in-a-different-repository) to close the issue when this pull request is merged. Example: `Fixes #1234`

`master` is the default branch. Merged pull requests to `master` go live on the site automatically. Any requested changes to content on the `master` branch must be related to the released codebase. Any content related to future releases goes in the `develop` branch.

See Contribution guidelines (https://github.com/magento/devdocs/blob/master/.github/CONTRIBUTING.md) for more information.
-->
