### PR TITLE
country field is wrong in graphql query

### DIFF
--- a/src/guides/v2.3/graphql/queries/customer.md
+++ b/src/guides/v2.3/graphql/queries/customer.md
@@ -40,7 +40,7 @@ The following call returns information about the logged-in customer. Provide the
         region_id
       }
       postcode
-      country_code
+      country_id
       telephone
     }
   }
@@ -72,7 +72,7 @@ The following call returns information about the logged-in customer. Provide the
            "region_id": 33
          }
          "postcode": "78758",
-         "country_code": "US",
+         "country_id": "US",
          "telephone": "512 555-1212"
         }
       ]


### PR DESCRIPTION
## Purpose of this pull request

This pull request (PR) - The field 'country_code' is used in graphql query. But that is wrong. Field  'country_id' should be used. 

## Affected DevDocs pages

<!-- REQUIRED List the affected pages on devdocs.magento.com (URLs). Not needed for large numbers of files. -->

-  https://devdocs.magento.com/guides/v2.3/graphql/queries/customer.html

