### PR TITLE
Adding ES troubleshooting entry

### DIFF
--- a/src/cloud/docker/docker-containers-service.md
+++ b/src/cloud/docker/docker-containers-service.md
@@ -65,7 +65,7 @@ ERROR: [1] bootstrap checks failed
 [1]: max virtual memory areas vm.max_map_count [65530] is too low, increase to at least [262144]
 ```
 
-To fix the erroro, adjust the next value on the host machine:
+To fix the error, adjust next value on the host machine:
 
 ```bash
 sysctl -w vm.max_map_count=262144

--- a/src/cloud/docker/docker-containers-service.md
+++ b/src/cloud/docker/docker-containers-service.md
@@ -60,7 +60,7 @@ The Elasticsearch container for {{site.data.var.mcd-prod}} is a standard Elastic
 
 On some Linux systems, when you launch the Docker environment, the Elasticsearch service fails to start and the following error displays:
 
-```bash
+```terminal
 ERROR: [1] bootstrap checks failed
 [1]: max virtual memory areas vm.max_map_count [65530] is too low, increase to at least [262144]
 ```
@@ -82,6 +82,7 @@ To permanently update the system setting for `vm.max_map_count`:
 
    ```bash
    sysctl vm.max_map_count
+   ```
 
 ## FPM container
 

--- a/src/cloud/docker/docker-containers-service.md
+++ b/src/cloud/docker/docker-containers-service.md
@@ -56,6 +56,23 @@ See [Manage the database] for details about using the database.
 
 The Elasticsearch container for {{site.data.var.mcd-prod}} is a standard Elasticsearch container with required plugins and configurations for {{site.data.var.ee}}.
 
+### Troubleshooting
+
+On some Linux systems Elasticsearch container may not start with the following error:
+
+```bash
+ERROR: [1] bootstrap checks failed
+[1]: max virtual memory areas vm.max_map_count [65530] is too low, increase to at least [262144]
+```
+
+To fix the erroro, adjust the next value on the host machine:
+
+```bash
+sysctl -w vm.max_map_count=262144
+```
+
+To set this value permanently, update the `vm.max_map_count` setting in `/etc/sysctl.conf`. To verify after rebooting, run `sysctl vm.max_map_count`.
+
 ## FPM container
 
 **Container name**: fpm<br/>

--- a/src/cloud/docker/docker-containers-service.md
+++ b/src/cloud/docker/docker-containers-service.md
@@ -58,7 +58,7 @@ The Elasticsearch container for {{site.data.var.mcd-prod}} is a standard Elastic
 
 ### Troubleshooting
 
-On some Linux systems Elasticsearch container may not start with the following error:
+On some Linux systems, when you launch the Docker environment, the Elasticsearch service fails to start and the following error displays:
 
 ```bash
 ERROR: [1] bootstrap checks failed

--- a/src/cloud/docker/docker-containers-service.md
+++ b/src/cloud/docker/docker-containers-service.md
@@ -65,7 +65,7 @@ ERROR: [1] bootstrap checks failed
 [1]: max virtual memory areas vm.max_map_count [65530] is too low, increase to at least [262144]
 ```
 
-To fix the error, adjust next value on the host machine:
+To fix the error, run the following `sysctl` command to increase the memory map area allocation.
 
 ```bash
 sysctl -w vm.max_map_count=262144

--- a/src/cloud/docker/docker-containers-service.md
+++ b/src/cloud/docker/docker-containers-service.md
@@ -71,7 +71,17 @@ To fix the error, run the following `sysctl` command to increase the memory map 
 sysctl -w vm.max_map_count=262144
 ```
 
-To set this value permanently, update the `vm.max_map_count` setting in `/etc/sysctl.conf`. To verify after rebooting, run `sysctl vm.max_map_count`.
+{:.procedure}
+To permanently update the system setting for `vm.max_map_count`:
+
+1. Edit the sysctl configuration file (`etc/sysctl.conf`) and set the required value for the `vm.max_map_count` option.
+
+1. Reboot your system.
+
+1. Run the following command to verify the change.
+
+   ```bash
+   sysctl vm.max_map_count
 
 ## FPM container
 


### PR DESCRIPTION
## Purpose of this pull request

Adds troubleshooting instructions for Elasticsearch service errors caused by insufficient virtual memory allocation in the `vm.max_map_count` system configuration setting. This error can occur when launching a Magento Cloud Docker environment on Linux systems.

## Affected DevDocs pages

<!-- REQUIRED List the affected pages on devdocs.magento.com (URLs). Not needed for large numbers of files. -->

-  https://devdocs.magento.com/cloud/docker/docker-containers-service.html

<!--
If you are fixing a GitHub issue, note it using GitHub keyword format (https://help.github.com/en/articles/closing-issues-using-keywords#closing-an-issue-in-a-different-repository) to close the issue when this pull request is merged. Example: `Fixes #1234`

`master` is the default branch. Merged pull requests to `master` go live on the site automatically. Any requested changes to content on the `master` branch must be related to the released codebase. Any content related to future releases goes in the `develop` branch.

See Contribution guidelines (https://github.com/magento/devdocs/blob/master/.github/CONTRIBUTING.md) for more information.
-->
