### PR TITLE
Products graphql - deprecated fields removed

### DIFF
--- a/src/guides/v2.3/graphql/product/bundle-product.md
+++ b/src/guides/v2.3/graphql/product/bundle-product.md
@@ -69,7 +69,7 @@ The following query returns information about bundle product `24-WG080`, which i
    {
       items{
          sku
-         type_id
+         __typename
          id
          name
           ... on BundleProduct {
@@ -98,7 +98,7 @@ The following query returns information about bundle product `24-WG080`, which i
                 id
                 name
                 sku
-                type_id
+                __typename
               }
             }
           }
@@ -117,7 +117,7 @@ The following query returns information about bundle product `24-WG080`, which i
       "items": [
         {
           "sku": "24-WG080",
-          "type_id": "bundle",
+          "__typename": "bundle",
           "id": 46,
           "name": "Sprite Yoga Companion Kit",
           "dynamic_sku": true,
@@ -147,7 +147,7 @@ The following query returns information about bundle product `24-WG080`, which i
                     "id": 26,
                     "name": "Sprite Stasis Ball 55 cm",
                     "sku": "24-WG081-blue",
-                    "type_id": "simple"
+                    "__typename": "simple"
                   }
                 },
                 {
@@ -163,7 +163,7 @@ The following query returns information about bundle product `24-WG080`, which i
                     "id": 29,
                     "name": "Sprite Stasis Ball 65 cm",
                     "sku": "24-WG082-blue",
-                    "type_id": "simple"
+                    "__typename": "simple"
                   }
                 },
                 {
@@ -179,7 +179,7 @@ The following query returns information about bundle product `24-WG080`, which i
                     "id": 32,
                     "name": "Sprite Stasis Ball 75 cm",
                     "sku": "24-WG083-blue",
-                    "type_id": "simple"
+                    "__typename": "simple"
                   }
                 }
               ]
@@ -205,7 +205,7 @@ The following query returns information about bundle product `24-WG080`, which i
                     "id": 21,
                     "name": "Sprite Foam Yoga Brick",
                     "sku": "24-WG084",
-                    "type_id": "simple"
+                    "__typename": "simple"
                   }
                 }
               ]
@@ -231,7 +231,7 @@ The following query returns information about bundle product `24-WG080`, which i
                     "id": 33,
                     "name": "Sprite Yoga Strap 6 foot",
                     "sku": "24-WG085",
-                    "type_id": "simple"
+                    "__typename": "simple"
                   }
                 },
                 {
@@ -247,7 +247,7 @@ The following query returns information about bundle product `24-WG080`, which i
                     "id": 34,
                     "name": "Sprite Yoga Strap 8 foot",
                     "sku": "24-WG086",
-                    "type_id": "simple"
+                    "__typename": "simple"
                   }
                 },
                 {
@@ -263,7 +263,7 @@ The following query returns information about bundle product `24-WG080`, which i
                     "id": 35,
                     "name": "Sprite Yoga Strap 10 foot",
                     "sku": "24-WG087",
-                    "type_id": "simple"
+                    "__typename": "simple"
                   }
                 }
               ]
@@ -289,7 +289,7 @@ The following query returns information about bundle product `24-WG080`, which i
                     "id": 22,
                     "name": "Sprite Foam Roller",
                     "sku": "24-WG088",
-                    "type_id": "simple"
+                    "__typename": "simple"
                   }
                 }
               ]

--- a/src/guides/v2.3/graphql/product/configurable-product.md
+++ b/src/guides/v2.3/graphql/product/configurable-product.md
@@ -92,10 +92,10 @@ The following `products` query returns `ConfigurableProduct` information about t
       attribute_set_id
       name
       sku
-      type_id
-      price {
-        regularPrice {
-          amount {
+      __typename
+      price_range{
+        minimum_price{
+          regular_price{
             value
             currency
           }
@@ -127,9 +127,9 @@ The following `products` query returns `ConfigurableProduct` information about t
             ... on PhysicalProductInterface {
               weight
             }
-            price {
-              regularPrice {
-                amount {
+            price_range{
+              minimum_price{
+                regular_price{
                   value
                   currency
                 }
@@ -160,10 +160,10 @@ The following `products` query returns `ConfigurableProduct` information about t
           "attribute_set_id": 9,
           "name": "Mona Pullover Hoodlie",
           "sku": "WH01",
-          "type_id": "configurable",
-          "price": {
-            "regularPrice": {
-              "amount": {
+          "__typename": "configurable",
+          "price_range": {
+            "minimum_price": {
+              "regular_price": {
                 "value": 57,
                 "currency": "USD"
               }
@@ -247,9 +247,9 @@ The following `products` query returns `ConfigurableProduct` information about t
                 "sku": "WH01-XS-Green",
                 "attribute_set_id": 9,
                 "weight": 1,
-                "price": {
-                  "regularPrice": {
-                    "amount": {
+                "price_range": {
+                  "minimum_price": {
+                    "regular_price": {
                       "value": 57,
                       "currency": "USD"
                     }
@@ -276,9 +276,9 @@ The following `products` query returns `ConfigurableProduct` information about t
                 "sku": "WH01-XS-Orange",
                 "attribute_set_id": 9,
                 "weight": 1,
-                "price": {
-                  "regularPrice": {
-                    "amount": {
+                "price_range": {
+                  "minimum_price": {
+                    "regular_price": {
                       "value": 57,
                       "currency": "USD"
                     }
@@ -305,9 +305,9 @@ The following `products` query returns `ConfigurableProduct` information about t
                 "sku": "WH01-XS-Purple",
                 "attribute_set_id": 9,
                 "weight": 1,
-                "price": {
-                  "regularPrice": {
-                    "amount": {
+                "price_range": {
+                  "minimum_price": {
+                    "regular_price": {
                       "value": 57,
                       "currency": "USD"
                     }
@@ -334,9 +334,9 @@ The following `products` query returns `ConfigurableProduct` information about t
                 "sku": "WH01-S-Green",
                 "attribute_set_id": 9,
                 "weight": 1,
-                "price": {
-                  "regularPrice": {
-                    "amount": {
+                "price_range": {
+                  "minimum_price": {
+                    "regular_price": {
                       "value": 57,
                       "currency": "USD"
                     }
@@ -363,9 +363,9 @@ The following `products` query returns `ConfigurableProduct` information about t
                 "sku": "WH01-S-Orange",
                 "attribute_set_id": 9,
                 "weight": 1,
-                "price": {
-                  "regularPrice": {
-                    "amount": {
+                "price_range": {
+                  "minimum_price": {
+                    "regular_price": {
                       "value": 57,
                       "currency": "USD"
                     }
@@ -392,9 +392,9 @@ The following `products` query returns `ConfigurableProduct` information about t
                 "sku": "WH01-S-Purple",
                 "attribute_set_id": 9,
                 "weight": 1,
-                "price": {
-                  "regularPrice": {
-                    "amount": {
+                "price_range": {
+                  "minimum_price": {
+                    "regular_price": {
                       "value": 57,
                       "currency": "USD"
                     }
@@ -421,9 +421,9 @@ The following `products` query returns `ConfigurableProduct` information about t
                 "sku": "WH01-M-Green",
                 "attribute_set_id": 9,
                 "weight": 1,
-                "price": {
-                  "regularPrice": {
-                    "amount": {
+                "price_range": {
+                  "minimum_price": {
+                    "regular_price": {
                       "value": 57,
                       "currency": "USD"
                     }
@@ -450,9 +450,9 @@ The following `products` query returns `ConfigurableProduct` information about t
                 "sku": "WH01-M-Orange",
                 "attribute_set_id": 9,
                 "weight": 1,
-                "price": {
-                  "regularPrice": {
-                    "amount": {
+                "price_range": {
+                  "minimum_price": {
+                    "regular_price": {
                       "value": 57,
                       "currency": "USD"
                     }
@@ -479,9 +479,9 @@ The following `products` query returns `ConfigurableProduct` information about t
                 "sku": "WH01-M-Purple",
                 "attribute_set_id": 9,
                 "weight": 1,
-                "price": {
-                  "regularPrice": {
-                    "amount": {
+                "price_range": {
+                  "minimum_price": {
+                    "regular_price": {
                       "value": 57,
                       "currency": "USD"
                     }
@@ -508,9 +508,9 @@ The following `products` query returns `ConfigurableProduct` information about t
                 "sku": "WH01-L-Green",
                 "attribute_set_id": 9,
                 "weight": 1,
-                "price": {
-                  "regularPrice": {
-                    "amount": {
+                "price_range": {
+                  "minimum_price": {
+                    "regular_price": {
                       "value": 57,
                       "currency": "USD"
                     }
@@ -537,9 +537,9 @@ The following `products` query returns `ConfigurableProduct` information about t
                 "sku": "WH01-L-Orange",
                 "attribute_set_id": 9,
                 "weight": 1,
-                "price": {
-                  "regularPrice": {
-                    "amount": {
+                "price_range": {
+                  "minimum_price": {
+                    "regular_price": {
                       "value": 57,
                       "currency": "USD"
                     }
@@ -566,9 +566,9 @@ The following `products` query returns `ConfigurableProduct` information about t
                 "sku": "WH01-L-Purple",
                 "attribute_set_id": 9,
                 "weight": 1,
-                "price": {
-                  "regularPrice": {
-                    "amount": {
+                "price_range": {
+                  "minimum_price": {
+                    "regular_price": {
                       "value": 57,
                       "currency": "USD"
                     }
@@ -595,9 +595,9 @@ The following `products` query returns `ConfigurableProduct` information about t
                 "sku": "WH01-XL-Green",
                 "attribute_set_id": 9,
                 "weight": 1,
-                "price": {
-                  "regularPrice": {
-                    "amount": {
+                "price_range": {
+                  "minimum_price": {
+                    "regular_price": {
                       "value": 57,
                       "currency": "USD"
                     }
@@ -624,9 +624,9 @@ The following `products` query returns `ConfigurableProduct` information about t
                 "sku": "WH01-XL-Orange",
                 "attribute_set_id": 9,
                 "weight": 1,
-                "price": {
-                  "regularPrice": {
-                    "amount": {
+                "price_range": {
+                  "minimum_price": {
+                    "regular_price": {
                       "value": 57,
                       "currency": "USD"
                     }
@@ -653,9 +653,9 @@ The following `products` query returns `ConfigurableProduct` information about t
                 "sku": "WH01-XL-Purple",
                 "attribute_set_id": 9,
                 "weight": 1,
-                "price": {
-                  "regularPrice": {
-                    "amount": {
+                "price_range": {
+                  "minimum_price": {
+                    "regular_price": {
                       "value": 57,
                       "currency": "USD"
                     }

--- a/src/guides/v2.3/graphql/product/gift-card-product.md
+++ b/src/guides/v2.3/graphql/product/gift-card-product.md
@@ -51,7 +51,7 @@ The following query returns information about gift card product `GiftCard25`. (I
   products(filter: { sku: { eq: "GiftCard25" } }) {
     items {
       id
-      type_id
+      __typename
       name
       sku
     }

--- a/src/guides/v2.3/graphql/product/grouped-product.md
+++ b/src/guides/v2.3/graphql/product/grouped-product.md
@@ -39,7 +39,7 @@ The following query returns information about downloadable product `24-WG085_Gro
       id
       name
       sku
-      type_id
+      __typename
       ... on GroupedProduct {
         items{
           qty
@@ -47,7 +47,7 @@ The following query returns information about downloadable product `24-WG085_Gro
           product{
             sku
             name
-            type_id
+            __typename
             url_key
           }
         }
@@ -68,7 +68,7 @@ The following query returns information about downloadable product `24-WG085_Gro
           "id": 45,
           "name": "Set of Sprite Yoga Straps",
           "sku": "24-WG085_Group",
-          "type_id": "grouped",
+          "__typename": "grouped",
           "items": [
             {
               "qty": 0,
@@ -76,7 +76,7 @@ The following query returns information about downloadable product `24-WG085_Gro
               "product": {
                 "sku": "24-WG085",
                 "name": "Sprite Yoga Strap 6 foot",
-                "type_id": "simple",
+                "__typename": "simple",
                 "url_key": "sprite-yoga-strap-6-foot"
               }
             },
@@ -86,7 +86,7 @@ The following query returns information about downloadable product `24-WG085_Gro
               "product": {
                 "sku": "24-WG086",
                 "name": "Sprite Yoga Strap 8 foot",
-                "type_id": "simple",
+                "__typename": "simple",
                 "url_key": "sprite-yoga-strap-8-foot"
               }
             },
@@ -96,7 +96,7 @@ The following query returns information about downloadable product `24-WG085_Gro
               "product": {
                 "sku": "24-WG087",
                 "name": "Sprite Yoga Strap 10 foot",
-                "type_id": "simple",
+                "__typename": "simple",
                 "url_key": "sprite-yoga-strap-10-foot"
               }
             }

--- a/src/guides/v2.3/graphql/product/product-interface-implementations.md
+++ b/src/guides/v2.3/graphql/product/product-interface-implementations.md
@@ -42,7 +42,7 @@ For example, to return `GroupedProduct` attributes, construct your query like th
       id
       name
       sku
-      type_id
+      __typename
       ... on GroupedProduct {
         items{
           qty
@@ -50,7 +50,7 @@ For example, to return `GroupedProduct` attributes, construct your query like th
           product{
             sku
             name
-            type_id
+            __typename
             url_key
           }
         }


### PR DESCRIPTION
## Purpose of this pull request

This pull request (PR) - Deprecated fields are removed in all product related graphql topics.

## Affected DevDocs pages

<!-- REQUIRED List the affected pages on devdocs.magento.com (URLs). Not needed for large numbers of files. -->

-  https://devdocs.magento.com/guides/v2.3/graphql/product/product-interface-implementations.html
-  https://devdocs.magento.com/guides/v2.3/graphql/product/bundle-product.html
-  https://devdocs.magento.com/guides/v2.3/graphql/product/configurable-product.html
-  https://devdocs.magento.com/guides/v2.3/graphql/product/grouped-product.html

