### PR TITLE
Removing deprecated customer id from createCustomerAddress mutation

### DIFF
--- a/src/_includes/graphql/customer-address-input.md
+++ b/src/_includes/graphql/customer-address-input.md
@@ -10,7 +10,7 @@ Attribute |  Data Type | Description
 `country_id` | String | Deprecated. Use `country_code` instead. The customer's country
 `custom_attributes` | [CustomerAddressAttributeInput](#customerAddressAttributeInput) | Deprecated. Not applicable for GraphQL
 `default_billing` | Boolean | Indicates whether the address is the default billing address
-`default_shipping` | Boolean | Indicates whether the address is the default shipping address\
+`default_shipping` | Boolean | Indicates whether the address is the default shipping address
 `fax` | String | The fax number
 `firstname` | String | The first name of the person associated with the shipping/billing address
 `lastname` | String | The family name of the person associated with the shipping/billing address

--- a/src/_includes/graphql/customer-address-input.md
+++ b/src/_includes/graphql/customer-address-input.md
@@ -9,19 +9,15 @@ Attribute |  Data Type | Description
 `country_code` | String | The customer's country
 `country_id` | String | Deprecated. Use `country_code` instead. The customer's country
 `custom_attributes` | [CustomerAddressAttributeInput](#customerAddressAttributeInput) | Deprecated. Not applicable for GraphQL
-`customer_id` | Int | Deprecated. This attribute is not applicable for GraphQL. The ID assigned to the customer
 `default_billing` | Boolean | Indicates whether the address is the default billing address
-`default_shipping` | Boolean | Indicates whether the address is the default shipping address
-`extension_attributes` | [CustomerAddressAttribute](#customerAddressAttributeInput) | Address extension attributes
+`default_shipping` | Boolean | Indicates whether the address is the default shipping address\
 `fax` | String | The fax number
 `firstname` | String | The first name of the person associated with the shipping/billing address
-`id` | Int | The ID assigned to the address object
 `lastname` | String | The family name of the person associated with the shipping/billing address
 `middlename` | String | The middle name of the person associated with the shipping/billing address
 `postcode` | String | The customer's ZIP or postal code
 `prefix` | String | An honorific, such as Dr., Mr., or Mrs.
 `region` | [CustomerAddressRegionInput](#customerAddressRegionInput) | An object that defines the customer's state or province
-`region_id` | Int | Deprecated. Use `region` instead. A number that uniquely identifies the state, province, or other area
 `street` | [String] | An array of strings that define the street number and name
 `suffix` | String | A value such as Sr., Jr., or III
 `telephone` | String | The telephone number

--- a/src/_includes/graphql/customer-address-input.md
+++ b/src/_includes/graphql/customer-address-input.md
@@ -9,7 +9,7 @@ Attribute |  Data Type | Description
 `country_code` | String | The customer's country
 `country_id` | String | Deprecated. Use `country_code` instead. The customer's country
 `custom_attributes` | [CustomerAddressAttributeInput](#customerAddressAttributeInput) | Deprecated. Not applicable for GraphQL
-`customer_id` | Int | The customer ID
+`customer_id` | Int | Deprecated. This attribute is not applicable for GraphQL. The ID assigned to the customer
 `default_billing` | Boolean | Indicates whether the address is the default billing address
 `default_shipping` | Boolean | Indicates whether the address is the default shipping address
 `extension_attributes` | [CustomerAddressAttribute](#customerAddressAttributeInput) | Address extension attributes

--- a/src/_includes/graphql/customer-address-output.md
+++ b/src/_includes/graphql/customer-address-output.md
@@ -11,7 +11,7 @@ Attribute |  Data Type | Description
 `country_code` | CountryCodeEnum | The customer's country
 `country_id` | String | Deprecated. Use `country_code` instead. The customer's country
 `custom_attributes` | [CustomerAddressAttribute](#customerAddressAttributeOutput) | Deprecated. Not applicable for GraphQL
-`customer_id` | Int | The customer ID
+`customer_id` | Int | Deprecated. This attribute is not applicable for GraphQL. The ID assigned to the customer
 `default_billing` | Boolean | Indicates whether the address is the default billing address
 `default_shipping` | Boolean | Indicates whether the address is the default shipping address
 `extension_attributes` | [CustomerAddressAttribute](#customerAddressAttributeOutput) | Address extension attributes

--- a/src/guides/v2.3/graphql/mutations/create-customer-address.md
+++ b/src/guides/v2.3/graphql/mutations/create-customer-address.md
@@ -35,7 +35,6 @@ mutation {
     default_billing: false
   }) {
     id
-    customer_id
     region {
       region
       region_id
@@ -59,7 +58,6 @@ mutation {
   "data": {
     "createCustomerAddress": {
       "id": 4,
-      "customer_id": 5,
       "region": {
         "region": "Arizona",
         "region_code": "AZ"


### PR DESCRIPTION
## Purpose of this pull request

This pull request (PR) removes deprecated customer id from createCustomerAddress mutation. source code
(https://github.com/magento/magento2/blob/5f3b86ab4bd3e3b94e65429fed33f748d29c1bbe/app/code/Magento/CustomerGraphQl/etc/schema.graphqls#L103)
(https://github.com/magento/magento2/blob/2.3/app/code/Magento/CustomerGraphQl/etc/schema.graphqls)

## Affected DevDocs pages

<!-- REQUIRED List the affected pages on devdocs.magento.com (URLs). Not needed for large numbers of files. -->

-  https://devdocs.magento.com/guides/v2.3/graphql/mutations/create-customer-address.html
