### PR TITLE
Add missing tags that can be specified in the page <head> section

### DIFF
--- a/src/guides/v2.3/frontend-dev-guide/layouts/layout-types.md
+++ b/src/guides/v2.3/frontend-dev-guide/layouts/layout-types.md
@@ -182,6 +182,7 @@ The following table describes the instructions specific for page configuration f
           <li><code>&lt;css&gt;</code></li>
           <li><code>&lt;font&gt;</code></li>
           <li><code>&lt;script&gt;</code></li>
+          <li><code>&lt;remove&gt;</code></li>
         </ul>
       </td>
       <td colspan="1" />

--- a/src/guides/v2.3/frontend-dev-guide/layouts/layout-types.md
+++ b/src/guides/v2.3/frontend-dev-guide/layouts/layout-types.md
@@ -183,6 +183,7 @@ The following table describes the instructions specific for page configuration f
           <li><code>&lt;font&gt;</code></li>
           <li><code>&lt;script&gt;</code></li>
           <li><code>&lt;remove&gt;</code></li>
+          <li><code>&lt;attribute&gt;</code></li>
         </ul>
       </td>
       <td colspan="1" />


### PR DESCRIPTION
## Purpose of this pull request

Updated the layout attributes available for the `<head>` section to include the `<remove>` and `<attribute>` tags.

## Affected DevDocs pages

<!-- REQUIRED List the affected pages on devdocs.magento.com (URLs). Not needed for large numbers of files. -->

-  https://devdocs.magento.com/guides/v2.3/frontend-dev-guide/layouts/layout-types.html

## Links to Magento source code

<!--  OPTIONAL - REMOVE THIS SECTION IF NOT USED. If this pull request references a file in a Magento codebase repository, add it here. -->

-  https://devdocs.magento.com/guides/v2.3/frontend-dev-guide/layouts/xml-instructions.html#fedg_layout_xml-instruc_ex_rmv

whatsnew

