### PR TITLE
Updating base_amount attribute in cart object graphql

### DIFF
--- a/src/_includes/graphql/cart-object.md
+++ b/src/_includes/graphql/cart-object.md
@@ -8,7 +8,7 @@ Attribute |  Data Type | Description
 `billing_address` | [BillingCartAddress][BillingCartAddress] | Contains the billing address specified in the customer's cart
 `email` | String | The customer's email address
 `id` | ID! | The ID of the cart
-`is_virtual` | Boolean | Indicates whether the cart contains only virtual products
+`is_virtual` | Boolean! | Indicates whether the cart contains only virtual products
 `items` | [[CartItemInterface]][CartItemInterface] | Contains the items in the customer's cart
 `prices` | [CartPrices][CartPrices] | Contains subtotals and totals
 `selected_payment_method` | [SelectedPaymentMethod][SelectedPaymentMethod] | Selected payment method

--- a/src/guides/v2.3/graphql/queries/cart.md
+++ b/src/guides/v2.3/graphql/queries/cart.md
@@ -564,7 +564,7 @@ query {
 
 Attribute |  Data Type | Description
 --- | --- | ---
-`cart_id` | String | A 32-character string that is created when you [create a cart]({{page.baseurl}}/graphql/mutations/create-empty-cart.html)
+`cart_id` | String! | A 32-character string that is created when you [create a cart]({{page.baseurl}}/graphql/mutations/create-empty-cart.html)
 
 ## Output attributes {#cart-output}
 
@@ -622,7 +622,7 @@ Attribute |  Data Type | Description
 --- | --- | ---
 `amount` | Money! | The cost of shipping using this shipping method
 `available` | Boolean! | Indicates whether this shipping method can be applied to the cart
-`base_amount` | Money | The base shipping cost, not including taxes or other cost adjustment. Could be null if method is not available
+`base_amount` | Money | Deprecated. This attribute is not applicable for GraphQL
 `carrier_code` | String! | A string that identifies a commercial carrier or an offline shipping method
 `carrier_title` | String! | The label for the carrier code
 `error_message` | String | Describes an error condition


### PR DESCRIPTION
## Purpose of this pull request

This pull request (PR) update base amount attribute and adds non nullable object symbol the attributes

## Affected DevDocs pages

<!-- REQUIRED List the affected pages on devdocs.magento.com (URLs). Not needed for large numbers of files. -->

- https://devdocs.magento.com/guides/v2.3/graphql/queries/cart.html

## Links to Magento source code

<!--  OPTIONAL - REMOVE THIS SECTION IF NOT USED. If this pull request references a file in a Magento codebase repository, add it here. -->

- https://github.com/magento/magento2/blob/5f3b86ab4bd3e3b94e65429fed33f748d29c1bbe/app/code/Magento/QuoteGraphQl/etc/schema.graphqls#L267
https://github.com/magento/magento2/blob/5f3b86ab4bd3e3b94e65429fed33f748d29c1bbe/app/code/Magento/QuoteGraphQl/etc/schema.graphqls#L208
https://github.com/magento/magento2/blob/5f3b86ab4bd3e3b94e65429fed33f748d29c1bbe/app/code/Magento/QuoteGraphQl/etc/schema.graphqls#L5


<!--
If you are fixing a GitHub issue, note it using GitHub keyword format (https://help.github.com/en/articles/closing-issues-using-keywords#closing-an-issue-in-a-different-repository) to close the issue when this pull request is merged. Example: `Fixes #1234`

`master` is the default branch. Merged pull requests to `master` go live on the site automatically. Any requested changes to content on the `master` branch must be related to the released codebase. Any content related to future releases goes in the `develop` branch.

See Contribution guidelines (https://github.com/magento/devdocs/blob/master/.github/CONTRIBUTING.md) for more information.
-->
