### PR TITLE
Updating output attribute in place order mutation output object

### DIFF
--- a/src/guides/v2.3/graphql/mutations/place-order.md
+++ b/src/guides/v2.3/graphql/mutations/place-order.md
@@ -73,7 +73,7 @@ Attribute |  Data Type | Description
 
 Attribute |  Data Type | Description
 --- | --- | ---
-`order_id` | String! | Deprecated. Use order_number instead. The unique ID that identifies the order
+`order_id` | String! | Deprecated. Use `order_number` instead. The unique ID that identifies the order
 `order_number` | String | The unique ID that identifies the order
 
 ## Errors

--- a/src/guides/v2.3/graphql/mutations/place-order.md
+++ b/src/guides/v2.3/graphql/mutations/place-order.md
@@ -73,7 +73,7 @@ Attribute |  Data Type | Description
 
 Attribute |  Data Type | Description
 --- | --- | ---
-`order_id` |String! | Deprecated.Use order_number instead.The unique ID that identifies the order
+`order_id` | String! | Deprecated. Use order_number instead. The unique ID that identifies the order
 `order_number`| String | The unique ID that identifies the order
 
 ## Errors

--- a/src/guides/v2.3/graphql/mutations/place-order.md
+++ b/src/guides/v2.3/graphql/mutations/place-order.md
@@ -73,8 +73,8 @@ Attribute |  Data Type | Description
 
 Attribute |  Data Type | Description
 --- | --- | ---
-`order_id` String | The unique ID that identifies the order
-`order_number` String | The unique ID that identifies the order
+`order_id` |String! | Deprecated.Use order_number instead.The unique ID that identifies the order
+`order_number`| String | The unique ID that identifies the order
 
 ## Errors
 

--- a/src/guides/v2.3/graphql/mutations/place-order.md
+++ b/src/guides/v2.3/graphql/mutations/place-order.md
@@ -74,7 +74,7 @@ Attribute |  Data Type | Description
 Attribute |  Data Type | Description
 --- | --- | ---
 `order_id` | String! | Deprecated. Use order_number instead. The unique ID that identifies the order
-`order_number`| String | The unique ID that identifies the order
+`order_number` | String | The unique ID that identifies the order
 
 ## Errors
 


### PR DESCRIPTION
## Purpose of this pull request

This pull request (PR) updates order_id which is deprecated in outupt object of place order mutation in graphql

## Affected DevDocs pages

<!-- REQUIRED List the affected pages on devdocs.magento.com (URLs). Not needed for large numbers of files. -->

- https://devdocs.magento.com/guides/v2.3/graphql/mutations/place-order.html

## Links to Magento source code

<!--  OPTIONAL - REMOVE THIS SECTION IF NOT USED. If this pull request references a file in a Magento codebase repository, add it here. -->

- https://github.com/magento/magento2/blob/a3c2af0498d21e3f689bc8dd690d7c633a025276/app/code/Magento/QuoteGraphQl/etc/schema.graphqls#L367
