### PR TITLE
Changing deprecated customer id to email in Customer mutation examples

### DIFF
--- a/src/guides/v2.3/graphql/mutations/index.md
+++ b/src/guides/v2.3/graphql/mutations/index.md
@@ -49,7 +49,7 @@ mutation myCreateCustomerNoVariables{
 }
 ```
 
-The mutation returns the customer Email:
+The mutation returns the customer email:
 
 ```json
 {

--- a/src/guides/v2.3/graphql/mutations/index.md
+++ b/src/guides/v2.3/graphql/mutations/index.md
@@ -29,7 +29,7 @@ mutation myCreateCustomer{
 
 In this example, `myCreateCustomer` identifies your implementation.  `CustomerInput` is a non-nullable object that defines a customer. (The exclamation point indicates the value is non-nullable.) The `CustomerOutput` object defines which fields to return.
 
-Now let's take a look at a fully-defined mutation. This time, we'll specify the minimum fields needed as input to create a customer (`firstname`, `lastname`, `email`, and `password`). We could include the same fields in the output, but GraphQL allows you to return only the data you need, which is the customer `id`.
+Now let's take a look at a fully-defined mutation. This time, we'll specify the minimum fields needed as input to create a customer (`firstname`, `lastname`, `email`, and `password`). We could include the same fields in the output, but GraphQL allows you to return only the data you need, which is the customer `email`.
 
 ```text
 mutation myCreateCustomerNoVariables{
@@ -43,20 +43,20 @@ mutation myCreateCustomerNoVariables{
     )
     {
         customer {
-            id
+            email
         }
     }
 }
 ```
 
-The mutation returns the customer ID:
+The mutation returns the customer Email:
 
 ```json
 {
   "data": {
       "createCustomer": {
           "customer": {
-              "id": 2
+              "email" : "mshaw@example.com"
             }
         }
     }
@@ -96,7 +96,7 @@ mutation myCreateCustomerWithVariables($CustomerInput: CustomerInput!){
     )
     {
         customer {
-            id
+            email
         }
     }
 }
@@ -127,7 +127,6 @@ mutation myUpdateCustomer($email: String!, $password: String!){
     )
     {
         customer {
-            id
             email
         }
     }


### PR DESCRIPTION
## Purpose of this pull request

This pull request (PR) changes deprecated customer id to customer email. since customer email is unique for  each customer showing this in the example will be useful.

## Affected DevDocs pages

<!-- REQUIRED List the affected pages on devdocs.magento.com (URLs). Not needed for large numbers of files. -->

-  https://devdocs.magento.com/guides/v2.3/graphql/mutations/index.html

## Links to Magento source code

<!--  OPTIONAL - REMOVE THIS SECTION IF NOT USED. If this pull request references a file in a Magento codebase repository, add it here. -->

-https://github.com/magento/magento2/blob/2.3/app/code/Magento/CustomerGraphQl/etc/schema.graphqls#L95

<!--
If you are fixing a GitHub issue, note it using GitHub keyword format (https://help.github.com/en/articles/closing-issues-using-keywords#closing-an-issue-in-a-different-repository) to close the issue when this pull request is merged. Example: `Fixes #1234`

`master` is the default branch. Merged pull requests to `master` go live on the site automatically. Any requested changes to content on the `master` branch must be related to the released codebase. Any content related to future releases goes in the `develop` branch.

See Contribution guidelines (https://github.com/magento/devdocs/blob/master/.github/CONTRIBUTING.md) for more information.
-->
