### PR TITLE
MCLOUD-5658: Add support of 2.3 release-line for URL-rewrites module

### DIFF
--- a/src/cloud/configure/import-url-rewrites.md
+++ b/src/cloud/configure/import-url-rewrites.md
@@ -10,7 +10,7 @@ functional_areas:
 You can easily migrate to the {{site.data.var.ece}} platform without losing SEO rankings and traffic. Use the `magento/url-rewrite-import-export` module to redirect traffic from your old, indexed URLs to new URLs.
 
 {:.bs-callout-info}
-This module supports ~7.0.13|~7.1.0 PHP versions and is available for Magento version 2.2.x only.
+This module supports ~7.0.13|~7.1.0|~7.2.0|~7.3.0 PHP versions and is available for Magento version 2.2.x and 2.3.x only.
 
 {:.procedure}
 To install the URL rewrite module:


### PR DESCRIPTION
## Purpose of this pull request

Updated the version support for the URL rewrites module on Magento Cloud projects. It is now supported on Magento 7.2.3.

## Affected DevDocs pages

- https://devdocs.magento.com/cloud/configure/import-url-rewrites.html


what’s new
Updated the PHP and Magento version support information for the [Magento URL rewrites module](https://devdocs.magento.com/cloud/configure/import-url-rewrites.html) on Magento Cloud projects.