### PR TITLE
Fixed wrong texts with unexisting links

### DIFF
--- a/src/guides/v2.3/extension-dev-guide/intro/developers_roadmap.md
+++ b/src/guides/v2.3/extension-dev-guide/intro/developers_roadmap.md
@@ -23,7 +23,4 @@ To satisfy the minimum required elements for creating or customizing your Magent
 
 *  Distribute your component:
    *  [Package your component]({{ page.baseurl }}/extension-dev-guide/package/package_module.html) in `.zip` format.
-
-      Use our [validation tool](https://github.com/magento/marketplace-tools){:target="_blank"} to check your package before you distribute it.
-
    *  If you upload the component to Magento Marketplace, it should be less than 30MB in size.

--- a/src/guides/v2.3/extension-dev-guide/package/package.md
+++ b/src/guides/v2.3/extension-dev-guide/package/package.md
@@ -10,5 +10,4 @@ menu_node: parent
 Use [Composer](https://getcomposer.org/) to package your [module](https://glossary.magento.com/module).
 
 *  [Using Composer to package a Magento 2 module](package_module.html)
-*  Use our [validation tool](https://github.com/magento/marketplace-tools){:target="_blank"} to check your package before you distribute it.
 *  *Distribution on Magento Marketplace only*. [Upload your package to the Magento Marketplace](http://docs.magento.com/marketplace/user_guide/getting-started.html){:target="_blank"}

--- a/src/guides/v2.3/extension-dev-guide/package/package_module.md
+++ b/src/guides/v2.3/extension-dev-guide/package/package_module.md
@@ -16,8 +16,6 @@ To package a component, you must:
 *  Register the component using `registration.php`
 *  Package and publish your component.
 
-    Use our [validation tool](https://github.com/magento/marketplace-tools){:target="_blank"} to check your package before you distribute it.
-
 ## Create a Magento Composer file {#composer}
 
 The Magento `composer.json` file defines the name, requirements, version, and other basic information about the component. This file must be placed in the root directory of the [module](https://glossary.magento.com/module).

--- a/src/guides/v2.3/extension-dev-guide/prepare/dev-summary.md
+++ b/src/guides/v2.3/extension-dev-guide/prepare/dev-summary.md
@@ -8,9 +8,6 @@ To develop your component, use the following steps:
 1. Learn about [using Composer with your component]({{ page.baseurl }}/extension-dev-guide/build/composer-integration.html).
 1. [Build your component]({{ page.baseurl }}/extension-dev-guide/build/build.html){:target="_blank"}
 1. [Package a component]({{ page.baseurl }}/extension-dev-guide/package/package_module.html){:target="_blank"}
-
-   Use our [validation tool](https://github.com/magento/marketplace-tools){:target="_blank"} to check your package before you distribute it.
-
 1. [Validate your component]({{ page.baseurl }}/extension-dev-guide/validate/test-module.html)
 1. Upload the components to the Magento Marketplace.
 


### PR DESCRIPTION
## Purpose of this pull request

This pull request (PR) This PR removes messages that propose to use the unexisting tool.

## Affected DevDocs pages

<!-- REQUIRED List the affected pages on devdocs.magento.com (URLs). Not needed for large numbers of files. -->

- [Roadmap for developing and packaging components](https://devdocs.magento.com/guides/v2.3/extension-dev-guide/prepare/dev-summary.html);
- [Package a component](https://devdocs.magento.com/guides/v2.3/extension-dev-guide/package/package_module.html);
- [Package](https://devdocs.magento.com/guides/v2.3/extension-dev-guide/package/package.html);
- [Developer roadmap](https://devdocs.magento.com/guides/v2.3/extension-dev-guide/intro/developers_roadmap.html).

### Fixed Issues (if relevant)

1. magento/devdocs#6684: Remove 404 links to MarketPlace tools repo

<!--
If you are fixing a GitHub issue, note it using GitHub keyword format (https://help.github.com/en/articles/closing-issues-using-keywords#closing-an-issue-in-a-different-repository) to close the issue when this pull request is merged. Example: `Fixes #1234`

`master` is the default branch. Merged pull requests to `master` go live on the site automatically. Any requested changes to content on the `master` branch must be related to the released codebase. Any content related to future releases goes in the `develop` branch.

See Contribution guidelines (https://github.com/magento/devdocs/blob/master/.github/CONTRIBUTING.md) for more information.
-->
