### PR TITLE
GraphQL: Fix attribute data type

### DIFF
--- a/src/guides/v2.3/graphql/mutations/add-configurable-products.md
+++ b/src/guides/v2.3/graphql/mutations/add-configurable-products.md
@@ -89,7 +89,7 @@ The `AddConfigurableProductsToCartInput` object contains the following attribute
 
 Attribute | Type | Description
 --- | --- | ---
-`cart_id` | String | The unique ID that identifies the customer's cart
+`cart_id` | String! | The unique ID that identifies the customer's cart
 `cart_items` | [[ConfigurableProductCartItemInput]](#configProdCartItemInput) | An array of configurable items to add to the cart
 
 ### ConfigurableProductCartItemInput object {#configProdCartItemInput}


### PR DESCRIPTION
## Purpose of this pull request

This pull request (PR) fixes the data type of the `cart_id` attribute of the `addConfigurableProductsToCart` mutation

## Affected DevDocs pages

<!-- REQUIRED List the affected pages on devdocs.magento.com (URLs). Not needed for large numbers of files. -->

-  https://devdocs.magento.com/guides/v2.3/graphql/mutations/add-configurable-products.html

