### PR TITLE
Add documentation for SCD_RUN_BALER env variable for Magento Cloud

### DIFF
--- a/src/cloud/env/variables-build.md
+++ b/src/cloud/env/variables-build.md
@@ -37,7 +37,7 @@ stage:
 ```
 
 {:.bs-callout-info}
-You must install and configure the Baler module before using this feature. Because Baler is currently in alpha release, enable this option only on Staging environments.
+You must install and configure the Baler module before using this feature. Because Baler is currently in alpha release, we do not recommend using it in Production environments.
 
 ### `ERROR_REPORT_DIR_NESTING_LEVEL`
 

--- a/src/cloud/env/variables-build.md
+++ b/src/cloud/env/variables-build.md
@@ -21,6 +21,24 @@ The following variables were removed in v2.2:
 -  `skip_di_clearing`
 -  `skip_di_compilation`
 
+### `SCD_USE_BALER`
+
+-  **Default**—_Not set_
+-  **Version**—Magento 2.3.0 and later
+
+[Baler](https://github.com/magento/baler) scans your generated JavaScript code and creates an optimized JavaScript bundle. Deploying the optimized bundle to your site can reduce the number of network requests when loading your site and improve page load times.
+
+Set to `true` to run Baler after performing static content deployment.
+
+```yaml
+stage:
+  build:
+    SCD_USE_BALER: true
+```
+
+{:.bs-callout-info}
+You must install and configure the Baler module before using this feature. Because Baler is currently in alpha release, enable this option only on Staging environments.
+
 ### `ERROR_REPORT_DIR_NESTING_LEVEL`
 
 -  **Default**—`1`

--- a/src/cloud/env/variables-global.md
+++ b/src/cloud/env/variables-global.md
@@ -16,6 +16,24 @@ stage:
 
 {% include cloud/customize-build-deploy.md %}
 
+### `SCD_USE_BALER`
+
+-  **Default**—_Not set_
+-  **Version**—Magento 2.3.0 and later
+
+[Baler](https://github.com/magento/baler) is a Magento module that scans your generated JavaScript code and creates an optimized JavaScript bundle. Deploying the optimized bundle to your site can reduce the number of network requests when loading your site and improve page load times.
+
+Set to `true` to run Baler after performing static content deployment.
+
+```yaml
+stage:
+  build:
+    SCD_USE_BALER: true
+```
+
+{:.bs-callout-info}
+You must install and configure the Baler module before using this feature. Because Baler is currently in alpha release, enable this option only on Staging environments.
+
 ### `MIN_LOGGING_LEVEL`
 
 -  **Default**—_Not set_

--- a/src/cloud/release-notes/ece-release-notes.md
+++ b/src/cloud/release-notes/ece-release-notes.md
@@ -17,6 +17,13 @@ The `{{site.data.var.ct}}` package uses the following release versioning sequenc
 {:.bs-callout-info}
 See [Upgrades and patches]({{ site.baseurl }}/cloud/project/project-upgrade-parent.html) for information about updating to the latest release of the `{{site.data.var.ct}}` package.
 
+## v2002.1.1
+*Release date: TBD*<br/>
+
+-  {:.new}**Environment variable updates**–
+
+   -  {:.new}Added the **SCD_USE_BALER** variable to enable the Magento Baler module for JavaScript bundling during the {{site.data.var.ece }} build process. See the variable description in the [build variables]({{site.variable}}/cloud/env/variables-build.html#scd_use_baler).<!-- MAGECLOUD-4593 -->
+
 ## v2002.1.0
 *Release date: February 6, 2020*<br/>
 


### PR DESCRIPTION
## Purpose of this pull request

Add documentation for SCD_RUN_BALER env variable for Magento Cloud to enable javascript bundling during the build process.

## Affected DevDocs pages

https://github.com/magento/devdocs/blob/master/src/cloud/env/variables-global.html
https://github.com/magento/devdocs/blob/master/src/cloud/env/variables-build.html
https://github.com/magento/devdocs/blob/master/src/cloud/release-notes/ece-tools.html

## Links to Magento source code

https://github.com/magento/ece-tools/pull/660


