### PR TITLE
Cloud: quick fix for broken link

### DIFF
--- a/src/cloud/docker/docker-containers.md
+++ b/src/cloud/docker/docker-containers.md
@@ -49,7 +49,7 @@ For example, the following command starts the Docker configuration generator in 
 ./vendor/bin/ece-docker build:compose --mode="developer" --php 7.2
 ```
 
-See [See Docker services containters] for details.
+See [Docker service containers] for details.
 
 ## Request Flow
 

--- a/src/cloud/docker/docker-mode-production.md
+++ b/src/cloud/docker/docker-mode-production.md
@@ -12,7 +12,7 @@ Production mode is the default configuration setting for launching the Docker en
 {%include cloud/note-docker-config-reference-link.md%}
 
 {:.procedure}
-To launch the Docker environment in developer mode:
+To launch the Docker environment in production mode:
 
 1. Download a Magento application template from the [Magento Cloud repository][cloud-repo]. Be careful to select the branch that corresponds with the Magento version.
 


### PR DESCRIPTION
This PR is a quick fix for a broken link on the Docker container architecture topic:
https://devdocs.magento.com/cloud/docker/docker-containers.html#service-containers