### PR TITLE
Add BIC reference for 2.3.5 (pre-release)

### DIFF
--- a/src/guides/v2.3/release-notes/backward-incompatible-changes/index.md
+++ b/src/guides/v2.3/release-notes/backward-incompatible-changes/index.md
@@ -3,8 +3,7 @@ group: release-notes
 title: Magento 2.3 backward incompatible changes
 ---
 
-Magento 2.3 introduces several major changes that may affect the correct functionality of already released external modules.
-The purpose of this document is to highlight the changes between Magento 2.2 and 2.3.
+This page highlights backward incompatible changes between releases that have a major impact and require detailed explanation and special instructions to ensure third-party modules continue working with Magento. High-level reference information for all backward incompatible changes in each release are documented in the [Backward incompatible changes reference]({{page.baseurl}}/release-notes/backward-incompatible-changes/reference.html) topic.
 
 ## API changes
 

--- a/src/guides/v2.3/release-notes/backward-incompatible-changes/reference.md
+++ b/src/guides/v2.3/release-notes/backward-incompatible-changes/reference.md
@@ -17,7 +17,7 @@ We use a custom tool that extends a PHP semantic version checker to auto-generat
 -  XSD changes
 
 {:.bs-callout-info}
-Patch releases are primarily focused on delivering security and quality enhancements on a regular basis to help you keep your sites performing at their peak. On an exceptional basis, breaking changes or additional patches or hotfixes may be released to address security or compliance issues and high-impact quality issues. On the module level, these are mostly PATCH-level changes; sometimes MINOR-level changes. See [Release policy]({{site.baseurl}}\release/policy/).
+Patch releases are primarily focused on delivering security and quality enhancements on a regular basis to help you keep your sites performing at their peak. On an exceptional basis, breaking changes or additional patches or hotfixes may be released to address security or compliance issues and high-impact quality issues. On the module level, these are mostly PATCH-level changes; sometimes MINOR-level changes. See [Release policy]({{site.baseurl}}/release/policy/).
 
 ## 2.3.4 - 2.3.5
 

--- a/src/guides/v2.3/release-notes/backward-incompatible-changes/reference.md
+++ b/src/guides/v2.3/release-notes/backward-incompatible-changes/reference.md
@@ -6,10 +6,24 @@ redirect_from:
 - /guides/v2.3/release-notes/backward-incompatible-changes/open-source.html
 ---
 
-The changes are aggregated into two tables:
+Use this page to review high-level reference information for all backward incompatible changes in each release. Backward incompatible changes that have a major impact and require detailed explanation and special instructions are documented in the [Backward incompatible changes highlights]({{page.baseurl}}/release-notes/backward-incompatible-changes/index.html) topic.
 
-1. **Changes in classes** that contains backward incompatible changes made to the PHP classes
-1. **Changes in interfaces** that contains backward incompatible changes made to the PHP interfaces
+We use a custom tool that extends a PHP semantic version checker to auto-generate this content. The tool compares the code base from a previous release with the code base from the latest release. Backward incompatible changes for each release are aggregated into the following tables (if applicable):
+
+-  Class changes
+-  Class API membership changes
+-  Interface changes
+-  System changes
+-  XSD changes
+
+{:.bs-callout-info}
+Patch releases are primarily focused on delivering security and quality enhancements on a regular basis to help you keep your sites performing at their peak. On an exceptional basis, breaking changes or additional patches or hotfixes may be released to address security or compliance issues and high-impact quality issues. On the module level, these are mostly PATCH-level changes; sometimes MINOR-level changes. See [Release policy]({{site.baseurl}}\release/policy/).
+
+## 2.3.4 - 2.3.5
+
+{% include backward-incompatible-changes/open-source/2.3.4-2.3.5-develop.html %}
+
+{% include backward-incompatible-changes/commerce/2.3.4-2.3.5-develop.html %}
 
 ## 2.3.3 - 2.3.4
 

--- a/src/guides/v2.3/release-notes/backward-incompatible-changes/reference.md
+++ b/src/guides/v2.3/release-notes/backward-incompatible-changes/reference.md
@@ -12,9 +12,15 @@ We use a custom tool that extends a PHP semantic version checker to auto-generat
 
 -  Class changes
 -  Class API membership changes
+-  Database changes
+-  Dependency injection (DI) changes
 -  Interface changes
+-  Interface API membership changes
+-  Layout changes
 -  System changes
 -  XSD changes
+
+We expanded documentation coverage of the types of changes in 2.3.5. Previously, the list included class changes, class API membership changes, and interface changes only.
 
 {:.bs-callout-info}
 Patch releases are primarily focused on delivering security and quality enhancements on a regular basis to help you keep your sites performing at their peak. On an exceptional basis, breaking changes or additional patches or hotfixes may be released to address security or compliance issues and high-impact quality issues. On the module level, these are mostly PATCH-level changes; sometimes MINOR-level changes. See [Release policy]({{site.baseurl}}/release/policy/).

--- a/src/release/policy/index.md
+++ b/src/release/policy/index.md
@@ -30,7 +30,7 @@ The following guidelines apply to patch releases:
 -  All supported versions receive security fixes.
 -  Newer versions receive full functional fixes and enhancements.
 -  Changes that could break extensions or code compatibility are avoided. For example, code written for 2.2.0 should still work on 2.2.7.
--  On an exceptional basis, breaking changes or additional patches or hotfixes may be released to address security or compliance issues. On the module level, these are mostly PATCH-level changes; sometimes MINOR-level changes.
+-  On an exceptional basis, breaking changes or additional patches or hotfixes may be released to address security or compliance issues and high-impact quality issues. On the module level, these are mostly PATCH-level changes; sometimes MINOR-level changes.
 -  Patches may include new features as long as they are not expected to break other code. The new feature can be included in the core code or as an extension, such as Page Builder.
 
 ## SECURITY release


### PR DESCRIPTION
## Purpose of this pull request

This pull request (PR) prepares 2.3.5 backward incompatible changes (BICs) documentation to support our upcoming pre-release effort. Changes include:

- Adding a section for 2.3.4 to 2.3.5 BICs to the reference topic
- Adding minor updates to our patch release policy to explain why we include BICs in patches
- Distinguishing between BIC reference and highlights topics and adds cross references

## Affected DevDocs pages

- https://devdocs.magento.com/guides/v2.3/release-notes/backward-incompatible-changes/reference.html
- https://devdocs.magento.com/guides/v2.3/release-notes/backward-incompatible-changes/reference.html
- https://devdocs.magento.com/release/policy/

> **NOTE:**
> The BIC docs are generated from the 2.3-develop branch of the code base and is not the final version. We will need to run the doc tool to generate reference from the stable release branch immediately following GA.

## Additional info

- See internal staging build `1607`.
- The anchor links for each table in the new reference section for 2.3.5 aren't working as expected. I suspect an issue with the HTML file that the doc tool is generating after recent enhancements.

## TODO

- [ ] Add blurb + links about BIC reference and highlights to 2.3.5 release notes
- [ ] Update BICs after GA to pull in the non-development version

whatsnew
Added 2.3.5-develop backward incompatible changes [reference](https://devdocs.magento.com/guides/v2.3/release-notes/backward-incompatible-changes/reference.html) for pre-release.