### PR TITLE
magento/devdocs#: How to declare a new CLI command via __construct method

### DIFF
--- a/src/guides/v2.3/extension-dev-guide/cli-cmds/cli-howto.md
+++ b/src/guides/v2.3/extension-dev-guide/cli-cmds/cli-howto.md
@@ -50,6 +50,15 @@ Before you begin, make sure you understand the following:
    </config>
    ```
 
+   or in the `__construct` method (declaration is similar to `di.xml`):
+
+   ```php
+   public function __construct()
+   {
+       parent::__construct('my:first:command');
+   }
+   ```
+
    Otherwise the [Symfony](https://github.com/symfony/console/blob/master/Application.php#L470) framework will return an `The command defined in "<Command class>" cannot have an empty name.` error.
 
 ## Add CLI commands using dependency injection {#cli-sample}


### PR DESCRIPTION



## Purpose of this pull request

This pull request (PR) extends a list of possible ways how to declare a custom CLI name.

## Affected DevDocs pages

<!-- REQUIRED List the affected pages on devdocs.magento.com (URLs). Not needed for large numbers of files. -->

-  https://devdocs.magento.com/guides/v2.3/extension-dev-guide/cli-cmds/cli-howto.html

## Links to Magento source code

<!--  OPTIONAL - REMOVE THIS SECTION IF NOT USED. If this pull request references a file in a Magento codebase repository, add it here. -->

- [dev:source-theme:deploy](https://github.com/magento/magento2/blob/f060ee7d46a5a88b97c846c1c37fd3d3c447c32d/app/code/Magento/Developer/Console/Command/SourceThemeDeployCommand.php#L76)

<!--
If you are fixing a GitHub issue, note it using GitHub keyword format (https://help.github.com/en/articles/closing-issues-using-keywords#closing-an-issue-in-a-different-repository) to close the issue when this pull request is merged. Example: `Fixes #1234`

`master` is the default branch. Merged pull requests to `master` go live on the site automatically. Any requested changes to content on the `master` branch must be related to the released codebase. Any content related to future releases goes in the `develop` branch.

See Contribution guidelines (https://github.com/magento/devdocs/blob/master/.github/CONTRIBUTING.md) for more information.
-->

Thank you!