### PR TITLE
remove spaces for non-alignment example

### DIFF
--- a/src/guides/v2.3/coding-standards/docblock-standard-general.md
+++ b/src/guides/v2.3/coding-standards/docblock-standard-general.md
@@ -797,8 +797,8 @@ For example, padding for visual alignment can be done in two ways:
 /**
  * ...
  *
- * @param string   $parentId
- * @param string   $childId
+ * @param string $parentId
+ * @param string $childId
  * @param int|null $position
  * @return int
  * @see _insertChild() for position explanation


### PR DESCRIPTION
## Purpose of this pull request

This pull request (PR) removes spaces for non-alignment example

## Affected DevDocs pages

-  https://devdocs.magento.com/guides/v2.3/coding-standards/docblock-standard-general.html
