### PR TITLE
Adding a missing symlink to 2.4

### DIFF
--- a/src/guides/v2.4/ui_comp_guide/components/ui-timeline-columns.md
+++ b/src/guides/v2.4/ui_comp_guide/components/ui-timeline-columns.md
@@ -1,0 +1,1 @@
+../../../v2.3/ui_comp_guide/components/ui-timeline-columns.md


### PR DESCRIPTION
## Purpose of this pull request

This pull request (PR) adds a missing symlink to 2.4 guides using rake:

```
rake symlink:create_from path=src/guides/v2.3/ui_comp_guide/components/ui-timeline-columns.md
```