### PR TITLE
Change references to TAM title to Customer Technical Advisor (CTA)

### DIFF
--- a/src/cloud/architecture/cloud-architecture.md
+++ b/src/cloud/architecture/cloud-architecture.md
@@ -82,7 +82,7 @@ For comparison, each plan includes the following infrastructure features and sup
       <td>24x7 monitoring and email support for the core application and the cloud infrastructure</td>
     </tr>
     <tr>
-      <td>Dedicated Customer Technical Advisor (CTA)</td>
+      <td>A dedicated Customer Technical Advisor (CTA)</td>
       <td class="blank"></td>
       <td>Dedicated technical account management for the initial launch period, starting with your subscription until your initial site launch</td>
     </tr>

--- a/src/cloud/architecture/cloud-architecture.md
+++ b/src/cloud/architecture/cloud-architecture.md
@@ -82,7 +82,7 @@ For comparison, each plan includes the following infrastructure features and sup
       <td>24x7 monitoring and email support for the core application and the cloud infrastructure</td>
     </tr>
     <tr>
-      <td>Dedicated Technical Account Manager</td>
+      <td>Dedicated Customer Technical Advisor (CTA)</td>
       <td class="blank"></td>
       <td>Dedicated technical account management for the initial launch period, starting with your subscription until your initial site launch</td>
     </tr>

--- a/src/cloud/cdn/configure-fastly.md
+++ b/src/cloud/cdn/configure-fastly.md
@@ -96,7 +96,7 @@ To enable Fastly CDN caching in Staging and Production:
 
    If the test fails, verify that the correct service ID and API token values match the credentials for the current environment.
 
-   If the test fails again, submit a support ticket or contact your Technical Account Manager. For Pro projects, include the URLs for your Production and Staging sites.  For Starter projects, include the URLs for your `Master` and Staging site.
+   If the test fails again, submit a support ticket or contact your Dedicated Customer Technical Advisor (CTA). For Pro projects, include the URLs for your Production and Staging sites.  For Starter projects, include the URLs for your `Master` and Staging site.
 
  {:.bs-callout-info}
 If you need to change the Fastly API token credential for a Staging or Production environment, see [Change Fastly credentials]({{ site.baseurl}}/cloud/cdn/cloud-fastly.html#change-your-fastly-api-token).

--- a/src/cloud/cdn/configure-fastly.md
+++ b/src/cloud/cdn/configure-fastly.md
@@ -96,7 +96,7 @@ To enable Fastly CDN caching in Staging and Production:
 
    If the test fails, verify that the correct service ID and API token values match the credentials for the current environment.
 
-   If the test fails again, submit a support ticket or contact your Dedicated Customer Technical Advisor (CTA). For Pro projects, include the URLs for your Production and Staging sites.  For Starter projects, include the URLs for your `Master` and Staging site.
+   If the test fails again, submit a support ticket or contact your Customer Technical Advisor (CTA). For Pro projects, include the URLs for your Production and Staging sites.  For Starter projects, include the URLs for your `Master` and Staging site.
 
  {:.bs-callout-info}
 If you need to change the Fastly API token credential for a Staging or Production environment, see [Change Fastly credentials]({{ site.baseurl}}/cloud/cdn/cloud-fastly.html#change-your-fastly-api-token).

--- a/src/cloud/configure/setup-cron-jobs.md
+++ b/src/cloud/configure/setup-cron-jobs.md
@@ -53,7 +53,7 @@ To review cron configuration on Pro plan environments:
    ```
 
    {:.bs-callout-info}
-   If the `crontab -l` command returns a `Command not found` error, contact your Dedicated Customer Technical Advisor or CSM about enabling the auto-crons self-service configuration option on your {{site.data.var.ece}} project.
+   If the `crontab -l` command returns a `Command not found` error, contact your Customer Technical Advisor or CSM about enabling the auto-crons self-service configuration option on your {{site.data.var.ece}} project.
 
 The following example shows the crontab output for an environment that has only the default crons configuration:
 

--- a/src/cloud/configure/setup-cron-jobs.md
+++ b/src/cloud/configure/setup-cron-jobs.md
@@ -53,7 +53,7 @@ To review cron configuration on Pro plan environments:
    ```
 
    {:.bs-callout-info}
-   If the `crontab -l` command returns a `Command not found` error, contact your Magento account manager or CSM about enabling the auto-crons self-service configuration option on your {{site.data.var.ece}} project.
+   If the `crontab -l` command returns a `Command not found` error, contact your Dedicated Customer Technical Advisor or CSM about enabling the auto-crons self-service configuration option on your {{site.data.var.ece}} project.
 
 The following example shows the crontab output for an environment that has only the default crons configuration:
 
@@ -120,7 +120,7 @@ The default cron interval for all environments provisioned in the US-3, EU-3, an
 
 ### Prerequisite
 
-On {{ site.data.var.ee }} Pro projects, the [auto-crons feature](#verify-cron-configuration-on-pro-projects) must be enabled on your {{site.data.var.ece}} project before you can add custom cron jobs to Staging and Production environments using `.magento.app.yaml`. If this feature is not enabled,contact your Magento account manager or CSM.
+On {{ site.data.var.ee }} Pro projects, the [auto-crons feature](#verify-cron-configuration-on-pro-projects) must be enabled on your {{site.data.var.ece}} project before you can add custom cron jobs to Staging and Production environments using `.magento.app.yaml`. If this feature is not enabled, contact your Customer Technical Advisor (CTA).
 
 {:.procedure}
 To add custom crons:


### PR DESCRIPTION
## Purpose of this pull request

Changes references to "Technical Account Manager" to the new title Customer Technical Adviser (CTA).

## Affected DevDocs pages

https://devdocs.magento.com/cloud/architecture/cloud-architecture.html
https://devdocs.magento.com/cloud/cdn/configure-fastly.html
https://devdocs.magento.com/cloud/configure/setup-cron-jobs.html

