### PR TITLE
MAGECLOUD-4890  Implement support for backup databases from split connections for `ece-tools`

### DIFF
--- a/src/cloud/project/project-webint-snap.md
+++ b/src/cloud/project/project-webint-snap.md
@@ -122,7 +122,7 @@ By default, this command creates backups for all database connections that are s
 You can also backup only selected databases by appending the database names to the command, for example:
 
 ```bash
-vendor/bin/ece-tools -- main sales
+php vendor/bin/ece-tools -- main sales
 
 For help, use the command: ```php vendor/bin/ece-tools db-dump --help ```
 

--- a/src/cloud/project/project-webint-snap.md
+++ b/src/cloud/project/project-webint-snap.md
@@ -117,6 +117,10 @@ To restore a snapshot using the Magento CLI:
 ## Dump your database {#db-dump}
 
 You can create a copy of your database using [`magento/ece-tools`]({{ site.baseurl }}/cloud/reference/cloud-composer.html#ece-tools).
+By default, the command creates backups using all the connections to the databases that are available through the environment configuration. That is, if split databases are used, by default backup copies will be created for these databases
+If you need to create backups by selecting one or more databases, for this you need to transfer the database names as an argument to the console command
+
+For help, use the command: ```php vendor/bin/ece-tools db-dump --help ```
 
 {:.procedure}
 To create a database dump:
@@ -140,7 +144,7 @@ To create a database dump:
  {:.bs-callout-info}
 
 -  We recommend putting the application in maintenance mode before doing a database dump in Production environments.
--  The command creates an archive in your local project directory called  `dump-<timestamp>.sql.gz`.
+-  The command creates an archive in your local project directory called  `dump-<label><timestamp>.sql.gz`.
 -  If an error occurs during the dump, the command deletes the dump file to conserve disk space. Review the logs for details (`var/log/cloud.log`).
 -  For Pro Production environments, this command dumps only from one of three high-availability nodes, so production data written to a different node during the dump may not be copied. It generates a `var/dbdump.lock` file to prevent running the command on more than one node.
 

--- a/src/cloud/project/project-webint-snap.md
+++ b/src/cloud/project/project-webint-snap.md
@@ -164,7 +164,7 @@ To create a database dump:
  {:.bs-callout-info}
 
 -  We recommend putting the application in maintenance mode before doing a database dump in Production environments.
--  This command creates an archive file for each database backup with the file name pattern `dump-<label><timestamp>.sql.gz` where  _label_ is replaced with the database name.  The archive files are available in your local project directory.
+-  This command creates an archive file for each database backup with the file name pattern `dump-<label><timestamp>.sql.gz` where  _label_ is replaced with the database name.  The archive files are saved to your remote project directory, and the path to each file is listed in the command output.
 -  If an error occurs during the dump, the command deletes any dump files to conserve disk space. Review the logs for details (`var/log/cloud.log`).
 -  For Pro Production environments, this command dumps only from one of three high-availability nodes, so production data written to a different node during the dump may not be copied. It generates a `var/dbdump.lock` file to prevent running the command on more than one node.
 

--- a/src/cloud/project/project-webint-snap.md
+++ b/src/cloud/project/project-webint-snap.md
@@ -146,7 +146,7 @@ To create a database dump:
 
 -  We recommend putting the application in maintenance mode before doing a database dump in Production environments.
 -  This command creates an archive file for each database backup with the file name pattern `dump-<label><timestamp>.sql.gz` where  _label_ is replaced with the database name.  The archive files are available in your local project directory.
--  If an error occurs during the dump, the command deletes the dump file to conserve disk space. Review the logs for details (`var/log/cloud.log`).
+-  If an error occurs during the dump, the command deletes any dump files to conserve disk space. Review the logs for details (`var/log/cloud.log`).
 -  For Pro Production environments, this command dumps only from one of three high-availability nodes, so production data written to a different node during the dump may not be copied. It generates a `var/dbdump.lock` file to prevent running the command on more than one node.
 
 {:.bs-callout-tip}

--- a/src/cloud/project/project-webint-snap.md
+++ b/src/cloud/project/project-webint-snap.md
@@ -145,7 +145,7 @@ To create a database dump:
  {:.bs-callout-info}
 
 -  We recommend putting the application in maintenance mode before doing a database dump in Production environments.
--  The command creates an archive in your local project directory called  `dump-<label><timestamp>.sql.gz`.
+-  This command creates an archive file for each database backup with the file name pattern `dump-<label><timestamp>.sql.gz` where  _label_ is replaced with the database name.  The archive files are available in your local project directory.
 -  If an error occurs during the dump, the command deletes the dump file to conserve disk space. Review the logs for details (`var/log/cloud.log`).
 -  For Pro Production environments, this command dumps only from one of three high-availability nodes, so production data written to a different node during the dump may not be copied. It generates a `var/dbdump.lock` file to prevent running the command on more than one node.
 

--- a/src/cloud/project/project-webint-snap.md
+++ b/src/cloud/project/project-webint-snap.md
@@ -119,7 +119,10 @@ To restore a snapshot using the Magento CLI:
 You can create a copy of your database using the [`magento/ece-tools`]({{ site.baseurl }}/cloud/reference/cloud-composer.html#ece-tools) `db-dump` command.
 
 By default, this command creates backups for all database connections that are specified in the environment configuration. For example, if you configured your project to use split databases, the `db-dump` operation creates backups for each of the configured databases.
-If you need to create backups by selecting one or more databases, for this you need to transfer the database names as an argument to the console command
+You can also backup only selected databases by appending the database names to the command, for example:
+
+```bash
+vendor/bin/ece-tools -- main sales
 
 For help, use the command: ```php vendor/bin/ece-tools db-dump --help ```
 

--- a/src/cloud/project/project-webint-snap.md
+++ b/src/cloud/project/project-webint-snap.md
@@ -116,8 +116,9 @@ To restore a snapshot using the Magento CLI:
 
 ## Dump your database {#db-dump}
 
-You can create a copy of your database using [`magento/ece-tools`]({{ site.baseurl }}/cloud/reference/cloud-composer.html#ece-tools).
-By default, the command creates backups using all the connections to the databases that are available through the environment configuration. That is, if split databases are used, by default backup copies will be created for these databases
+You can create a copy of your database using the [`magento/ece-tools`]({{ site.baseurl }}/cloud/reference/cloud-composer.html#ece-tools) `db-dump` command.
+
+By default, this command creates backups for all database connections that are specified in the environment configuration. For example, if you configured your project to use split databases, the `db-dump` operation creates backups for each of the configured databases.
 If you need to create backups by selecting one or more databases, for this you need to transfer the database names as an argument to the console command
 
 For help, use the command: ```php vendor/bin/ece-tools db-dump --help ```

--- a/src/cloud/project/project-webint-snap.md
+++ b/src/cloud/project/project-webint-snap.md
@@ -139,7 +139,23 @@ To create a database dump:
 1. Enter the following command:
 
     ```bash
-    vendor/bin/ece-tools db-dump
+    php vendor/bin/ece-tools db-dump
+    ```
+
+    ```terminal
+    php vendor/bin/ece-tools db-dump
+    The db-dump operation switches the site to maintenance mode, stops all active cron jobs and consumer queue processes, and     disables cron jobs before starting the the dump process.
+    Your site will not receive any traffic until the operation completes.
+    Do you wish to proceed with this process? (y/N)? y
+    2020-01-28 16:38:08] INFO: Starting backup.
+    [2020-01-28 16:38:08] NOTICE: Enabling Maintenance mode
+    [2020-01-28 16:38:10] INFO: Trying to kill running cron jobs and consumers processes
+    [2020-01-28 16:38:10] INFO: Running Magento cron and consumers processes were not found.
+    [2020-01-28 16:38:10] INFO: Waiting for lock on db dump.
+    [2020-01-28 16:38:10] INFO: Start creation DB dump for main database...
+    [2020-01-28 16:38:10] INFO: Finished DB dump for main database, it can be found here: /tmp/qxmtlseakof6y/dump-main-1580229490.sql.gz
+    [2020-01-28 16:38:10] INFO: Backup completed.
+    [2020-01-28 16:38:11] NOTICE: Maintenance mode is disabled.
     ```
 
  {:.bs-callout-info}


### PR DESCRIPTION
## Purpose of this pull request
Added information about using the CLI `ece-tools db-dump`
## Affected DevDocs pages
https://devdocs.magento.com/cloud/project/project-webint-snap.html
<!--
If you are fixing a GitHub issue, note it using GitHub keyword format (https://help.github.com/en/articles/closing-issues-using-keywords#closing-an-issue-in-a-different-repository) to close the issue when this pull request is merged. Example: `Fixes #1234`

`master` is the default branch. Merged pull requests to `master` go live on the site automatically. Any requested changes to content on the `master` branch must be related to the released codebase. Any content related to future releases goes in the `develop` branch.

See Contribution guidelines (https://github.com/magento/devdocs/blob/master/.github/CONTRIBUTING.md) for more information.
-->
