### PR TITLE
#7008 Clarify Configure Consumers page

### DIFF
--- a/src/_data/toc/installation-guide.yml
+++ b/src/_data/toc/installation-guide.yml
@@ -210,6 +210,9 @@ pages:
             - label: Enable or disable maintenance mode
               url: /install-gde/install/cli/install-cli-subcommands-maint.html
 
+            - label: Configure consumer behavior
+              url: /install-gde/install/cli/install-cli-subcommands-consumers.html
+
             - label: Create the Magento database schema
               url: /install-gde/install/cli/install-cli-subcommands-db.html
 

--- a/src/_includes/config/consumers.md
+++ b/src/_includes/config/consumers.md
@@ -1,7 +1,6 @@
-Name|Value|Required?|
-|`--consumers-wait-for-messages`|Should consumers wait for a message from the queue? 1 - Yes, 0 - No|No|
-{:style="table-layout:auto;"}
+| Name | Description | Value | Required |
+| `--consumers-wait-for-messages` | Determines if consumers will wait for a message from the queue. | 1 - Yes, 0 - No | No |
 
-`0`—Consumers process available messages in the queue, close the TCP connection, and terminate. Consumers do not wait for additional messages to enter the queue, even if the number of processed messages is less than the `--max_messages` value specified during starting consumers.
+*  `0`: Consumers process available messages in the queue, close the TCP connection, and terminate. Consumers do not wait for additional messages to enter the queue, even if the number of processed messages is less than the `--max_messages` value specified during starting consumers.
 
-`1`—Consumers continue to process messages from the message queue until reaching the maximum number of messages (the value specified for `--max_messages` on the `queue:consumers:start` command) before closing the TCP connection and terminating the consumer process. If the queue empties before reaching `--max_messages` the consumer waits for more messages to arrive. If you use workers to run consumers instead of using a cron job, set this variable to `1`.
+*  `1`: Consumers continue to process messages from the message queue until reaching the maximum number of messages (the value specified for `--max_messages` on the `queue:consumers:start` command) before closing the TCP connection and terminating the consumer process. If the queue empties before reaching `--max_messages` the consumer waits for more messages to arrive. If you use workers to run consumers instead of using a cron job, set this variable to `1`.

--- a/src/guides/v2.3/install-gde/install/cli/install-cli-subcommands-consumers.md
+++ b/src/guides/v2.3/install-gde/install/cli/install-cli-subcommands-consumers.md
@@ -12,7 +12,7 @@ Before you run this command, you must do all of the following *or* you must [ins
 *  [Create or update the deployment configuration]({{ page.baseurl }}/install-gde/install/cli/install-cli-subcommands-deployment.html)
 *  [Create the Magento database schema]({{ page.baseurl }}/install-gde/install/cli/install-cli-subcommands-db.html)
 
-## Configure the consumers behaviour {#instgde-cli-consumersconfig}
+## Configure the consumers behavior {#instgde-cli-consumersconfig}
 
 Configuring consumer behavior is done by sending key/value pairs within the setup function:
 

--- a/src/guides/v2.3/install-gde/install/cli/install-cli-subcommands-consumers.md
+++ b/src/guides/v2.3/install-gde/install/cli/install-cli-subcommands-consumers.md
@@ -1,17 +1,11 @@
 ---
 group: installation-guide
-title: Configure the lock provider
+title: Configure consumer behavior
 functional_areas:
   - Install
   - System
   - Setup
 ---
-
-## First steps {#instgde-cli-before}
-{% include install/first-steps-cli.md %}
-In addition to the command arguments discussed here, see [Common arguments]({{ page.baseurl }}/install-gde/install/cli/install-cli-subcommands.html#instgde-cli-subcommands-common).
-
-## Prerequisites {#instgde-cli-subcommands-store-prereq}
 
 Before you run this command, you must do all of the following *or* you must [install the Magento software]({{ page.baseurl }}/install-gde/install/cli/install-cli-install.html):
 
@@ -20,12 +14,12 @@ Before you run this command, you must do all of the following *or* you must [ins
 
 ## Configure the consumers behaviour {#instgde-cli-consumersconfig}
 
-> Command usage
+Configuring consumer behavior is done by sending key/value pairs within the setup function:
 
 ```bash
 magento setup:config:set [--<parameter_name>=<value>, ...]
 ```
 
-> Parameter descriptions
+### Parameter descriptions
 
 {% include config/consumers.md %}


### PR DESCRIPTION
## Purpose of this pull request

This pull request (PR) clarifies the topic title and simplifies the page a bit.

## Affected DevDocs pages

-  https://devdocs.magento.com/guides/v2.3/install-gde/install/cli/install-cli-subcommands-consumers.html

Fixes #7008 