### PR TITLE
Adding Commerce Tag to Header

### DIFF
--- a/src/recommendations/configure.md
+++ b/src/recommendations/configure.md
@@ -1,6 +1,7 @@
 ---
 group: product-recommendations
 title: Configure Recommendations
+ee_only: True
 ---
 
 After you [install]({{ page.baseurl }}/recommendations/product-recs.html) the `product-recommendations` module, you must configure the catalog SaaS export module, set the environment, and specify the SaaS Environment ID.

--- a/src/recommendations/events.md
+++ b/src/recommendations/events.md
@@ -1,6 +1,7 @@
 ---
 group: product-recommendations
 title: Recommendation Events
+ee_only: True
 ---
 
 When you deploy the `product-recommendations` module, the module tracks the following user events. These events enable  behavioral data collection.

--- a/src/recommendations/product-recs.md
+++ b/src/recommendations/product-recs.md
@@ -3,6 +3,7 @@ group: product-recommendations
 title: Product Recommendations
 redirect_from:
   - /recommendations/install.html
+ee_only: True
 ---
 
 Product recommendations are a powerful marketing tool you can use to increase conversions, boost revenue, and stimulate shopper engagement. Recommendations are surfaced on the storefront in the form of units such as “Customers who viewed this product also viewed”. Because these suggestions are backed by a deep analysis of aggregated visitor data using Adobe Sensei, they result in highly engaging, relevant, and personalized experiences for the shopper.

--- a/src/recommendations/recs-api.md
+++ b/src/recommendations/recs-api.md
@@ -1,6 +1,7 @@
 ---
 group: product-recommendations
 title: Recommendations SDK
+ee_only: True
 ---
 
 If you need to programmatically access product recommendations for your storefront, use the [Recommendations JavaScript SDK](https://www.npmjs.com/package/@magento/recommendations-js-sdk). The SDK is a web services API wrapper that allows you to fetch recommendations programmatically in the browser. With the SDK, you do not need to manage the full lifecycle or understand the complexity of the web services API.

--- a/src/recommendations/support.md
+++ b/src/recommendations/support.md
@@ -1,6 +1,7 @@
 ---
 group: product-recommendations
 title: Get Support
+ee_only: True
 ---
 
 As we continue to evolve this technology and ensure you are successful in implementing product recommendations, it is critical that we address any issues you encounter and plan for any feature requests.

--- a/src/recommendations/test.md
+++ b/src/recommendations/test.md
@@ -1,6 +1,7 @@
 ---
 group: product-recommendations
 title: Test Recommendations
+ee_only: True
 ---
 
 Before you deploy recommendations to your production environment, you should test on a non-production environment to ensure everything is working as expected.

--- a/src/recommendations/troubleshooting.md
+++ b/src/recommendations/troubleshooting.md
@@ -1,6 +1,7 @@
 ---
 group: product-recommendations
 title: Troubleshoot Recommendations
+ee_only: True
 ---
 
 If you have configured the `product-recommendations` module correctly, but you are not seeing any recommendations, try the following:

--- a/src/recommendations/verify.md
+++ b/src/recommendations/verify.md
@@ -1,6 +1,7 @@
 ---
 group: product-recommendations
 title: Verify Event Collection
+ee_only: True
 ---
 
 After you [install]({{ page.baseurl }}/recommendations/product-recs.html) and [configure]({{ page.baseurl }}/recommendations/configure.html) the product recommendations module, you can verify that the behavioral data is being sent to Magento. Magento uses the `DataServices.js` file to collect and send behavioral data. You can use developer tools available in Chrome, or you can install the Snowplow Chrome extension.


### PR DESCRIPTION
## Purpose of this pull request

This pull request (PR) adds the commerce only tag to the top of each p-rex topic.

## Affected DevDocs pages

<!-- REQUIRED List the affected pages on devdocs.magento.com (URLs). Not needed for large numbers of files. -->

-  https://devdocs.magento.com/recommendations/product-recs.html
