### PR TITLE
magento/devdocs#6896: Using the name variable in Symphony commands

### DIFF
--- a/src/guides/v2.3/extension-dev-guide/cli-cmds/cli-howto.md
+++ b/src/guides/v2.3/extension-dev-guide/cli-cmds/cli-howto.md
@@ -22,7 +22,7 @@ Before you begin, make sure you understand the following:
 *  All Magento command-line interface (CLI) commands rely on the Magento application and must have access to its context, dependency injections, plug-ins, and so on.
 *  All CLI commands should be implemented in the scope of your [module](https://glossary.magento.com/module) and should depend on the module's status.
 *  Your command can use the Object Manager and Magento dependency injection features; for example, it can use [constructor dependency injection]({{ page.baseurl }}/extension-dev-guide/depend-inj.html#constructor-injection).
-*  Your command should have an unique `name` which can be defined in the `configure()` method of Command class:
+*  Your command should have an unique `name`, defined in the `configure()` method of the Command class:
 
    ```php
    protected function configure()
@@ -50,7 +50,7 @@ Before you begin, make sure you understand the following:
    </config>
    ```
 
-   otherwise [Symfony](https://github.com/symfony/console/blob/master/Application.php#L470) framework will return an `The command defined in "<Command class>" cannot have an empty name.` error.
+   Otherwise the [Symfony](https://github.com/symfony/console/blob/master/Application.php#L470) framework will return an `The command defined in "<Command class>" cannot have an empty name.` error.
 
 ## Add CLI commands using dependency injection {#cli-sample}
 

--- a/src/guides/v2.3/extension-dev-guide/cli-cmds/cli-howto.md
+++ b/src/guides/v2.3/extension-dev-guide/cli-cmds/cli-howto.md
@@ -22,6 +22,35 @@ Before you begin, make sure you understand the following:
 *  All Magento command-line interface (CLI) commands rely on the Magento application and must have access to its context, dependency injections, plug-ins, and so on.
 *  All CLI commands should be implemented in the scope of your [module](https://glossary.magento.com/module) and should depend on the module's status.
 *  Your command can use the Object Manager and Magento dependency injection features; for example, it can use [constructor dependency injection]({{ page.baseurl }}/extension-dev-guide/depend-inj.html#constructor-injection).
+*  Your command should have an unique `name` which can be defined in the `configure()` method of Command class:
+
+   ```php
+   protected function configure()
+   {
+      $this->setName('my:first:command');
+      $this->setDescription('This is my first console command.');
+
+      parent::configure();
+   }
+   ...
+   ```
+
+   or in the `di.xml` file:
+
+   ```xml
+   <config xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="urn:magento:framework:ObjectManager/etc/config.xsd">
+      ...
+      <type name="Magento\CommandExample\Console\Command\SomeCommand">
+         <arguments>
+            <!-- configure the command name via constructor $name argument -->
+            <argument name="name" xsi:type="string">my:first:command</argument>
+         </arguments>
+      </type>
+      ...
+   </config>
+   ```
+
+   otherwise [Symfony](https://github.com/symfony/console/blob/master/Application.php#L470) framework will return an `The command defined in "<Command class>" cannot have an empty name.` error.
 
 ## Add CLI commands using dependency injection {#cli-sample}
 
@@ -62,6 +91,7 @@ Following is a summary of the process:
                         'Name'
                     )
                ];
+               $this->setName('my:first:command');
                $this->setDescription('This is my first console command.');
                $this->setDefinition($options);
 
@@ -97,12 +127,6 @@ Following is a summary of the process:
    ```xml
    <config xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="urn:magento:framework:ObjectManager/etc/config.xsd">
        ...
-       <type name=" Magento\CommandExample\Console\Command\SomeCommand">
-           <arguments>
-               <!-- configure the command name via constructor $name argument -->
-               <argument name="name" xsi:type="string">my:first:command</argument>
-           </arguments>
-       </type>
        <type name="Magento\Framework\Console\CommandListInterface">
            <arguments>
                <argument name="commands" xsi:type="array">


### PR DESCRIPTION
## Purpose of this pull request

This pull request (PR) fixes https://github.com/magento/devdocs/issues/6896.

## Affected DevDocs pages

<!-- REQUIRED List the affected pages on devdocs.magento.com (URLs). Not needed for large numbers of files. -->

-  https://devdocs.magento.com/guides/v2.3/extension-dev-guide/cli-cmds/cli-howto.html

## Links to Magento source code

<!--  OPTIONAL - REMOVE THIS SECTION IF NOT USED. If this pull request references a file in a Magento codebase repository, add it here. -->

-  [Symfony\Component\Console\Application::add()](https://github.com/symfony/console/blob/master/Application.php#L470)

<!--
If you are fixing a GitHub issue, note it using GitHub keyword format (https://help.github.com/en/articles/closing-issues-using-keywords#closing-an-issue-in-a-different-repository) to close the issue when this pull request is merged. Example: `Fixes #1234`

`master` is the default branch. Merged pull requests to `master` go live on the site automatically. Any requested changes to content on the `master` branch must be related to the released codebase. Any content related to future releases goes in the `develop` branch.

See Contribution guidelines (https://github.com/magento/devdocs/blob/master/.github/CONTRIBUTING.md) for more information.
-->

Thank you!