### PR TITLE
Fix instructions for deploying Magento in Docker

### DIFF
--- a/src/cloud/docker/docker-mode-developer.md
+++ b/src/cloud/docker/docker-mode-developer.md
@@ -89,7 +89,7 @@ To launch the Docker environment in developer mode:
       ```bash
       docker-compose run deploy cloud-deploy
       ```
-      
+
       ```bash
       docker-compose run deploy magento-command deploy:mode:set developer
       ```

--- a/src/cloud/docker/docker-mode-developer.md
+++ b/src/cloud/docker/docker-mode-developer.md
@@ -89,6 +89,7 @@ To launch the Docker environment in developer mode:
       ```bash
       docker-compose run deploy cloud-deploy
       ```
+      
       ```bash
       docker-compose run deploy magento-command deploy:mode:set developer
       ```

--- a/src/cloud/docker/docker-mode-developer.md
+++ b/src/cloud/docker/docker-mode-developer.md
@@ -87,7 +87,9 @@ To launch the Docker environment in developer mode:
    -  Deploy Magento in the Docker container.
 
       ```bash
-      docker-compose run deploy cloud-deploy && \
+      docker-compose run deploy cloud-deploy
+      ```
+      ```bash
       docker-compose run deploy magento-command deploy:mode:set developer
       ```
 


### PR DESCRIPTION
Separated the bash commands in the step to deploy Magento in a Docker container

## Purpose of this pull request

Per user feedback, fixed an issue with running the commands to deploy Magento in a Docker container.

## Affected DevDocs pages

- https://devdocs.magento.com/cloud/docker/docker-mode-developer.html