### PR TITLE
Deprecated type_id field in graphql

### DIFF
--- a/src/guides/v2.3/graphql/product/customizable-option-interface.md
+++ b/src/guides/v2.3/graphql/product/customizable-option-interface.md
@@ -211,7 +211,7 @@ The following query returns information about the customizable options configure
       id
       name
       sku
-      type_id
+      __typename
       ... on CustomizableProductInterface {
         options {
           title

--- a/src/guides/v2.3/graphql/product/customizable-option-interface.md
+++ b/src/guides/v2.3/graphql/product/customizable-option-interface.md
@@ -206,6 +206,7 @@ Attribute | Type | Description
 The following query returns information about the customizable options configured for the product with a `sku` of `xyz`.
 
 ```text
+{
   products(filter: {sku: {eq: "xyz"}}) {
     items {
       id


### PR DESCRIPTION
## Purpose of this pull request

This pull request (PR) - Deprecated type_id field removed from graphql query. 

## Affected DevDocs pages

<!-- REQUIRED List the affected pages on devdocs.magento.com (URLs). Not needed for large numbers of files. -->

-  https://devdocs.magento.com/guides/v2.3/graphql/product/customizable-option-interface.html
