### PR TITLE
Small grammar updates

### DIFF
--- a/src/guides/v2.3/howdoi/checkout/checkout_payment.md
+++ b/src/guides/v2.3/howdoi/checkout/checkout_payment.md
@@ -159,7 +159,7 @@ This configuration is stored in the `window.checkoutConfig` variable that is def
 
 In order to get access to the system configuration, your payment method or a group of payment methods has to implement the [`\Magento\Checkout\Model\ConfigProviderInterface`]({{ site.mage2bloburl }}/{{ page.guide_version }}/app/code/Magento/Checkout/Model/ConfigProviderInterface.php) interface, and the class implementing it must be injected to the composite config provider via DI [frontend](https://glossary.magento.com/frontend) configuration. The following code samples illustrate this.
 
-A sample `.php` class implementing `\Magento\Checkout\Model\ConfigProviderInterface`:
+This is a sample `.php` file implementing `\Magento\Checkout\Model\ConfigProviderInterface`:
 
 ```php?start_inline=1
 class MyCustomPaymentConfigProvider implements \Magento\Checkout\Model\ConfigProviderInterface
@@ -175,7 +175,7 @@ class MyCustomPaymentConfigProvider implements \Magento\Checkout\Model\ConfigPro
 }
 ```
 
-A sample DI configuration file of a custom module `<your_module_dir>/etc/frontend/di.xml`:
+Here is the associated sample DI configuration file of a custom module `<your_module_dir>/etc/frontend/di.xml`:
 
 ```xml
 ...

--- a/src/guides/v2.3/javascript-dev-guide/javascript/requirejs.md
+++ b/src/guides/v2.3/javascript-dev-guide/javascript/requirejs.md
@@ -52,7 +52,7 @@ You can also use the `map` configuration to override a JS module with a custom J
 
 ### paths {#requirejs-config-paths}
 
-The `paths` configuration, similar to `map`, is used for aliasing not just any real AMD module that calls `define()`, but also any JS file (event from a URL), HTML templates, etc. Magento uses this to alias URLs and third party libraries.
+The `paths` configuration, similar to `map`, is used for aliasing not just any real AMD module that calls `define()`, but also any JS file (even from a URL), HTML templates, etc. Magento uses this to alias URLs and third party libraries.
 
 ```javascript
 paths: {
@@ -95,7 +95,7 @@ shim: {
 
 ### mixins {#requirejs-config-mixin}
 
-The `mixins` configuration is used to overwrite component methods of an AMD module which returns either a UI component,a jQuery widget, or a JS object. Unlike the above configuration properties, the `mixins` property is under the `config` property, apart from the parent object called **config**.
+The `mixins` configuration is used to overwrite component methods of an AMD module which returns either a UI component, a jQuery widget, or a JS object. Unlike the above configuration properties, the `mixins` property is under the `config` property, apart from the parent object called **config**.
 
 In this snippet, `Vendor_Module/js/module-mixin` will overwrite the existing component methods in `Vendor_Module/js/module` with the specified component methods. It is a convention to name the mixin by appending a `-mixin` to the original `path/to/js`, although not required.
 


### PR DESCRIPTION
## Purpose of this pull request

This pull request (PR) fixes some grammar on the checkout JS and require JS pages.

## Affected DevDocs pages

- https://devdocs.magento.com/guides/v2.3/howdoi/checkout/checkout_payment.html
- https://devdocs.magento.com/guides/v2.3/javascript-dev-guide/javascript/requirejs.html


<!--
If you are fixing a GitHub issue, note it using GitHub keyword format (https://help.github.com/en/articles/closing-issues-using-keywords#closing-an-issue-in-a-different-repository) to close the issue when this pull request is merged. Example: `Fixes #1234`

`master` is the default branch. Merged pull requests to `master` go live on the site automatically. Any requested changes to content on the `master` branch must be related to the released codebase. Any content related to future releases goes in the `develop` branch.

See Contribution guidelines (https://github.com/magento/devdocs/blob/master/.github/CONTRIBUTING.md) for more information.
-->
