### PR TITLE
Added input attributes for cartItemUpdateInput object in graphql

### DIFF
--- a/src/_includes/graphql/cart-object.md
+++ b/src/_includes/graphql/cart-object.md
@@ -13,6 +13,7 @@ Attribute |  Data Type | Description
 `prices` | [CartPrices][CartPrices] | Contains subtotals and totals
 `selected_payment_method` | [SelectedPaymentMethod][SelectedPaymentMethod] | Selected payment method
 `shipping_addresses` | [[ShippingCartAddress]][ShippingCartAddress]! | Contains one or more shipping addresses
+`total_quantity` | Float! | Total Quantity of products in the cart
 
 [AppliedCoupon]: {{page.baseurl}}/graphql/queries/cart.html#AppliedCoupon
 [AppliedGiftCard]: {{page.baseurl}}/graphql/queries/cart.html#AppliedGiftCard

--- a/src/guides/v2.3/graphql/mutations/update-cart-items.md
+++ b/src/guides/v2.3/graphql/mutations/update-cart-items.md
@@ -107,7 +107,14 @@ The `CartItemUpdateInput` object must contain the following attributes:
 Attribute |  Data Type | Description
 --- | --- | ---
 `cart_item_id` | Int! | The unique ID assigned when a customer places an item in the cart
-`quantity` | Float! | The new quantity of the item. A value of `0` removes the item from the cart
+`quantity` | Float | The new quantity of the item. A value of `0` removes the item from the cart
+`customizable_options` | [CustomizableOptionInput!] | An array that defines customizable options for the product
+
+### CustomizableOptionInput object {#CustomizableOptionInputSimple}
+
+The `CustomizableOptionInput` object must contain the following attributes:
+
+{% include graphql/customizable-option-input.md %}
 
 ## Output attributes
 

--- a/src/guides/v2.3/graphql/mutations/update-cart-items.md
+++ b/src/guides/v2.3/graphql/mutations/update-cart-items.md
@@ -107,8 +107,8 @@ The `CartItemUpdateInput` object must contain the following attributes:
 Attribute |  Data Type | Description
 --- | --- | ---
 `cart_item_id` | Int! | The unique ID assigned when a customer places an item in the cart
-`quantity` | Float | The new quantity of the item. A value of `0` removes the item from the cart
 `customizable_options` | [CustomizableOptionInput!] | An array that defines customizable options for the product
+`quantity` | Float | The new quantity of the item. A value of `0` removes the item from the cart
 
 ### CustomizableOptionInput object {#CustomizableOptionInputSimple}
 


### PR DESCRIPTION
## Purpose of this pull request

This pull request (PR) adds input attributes for cartItemUpdateInput object in graphql.The customizable options  attribute is missing in cartItemUpdateInput object.Also added the missing total quantity attribute in cart object.

## Affected DevDocs pages

<!-- REQUIRED List the affected pages on devdocs.magento.com (URLs). Not needed for large numbers of files. -->

-  https://devdocs.magento.com/guides/v2.3/graphql/mutations/update-cart-items.html

## Links to Magento source code

<!--  OPTIONAL - REMOVE THIS SECTION IF NOT USED. If this pull request references a file in a Magento codebase repository, add it here. -->

-  https://github.com/magento/magento2/blob/5f3b86ab4bd3e3b94e65429fed33f748d29c1bbe/app/code/Magento/QuoteGraphQl/etc/schema.graphqls#L74
https://github.com/magento/magento2/blob/5f3b86ab4bd3e3b94e65429fed33f748d29c1bbe/app/code/Magento/QuoteGraphQl/etc/schema.graphqls#L73
https://github.com/magento/magento2/blob/5f3b86ab4bd3e3b94e65429fed33f748d29c1bbe/app/code/Magento/QuoteGraphQl/etc/schema.graphqls#L207

<!--
If you are fixing a GitHub issue, note it using GitHub keyword format (https://help.github.com/en/articles/closing-issues-using-keywords#closing-an-issue-in-a-different-repository) to close the issue when this pull request is merged. Example: `Fixes #1234`

`master` is the default branch. Merged pull requests to `master` go live on the site automatically. Any requested changes to content on the `master` branch must be related to the released codebase. Any content related to future releases goes in the `develop` branch.

See Contribution guidelines (https://github.com/magento/devdocs/blob/master/.github/CONTRIBUTING.md) for more information.
-->
