### PR TITLE
Update information in the 3rd step of GrapqQl tutorial

### DIFF
--- a/src/guides/v2.3/graphql/tutorials/checkout/checkout-add-product-to-cart.md
+++ b/src/guides/v2.3/graphql/tutorials/checkout/checkout-add-product-to-cart.md
@@ -14,10 +14,13 @@ contributor_name: Atwix
 contributor_link: https://www.atwix.com/
 ---
 
-GraphQL supports [two types of product]({{ page.baseurl }}/graphql/product/product-interface-implementations.html) which can be added into shopping cart:
+GraphQL supports [several types of product]({{ page.baseurl }}/graphql/product/product-interface-implementations.html) which can be added into shopping cart:
 
 -  simple product
 -  virtual product
+-  configurable product
+-  bundle product
+-  downloadable product
 
 {:.bs-callout-info}
 If you add a product to the shopping cart as a registered customer, be sure to send the customer's authorization token in the `Authorization` parameter of the header. See ["Get customer authorization token"]({{ page.baseurl }}/graphql/get-customer-authorization-token.html) for more details.
@@ -139,6 +142,13 @@ mutation {
   }
 }
 ```
+
+### More details and examples for other product types can be found here:
+-  [Simple Products]({{ page.baseurl }}/graphql/mutations/add-simple-products.html)
+-  [Virtual Products]({{ page.baseurl }}/graphql/mutations/add-virtual-products.html)
+-  [Configurable Products]({{ page.baseurl }}/graphql/mutations/add-configurable-products.html)
+-  [Bundle Products]({{ page.baseurl }}/graphql/mutations/add-bundle-products.html)
+-  [Downloadable Products]({{ page.baseurl }}/graphql/mutations/add-downloadable-products.html)
 
 Use the `updateCartItems` mutation to update shopping cart items and `removeItemFromCart` to remove a product from the shopping cart.
 

--- a/src/guides/v2.3/graphql/tutorials/checkout/checkout-add-product-to-cart.md
+++ b/src/guides/v2.3/graphql/tutorials/checkout/checkout-add-product-to-cart.md
@@ -14,26 +14,30 @@ contributor_name: Atwix
 contributor_link: https://www.atwix.com/
 ---
 
-GraphQL supports [several types of product]({{ page.baseurl }}/graphql/product/product-interface-implementations.html) which can be added into shopping cart:
+GraphQL supports all product types, but this tutorial only demonstrates how to add a simple product and a virtual product to the shopping cart. You can find more details and examples in the following topics:
 
--  simple product
--  virtual product
--  configurable product
--  bundle product
--  downloadable product
+-  [Bundle products]({{ page.baseurl }}/graphql/mutations/add-bundle-products.html)
+-  [Configurable products]({{ page.baseurl }}/graphql/mutations/add-configurable-products.html)
+-  [Downloadable products]({{ page.baseurl }}/graphql/mutations/add-downloadable-products.html)
+-  [Simple and grouped products]({{ page.baseurl }}/graphql/mutations/add-simple-products.html)
+-  [Virtual products]({{ page.baseurl }}/graphql/mutations/add-virtual-products.html)
+
+[Product interface implementations]({{ page.baseurl }}/graphql/product/product-interface-implementations.html) also describes how to create queries that access product interfaces.
+
+Use the `updateCartItems` mutation to update shopping cart items and `removeItemFromCart` to remove a product from the shopping cart.
 
 {:.bs-callout-info}
 If you add a product to the shopping cart as a registered customer, be sure to send the customer's authorization token in the `Authorization` parameter of the header. See ["Get customer authorization token"]({{ page.baseurl }}/graphql/get-customer-authorization-token.html) for more details.
 
-`{ CART_ID }` is the unique shopping cart ID from [Step 2. Create empty cart]({{ page.baseurl }}/graphql/tutorials/checkout/checkout-add-product-to-cart.html).
-
 ## Add a simple product into the shopping cart
+
+`{ CART_ID }` is the unique shopping cart ID from [Step 2. Create empty cart]({{ page.baseurl }}/graphql/tutorials/checkout/checkout-add-product-to-cart.html).
 
 The following mutation adds a **simple product** into shopping cart.
 
 **Request:**
 
-```text
+```graphql
 mutation {
   addSimpleProductsToCart(
     input: {
@@ -91,7 +95,7 @@ The following mutation adds a **virtual product** into shopping cart.
 
 **Request:**
 
-```text
+```graphql
 mutation {
   addVirtualProductsToCart(
     input: {
@@ -142,16 +146,6 @@ mutation {
   }
 }
 ```
-
-### More details and examples for other product types can be found here:
-
--  [Simple Products]({{ page.baseurl }}/graphql/mutations/add-simple-products.html)
--  [Virtual Products]({{ page.baseurl }}/graphql/mutations/add-virtual-products.html)
--  [Configurable Products]({{ page.baseurl }}/graphql/mutations/add-configurable-products.html)
--  [Bundle Products]({{ page.baseurl }}/graphql/mutations/add-bundle-products.html)
--  [Downloadable Products]({{ page.baseurl }}/graphql/mutations/add-downloadable-products.html)
-
-Use the `updateCartItems` mutation to update shopping cart items and `removeItemFromCart` to remove a product from the shopping cart.
 
 ## Verify this step {#verify-step}
 

--- a/src/guides/v2.3/graphql/tutorials/checkout/checkout-add-product-to-cart.md
+++ b/src/guides/v2.3/graphql/tutorials/checkout/checkout-add-product-to-cart.md
@@ -144,6 +144,7 @@ mutation {
 ```
 
 ### More details and examples for other product types can be found here:
+
 -  [Simple Products]({{ page.baseurl }}/graphql/mutations/add-simple-products.html)
 -  [Virtual Products]({{ page.baseurl }}/graphql/mutations/add-virtual-products.html)
 -  [Configurable Products]({{ page.baseurl }}/graphql/mutations/add-configurable-products.html)


### PR DESCRIPTION
## Purpose of this pull request

This PR adds information which can help to find examples of how to add other types of product to a shopping cart via GraphQL (currently only simple and virtual products are mentioned).

## Affected DevDocs pages

https://devdocs.magento.com/guides/v2.3/graphql/tutorials/checkout/checkout-add-product-to-cart.html

