### PR TITLE
Cloud: remove statement to call support

### DIFF
--- a/src/cloud/project/project-upgrade.md
+++ b/src/cloud/project/project-upgrade.md
@@ -96,7 +96,7 @@ Review the [service versions][version compatibility matrix] information for the 
 
 ### Complete the upgrade
 
-If you use PHP version 7.2, you must remove the `mcrypt` extension from the [extensions section of the .magento.app.yaml file]. For Pro projects, you need to create a support ticket to completely disable the `mcrypt` extension.
+If you use PHP version 7.2, you must remove the `mcrypt` extension from the [extensions section of the .magento.app.yaml file].
 
  {:.bs-callout-info}
 When upgrading to 2.3.x from 2.2.x, you must verify that the `composer.json` file contains `"Zend\\Mvc\\Controller\\": "setup/src/Zend/Mvc/Controller/"` in the `"psr-4":` section of the `autoload` property.


### PR DESCRIPTION
The `mcrypt` extension has been removed from the Pro environments. We no longer need to provide instruction to call support, as seen in the [Complete the upgrade](https://devdocs.magento.com/cloud/project/project-upgrade.html#complete-the-upgrade) section.

I noticed this was part of the request in #6411 , but I did not address anything related to other extensions. This was a quick plea that I received.