### PR TITLE
Wrong widget's template output

### DIFF
--- a/src/guides/v2.3/ext-best-practices/tutorials/custom-widget.md
+++ b/src/guides/v2.3/ext-best-practices/tutorials/custom-widget.md
@@ -153,7 +153,7 @@ And finally, create the template that will be used for showing the widget's data
 <?php
 /** \OrangeCompany\Learning\Block\Widget\Test $block */
 ?>
-<h3><?= $block->escapeHtml($block->getData('label')) ?></h3>
+<h3><?= $block->escapeHtml($block->getData('title')) ?></h3>
 <h3><?= $block->escapeHtml(__('Size:')) ?> <?= $block->escapeHtml($block->getData('size')) ?></h3>
 ```
 


### PR DESCRIPTION
## Purpose of this pull request
This pull request (PR) fixes title in widget's template

## Affected DevDocs pages
-  https://devdocs.magento.com/guides/v2.3/ext-best-practices/tutorials/custom-widget.html