### PR TITLE
Remove Marketplace User Guide from federated search

### DIFF
--- a/src/_includes/layout/header-scripts.html
+++ b/src/_includes/layout/header-scripts.html
@@ -30,11 +30,6 @@
       baseUrl: "https://docs.magento.com/mbi"
     },
     {
-      label: "Marketplace User Guide",
-      name: "merchdocs-marketplace",
-      baseUrl: "https://docs.magento.com/marketplace/user_guide"
-    },
-    {
       label: "PWA",
       name: "pwa-devdocs",
       baseUrl: "https://magento.github.io/pwa-studio"


### PR DESCRIPTION
## Purpose of this pull request

With the migration of Marketplace User Guide content to DevDocs and the Magento User Guide, it should not be a property in the federated search.

## Affected DevDocs pages

N/A

