### PR TITLE
Custom Config Files Require Full or Relative Paths

### DIFF
--- a/src/guides/v2.3/migration/migration-tool-configure.md
+++ b/src/guides/v2.3/migration/migration-tool-configure.md
@@ -205,7 +205,7 @@ To use the mapping files:
 
 1. Copy them from `<your Magento 2 install dir>/vendor/magento/data-migration-tool/etc/<migration edition>/<ce or version>/` to `<your Magento 2 install dir>/app/code/Vendor/Migration/etc/<migration edition>/<ce or version>/` and remove the `.dist` [extension](https://glossary.magento.com/extension).
 
-1. Update the path to the new copied file in the `<options>` node of `config.xml`. The updated path should be a full file path (e.g., /path/to/copied-file.xml) or module `magento/data-migration-tool` install relative file path (e.g., etc/path/to/copied-file.xml). 
+1. Update the path to the new copied file in the `<options>` node of `config.xml`. The updated path should be a full file path (e.g., /path/to/copied-file.xml) or magento/data-migration-tool module relative file path (e.g., etc/path/to/copied-file.xml). 
 
 The `<your Magento 2 install dir>/vendor/magento/data-migration-tool/etc` and `<your Magento 2 install dir>/vendor/magento/data-migration-tool/etc/<ce version>` directories contain the following configuration files:
 

--- a/src/guides/v2.3/migration/migration-tool-configure.md
+++ b/src/guides/v2.3/migration/migration-tool-configure.md
@@ -205,7 +205,7 @@ To use the mapping files:
 
 1. Copy them from `<your Magento 2 install dir>/vendor/magento/data-migration-tool/etc/<migration edition>/<ce or version>/` to `<your Magento 2 install dir>/app/code/Vendor/Migration/etc/<migration edition>/<ce or version>/` and remove the `.dist` [extension](https://glossary.magento.com/extension).
 
-1. Update the path to the new copied file in the `<options>` node of `config.xml`. The updated path should be a full file path: `/path/to/copied-file.xml` or a magento/data-migration-tool module relative file path: `etc/path/to/copied-file.xml`.
+1. Update the path to the new copied file in the `<options>` node of `config.xml`. The updated path should be a full file path: `/path/to/copied/config.xml` or a magento/data-migration-tool module relative file path: `etc/path/to/copied/config.xml`.
 
 The `<your Magento 2 install dir>/vendor/magento/data-migration-tool/etc` and `<your Magento 2 install dir>/vendor/magento/data-migration-tool/etc/<ce version>` directories contain the following configuration files:
 

--- a/src/guides/v2.3/migration/migration-tool-configure.md
+++ b/src/guides/v2.3/migration/migration-tool-configure.md
@@ -205,7 +205,7 @@ To use the mapping files:
 
 1. Copy them from `<your Magento 2 install dir>/vendor/magento/data-migration-tool/etc/<migration edition>/<ce or version>/` to `<your Magento 2 install dir>/app/code/Vendor/Migration/etc/<migration edition>/<ce or version>/` and remove the `.dist` [extension](https://glossary.magento.com/extension).
 
-1. Change the file name in the `<options>` node in the `config.xml` file to the new name of the file.
+1. Change the file path in the `<options>` node in the `config.xml` file to the new file by providing a full (/path/to/file.xml) or magento install directory relative (vendor/package/module/etc/file.xml) file path.
 
 The `<your Magento 2 install dir>/vendor/magento/data-migration-tool/etc` and `<your Magento 2 install dir>/vendor/magento/data-migration-tool/etc/<ce version>` directories contain the following configuration files:
 

--- a/src/guides/v2.3/migration/migration-tool-configure.md
+++ b/src/guides/v2.3/migration/migration-tool-configure.md
@@ -205,7 +205,7 @@ To use the mapping files:
 
 1. Copy them from `<your Magento 2 install dir>/vendor/magento/data-migration-tool/etc/<migration edition>/<ce or version>/` to `<your Magento 2 install dir>/app/code/Vendor/Migration/etc/<migration edition>/<ce or version>/` and remove the `.dist` [extension](https://glossary.magento.com/extension).
 
-1. Update the path to the new copied file in the `<options>` node of `config.xml`. The updated path should be a full file path (e.g., /path/to/copied-file.xml) or magento/data-migration-tool module relative file path (e.g., etc/path/to/copied-file.xml). 
+1. Update the path to the new copied file in the `<options>` node of `config.xml`. The updated path should be a full file path: `/path/to/copied-file.xml` or a magento/data-migration-tool module relative file path: `etc/path/to/copied-file.xml`.
 
 The `<your Magento 2 install dir>/vendor/magento/data-migration-tool/etc` and `<your Magento 2 install dir>/vendor/magento/data-migration-tool/etc/<ce version>` directories contain the following configuration files:
 

--- a/src/guides/v2.3/migration/migration-tool-configure.md
+++ b/src/guides/v2.3/migration/migration-tool-configure.md
@@ -205,7 +205,7 @@ To use the mapping files:
 
 1. Copy them from `<your Magento 2 install dir>/vendor/magento/data-migration-tool/etc/<migration edition>/<ce or version>/` to `<your Magento 2 install dir>/app/code/Vendor/Migration/etc/<migration edition>/<ce or version>/` and remove the `.dist` [extension](https://glossary.magento.com/extension).
 
-1. Change the file path in the `<options>` node in the `config.xml` file to the new file by providing a full (/path/to/file.xml) or magento install directory relative (vendor/package/module/etc/file.xml) file path.
+1. Update the path to the new copied file in the `<options>` node of `config.xml`. The updated path should be a full file path (e.g., /path/to/copied-file.xml) or module `magento/data-migration-tool` install relative file path (e.g., etc/path/to/copied-file.xml). 
 
 The `<your Magento 2 install dir>/vendor/magento/data-migration-tool/etc` and `<your Magento 2 install dir>/vendor/magento/data-migration-tool/etc/<ce version>` directories contain the following configuration files:
 


### PR DESCRIPTION
When defining custom config files within a custom Migration Module used to extend the migration tool, it is not enough to just remove the '.dist' extension. You must provide a full path or path relative to the Magento install directory. 

- Issue: magento/data-migration-tool/issues/757 
-  File: https://github.com/magento/data-migration-tool/commit/e80bddf8c00d1ef946745acb89b5fe3538ca4eb9

## Purpose of this pull request

To provide further clarification on what value to provide within a custom module for a custom configuration file. It seems that some type of fallback mechanism is not used to load custom configuration files. 

## Affected DevDocs pages

<!-- REQUIRED List the affected pages on devdocs.magento.com (URLs). Not needed for large numbers of files. -->

-  https://devdocs.magento.com/guides/v2.3/migration/migration-tool-configure.html

## Links to Magento source code

<!--  OPTIONAL - REMOVE THIS SECTION IF NOT USED. If this pull request references a file in a Magento codebase repository, add it here. -->

-  https://github.com/magento/data-migration-tool/commit/e80bddf8c00d1ef946745acb89b5fe3538ca4eb9

<!--
If you are fixing a GitHub issue, note it using GitHub keyword format (https://help.github.com/en/articles/closing-issues-using-keywords#closing-an-issue-in-a-different-repository) to close the issue when this pull request is merged. Example: `Fixes #1234`

`master` is the default branch. Merged pull requests to `master` go live on the site automatically. Any requested changes to content on the `master` branch must be related to the released codebase. Any content related to future releases goes in the `develop` branch.

See Contribution guidelines (https://github.com/magento/devdocs/blob/master/.github/CONTRIBUTING.md) for more information.
-->
