### PR TITLE
local-themes.js changed to themes.js

### DIFF
--- a/src/guides/v2.3/frontend-dev-guide/css-topics/css_debug.md
+++ b/src/guides/v2.3/frontend-dev-guide/css-topics/css_debug.md
@@ -44,7 +44,7 @@ To compile `.less` files, add your theme to `module.exports` in the Grunt config
    npm update
    ```
 
-1. Add your [theme](https://glossary.magento.com/theme) to Grunt configuration. To do this, in the `dev/tools/grunt/configs/local-themes.js` file, add your theme to `module.exports` like following:
+1. Add your [theme](https://glossary.magento.com/theme) to Grunt configuration. To do this, in the `dev/tools/grunt/configs/themes.js` file, add your theme to `module.exports` like following:
 
    ```javascript
    <theme>: {


### PR DESCRIPTION
## Purpose of this pull request

This pull request (PR) ...

As earlier, In Devdocs mentioned themes.js

![screenshot-devdocs magento com-2020 03 03-16_58_37](https://user-images.githubusercontent.com/33890083/75771683-7e9a8e80-5d70-11ea-8f4d-1918f37020f5.png)

local-themes.js changed **themes.js**

## Affected DevDocs pages

https://devdocs.magento.com/guides/v2.3/frontend-dev-guide/css-topics/css_debug.html
