### PR TITLE
magento/devdocs#: Configure Xdebug. Wrong port.

### DIFF
--- a/src/cloud/howtos/debug.md
+++ b/src/cloud/howtos/debug.md
@@ -113,7 +113,7 @@ To configure PhpStorm to work with Xdebug:
       -  Production: `/app/<project_code>/`
       -  Staging:  `/app/<project_code>_stg/`
 
-1. Change the Xdebug port to 9001 in the **Languages & Frameworks** > **PHP** > **Debug** > **Xdebug** > **Debug Port** panel.
+1. Change the Xdebug port to 9000 in the **Languages & Frameworks** > **PHP** > **Debug** > **Xdebug** > **Debug Port** panel.
 
 1. Click **Apply**.
 


### PR DESCRIPTION

## Purpose of this pull request

This pull request (PR) fixes incorrect port number in the `point 7` of `Configure PhpStorm` section.


[Set up port forwarding](https://devdocs.magento.com/cloud/howtos/debug.html#port) provides a command which maps `9000` port instead of `9001`:

```
ssh -R 9000:localhost:9000 <ssh url>
```

## Affected DevDocs pages

<!-- REQUIRED List the affected pages on devdocs.magento.com (URLs). Not needed for large numbers of files. -->

- https://devdocs.magento.com/cloud/howtos/debug.html

## Links to Magento source code

<!--  OPTIONAL - REMOVE THIS SECTION IF NOT USED. If this pull request references a file in a Magento codebase repository, add it here. -->

- [Set up port forwarding](https://devdocs.magento.com/cloud/howtos/debug.html#port) 

<!--
If you are fixing a GitHub issue, note it using GitHub keyword format (https://help.github.com/en/articles/closing-issues-using-keywords#closing-an-issue-in-a-different-repository) to close the issue when this pull request is merged. Example: `Fixes #1234`

`master` is the default branch. Merged pull requests to `master` go live on the site automatically. Any requested changes to content on the `master` branch must be related to the released codebase. Any content related to future releases goes in the `develop` branch.

See Contribution guidelines (https://github.com/magento/devdocs/blob/master/.github/CONTRIBUTING.md) for more information.
-->

Thank you!
