### PR TITLE
Add warning about not changing Cloud app name

### DIFF
--- a/src/cloud/project/project-conf-files_magento-app.md
+++ b/src/cloud/project/project-conf-files_magento-app.md
@@ -20,8 +20,8 @@ Use the following properties to build your application configuration file. The `
 
 The name is used in the [`routes.yaml`]({{ site.baseurl }}/cloud/project/project-conf-files_routes.html) file to define the HTTP upstream (by default, `php:http`). For example, if the value of `name` is `app`, you must use `app:http` in the upstream field. You can also use this name in multi-application relationships.
 
-{:.bs-callout-info}
-Do not change the name of an application after it has been deployed.
+{:.bs-callout-warning}
+Do not change the name of an application after it has been deployed. Doing so will result in data loss. 
 
 ### `type` and `build`
 


### PR DESCRIPTION
Fixes #6697 .

## Purpose of this pull request

Updated the instructions in the `.magento.app.yaml` to warn customers that changing the name of a deployed app results in data loss.

## Affected DevDocs pages

- https://devdocs.magento.com/cloud/project/project-conf-files_magento-app.html