### PR TITLE
Updated example for cacheable query in graphql

### DIFF
--- a/src/guides/v2.3/graphql/develop/identity-class.md
+++ b/src/guides/v2.3/graphql/develop/identity-class.md
@@ -52,9 +52,8 @@ class MyIdentity implements IdentityInterface
 Use the `@cache` directive in your module’s [`graphqls` file]({{page.baseurl}}/graphql/develop/create-graphqls-file.html) to specify the location to your `Identity` class. Your module’s `graphqls` file must point to your `Identity` class, as shown below:
 
 ```text
-    category (
-        id: Int @doc(description: "Id of the category")
-    ): CategoryTree
-    @resolver(class: "Magento\\CatalogGraphQl\\Model\\Resolver\\CategoryTree") @doc(description: "The category query searches for categories that match the criteria specified in the search and filter attributes") @cache(cacheIdentity: "Magento\\CatalogGraphQl\\Model\\Resolver\\Category\\CategoryTreeIdentity")
+      categoryList(
+    filters: CategoryFilterInput @doc(description: "Identifies which Category filter inputs to search for and return.")
+    ): [CategoryTree] @doc(description: "Returns an array of categories based on the specified filters.") @resolver(class: "Magento\\CatalogGraphQl\\Model\\Resolver\\CategoryList") @cache(cacheIdentity: "Magento\\CatalogGraphQl\\Model\\Resolver\\Category\\CategoriesIdentity")
 }
 ```


### PR DESCRIPTION
## Purpose of this pull request

This pull request (PR) replaces the deprecated category query with updated category list query for cacheable query example

## Affected DevDocs pages

<!-- REQUIRED List the affected pages on devdocs.magento.com (URLs). Not needed for large numbers of files. -->

-  https://devdocs.magento.com/guides/v2.3/graphql/develop/identity-class.html

## Links to Magento source code

<!--  OPTIONAL - REMOVE THIS SECTION IF NOT USED. If this pull request references a file in a Magento codebase repository, add it here. -->

- https://github.com/magento/magento2/blob/047f5b943cb74e5bac67360aaadae31e165c09db/app/code/Magento/CatalogGraphQl/etc/schema.graphqls#L13
https://github.com/magento/magento2/blob/047f5b943cb74e5bac67360aaadae31e165c09db/app/code/Magento/CatalogGraphQl/etc/schema.graphqls#L17

<!--
If you are fixing a GitHub issue, note it using GitHub keyword format (https://help.github.com/en/articles/closing-issues-using-keywords#closing-an-issue-in-a-different-repository) to close the issue when this pull request is merged. Example: `Fixes #1234`

`master` is the default branch. Merged pull requests to `master` go live on the site automatically. Any requested changes to content on the `master` branch must be related to the released codebase. Any content related to future releases goes in the `develop` branch.

See Contribution guidelines (https://github.com/magento/devdocs/blob/master/.github/CONTRIBUTING.md) for more information.
-->
