### PR TITLE
Updating EntityUrl output object in urlResolvers query

### DIFF
--- a/src/guides/v2.3/graphql/queries/url-resolver.md
+++ b/src/guides/v2.3/graphql/queries/url-resolver.md
@@ -26,7 +26,9 @@ The following query returns information about the URL containing `joust-duffle-b
   urlResolver(url: "joust-duffle-bag.html") {
     id
     relative_url
+    redirectCode
     type
+
   }
 }
 ```
@@ -39,6 +41,7 @@ The following query returns information about the URL containing `joust-duffle-b
     "urlResolver": {
       "id": 1,
       "relative_url": "catalog/product/view/id/1",
+      "redirectCode": 0,
       "type": "PRODUCT"
     }
   }
@@ -63,7 +66,7 @@ Attribute |  Data Type | Description
 `id` | Int | The ID assigned to the object associated with the specified `url`. This could be a product ID, category ID, or page ID.
 `relative_url` | String | The internal relative URL. If the specified  `url` is a redirect, the query returns the redirected URL, not the original.
 `type` | UrlRewriteEntityTypeEnum | The value of `UrlRewriteEntityTypeEnum` is one of PRODUCT, CATEGORY, or CMS_PAGE.
-`url` | String | The URL to resolve. Magento stores product and category URLs with the `.html` extension.  CMS URLs do not contain the extension.
+`redirectCode` | Int | 301 or 302 HTTP code for url permanent or temporary redirect or 0 for the 200 no redirect.
 
 ## Related topics
 

--- a/src/guides/v2.3/graphql/queries/url-resolver.md
+++ b/src/guides/v2.3/graphql/queries/url-resolver.md
@@ -61,11 +61,11 @@ The `EntityUrl` output object contains the `id`, `relative_url`, and `type` attr
 
 Attribute |  Data Type | Description
 --- | --- | ---
-`canonical_url` | String | Deprecated. Use `relative_url` instead.
-`id` | Int | The ID assigned to the object associated with the specified `url`. This could be a product ID, category ID, or page ID.
-`relative_url` | String | The internal relative URL. If the specified  `url` is a redirect, the query returns the redirected URL, not the original.
-`type` | UrlRewriteEntityTypeEnum | The value of `UrlRewriteEntityTypeEnum` is one of PRODUCT, CATEGORY, or CMS_PAGE.
-`redirectCode` | Int | 301 or 302 HTTP code for url permanent or temporary redirect. Contains 0 when there's no redirect.
+`canonical_url` | String | Deprecated. Use `relative_url` instead
+`id` | Int | The ID assigned to the object associated with the specified `url`. This could be a product ID, category ID, or page ID
+`redirectCode` | Int | Contains 0 when there is no redirect error. A value of 301 indicates the URL of the requested resource has been changed permanently, while a value of 302 indicates a temporary redirect
+`relative_url` | String | The internal relative URL. If the specified  `url` is a redirect, the query returns the redirected URL, not the original
+`type` | UrlRewriteEntityTypeEnum | The value of `UrlRewriteEntityTypeEnum` is one of PRODUCT, CATEGORY, or CMS_PAGE
 
 ## Related topics
 

--- a/src/guides/v2.3/graphql/queries/url-resolver.md
+++ b/src/guides/v2.3/graphql/queries/url-resolver.md
@@ -28,7 +28,6 @@ The following query returns information about the URL containing `joust-duffle-b
     relative_url
     redirectCode
     type
-
   }
 }
 ```
@@ -66,7 +65,7 @@ Attribute |  Data Type | Description
 `id` | Int | The ID assigned to the object associated with the specified `url`. This could be a product ID, category ID, or page ID.
 `relative_url` | String | The internal relative URL. If the specified  `url` is a redirect, the query returns the redirected URL, not the original.
 `type` | UrlRewriteEntityTypeEnum | The value of `UrlRewriteEntityTypeEnum` is one of PRODUCT, CATEGORY, or CMS_PAGE.
-`redirectCode` | Int | 301 or 302 HTTP code for url permanent or temporary redirect or 0 for the 200 no redirect.
+`redirectCode` | Int | 301 or 302 HTTP code for url permanent or temporary redirect. Contains 0 when there's no redirect.
 
 ## Related topics
 


### PR DESCRIPTION
## Purpose of this pull request

This pull request (PR) updates the EntityUrl output object in urlResolvers query.As seen in this page (https://github.com/magento/magento2/blob/5f3b86ab4bd3e3b94e65429fed33f748d29c1bbe/app/code/Magento/UrlRewriteGraphQl/etc/schema.graphqls#L12) there is no url attribute in EntityUrl output object also the redirectCode attribute is missing in the docs.

## Affected DevDocs pages

<!-- REQUIRED List the affected pages on devdocs.magento.com (URLs). Not needed for large numbers of files. -->

-  https://devdocs.magento.com/guides/v2.3/graphql/queries/url-resolver.html

## Links to Magento source code

<!--  OPTIONAL - REMOVE THIS SECTION IF NOT USED. If this pull request references a file in a Magento codebase repository, add it here. -->

-  https://github.com/magento/magento2/blob/5f3b86ab4bd3e3b94e65429fed33f748d29c1bbe/app/code/Magento/UrlRewriteGraphQl/etc/schema.graphqls#L12
https://github.com/magento/magento2/blob/5f3b86ab4bd3e3b94e65429fed33f748d29c1bbe/app/code/Magento/UrlRewriteGraphQl/Model/Resolver/EntityUrl.php#L115

<!--
If you are fixing a GitHub issue, note it using GitHub keyword format (https://help.github.com/en/articles/closing-issues-using-keywords#closing-an-issue-in-a-different-repository) to close the issue when this pull request is merged. Example: `Fixes #1234`

`master` is the default branch. Merged pull requests to `master` go live on the site automatically. Any requested changes to content on the `master` branch must be related to the released codebase. Any content related to future releases goes in the `develop` branch.

See Contribution guidelines (https://github.com/magento/devdocs/blob/master/.github/CONTRIBUTING.md) for more information.
-->
