### PR TITLE
Minor/typo fix

### DIFF
--- a/_data/toc/page-builder.yml
+++ b/_data/toc/page-builder.yml
@@ -201,5 +201,5 @@ pages:
   versionless: true
 
 - label: Contribution guide
-  url: https://github.com/magento/magento2-page-builder/blob/develop/CONTRIBUTING.md
+  url: https://github.com/magento/magento2-page-builder/blob/1.0-develop/CONTRIBUTING.md
   versionless: true

--- a/guides/v2.1/install-gde/install/cli/install-cli-subcommands-enable.md
+++ b/guides/v2.1/install-gde/install/cli/install-cli-subcommands-enable.md
@@ -33,7 +33,7 @@ where
 
 	Failure to clear static view files might result in issues if there are multiple files with the same name and you don't clear all of them.
 
-	In other words, because of [static file fallback]({{ page.baseurl }}/config-guide/cli/config-cli-subcommands-static-view.html) rules, if you do not clear static files and there is more than one file named `logo.gif` that are different, fallback might cause the wrong file to display.
+	In other words, because of [static file fallback]({{ page.baseurl }}/config-guide/cli/config-cli-subcommands-static-view.html) rules, if you do not clear static files and there is more than one file named `logo.svg` that are different, fallback might cause the wrong file to display.
 
 Use the following command to list enabled and disabled modules:
 


### PR DESCRIPTION
## Purpose of this pull request

Corrects the file ending of the logo.gif to the right one which is logo.svg
As far as I know and see inside the Default Magento2 installations, the logo is SVG.
Why to put a GIF logo...? 
I think this must had been overlooked in all the previous documentations for v2.1 and v2.2 too because its also referenced wrong there too.

## Affected DevDocs pages

https://docs.magento.com/m2/ce/user_guide/design/logo-upload.html

<!--
If you are fixing a GitHub issue, note it using GitHub keyword format (https://help.github.com/en/articles/closing-issues-using-keywords#closing-an-issue-in-a-different-repository) to close the issue when this pull request is merged. Example: `Fixes #1234`

`master` is the default branch. Merged pull requests to `master` go live on the site automatically. Any requested changes to content on the `master` branch must be related to the released codebase. Any content related to future releases goes in the `develop` branch.

See Contribution guidelines (https://github.com/magento/devdocs/blob/master/.github/CONTRIBUTING.md) for more information.
-->
