### PR TITLE
Customize Product view page help of many containers

### DIFF
--- a/src/guides/v2.3/frontend-dev-guide/layouts/product-layouts.md
+++ b/src/guides/v2.3/frontend-dev-guide/layouts/product-layouts.md
@@ -33,6 +33,12 @@ With the help gives numerous containers on the product page, You should simply r
 *  `product.info.social`
 *  `product.info.media`
 
+Sample of usage in the product page layout containers:
+
+```xml
+<move element="product.info.social" destination="product.info.main" before="product.info.price"/>
+```
+
 ## Checkout cart configure page
 
 Layout file | Description

--- a/src/guides/v2.3/frontend-dev-guide/layouts/product-layouts.md
+++ b/src/guides/v2.3/frontend-dev-guide/layouts/product-layouts.md
@@ -21,6 +21,18 @@ Layout file | Description
 `catalog_product_view_type_simple.xml` | Layout from this file is applied to `simple` product only
 `catalog_product_view_type_virtual.xml` | Layout from this file is applied to `virtual` product only
 
+## Customize Product view page
+
+With the help gives numerous containers on the product page, You should simply reference the container and add blocks to it.
+
+*  `product.info.main`
+*  `product.info.price`
+*  `product.info.stock.sku`
+*  `product.info.form.content`
+*  `product.info.extrahint`
+*  `product.info.social`
+*  `product.info.media`
+
 ## Checkout cart configure page
 
 Layout file | Description

--- a/src/guides/v2.3/frontend-dev-guide/layouts/product-layouts.md
+++ b/src/guides/v2.3/frontend-dev-guide/layouts/product-layouts.md
@@ -23,7 +23,9 @@ Layout file | Description
 
 ## Customize product view pages
 
-With the help gives numerous containers on the product page, You should simply reference the container and add blocks to it.
+Use containers on the product page to structure content in the layout. You can reference the container and add blocks to it.
+
+Containers assign content structure to a page using container tags within a layout XML file. A container has no additional content except the content of included elements. Examples of containers include:
 
 *  `product.info.main`
 *  `product.info.price`

--- a/src/guides/v2.3/frontend-dev-guide/layouts/product-layouts.md
+++ b/src/guides/v2.3/frontend-dev-guide/layouts/product-layouts.md
@@ -21,7 +21,7 @@ Layout file | Description
 `catalog_product_view_type_simple.xml` | Layout from this file is applied to `simple` product only
 `catalog_product_view_type_virtual.xml` | Layout from this file is applied to `virtual` product only
 
-## Customize Product view page
+## Customize product view pages
 
 With the help gives numerous containers on the product page, You should simply reference the container and add blocks to it.
 

--- a/src/guides/v2.3/frontend-dev-guide/layouts/product-layouts.md
+++ b/src/guides/v2.3/frontend-dev-guide/layouts/product-layouts.md
@@ -33,7 +33,7 @@ With the help gives numerous containers on the product page, You should simply r
 *  `product.info.social`
 *  `product.info.media`
 
-Sample of usage in the product page layout containers:
+### Example
 
 ```xml
 <move element="product.info.social" destination="product.info.main" before="product.info.price"/>


### PR DESCRIPTION
## Purpose of this pull request

This pull request (PR) will provide information on Customize Product view page help of many containers.

## Affected DevDocs pages

<!-- REQUIRED List the affected pages on devdocs.magento.com (URLs). Not needed for large numbers of files. -->

-  https://devdocs.magento.com/guides/v2.3/frontend-dev-guide/layouts/product-layouts.html

## Links to Magento source code

<!--  OPTIONAL - REMOVE THIS SECTION IF NOT USED. If this pull request references a file in a Magento codebase repository, add it here. -->



<!--
If you are fixing a GitHub issue, note it using GitHub keyword format (https://help.github.com/en/articles/closing-issues-using-keywords#closing-an-issue-in-a-different-repository) to close the issue when this pull request is merged. Example: `Fixes #1234`

`master` is the default branch. Merged pull requests to `master` go live on the site automatically. Any requested changes to content on the `master` branch must be related to the released codebase. Any content related to future releases goes in the `develop` branch.

See Contribution guidelines (https://github.com/magento/devdocs/blob/master/.github/CONTRIBUTING.md) for more information.
-->
