### PR TITLE
Add Baler module install and config instructions

### DIFF
--- a/src/cloud/deploy/static-content-deployment.md
+++ b/src/cloud/deploy/static-content-deployment.md
@@ -14,7 +14,7 @@ You can use bundling and minification to build optimized JavaScript and HTML con
 
 ### Bundle JavaScript files
 
-JavaScript bundling is an optimization technique you can use to reduce the number of server requests for JavaScript files.
+Javascript bundling is an optimization technique you can use to reduce the number of server requests for JavaScript files.
 
 For {{site.data.var.ece}} projects, you can use the Magento [Baler](https://github.com/magento/baler) extension to scan generated JavaScript code and create an optimized JavaScript bundle during the build process. Deploying the optimized bundle to your site can reduce the number of network requests when loading your site and improve page load times.
 
@@ -23,23 +23,30 @@ You must install and configure your project to use Baler.
 {:.procedure}
 To install and configure Baler:
 
-1. Use the following Baler extension information to [install the the Baler extension]({{ site.baseurl }}/cloud/howtos/install-components.html#install) in a {{site.var.data.ece}} development branch.
+1. Use the following Baler extension information to [install the Baler extension]({{ site.baseurl }}/cloud/howtos/install-components.html#install) in a {{site.var.data.ece}} development branch.
 
    ```text
    module name: magento/module-baler
    repository: https://github.com/magento/m2-baler
    ```
 
-1. In the same environment, update the `config.php` project configuration file with the following settings to enable the javascript bundling options required to use Baler.
+1. In the same environment, update the `config.php` project configuration file with the following settings required to use Baler for JavaScript bundling.
 
    > `config.php`
 
    ```php
-       'js' => [
-         'merge_files' => '0',
-         'minify_files' => '0',
-         'enable_js_bundling' => '0',
-         'enable_baler_js_bundling' => '1',
+   'system' => [
+       'default' => [
+           'dev' => [
+               'js' => [
+                   'merge_files' => '0',
+                   'minify_files' => '0',
+                   'enable_js_bundling' => '0',
+                   'enable_baler_js_bundling' => '1',
+               ],
+            ],
+       ],
+   ],
    ```
 
    {:.bs-callout-tip}
@@ -51,12 +58,11 @@ To install and configure Baler:
 
    ```yaml
    stage:
-      build:
-         SCD_USE_BALER:
-            - "index.php"
+       build:
+           SCD_USE_BALER: true
    ```
 
-1. Update the .magento.app.yaml `hooks` configuration with the Node Version Manager (nvm) configuration that Baler requires to generate the Javascript bundle.
+1. In the `.magento.app.yaml` file, update the `hooks` configuration to install the Node Version Manager (nvm) and the Node version required to use Baler.
 
    > `.magento.app.yaml`
 
@@ -64,16 +70,16 @@ To install and configure Baler:
    hooks:
        build: |
            set -e
-        
+
            unset NPM_CONFIG_PREFIX
            curl -o- https://raw.githubusercontent.com/creationix/nvm/v0.35.2/install.sh | dash
            export NVM_DIR="$HOME/.nvm"
            [ -s "$NVM_DIR/nvm.sh" ] && \. "$NVM_DIR/nvm.sh"
            nvm install --lts=dubnium
-           
+
            php ./vendor/bin/ece-tools build:generate
            php ./vendor/bin/ece-tools build:transfer
-   
+   ```
 
 1. Add, commit, and push your code changes.
 

--- a/src/cloud/deploy/static-content-deployment.md
+++ b/src/cloud/deploy/static-content-deployment.md
@@ -8,7 +8,83 @@ functional_areas:
 
 Static content deployment (SCD) has a significant impact on the store deployment process that depends on how much content to generate—such as images, scripts, CSS, videos, themes, locales, and web pages—and when to generate the content. For example, the default strategy generates static content during the [deploy phase]({{ site.baseurl }}/cloud/deploy/cloud-deployment-process.html#-deploy-phase) when the site is in maintenance mode; however, this deployment strategy takes time to write the content directly to the mounted `pub/static` directory. You have several options or strategies to help you improve the deployment time depending on your needs.
 
-## Minify content
+## Optimize javascript and css content builds
+
+You can use bundling and minification to build optimized javascript and html content for static content deployment.
+
+### Bundle JavaScript files
+
+JavaScript bundling is an optimization technique you can use to reduce the number of server requests for JavaScript files.
+
+For {{site.data.var.ece}} projects, you can use the Magento [Baler](https://github.com/magento/baler) extension to scan generated JavaScript code and create an optimized JavaScript bundle during the build process. Deploying the optimized bundle to your site can reduce the number of network requests when loading your site and improve page load times.
+
+You must install and configure your project to use Baler.
+
+{:.procedure}
+To install and configure Baler:
+
+1. Use the following Baler extension information to [install the the Baler extension]({{ site.baseurl }}/cloud/howtos/install-components.html#install) in a {{site.var.data.ece}} development branch.
+
+   ```text
+   module name: fastly/magento2
+   repository: https://github.com/magento/m2-baler
+   ```
+
+1. In the same environment, update the `config.php` project configuration file with the following settings to enable the javascript bundling options required to use Baler.
+
+   > `config.php`
+
+   ```php
+       'js' => [
+         'merge_files' => '0',
+         'minify_files' => '0',
+         'enable_js_bundling' => '0',
+         'enable_baler_js_bundling' => '1',
+   ```
+
+   {:.bs-callout-tip}
+   If you do not have a copy of the `config.php` file in your development branch, see [Recommended procedure to manage your settings]({{site.baseurl}}/cloud/live/sens-data-over.html#cloud-config-specific-recomm) to learn how to generate and use this file to manage Magento store configuration for Cloud projects.
+
+1. Update your `.magento.env.yaml` environment configuration file to enable the SCD_USE_BALER option during the build process:
+
+   >  `.magento.env.yaml`
+
+   ```yaml
+   stage:
+      build:
+         SCD_USE_BALER:
+            - "index.php"
+   ```
+
+1. Update the .magento.app.yaml `hooks` configuration with the Node Version Manager (nvm) configuration that Baler requires to generate the Javascript bundle:
+
+   > `.magento.app.yaml`
+
+   ```yaml
+   hooks:
+      build: |
+         unset NPM_CONFIG_PREFIX
+         curl -o- https://raw.githubusercontent.com/creationix/nvm/v0.35.2/install.sh | dash
+         export NVM_DIR="$HOME/.nvm"
+         [ -s "$NVM_DIR/nvm.sh" ] && \. "$NVM_DIR/nvm.sh"
+         nvm install --lts=dubnium
+   ```
+
+1. Add, commit, and push your code changes.
+
+   ```bash
+   git add -A
+   ```
+
+   ```bash
+   git commit -m "Install and configure Baler for Javascript bundling"
+   ```
+
+   ```bash
+   git push origin <branch-name>
+   ```
+
+### Minify content
 
 You can improve the SCD load time during the deployment process if you skip copying the static view files in the `var/view_preprocessed` directory and generate _minified_ HTML when requested. You can activate this by setting the [SKIP_HTML_MINIFICATION]({{ site.baseurl }}/cloud/env/variables-global.html#skip_html_minification) global environment variable to `true` in the `.magento.env.yaml` file.
 

--- a/src/cloud/deploy/static-content-deployment.md
+++ b/src/cloud/deploy/static-content-deployment.md
@@ -8,9 +8,9 @@ functional_areas:
 
 Static content deployment (SCD) has a significant impact on the store deployment process that depends on how much content to generate—such as images, scripts, CSS, videos, themes, locales, and web pages—and when to generate the content. For example, the default strategy generates static content during the [deploy phase]({{ site.baseurl }}/cloud/deploy/cloud-deployment-process.html#-deploy-phase) when the site is in maintenance mode; however, this deployment strategy takes time to write the content directly to the mounted `pub/static` directory. You have several options or strategies to help you improve the deployment time depending on your needs.
 
-## Optimize javascript and css content builds
+## Optimize JavaScript and HTML content
 
-You can use bundling and minification to build optimized javascript and html content for static content deployment.
+You can use bundling and minification to build optimized JavaScript and HTML content during static content deployment.
 
 ### Bundle JavaScript files
 
@@ -26,7 +26,7 @@ To install and configure Baler:
 1. Use the following Baler extension information to [install the the Baler extension]({{ site.baseurl }}/cloud/howtos/install-components.html#install) in a {{site.var.data.ece}} development branch.
 
    ```text
-   module name: fastly/magento2
+   module name: magento/module-baler
    repository: https://github.com/magento/m2-baler
    ```
 
@@ -45,7 +45,7 @@ To install and configure Baler:
    {:.bs-callout-tip}
    If you do not have a copy of the `config.php` file in your development branch, see [Recommended procedure to manage your settings]({{site.baseurl}}/cloud/live/sens-data-over.html#cloud-config-specific-recomm) to learn how to generate and use this file to manage Magento store configuration for Cloud projects.
 
-1. Update your `.magento.env.yaml` environment configuration file to enable the SCD_USE_BALER option during the build process:
+1. Update your `.magento.env.yaml` environment configuration file to enable the `SCD_USE_BALER` option during the build process:
 
    >  `.magento.env.yaml`
 
@@ -62,13 +62,18 @@ To install and configure Baler:
 
    ```yaml
    hooks:
-      build: |
-         unset NPM_CONFIG_PREFIX
-         curl -o- https://raw.githubusercontent.com/creationix/nvm/v0.35.2/install.sh | dash
-         export NVM_DIR="$HOME/.nvm"
-         [ -s "$NVM_DIR/nvm.sh" ] && \. "$NVM_DIR/nvm.sh"
-         nvm install --lts=dubnium
-   ```
+       build: |
+           set -e
+        
+           unset NPM_CONFIG_PREFIX
+           curl -o- https://raw.githubusercontent.com/creationix/nvm/v0.35.2/install.sh | dash
+           export NVM_DIR="$HOME/.nvm"
+           [ -s "$NVM_DIR/nvm.sh" ] && \. "$NVM_DIR/nvm.sh"
+           nvm install --lts=dubnium
+           
+           php ./vendor/bin/ece-tools build:generate
+           php ./vendor/bin/ece-tools build:transfer
+   
 
 1. Add, commit, and push your code changes.
 

--- a/src/cloud/deploy/static-content-deployment.md
+++ b/src/cloud/deploy/static-content-deployment.md
@@ -56,7 +56,7 @@ To install and configure Baler:
             - "index.php"
    ```
 
-1. Update the .magento.app.yaml `hooks` configuration with the Node Version Manager (nvm) configuration that Baler requires to generate the Javascript bundle:
+1. Update the .magento.app.yaml `hooks` configuration with the Node Version Manager (nvm) configuration that Baler requires to generate the Javascript bundle.
 
    > `.magento.app.yaml`
 


### PR DESCRIPTION
## Purpose of this pull request

Added documentation to install and configure the Magento Baler extension to bundle javascript content during the Magento Cloud build process.

## Affected DevDocs pages

https://devdocs.magento.com/cloud/deploy/static-content-deployment.html

## Links to Magento source code

https://github.com/magento/ece-tools/pull/660

whatsnew
Added documentation to install and configure the Magento Baler extension to bundle javascript content during the Magento Cloud build process.
