### PR TITLE
Removal of Blackfire.io

### DIFF
--- a/src/cloud/architecture/pro-architecture.md
+++ b/src/cloud/architecture/pro-architecture.md
@@ -57,12 +57,6 @@ The following table summarizes the differences between environments:
       <td>Yes</td>
     </tr>
    <tr>
-     <td>Includes Blackfire.io</td>
-     <td>Yes</td>
-     <td>Yes</td>
-     <td>Yes</td>
-   </tr>
-   <tr>
      <td>Includes New Relic</td>
      <td>No</td>
      <td>APM</td>


### PR DESCRIPTION
Remove Blackfire.io no longer part of Pro architecture

## Purpose of this pull request

This pull request (PR) affects the display of the Magento Cloud Pro architecture stack

## Affected DevDocs pages

https://devdocs.magento.com/cloud/architecture/pro-architecture.html

