### PR TITLE
Fixes config for register sample files

### DIFF
--- a/src/guides/v2.3/ext-best-practices/tutorials/custom-import-entity.md
+++ b/src/guides/v2.3/ext-best-practices/tutorials/custom-import-entity.md
@@ -441,7 +441,7 @@ When updating the table's data, you must provide the `entity_id` value for each 
 
 Next, register the sample file for our entity.
 
-> `etc/adminhtml/di.xml`
+> `etc/di.xml`
 
 ```xml
 <config xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"


### PR DESCRIPTION
## Purpose of this pull request

A little update for PR https://github.com/magento/devdocs/pull/6994
If we register sample file in adminhtml folder - sample files in other modules are crashed

## Affected DevDocs pages

https://devdocs.magento.com/guides/v2.3/ext-best-practices/tutorials/custom-import-entity.html