### PR TITLE
Adding documentation for WARM_UP_CONCURRENCY config variable on cloud

### DIFF
--- a/src/cloud/env/variables-post-deploy.md
+++ b/src/cloud/env/variables-post-deploy.md
@@ -136,7 +136,7 @@ Customize the list of pages used to preload the cache in the `post_deploy` stage
 -  **Default**—_Not set_
 -  **Version**—Magento 2.1.4 and later
 
-Configure _CONCURRENCY_ with which requests to _WARM_UP_PAGES_ will be sent. This configuration limits number of parallel connections. It can help to decrease server load in case of a big amount of pages to warm-up.
+Specify the number of concurrent requests to send during cache warmup operations to reduce server load. This value limits the number of parallel connections and is useful for environment configurations where the `WARM_UP_PAGES` post-deploy variable specifies a large number of pages for cache preloading.
 
 ```yaml
 stage:

--- a/src/cloud/env/variables-post-deploy.md
+++ b/src/cloud/env/variables-post-deploy.md
@@ -41,6 +41,19 @@ After you specify the pages to test and commit your changes, the _Time To First 
 
 For redirected paths, the log reports the path of the redirect target instead of the one configured in the environment variable. If you specify an invalid path, the log displays a warning message.
 
+### `WARM_UP_CONCURRENCY`
+
+-  **Default**—_Not set_
+-  **Version**—Magento 2.1.4 and later
+
+Specify the number of concurrent requests to send during cache warmup operations to reduce server load. This value limits the number of parallel connections and is useful for environment configurations where the `WARM_UP_PAGES` post-deploy variable specifies a large number of pages for cache preloading.
+
+```yaml
+stage:
+  post-deploy:
+    WARM_UP_CONCURRENCY: 4
+```
+
 ### `WARM_UP_PAGES`
 
 -  **Default**— `index.php`
@@ -130,19 +143,6 @@ Customize the list of pages used to preload the cache in the `post_deploy` stage
                - "store-page:/contact-us:1"
                - "store-page:/contact-us:code1|code2"
    ```
-
-### `WARM_UP_CONCURRENCY`
-
--  **Default**—_Not set_
--  **Version**—Magento 2.1.4 and later
-
-Specify the number of concurrent requests to send during cache warmup operations to reduce server load. This value limits the number of parallel connections and is useful for environment configurations where the `WARM_UP_PAGES` post-deploy variable specifies a large number of pages for cache preloading.
-
-```yaml
-stage:
-  post-deploy:
-    WARM_UP_CONCURRENCY: 4
-```
 
 [hooks section]: {{site.baseurl}}/cloud/project/project-conf-files_magento-app.html#hooks
 [CMS]: https://glossary.magento.com/cms/

--- a/src/cloud/env/variables-post-deploy.md
+++ b/src/cloud/env/variables-post-deploy.md
@@ -131,6 +131,19 @@ Customize the list of pages used to preload the cache in the `post_deploy` stage
                - "store-page:/contact-us:code1|code2"
    ```
 
+### `WARM_UP_CONCURRENCY`
+
+-  **Default**—_Not set_
+-  **Version**—Magento 2.1.4 and later
+
+Configure _CONCURRENCY_ with which requests to _WARM_UP_PAGES_ will be sent. This configuration limits number of parallel connections. It can help to decrease server load in case of a big amount of pages to warm-up.
+
+```yaml
+stage:
+  post-deploy:
+    WARM_UP_CONCURRENCY: 4
+```
+
 [hooks section]: {{site.baseurl}}/cloud/project/project-conf-files_magento-app.html#hooks
 [CMS]: https://glossary.magento.com/cms/
 [Content elements]: https://docs.magento.com/m2/ce/user_guide/cms/content-elements.html


### PR DESCRIPTION
## Purpose of this pull request

Add documentation for the the WARM_UP_CONCURRENCY post-deploy variable to specify the number of warm-up requests that the cache warm up script can send concurrently. This variable helps manage load on the Magento Cloud infrastructure.

## Affected DevDocs pages

https://devdocs.magento.com/cloud/env/variables-post-deploy.html

## Magento source code

https://github.com/magento/ece-tools/pull/700

whatsnew
Added documentation for the [WARM_UP_CONCURRENCY post-deploy variable](https://devdocs.magento.com/cloud/env/variables-post-deploy.html) to specify the number of warm-up requests that the cache warm up script can send concurrently. This variable helps manage load on the Magento Cloud infrastructure.
