### PR TITLE
GraphQL: Add send_friend object to storeConfig query

### DIFF
--- a/src/guides/v2.3/graphql/queries/store-config.md
+++ b/src/guides/v2.3/graphql/queries/store-config.md
@@ -39,7 +39,7 @@ The following call returns all details of a store's configuration.
     secure_base_static_url
     secure_base_media_url
     store_name
-    sendFriend {
+    send_friend {
       enabled_for_customers
       enabled_for_guests
     }
@@ -70,7 +70,7 @@ The following call returns all details of a store's configuration.
       "secure_base_static_url": "http://magento2.vagrant193/pub/static/version1536249714/",
       "secure_base_media_url": "http://magento2.vagrant193/pub/media/",
       "store_name": "My Store",
-      "sendFriend": {
+      "send_friend": {
         "enabled_for_customers": true,
         "enabled_for_guests": false
       }
@@ -238,7 +238,7 @@ Attribute |  Data Type | Description | Example
 `secure_base_media_url` | String | The secure fully-qualified URL that specifies the location of user media files | `https://magentohost.example.com/pub/media/`
 `secure_base_static_url` | String | The secure fully-qualified URL that specifies the location of static view files | `https://magentohost.example.com/pub/static/`
 `secure_base_url` | String | The store's fully-qualified secure base URL | `https://magentohost.example.com/`
-`sendFriend` | SendFriendConfiguration | Email to a Friend configuration | Not applicable
+`send_friend` | SendFriendConfiguration | Email to a Friend configuration | Not applicable
 `store_name` | String | The store's name | `My Store`
 `timezone` | String | The store's time zone | `America/Chicago`
 `website_id` | Integer | The ID number assigned to the parent website | `1`

--- a/src/guides/v2.3/graphql/queries/store-config.md
+++ b/src/guides/v2.3/graphql/queries/store-config.md
@@ -39,6 +39,10 @@ The following call returns all details of a store's configuration.
     secure_base_static_url
     secure_base_media_url
     store_name
+    sendFriend {
+      enabled_for_customers
+      enabled_for_guests
+    }
   }
 }
 ```
@@ -65,7 +69,11 @@ The following call returns all details of a store's configuration.
       "secure_base_link_url": "http://magento2.vagrant193/",
       "secure_base_static_url": "http://magento2.vagrant193/pub/static/version1536249714/",
       "secure_base_media_url": "http://magento2.vagrant193/pub/media/",
-      "store_name": "My Store"
+      "store_name": "My Store",
+      "sendFriend": {
+        "enabled_for_customers": 0,
+        "enabled_for_guests": 0
+      }
     }
   }
 }
@@ -230,10 +238,18 @@ Attribute |  Data Type | Description | Example
 `secure_base_media_url` | String | The secure fully-qualified URL that specifies the location of user media files | `https://magentohost.example.com/pub/media/`
 `secure_base_static_url` | String | The secure fully-qualified URL that specifies the location of static view files | `https://magentohost.example.com/pub/static/`
 `secure_base_url` | String | The store's fully-qualified secure base URL | `https://magentohost.example.com/`
+`sendFriend` | SendFriendConfiguration | Email to a Friend configuration
 `store_name` | String | The store's name | `My Store`
 `timezone` | String | The store's time zone | `America/Chicago`
 `website_id` | Integer | The ID number assigned to the parent website | `1`
 `weight_unit` | String | The weight unit for products | `lbs`, `kgs`, etc
+
+#### SendFriendConfiguration attributes
+
+Attribute |  Data Type | Description
+--- | --- | ---
+`enabled_for_customers` | Boolean! | Indicates whether the Email to a Friend feature is enabled for customers
+`enabled_for_guests` | Boolean! | Indicates whether the Email to a Friend feature is enabled for guests
 
 ### Supported theme attributes
 

--- a/src/guides/v2.3/graphql/queries/store-config.md
+++ b/src/guides/v2.3/graphql/queries/store-config.md
@@ -238,11 +238,11 @@ Attribute |  Data Type | Description | Example
 `secure_base_media_url` | String | The secure fully-qualified URL that specifies the location of user media files | `https://magentohost.example.com/pub/media/`
 `secure_base_static_url` | String | The secure fully-qualified URL that specifies the location of static view files | `https://magentohost.example.com/pub/static/`
 `secure_base_url` | String | The store's fully-qualified secure base URL | `https://magentohost.example.com/`
-`sendFriend` | SendFriendConfiguration | Email to a Friend configuration
+`sendFriend` | SendFriendConfiguration | Email to a Friend configuration | Not applicable
 `store_name` | String | The store's name | `My Store`
 `timezone` | String | The store's time zone | `America/Chicago`
 `website_id` | Integer | The ID number assigned to the parent website | `1`
-`weight_unit` | String | The weight unit for products | `lbs`, `kgs`, etc
+`weight_unit` | String | The weight unit for products | `lbs`, `kgs`, or similar
 
 #### SendFriendConfiguration attributes
 

--- a/src/guides/v2.3/graphql/queries/store-config.md
+++ b/src/guides/v2.3/graphql/queries/store-config.md
@@ -71,8 +71,8 @@ The following call returns all details of a store's configuration.
       "secure_base_media_url": "http://magento2.vagrant193/pub/media/",
       "store_name": "My Store",
       "sendFriend": {
-        "enabled_for_customers": 0,
-        "enabled_for_guests": 0
+        "enabled_for_customers": true,
+        "enabled_for_guests": false
       }
     }
   }

--- a/src/guides/v2.3/graphql/release-notes.md
+++ b/src/guides/v2.3/graphql/release-notes.md
@@ -20,7 +20,7 @@ These release notes can include:
 -  {:.new} **The `products` and `categoryList` queries can now be used to retrieve information about products and categories that have been added to a staged campaign.** These queries require an admin authorization token. See [Using queries](https://devdocs.magento.com/guides/v2.3/graphql/queries/index.html#staging) for details.
 -  {:.fix} Custom attributes used in layered navigation no longer require the **Use in Search**, **Visible in Advanced Search**, and **Use in Search Results Layered Navigation** fields be set to Yes.
 -  {:.fix} Added the `position` and `disabled` attributes to the `MediaGalleryInterface`.
--  {:.fix} Added the `sendFriend` object to the `storeConfig` query to prevent Magento from sending emails when the Email to Friend feature is disabled.
+-  {:.fix} Added the `sendFriend` object to the `storeConfig` query so that you can determine whether the Email to Friend feature is enabled.
 -  {:.fix} When you apply a gift card to a cart, an exception is no longer thrown when the last product is removed from the cart.
 -  {:.fix} In a category search, the `image` attribute returns the full path to an image, rather than a truncated path.
 -  {:.fix} Flat rate shipping amounts are calculated correctly when you add a configurable product to a cart.

--- a/src/guides/v2.3/graphql/release-notes.md
+++ b/src/guides/v2.3/graphql/release-notes.md
@@ -20,7 +20,7 @@ These release notes can include:
 -  {:.new} **The `products` and `categoryList` queries can now be used to retrieve information about products and categories that have been added to a staged campaign.** These queries require an admin authorization token. See [Using queries](https://devdocs.magento.com/guides/v2.3/graphql/queries/index.html#staging) for details.
 -  {:.fix} Custom attributes used in layered navigation no longer require the **Use in Search**, **Visible in Advanced Search**, and **Use in Search Results Layered Navigation** fields be set to Yes.
 -  {:.fix} Added the `position` and `disabled` attributes to the `MediaGalleryInterface`.
--  {:.fix} Added the sendFriend object to the `storeConfig` query.
+-  {:.fix} Added the `sendFriend` object to the `storeConfig` query to prevent Magento from sending emails when the Email to Friend feature is disabled.
 -  {:.fix} When you apply a gift card to a cart, an exception is no longer thrown when the last product is removed from the cart.
 -  {:.fix} In a category search, the `image` attribute returns the full path to an image, rather than a truncated path.
 -  {:.fix} Flat rate shipping amounts are calculated correctly when you add a configurable product to a cart.

--- a/src/guides/v2.3/graphql/release-notes.md
+++ b/src/guides/v2.3/graphql/release-notes.md
@@ -20,6 +20,7 @@ These release notes can include:
 -  {:.new} **The `products` and `categoryList` queries can now be used to retrieve information about products and categories that have been added to a staged campaign.** These queries require an admin authorization token. See [Using queries](https://devdocs.magento.com/guides/v2.3/graphql/queries/index.html#staging) for details.
 -  {:.fix} Custom attributes used in layered navigation no longer require the **Use in Search**, **Visible in Advanced Search**, and **Use in Search Results Layered Navigation** fields be set to Yes.
 -  {:.fix} Added the `position` and `disabled` attributes to the `MediaGalleryInterface`.
+-  {:.fix} Added the sendFriend object to the `storeConfig` query.
 -  {:.fix} When you apply a gift card to a cart, an exception is no longer thrown when the last product is removed from the cart.
 -  {:.fix} In a category search, the `image` attribute returns the full path to an image, rather than a truncated path.
 -  {:.fix} Flat rate shipping amounts are calculated correctly when you add a configurable product to a cart.

--- a/src/guides/v2.3/graphql/release-notes.md
+++ b/src/guides/v2.3/graphql/release-notes.md
@@ -20,7 +20,7 @@ These release notes can include:
 -  {:.new} **The `products` and `categoryList` queries can now be used to retrieve information about products and categories that have been added to a staged campaign.** These queries require an admin authorization token. See [Using queries](https://devdocs.magento.com/guides/v2.3/graphql/queries/index.html#staging) for details.
 -  {:.fix} Custom attributes used in layered navigation no longer require the **Use in Search**, **Visible in Advanced Search**, and **Use in Search Results Layered Navigation** fields be set to Yes.
 -  {:.fix} Added the `position` and `disabled` attributes to the `MediaGalleryInterface`.
--  {:.fix} Added the `sendFriend` object to the `storeConfig` query so that you can determine whether the Email to Friend feature is enabled.
+-  {:.fix} Added the `send_friend` object to the `storeConfig` query so that you can determine whether the Email to Friend feature is enabled.
 -  {:.fix} When you apply a gift card to a cart, an exception is no longer thrown when the last product is removed from the cart.
 -  {:.fix} In a category search, the `image` attribute returns the full path to an image, rather than a truncated path.
 -  {:.fix} Flat rate shipping amounts are calculated correctly when you add a configurable product to a cart.


### PR DESCRIPTION
## Purpose of this pull request

This pull request (PR) updates the `storeConfig` query per internal bug MC-29423.  

## Affected DevDocs pages

<!-- REQUIRED List the affected pages on devdocs.magento.com (URLs). Not needed for large numbers of files. -->

-  https://devdocs.magento.com/guides/v2.3/graphql/queries/store-config.html

## Links to Magento source code

<!--  OPTIONAL - REMOVE THIS SECTION IF NOT USED. If this pull request references a file in a Magento codebase repository, add it here. -->

-  ...

<!--
If you are fixing a GitHub issue, note it using GitHub keyword format (https://help.github.com/en/articles/closing-issues-using-keywords#closing-an-issue-in-a-different-repository) to close the issue when this pull request is merged. Example: `Fixes #1234`

`master` is the default branch. Merged pull requests to `master` go live on the site automatically. Any requested changes to content on the `master` branch must be related to the released codebase. Any content related to future releases goes in the `develop` branch.

See Contribution guidelines (https://github.com/magento/devdocs/blob/master/.github/CONTRIBUTING.md) for more information.
-->
