### PR TITLE
DEVDOCS-7063: Fixed link for Magento Cloud CLI reference page

### DIFF
--- a/src/cloud/setup/first-time-setup-import-first-steps.md
+++ b/src/cloud/setup/first-time-setup-import-first-steps.md
@@ -21,7 +21,7 @@ Before you begin, do the following:
 
 ### SSH access to cloud environments {#ssh}
 
-To transfer the database dump and files to {{site.data.var.ece}}, you must know the SSH access link. You can locate the SSH access link using the [`magento-cloud`] CLI tool({{ site.baseurl }}/cloud/reference/cli-ref-topic.html):
+To transfer the database dump and files to {{site.data.var.ece}}, you must know the SSH access link. You can locate the SSH access link using the [Magento Cloud CLI tool]({{ site.baseurl }}/cloud/reference/cli-ref-topic.html):
 
 ```bash
 magento-cloud environment:ssh --pipe


### PR DESCRIPTION
## Purpose of this pull request

This pull request (PR) fixes Unencoded link in SSH access to cloud environments section of the page "Import existing code into a project"

## Affected DevDocs pages

<!-- REQUIRED List the affected pages on devdocs.magento.com (URLs). Not needed for large numbers of files. -->

-  [Import existing code into a project](https://devdocs.magento.com/cloud/setup/first-time-setup-import-first-steps.html)

## Fixed Issues (if relevant)
<!---
    If relevant, please provide a list of fixed issues in the format magento/magento2#<issue_number>.
    There could be 1 or more issues linked here and it will help us find some more information about the reasoning behind this change.
-->
1. magento/devdocs#7063: Feedback on page: /cloud/setup/first-time-setup-import-first-steps.html

<!--
If you are fixing a GitHub issue, note it using GitHub keyword format (https://help.github.com/en/articles/closing-issues-using-keywords#closing-an-issue-in-a-different-repository) to close the issue when this pull request is merged. Example: `Fixes #1234`

`master` is the default branch. Merged pull requests to `master` go live on the site automatically. Any requested changes to content on the `master` branch must be related to the released codebase. Any content related to future releases goes in the `develop` branch.

See Contribution guidelines (https://github.com/magento/devdocs/blob/master/.github/CONTRIBUTING.md) for more information.
-->
