### PR TITLE
GraphQL: replace region attribute

### DIFF
--- a/src/_includes/graphql/cart-address-input.md
+++ b/src/_includes/graphql/cart-address-input.md
@@ -1,12 +1,20 @@
 Attribute |  Data Type | Description
 --- | --- | ---
+`address_region` | CartAddressRegionInput | An object containing the region label and code
 `city` | String! | The city specified for the billing or shipping address
 `company` | String | The company specified for the billing or shipping address
 `country_code` | String! | The country code and label for the billing or shipping address
 `firstname` | String! | The customer's first name
 `lastname` | String! | The customer's last name
 `postcode` | String | The postal code for the billing or shipping address
-`region` | String | The region code and label for the billing or shipping address
+`region` | String | Deprecated. Use `address_region` instead. The region code and label for the billing or shipping address
 `save_in_address_book` | Boolean! | Specifies whether to save the address (`True`/`False`)
 `street` | [String]! | An array containing the street for the billing or shipping address
 `telephone` | String | The telephone number for the billing or shipping address
+
+### CartAddressRegionInput
+
+Attribute |  Data Type | Description
+--- | --- | ---
+`code` | String | A code representing the state or province
+`label` | String | The state or province name

--- a/src/guides/v2.3/graphql/mutations/set-billing-address.md
+++ b/src/guides/v2.3/graphql/mutations/set-billing-address.md
@@ -29,7 +29,10 @@ mutation {
           company: "Magento"
           street: ["Magento Pkwy", "Main Street"]
           city: "Austin"
-          region: "TX"
+          address_region: {
+            code: "TX"
+            label: "Texas"
+          }
           postcode: "78758"
           country_code: "US"
           telephone: "8675309"

--- a/src/guides/v2.3/graphql/mutations/set-shipping-address.md
+++ b/src/guides/v2.3/graphql/mutations/set-shipping-address.md
@@ -31,7 +31,10 @@ mutation {
             company: "Magento"
             street: ["Magento Pkwy", "Main Street"]
             city: "Austin"
-            region: "TX"
+            address_region: {
+              code: "TX"
+              label: "Texas"
+            }
             postcode: "78758"
             country_code: "US"
             telephone: "8675309"

--- a/src/guides/v2.3/graphql/tutorials/checkout/checkout-shipping-address.md
+++ b/src/guides/v2.3/graphql/tutorials/checkout/checkout-shipping-address.md
@@ -44,7 +44,10 @@ mutation {
             company: "Company Name"
             street: ["320 N Crescent Dr", "Beverly Hills"]
             city: "Los Angeles"
-            region: "CA"
+            address_region: {
+              code: "CA"
+              label: "California"
+            }
             postcode: "90210"
             country_code: "US"
             telephone: "123-456-0000"


### PR DESCRIPTION
## Purpose of this pull request

This pull request (PR) replaces the `region` attribute in the setShippingAddressesOnCart and setBillingAddressesOnCart mutations per internal ticket MC-30886.

## Affected DevDocs pages

https://devdocs.magento.com/guides/v2.3/graphql/mutations/set-billing-address.html
https://devdocs.magento.com/guides/v2.3/graphql/mutations/set-shipping-address.html
https://devdocs.magento.com/guides/v2.3/graphql/tutorials/checkout/checkout-shipping-address.html

## Links to Magento source code

<!--  OPTIONAL - REMOVE THIS SECTION IF NOT USED. If this pull request references a file in a Magento codebase repository, add it here. -->

-  ...

<!--
If you are fixing a GitHub issue, note it using GitHub keyword format (https://help.github.com/en/articles/closing-issues-using-keywords#closing-an-issue-in-a-different-repository) to close the issue when this pull request is merged. Example: `Fixes #1234`

`master` is the default branch. Merged pull requests to `master` go live on the site automatically. Any requested changes to content on the `master` branch must be related to the released codebase. Any content related to future releases goes in the `develop` branch.

See Contribution guidelines (https://github.com/magento/devdocs/blob/master/.github/CONTRIBUTING.md) for more information.
-->
