### PR TITLE
Apply the devdocs theme update #55

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,6 +1,6 @@
 GIT
   remote: https://github.com/magento-devdocs/devdocs-theme.git
-  revision: e1a4ff6880d5047cb8e14ac44849aca8ffaecf2a
+  revision: d72768697309f7f13af8a37073af776420f6c3a7
   specs:
     devdocs (7)
       jekyll (>= 4.0)
@@ -17,7 +17,7 @@ GEM
       httpclient (~> 2.8, >= 2.8.3)
       json (>= 1.5.1)
     colorator (1.1.0)
-    concurrent-ruby (1.1.5)
+    concurrent-ruby (1.1.6)
     em-websocket (0.5.1)
       eventmachine (>= 0.12.9)
       http_parser.rb (~> 0.6.0)
@@ -27,7 +27,7 @@ GEM
     exifr (1.3.6)
     faraday (1.0.0)
       multipart-post (>= 1.2, < 3)
-    ffi (1.12.1)
+    ffi (1.12.2)
     filesize (0.2.0)
     forwardable-extended (2.6.0)
     fspath (3.1.2)
@@ -49,7 +49,7 @@ GEM
       image_size (>= 1.5, < 3)
       in_threads (~> 1.3)
       progress (~> 3.0, >= 3.0.1)
-    image_optim_pack (0.6.0.20200116)
+    image_optim_pack (0.6.0.20200215)
       fspath (>= 2.1, < 4)
       image_optim (~> 0.19)
     image_size (2.0.2)
@@ -84,7 +84,7 @@ GEM
       jekyll (>= 3.3, < 5.0)
     jekyll-relative-links (0.6.1)
       jekyll (>= 3.3, < 5.0)
-    jekyll-sass-converter (2.0.1)
+    jekyll-sass-converter (2.1.0)
       sassc (> 2.0.1, < 3.0)
     jekyll-sitemap (1.4.0)
       jekyll (>= 3.7, < 5.0)
@@ -96,8 +96,8 @@ GEM
     kramdown (2.1.0)
     kramdown-parser-gfm (1.1.0)
       kramdown (~> 2.0)
-    launchy (2.4.3)
-      addressable (~> 2.3)
+    launchy (2.5.0)
+      addressable (~> 2.7)
     liquid (4.0.3)
     listen (3.2.1)
       rb-fsevent (~> 0.10, >= 0.10.3)
@@ -114,11 +114,11 @@ GEM
       tomlrb
     multipart-post (2.1.1)
     netrc (0.11.0)
-    nokogiri (1.10.8)
+    nokogiri (1.10.9)
       mini_portile2 (~> 2.4.0)
     nokogumbo (2.0.2)
       nokogiri (~> 1.8, >= 1.8.4)
-    octokit (4.15.0)
+    octokit (4.16.0)
       faraday (>= 0.9)
       sawyer (~> 0.8.0, >= 0.5.3)
     parallel (1.19.1)
@@ -132,7 +132,7 @@ GEM
     rb-fsevent (0.10.3)
     rb-inotify (0.10.1)
       ffi (~> 1.0)
-    rouge (3.15.0)
+    rouge (3.16.0)
     safe_yaml (1.0.5)
     sassc (2.2.1)
       ffi (~> 1.9)
@@ -152,7 +152,7 @@ GEM
       netrc (~> 0.10)
       octokit (~> 4.14)
       thor (~> 0.20)
-    yell (2.2.1)
+    yell (2.2.2)
 
 PLATFORMS
   ruby


### PR DESCRIPTION
## Purpose of this pull request

This pull request (PR) applies the devdocs theme update (magento-devdocs/devdocs-theme#55)
and updates other gems too.

## Expected changes

The Marketplace User Guide is removed from the federated search and as an item in the site switcher.