### PR TITLE
Graphql query field is wrong 

### DIFF
--- a/src/guides/v2.3/graphql/queries/cart.md
+++ b/src/guides/v2.3/graphql/queries/cart.md
@@ -106,7 +106,7 @@ The following query shows the status of a cart that is ready to be converted int
       code
       title
     }
-    applied_coupons {
+    applied_coupon {
       code
     }
     prices {
@@ -251,7 +251,7 @@ The following query shows the status of a cart that is ready to be converted int
         "code": "checkmo",
         "title": "Check / Money order"
       },
-      "applied_coupons": null,
+      "applied_coupon": null,
       "prices": {
         "grand_total": {
           "value": 105.26,
@@ -297,7 +297,7 @@ The `3T1free` rule is applied first, and Magento returns the price of a single s
       }
       quantity
     }
-    applied_coupons {
+    applied_coupon {
       code
     }
     prices {
@@ -354,7 +354,7 @@ The `3T1free` rule is applied first, and Magento returns the price of a single s
           "quantity": 4
         }
       ],
-      "applied_coupons": [
+      "applied_coupon": [
         {
           "code": "NEW"
         }


### PR DESCRIPTION
## Purpose of this pull request

This pull request (PR) - For getting status of cart through graphql query the field name 'applied_coupons' is used. But this is wrong one. 'applied_coupon' is correct. So changed the field name in query.

## Affected DevDocs pages

<!-- REQUIRED List the affected pages on devdocs.magento.com (URLs). Not needed for large numbers of files. -->

-  https://devdocs.magento.com/guides/v2.3/graphql/queries/cart.html

