### PR TITLE
The gallery jQuery widget more view thumbnails in mobile 

### DIFF
--- a/src/guides/v2.3/javascript-dev-guide/widgets/widget_gallery.md
+++ b/src/guides/v2.3/javascript-dev-guide/widgets/widget_gallery.md
@@ -358,7 +358,7 @@ Sliding direction of thumbnails in the fullscreen view.
 
 ```xml
 <var name="gallery">
-    <var name="navdir">horizontal</var> <!-- Sliding direction of thumbnails (horizontal/vertical) -->    
+   <var name="navdir">horizontal</var> <!-- Sliding direction of thumbnails (horizontal/vertical) -->    
 </var>
 ```
 

--- a/src/guides/v2.3/javascript-dev-guide/widgets/widget_gallery.md
+++ b/src/guides/v2.3/javascript-dev-guide/widgets/widget_gallery.md
@@ -357,10 +357,9 @@ Sliding direction of thumbnails in the fullscreen view.
 *  `horizontal`
 
 ```xml
-	<var name="gallery">
-	        <var name="navdir">horizontal</var> <!-- Sliding direction of thumbnails (horizontal/vertical) -->
-	    </var>
-	</var>
+<var name="gallery">
+    <var name="navdir">horizontal</var> <!-- Sliding direction of thumbnails (horizontal/vertical) -->    
+</var>
 ```
 
 #### `fullscreen/navarrows` {#full_navarrows}

--- a/src/guides/v2.3/javascript-dev-guide/widgets/widget_gallery.md
+++ b/src/guides/v2.3/javascript-dev-guide/widgets/widget_gallery.md
@@ -356,14 +356,12 @@ Sliding direction of thumbnails in the fullscreen view.
 *  `vertical`
 *  `horizontal`
 
-```javascript
-	<var name="options">
-	    <var name="options">
+```xml
+	<var name="gallery">
 	        <var name="navdir">horizontal</var> <!-- Sliding direction of thumbnails (horizontal/vertical) -->
 	    </var>
 	</var>
 ```
-
 
 #### `fullscreen/navarrows` {#full_navarrows}
 

--- a/src/guides/v2.3/javascript-dev-guide/widgets/widget_gallery.md
+++ b/src/guides/v2.3/javascript-dev-guide/widgets/widget_gallery.md
@@ -358,7 +358,7 @@ Sliding direction of thumbnails in the fullscreen view.
 
 ```xml
 <var name="gallery">
-   <var name="navdir">horizontal</var> <!-- Sliding direction of thumbnails (horizontal/vertical) -->    
+   <var name="navdir">horizontal</var> <!-- Sliding direction of thumbnails (horizontal/vertical) -->
 </var>
 ```
 

--- a/src/guides/v2.3/javascript-dev-guide/widgets/widget_gallery.md
+++ b/src/guides/v2.3/javascript-dev-guide/widgets/widget_gallery.md
@@ -356,6 +356,15 @@ Sliding direction of thumbnails in the fullscreen view.
 *  `vertical`
 *  `horizontal`
 
+```javascript
+	<var name="options">
+	    <var name="options">
+	        <var name="navdir">horizontal</var> <!-- Sliding direction of thumbnails (horizontal/vertical) -->
+	    </var>
+	</var>
+```
+
+
 #### `fullscreen/navarrows` {#full_navarrows}
 
 Show/hide arrows in thumb navigation.


### PR DESCRIPTION
## Purpose of this pull request

This pull request (PR) provide the information The gallery jQuery widget more view thumbnails set horizontal and vertical. 

## Affected DevDocs pages

<!-- REQUIRED List the affected pages on devdocs.magento.com (URLs). Not needed for large numbers of files. -->

- https://devdocs.magento.com/guides/v2.3/javascript-dev-guide/widgets/widget_gallery.html

## Links to Magento source code

<!--  OPTIONAL - REMOVE THIS SECTION IF NOT USED. If this pull request references a file in a Magento codebase repository, add it here. -->


<!--
If you are fixing a GitHub issue, note it using GitHub keyword format (https://help.github.com/en/articles/closing-issues-using-keywords#closing-an-issue-in-a-different-repository) to close the issue when this pull request is merged. Example: `Fixes #1234`

`master` is the default branch. Merged pull requests to `master` go live on the site automatically. Any requested changes to content on the `master` branch must be related to the released codebase. Any content related to future releases goes in the `develop` branch.

See Contribution guidelines (https://github.com/magento/devdocs/blob/master/.github/CONTRIBUTING.md) for more information.
-->
