### PR TITLE
GraphQL: Add url_path filter to categoryList query

### DIFF
--- a/src/guides/v2.3/graphql/queries/category-list.md
+++ b/src/guides/v2.3/graphql/queries/category-list.md
@@ -293,6 +293,7 @@ Attribute | Data type | Description
 `ids` | FilterEqualTypeInput | Filters by the specified category IDs
 `name` | FilterMatchTypeInput | Filters by the display name of the category
 `url_key` | FilterEqualTypeInput | Filters by the part of the URL that identifies the category
+`url_path` | FilterEqualTypeInput | Filters by the URL path for the category
 
 ### FilterEqualTypeInput object
 


### PR DESCRIPTION
## Purpose of this pull request

This pull request adds the url_path filter to the categoryList query, per intenrnal ticlet MC-32388

## Affected DevDocs pages

- https://devdocs.magento.com/guides/v2.4/graphql/queries/category-list.html
