### PR TITLE
MAGECLOUD-4894: [MTS] Add support of split DB on docker

### DIFF
--- a/src/cloud/docker/docker-manage-database.md
+++ b/src/cloud/docker/docker-manage-database.md
@@ -11,6 +11,9 @@ The Cloud Docker development environment provides MySQL services through a Maria
 
 ## Connect to the database
 
+ {: .bs-callout-note }
+ If you work with the split database architecture, then all actions are true for split databases too. Only identifiers will change for command related with split databases
+ 
 There are two ways to connect to the database. Before you begin, locate the database credentials in the `database` section of the `.docker/config.php` file. The examples use the following default credentials:
 
 > Filename: `.docker/config.php`
@@ -21,6 +24,25 @@ return [
         'database' => [
             [
                 'host' => 'db',
+                'path' => 'magento2',
+                'password' => 'magento2',
+                'username' => 'magento2',
+                'port' => '3306'
+            ],
+        ],
+        // The following configuration will be available if you are using the split database architecture.
+        'database-quote' => [
+            [
+                'host' => 'db-quote',
+                'path' => 'magento2',
+                'password' => 'magento2',
+                'username' => 'magento2',
+                'port' => '3306'
+            ],
+        ],
+        'database-sales' => [
+            [
+                'host' => 'db-sales',
                 'path' => 'magento2',
                 'password' => 'magento2',
                 'username' => 'magento2',
@@ -44,6 +66,17 @@ To connect to the database using Docker commands:
    ```bash
    mysql --host=db --user=magento2 --password=magento2
    ```
+   
+   If you use the split database architecture:
+   
+   ```bash
+      mysql --host=db-quote --user=magento2 --password=magento2
+   ```
+
+   ```bash
+      mysql --host=db-sales --user=magento2 --password=magento2
+   ```
+   
 
 1. Verify the version of the database service.
 
@@ -71,7 +104,13 @@ To connect to the database port:
    ```terminal
              Name                         Command               State               Ports
    --------------------------------------------------------------------------------------------------
-   mc-master_db_1              docker-entrypoint.sh mysqld      Up       0.0.0.0:32769->3306/tcp
+   magento-cloud_db_1          docker-entrypoint.sh mysqld      Up       0.0.0.0:32769->3306/tcp
+   
+   # The following lines will be available if you are using the split database architecture.
+   
+   magento-cloud_db-quote_1    docker-entrypoint.sh mysqld      Up       0.0.0.0:32873->3306/tcp
+   magento-cloud_db-sales_1    docker-entrypoint.sh mysqld      Up       0.0.0.0:32874->3306/tcp
+
    ```
    {:.no-copy}
 
@@ -80,7 +119,19 @@ To connect to the database port:
    ```bash
    mysql -h127.0.0.1 -P32769 -umagento2 -pmagento2
    ```
-
+   
+   If you use the split database architecture then use the appropriate ports:
+   
+   For 'db-quote' service: 
+   ```bash
+      mysql -h127.0.0.1 -32873 -umagento2 -pmagento2
+   ```
+   
+   For 'db-sales' service: 
+   ```bash
+      mysql -h127.0.0.1 -32874 -umagento2 -pmagento2
+   ```
+   
 1. Verify the version of the database service.
 
    ```mysql

--- a/src/cloud/docker/docker-split-db.md
+++ b/src/cloud/docker/docker-split-db.md
@@ -1,0 +1,187 @@
+---
+group: cloud-guide
+title: Configure Split Databases for Docker
+functional_areas:
+- Cloud
+- Setup
+- Configuration
+- Debug
+- Split Databases
+---
+
+## Configure Split Databases for Docker
+To prepare the configuration before deploying the split db architecture, you will need to modify several files:
+
+1. Add the next database services to the config file `.magento/services.yaml`:
+
+```yaml
+ ...
+mysql-quote:
+    type: mysql:10.2
+    disk: 512
+mysql-sales:
+    type: mysql:10.2
+    disk: 512
+ ...
+```
+
+4. Add the next relationships to the config file `.magento.app.yaml`:
+
+```yaml
+relationships:
+    ...
+    database-quote: "mysql-quote:mysql"
+    database-sales: "mysql-sales:mysql"
+   ...
+```
+
+5. Let's now generate the file by running the cli command:
+```shell script
+php vendor/bin/ece-docker build:compose
+```
+NOTES: As with the 'db' container, you can use the options to set the ports to forward to your local environment:
+  
+```shell script
+php vendor/bin/ece-docker build:compose --expose-db-quote-port=<port for quotee db service> --expose-db-sales-port=<port for sales db service>
+```
+
+6. Аfter generation, open the file `./docker-compose.yml` and you will see that the configuration for database services has been added:
+
+```shell script
+$ cat  ./docker-compose.yml
+...
+services:
+  ...
+  db-quote:
+    hostname: db-quote.magento2.docker
+    image: 'mariadb:10.2'
+    environment:
+      - MYSQL_ROOT_PASSWORD=magento2
+      - MYSQL_DATABASE=magento2
+      - MYSQL_USER=magento2
+      - MYSQL_PASSWORD=magento2
+    ports:
+      - '3306'
+    volumes:
+      - 'magento-db-quote:/var/lib/mysql'
+      - 'docker-entrypoint-quote:/docker-entrypoint-initdb.d'
+      - 'mariadb-conf:/etc/mysql/mariadb.conf.d'
+      - 'docker-mnt:/mnt:delegated'
+    networks:
+      magento:
+        aliases:
+          - db-quote.magento2.docker
+  db-sales:
+    hostname: db-sales.magento2.docker
+    image: 'mariadb:10.2'
+    environment:
+      - MYSQL_ROOT_PASSWORD=magento2
+      - MYSQL_DATABASE=magento2
+      - MYSQL_USER=magento2
+      - MYSQL_PASSWORD=magento2
+    ports:
+      - '3306'
+    volumes:
+      - 'magento-db-sales:/var/lib/mysql'
+      - 'docker-entrypoint-sales:/docker-entrypoint-initdb.d'
+      - 'mariadb-conf:/etc/mysql/mariadb.conf.d'
+      - 'docker-mnt:/mnt:delegated'
+    networks:
+      magento:
+        aliases:
+          - db-sales.magento2.docker
+...
+```
+     
+6. The file `./.docker/config.php.dist` was generated with next configurations:
+
+```php
+<?php
+
+return [
+    'MAGENTO_CLOUD_RELATIONSHIPS' => base64_encode(json_encode([
+       //...
+        'database-sales' => [
+            [
+                'host' => 'db-sales',
+                'path' => 'magento2',
+                'password' => 'magento2',
+                'username' => 'magento2',
+                'port' => '3306'
+            ]
+        ],
+        'database-quote' => [
+            [
+                'host' => 'db-quote',
+                'path' => 'magento2',
+                'password' => 'magento2',
+                'username' => 'magento2',
+                'port' => '3306'
+            ]
+        ],
+    ])),
+   //...
+];
+```
+
+7. Run 
+
+```shell script
+docker-compose up -d
+```
+
+8. Run command 
+
+```shell script
+docker-compose run deploy bash
+```
+
+9. In the environment variable, 'MAGENTO_CLOUD_RELATIONSHIPS' of "deploy" service has also added data to access new database services. 
+Run command in the container: ` echo $MAGENTO_CLOUD_RELATIONSHIPS | base64 -d | json_pp `:
+
+```json
+{
+   "database-quote" : [
+      {
+         "host" : "db-quote",
+         "port" : "3306",
+         "path" : "magento2",
+         "username" : "magento2",
+         "password" : "magento2"
+      }
+   ],
+   "database-sales" : [
+      {
+         "path" : "magento2",
+         "port" : "3306",
+         "username" : "magento2",
+         "host" : "db-sales",
+         "password" : "magento2"
+      }
+   ]
+}
+ ```
+
+10. Yuo can use this credentials to connect to DB services
+11. Exit from container and run `docker-compose ps`:
+
+```shell script
+docker-compose ps
+            Name                           Command                  State                Ports
+-------------------------------------------------------------------------------------------------------
+...
+magento-cloud_db-quote_1        docker-entrypoint.sh mysqld      Up             0.0.0.0:32873->3306/tcp
+magento-cloud_db-sales_1        docker-entrypoint.sh mysqld      Up             0.0.0.0:32874->3306/tcp
+magento-cloud_db_1              docker-entrypoint.sh mysqld      Up             0.0.0.0:32872->3306/tcp
+...
+```
+
+12. Yuo can use this ports to connect to DB services from your host
+ 
+Now everything is ready to install Magento with Split Databases
+
+
+   ![Xdebug Helper options]({{ site.baseurl }}/common/images/cloud-xdebug_helper-options.png){:width="400px"}
+
+[docker-config]: {{site.baseurl}}/cloud/docker/docker-config.html
+[Xdebug Helper extension]: https://chrome.google.com/webstore/detail/xdebug-helper/eadndfjplgieldjbigjakmdgkmoaaaoc?hl=en

--- a/src/cloud/docker/docker-split-db.md
+++ b/src/cloud/docker/docker-split-db.md
@@ -93,7 +93,7 @@ services:
 ...
 ```
      
-6. The file `./.docker/config.php.dist` was generated with next configurations:
+6.  Verify that the `./.docker/config.php.dist`  environment configuration file includes the updated database service configuration:
 
 ```php
 <?php

--- a/src/cloud/docker/docker-split-db.md
+++ b/src/cloud/docker/docker-split-db.md
@@ -1,6 +1,6 @@
 ---
 group: cloud-guide
-title: Configure Split Databases for Docker
+title: Configure Magento split databases for Docker
 functional_areas:
 - Cloud
 - Setup
@@ -10,9 +10,9 @@ functional_areas:
 ---
 
 ## Configure Split Databases for Docker
-To prepare the configuration before deploying the split db architecture, you will need to modify several files:
+To prepare the configuration before deploying the split db architecture, you must modify several files:
 
-1. Add the next database services to the config file `.magento/services.yaml`:
+1. Add the following database services to the `.magento/services.yaml` configuration file:
 
 ```yaml
  ...
@@ -25,7 +25,7 @@ mysql-sales:
  ...
 ```
 
-4. Add the next relationships to the config file `.magento.app.yaml`:
+4. In the `magento.app.yaml` file, add the database relationships for the additional databases:
 
 ```yaml
 relationships:
@@ -36,7 +36,7 @@ relationships:
 ```
 
 5. Let's now generate the file by running the cli command:
-```shell script
+```bash
 php vendor/bin/ece-docker build:compose
 ```
 NOTES: As with the 'db' container, you can use the options to set the ports to forward to your local environment:
@@ -47,7 +47,7 @@ php vendor/bin/ece-docker build:compose --expose-db-quote-port=<port for quotee 
 
 6. Аfter generation, open the file `./docker-compose.yml` and you will see that the configuration for database services has been added:
 
-```shell script
+```bash
 $ cat  ./docker-compose.yml
 ...
 services:
@@ -126,13 +126,13 @@ return [
 
 7. Run 
 
-```shell script
+```bash
 docker-compose up -d
 ```
 
 8. Run command 
 
-```shell script
+```bash
 docker-compose run deploy bash
 ```
 

--- a/src/cloud/docker/docker-split-db.md
+++ b/src/cloud/docker/docker-split-db.md
@@ -38,7 +38,8 @@ relationships:
 ```bash
 php vendor/bin/ece-docker build:compose
 ```
-NOTES: As with the 'db' container, you can use the options to set the ports to forward to your local environment:
+{: .bs-callout-note } 
+As with the 'db' container, you can use the options to set the ports to forward to your local environment:
   
 ```bash
 php vendor/bin/ece-docker build:compose --expose-db-quote-port=<port for quotee db service> --expose-db-sales-port=<port for sales db service>
@@ -142,7 +143,7 @@ magento-cloud_db_1              docker-entrypoint.sh mysqld      Up             
 ...
 ```
 
-8. In the environment variable 'MAGENTO_CLOUD_RELATIONSHIPS' of "deploy" service has also added data about credentials to access new database services. 
+8. In the environment variable 'MAGENTO_CLOUD_RELATIONSHIPS' of 'deploy' service has also added data about credentials to access new database services. 
 
 ```bash
 docker-compose run deploy bash -c "echo $MAGENTO_CLOUD_RELATIONSHIPS | base64 -d | json_pp"
@@ -173,4 +174,29 @@ Expected result:
 }
  ```
  
-Now everything is ready to install Magento with Split Databases
+Now everything is ready to install Magento with split database solution
+The process for deploying Magento with the split database solution in the Magento Cloud Docker is similar to the deployment process in Magento Cloud environment.
+
+9. Add the SPLIT_DB property with type or types of tables that will be imported into other databases into `.magento.env.yaml`
+
+```yaml
+stage:
+    deploy:
+        SPLIT_DB:
+            - quote
+            - sales
+```
+
+10. Run build phase of deployment process 
+```bash
+docker-compose run build cloud-build
+```
+
+11. Run deploy phase of deployment process
+```bash
+docker-compose run deploy cloud-deploy
+```
+
+At the deploy phase, `ece-tools` runs all the necessary commands to deploy the split DB solution for types specify in the SPLIT DB property of `.magento env.yaml` file
+
+After deploying Magento with the split DB solution, use the database credentials and port information to manage each database. See [Manage the database]({{site.baseurl}}/cloud/docker/docker-manage-database.html.


### PR DESCRIPTION
## Purpose of this pull request
Adds instructions on how to prepare `magento-cloud-docker` (ece-docker) for deploying Magento in Split Database mode
