### PR TITLE
New topic for filter orders through API endpoint totorial

### DIFF
--- a/src/_data/toc/rest-api.yml
+++ b/src/_data/toc/rest-api.yml
@@ -99,6 +99,11 @@ pages:
         url: /rest/tutorials/orders/order-intro.html
         include_versions: ["2.1", "2.2", "2.3"]
 
+      - label: Filter orders
+        class: tutorial
+        url: /rest/tutorials/orders/filter-orders.html
+        include_versions: [2.3"]
+
       - label: Order processing with Inventory Management
         class: tutorial
         url: /rest/tutorials/inventory/index.html

--- a/src/guides/v2.3/rest/tutorials/orders/filter-orders.md
+++ b/src/guides/v2.3/rest/tutorials/orders/filter-orders.md
@@ -1,0 +1,72 @@
+---
+layout: tutorial
+group: rest-api
+title: Step 11. Filter orders.
+subtitle: Order processing tutorial
+contributor_name: Ziffity
+contributor_link: https://www.Ziffity.com/
+return_to:
+  title: REST tutorials
+  url: rest/tutorials/index.html
+menu_order: 11
+level3_subgroup: order-tutorial
+redirect_from:
+  - /guides/v2.3/get-started/order-tutorial/filter-orders.html
+functional_areas:
+  - Integration
+  - Orders
+  - Sales
+---
+
+We can filter orders by attributes using REST Api endpoints. Here I take one example, filtering orders by attribute `status`.
+
+**Endpoint:**
+
+`GET <host>/rest/<store_code>/V1/orders/`
+
+**Headers:**
+
+`Content-Type` `application/json`
+
+`Authorization` `Bearer <administrator token>`
+
+**Params**
+
+Param | Value | Description
+--- | --- | ---
+searchCriteria[filter_groups][0][filters][0][field] | status | Attribute name to filter
+searchCriteria[filter_groups][0][filters][0][value] | pending | Attribute value to filter
+fields | items[increment_id,entity_id] | Attributes needs to be return as response
+
+**Payload:**
+
+Not applicable
+
+**Response:**
+
+```json
+{
+    "items": [
+        {
+            "entity_id": 13403,
+            "increment_id": "WA0013403"
+        },
+        {
+            "entity_id": 2490,
+            "increment_id": "WA0002490"
+        },
+        {
+            "entity_id": 925,
+            "increment_id": "WA0000925"
+        }
+    ]
+}
+```
+
+### Verify this step {#verify-step}
+
+1. Log in to [Admin](https://glossary.magento.com/admin). Click **Sales** > **Orders**. Filter orders grid by attribute status = 'pending'. Verify the data is same as we get in API response.
+
+
+
+

--- a/src/guides/v2.3/rest/tutorials/orders/filter-orders.md
+++ b/src/guides/v2.3/rest/tutorials/orders/filter-orders.md
@@ -48,16 +48,16 @@ Not applicable
 {
     "items": [
         {
-            "entity_id": 13403,
-            "increment_id": "WA0013403"
+            "entity_id": 13123,
+            "increment_id": "WA0013123"
         },
         {
-            "entity_id": 2490,
-            "increment_id": "WA0002490"
+            "entity_id": 2440,
+            "increment_id": "WA0002440"
         },
         {
-            "entity_id": 925,
-            "increment_id": "WA0000925"
+            "entity_id": 9235,
+            "increment_id": "WA00009235"
         }
     ]
 }


### PR DESCRIPTION
## Purpose of this pull request

This pull request (PR) : Added new tutorial for filtering orders in order processing through rest api. The tutorial for getting filtered order details is missing in rest tutorials. 

## Affected DevDocs pages

<!-- REQUIRED List the affected pages on devdocs.magento.com (URLs). Not needed for large numbers of files. -->

-  new page

What new - There is the document in devdocs about filtering orders with rest api. But in tutorial format there is none exist. So added  a new tutorial for this.