### PR TITLE
Removing Blackfire.io from the stack

### DIFF
--- a/src/cloud/architecture/cloud-architecture.md
+++ b/src/cloud/architecture/cloud-architecture.md
@@ -45,9 +45,6 @@ For comparison, each plan includes the following infrastructure features and sup
           <li>
             <a href="{{ site.baseurl }}/cloud/project/new-relic.html">New Relic</a> APM (Performance Monitoring) on 3 branches: <code>master</code> and 2 of your choice
           </li>
-          <li>
-            <a href="{{ site.baseurl }}/cloud/project/project-integrate-blackfire.html">Blackfire.io</a> Enterprise (Performance Testing)
-          </li>
           <li>Platform-as-a-service (PaaS) based Production, Staging, and development environments (4 total active environments) optimized for {{site.data.var.ee}}</li>
         </ul>
       </td>
@@ -57,9 +54,6 @@ For comparison, each plan includes the following infrastructure features and sup
           <li>Fastly Content Delivery Network (CDN), Image Optimization (IO), and added security with generous bandwidth allowances. The Web Application Firewall (WAF) service is available on Production environments only.</li>
           <li>
             <a href="{{ site.baseurl }}/cloud/project/new-relic.html">New Relic</a> Infrastructure on Production + APM (Performance Monitoring) on Staging and Production. <a href="{{ site.baseurl }}/cloud/project/new-relic.html">Adobe-generated alert policies</a> implement monitoring best practices to proactively notify you about application and infrastructure issues affecting site performance.
-          </li>
-          <li>
-            <a href="{{ site.baseurl }}/cloud/project/project-integrate-blackfire.html">Blackfire.io</a> Enterprise (Performance Testing)
           </li>
           <li>Platform-as-a-service (PaaS) based Integration development environments (8 total active environments) optimized for {{site.data.var.ee}}</li>
           <li>Infrastructure-as-a-Service (IaaS)—dedicated virtual infrastructure for Production environments and for Staging environments</li>


### PR DESCRIPTION
Blackfire will be removed from the Magento Cloud architecture as per https://support.magento.com/hc/en-us/articles/360038412872-Blackfire-access-removal-for-Magento-Commerce-Cloud

## Purpose of this pull request

This pull request (PR) is to remove Blackfire.io from the Magento Cloud architecture overview

## Affected DevDocs pages
- https://devdocs.magento.com/cloud/architecture/cloud-architecture.html

