### PR TITLE
Removed deprecated field in graphql query

### DIFF
--- a/src/guides/v2.3/graphql/queries/customer.md
+++ b/src/guides/v2.3/graphql/queries/customer.md
@@ -37,7 +37,6 @@ The following call returns information about the logged-in customer. Provide the
       region {
         region_code
         region
-        region_id
       }
       postcode
       country_code
@@ -68,8 +67,7 @@ The following call returns information about the logged-in customer. Provide the
          "city": "Anytown",
          "region": {
            "region_code": "MI",
-           "region": "Michigan",
-           "region_id": 33
+           "region": "Michigan"
          }
          "postcode": "78758",
          "country_code": "US",


### PR DESCRIPTION
## Purpose of this pull request

This pull request (PR) - region_id is deprecated.can refer this [2.3 schema graphql](https://github.com/magento/magento2/blob/2.3/app/code/Magento/CustomerGraphQl/etc/schema.graphqls). So it has been removed.

## Affected DevDocs pages

<!-- REQUIRED List the affected pages on devdocs.magento.com (URLs). Not needed for large numbers of files. -->

-  https://devdocs.magento.com/guides/v2.3/graphql/queries/customer.html
