### PR TITLE
Add redirect for deprecated Blackfire.io content

### DIFF
--- a/src/cloud/project/project-integrate-blackfire.md
+++ b/src/cloud/project/project-integrate-blackfire.md
@@ -1,0 +1,12 @@
+---
+group: cloud-guide
+title: Blackfire.io for Magento Cloud
+functional_areas:
+  - Cloud
+  - Integration
+  - Setup
+  - Services
+redirect_from:
+  - guides/v2.2/cloud/project/project-integrate-blackfire.html
+redirect_to: https://support.blackfire.io/en/articles/771436-step-3-configure-blackfire-to-run-in-all-magento-cloud-environments
+---

--- a/src/cloud/project/project-integrate-blackfire.md
+++ b/src/cloud/project/project-integrate-blackfire.md
@@ -1,11 +1,5 @@
 ---
-group: cloud-guide
 title: Blackfire.io for Magento Cloud
-functional_areas:
-  - Cloud
-  - Integration
-  - Setup
-  - Services
 redirect_from:
   - guides/v2.2/cloud/project/project-integrate-blackfire.html
 redirect_to: https://support.blackfire.io/en/articles/771436-step-3-configure-blackfire-to-run-in-all-magento-cloud-environments


### PR DESCRIPTION
## Purpose of this pull request

Add redirects for deprecated Blackfire.io content.  Blackfire is no longer bundled with Magento Cloud. Customers can still use Blackfire by setting up their own account and following the [Blackfire configuration instructions](https://support.blackfire.io/en/articles/771436-step-3-configure-blackfire-to-run-in-all-magento-cloud-environments).

## Affected DevDocs pages

- https://devdocs.magento.com//cloud/project/project-integrate-blackfire.html