### PR TITLE
Removing deprecated customer id from create customer tutorial

### DIFF
--- a/src/guides/v2.3/graphql/tutorials/checkout/checkout-customer.md
+++ b/src/guides/v2.3/graphql/tutorials/checkout/checkout-customer.md
@@ -34,7 +34,6 @@ mutation {
     }
   ) {
     customer {
-      id
       firstname
       lastname
       email
@@ -51,7 +50,6 @@ mutation {
   "data": {
     "createCustomer": {
       "customer": {
-        "id": 6,
         "firstname": "John",
         "lastname": "Doe",
         "email": "john.doe@example.com",


### PR DESCRIPTION
## Purpose of this pull request

This pull request (PR) removes deprecated customer id from create customer tutorial

## Affected DevDocs pages

<!-- REQUIRED List the affected pages on devdocs.magento.com (URLs). Not needed for large numbers of files. -->

- https://devdocs.magento.com/guides/v2.3/graphql/tutorials/checkout/checkout-customer.html

## Links to Magento source code

<!--  OPTIONAL - REMOVE THIS SECTION IF NOT USED. If this pull request references a file in a Magento codebase repository, add it here. -->

-  https://github.com/magento/magento2/blob/5f3b86ab4bd3e3b94e65429fed33f748d29c1bbe/app/code/Magento/CustomerGraphQl/etc/schema.graphqls#L95

<!--
If you are fixing a GitHub issue, note it using GitHub keyword format (https://help.github.com/en/articles/closing-issues-using-keywords#closing-an-issue-in-a-different-repository) to close the issue when this pull request is merged. Example: `Fixes #1234`

`master` is the default branch. Merged pull requests to `master` go live on the site automatically. Any requested changes to content on the `master` branch must be related to the released codebase. Any content related to future releases goes in the `develop` branch.

See Contribution guidelines (https://github.com/magento/devdocs/blob/master/.github/CONTRIBUTING.md) for more information.
-->
