### PR TITLE
Removing deprecated region_id from createCustomerAddress Mutation

### DIFF
--- a/src/guides/v2.3/graphql/mutations/create-customer-address.md
+++ b/src/guides/v2.3/graphql/mutations/create-customer-address.md
@@ -37,7 +37,6 @@ mutation {
     id
     region {
       region
-      region_id
       region_code
     }
     country_code


### PR DESCRIPTION
## Purpose of this pull request

This pull request (PR) removes deprecated region_id from the createCustomerAddress Mutation.As you can see in this page(https://devdocs.magento.com/guides/v2.3/graphql/mutations/create-customer-address.html) the region_id is used in request output but not showed in response.Also it creates confusion,because  to create customer addres there is no need to know or want region_id.

## Affected DevDocs pages

<!-- REQUIRED List the affected pages on devdocs.magento.com (URLs). Not needed for large numbers of files. -->

- https://devdocs.magento.com/guides/v2.3/graphql/mutations/create-customer-address.html

## Links to Magento source code

<!--  OPTIONAL - REMOVE THIS SECTION IF NOT USED. If this pull request references a file in a Magento codebase repository, add it here. -->

-  https://github.com/magento/magento2/blob/a3c2af0498d21e3f689bc8dd690d7c633a025276/app/code/Magento/CustomerGraphQl/etc/schema.graphqls#L129
