### PR TITLE
applied_coupon field is deprecated

### DIFF
--- a/src/guides/v2.3/graphql/mutations/apply-coupon.md
+++ b/src/guides/v2.3/graphql/mutations/apply-coupon.md
@@ -32,7 +32,7 @@ mutation {
         }
         quantity
       }
-      applied_coupon {
+      applied_coupons {
         code
       }
       prices {
@@ -73,7 +73,7 @@ mutation {
             "quantity": 1
           }
         ],
-        "applied_coupon": {
+        "applied_coupons": {
           "code": "H20"
         },
         "prices": {

--- a/src/guides/v2.3/graphql/mutations/remove-coupon.md
+++ b/src/guides/v2.3/graphql/mutations/remove-coupon.md
@@ -30,7 +30,7 @@ mutation {
         }
         quantity
       }
-      applied_coupon {
+      applied_coupons {
         code
       }
       prices {
@@ -65,7 +65,7 @@ mutation {
             "quantity": 1
           }
         ],
-        "applied_coupon": null,
+        "applied_coupons": null,
         "prices": {
           "grand_total": {
             "value": 39,

--- a/src/guides/v2.3/graphql/tutorials/checkout/checkout-coupon.md
+++ b/src/guides/v2.3/graphql/tutorials/checkout/checkout-coupon.md
@@ -34,7 +34,7 @@ mutation {
     }
   ) {
     cart {
-      applied_coupon {
+      applied_coupons {
         code
       }
     }
@@ -49,7 +49,7 @@ mutation {
   "data": {
     "applyCouponToCart": {
       "cart": {
-        "applied_coupon": {
+        "applied_coupons": {
           "code": "{ COUPON_CODE }"
         }
       }
@@ -69,7 +69,7 @@ For logged-in customers, send the customer's authorization token in the `Authori
 mutation {
   removeCouponFromCart(input: { cart_id: "{ CART_ID }" }) {
     cart {
-      applied_coupon {
+      applied_coupons {
         code
       }
     }
@@ -84,7 +84,7 @@ mutation {
   "data": {
     "removeCouponFromCart": {
       "cart": {
-        "applied_coupon": {
+        "applied_coupons": {
           "applied_coupon": null
         }
       }


### PR DESCRIPTION
## Purpose of this pull request

This pull request (PR) - applied_coupon field is deprecated. we should use applied_coupons instead. So updated the document.

## Affected DevDocs pages

<!-- REQUIRED List the affected pages on devdocs.magento.com (URLs). Not needed for large numbers of files. -->

-  https://devdocs.magento.com/guides/v2.3/graphql/tutorials/checkout/checkout-coupon.html

