### PR TITLE
magento/devdocs#7029: for text column in db_schema the attribute 'length' is not allowed.

### DIFF
--- a/src/guides/v2.3/extension-dev-guide/declarative-schema/db-schema.md
+++ b/src/guides/v2.3/extension-dev-guide/declarative-schema/db-schema.md
@@ -353,7 +353,7 @@ The following example changes the `type` of the `title` column from `varchar` to
         <column xsi:type="int" name="id_column" padding="10" unsigned="true" nullable="false" comment="Entity Id"/>
         <column xsi:type="int" name="severity" padding="10" unsigned="true" nullable="false" comment="Severity code"/>
 -       <column xsi:type="varchar" name="title" nullable="false" length="255" comment="Title"/>
-+       <column xsi:type="text" name="title" nullable="false" length="255" comment="Title"/>
++       <column xsi:type="text" name="title" nullable="false" comment="Title"/>
         <column xsi:type="timestamp" name="time_occurred" padding="10" comment="Time of event"/>
         <constraint xsi:type="primary" referenceId="PRIMARY">
             <column name="id_column"/>


### PR DESCRIPTION

## Purpose of this pull request

This pull request (PR) fixes https://github.com/magento/devdocs/issues/7029.

## Affected DevDocs pages

<!-- REQUIRED List the affected pages on devdocs.magento.com (URLs). Not needed for large numbers of files. -->

- https://devdocs.magento.com/guides/v2.3/extension-dev-guide/declarative-schema/db-schema.html

## Links to Magento source code

<!--  OPTIONAL - REMOVE THIS SECTION IF NOT USED. If this pull request references a file in a Magento codebase repository, add it here. -->

-  [TEXT](https://www.mysqltutorial.org/mysql-text/) MySQL string data type

<!--
If you are fixing a GitHub issue, note it using GitHub keyword format (https://help.github.com/en/articles/closing-issues-using-keywords#closing-an-issue-in-a-different-repository) to close the issue when this pull request is merged. Example: `Fixes #1234`

`master` is the default branch. Merged pull requests to `master` go live on the site automatically. Any requested changes to content on the `master` branch must be related to the released codebase. Any content related to future releases goes in the `develop` branch.

See Contribution guidelines (https://github.com/magento/devdocs/blob/master/.github/CONTRIBUTING.md) for more information.
-->

Thank you!