### PR TITLE
Fix customer auth example with cURL

### DIFF
--- a/src/guides/v2.3/get-started/authentication/gs-authentication-token.md
+++ b/src/guides/v2.3/get-started/authentication/gs-authentication-token.md
@@ -71,7 +71,7 @@ The following example uses the `curl` command to request a token for a customer 
 ```bash
 curl -X POST "https://magento.host/index.php/rest/V1/integration/customer/token" \
      -H "Content-Type:application/json" \
-     -d "{"username":"customer1", "password":"customer1pw"}"
+     -d '{"username":"admin_username", "password":"admin_password"}'
 ```
 
 The following example makes the same request with [XML](https://glossary.magento.com/xml) for a customer account token:

--- a/src/guides/v2.3/get-started/authentication/gs-authentication-token.md
+++ b/src/guides/v2.3/get-started/authentication/gs-authentication-token.md
@@ -71,7 +71,7 @@ The following example uses the `curl` command to request a token for a customer 
 ```bash
 curl -X POST "https://magento.host/index.php/rest/V1/integration/customer/token" \
      -H "Content-Type:application/json" \
-     -d '{"username":"admin_username", "password":"admin_password"}'
+     -d '{"username":"customer@example.com", "password":"customer_password"}'
 ```
 
 The following example makes the same request with [XML](https://glossary.magento.com/xml) for a customer account token:


### PR DESCRIPTION
## Purpose of this pull request

This pull request (PR) fixes authentication example with cURL

## Affected DevDocs pages

-  https://devdocs.magento.com/guides/v2.3/get-started/authentication/gs-authentication-token.html#token-example