### PR TITLE
PB-480: Update content type styling concepts

### DIFF
--- a/src/_data/toc/page-builder.yml
+++ b/src/_data/toc/page-builder.yml
@@ -77,8 +77,8 @@ pages:
 - label: How-Tos
   versionless: true
   children:
-  - label: Use attributes for CSS styling
-    url: /page-builder/docs/how-to/how-to-use-attributes-for-styling.html
+  - label: Configure styling options
+    url: /page-builder/docs/how-to/how-to-configure-styling-options.html
     versionless: true
 
   - label: Add an appearance


### PR DESCRIPTION
Updated TOC entry for existing PB topic

## Purpose of this pull request

This pull request (PR) changes the TOC link to the updated Page Builder topic `How to configure styling options`. The previous link no longer described the topic adequately after the topic was updated and expanded in scope. 

## Affected DevDocs pages

https://devdocs.magento.com/page-builder/docs/how-to/how-to-use-attributes-for-styling.html

whatsnew
New Page Builder topic on how to configure three different options for styling elements in your content types: [How to configure styling options](https://devdocs.magento.com/page-builder/docs/how-to/how-to-configure-styling-options.html).