### PR TITLE
Update Contributor Assistance Documentation on issue self-assign automation

### DIFF
--- a/src/guides/v2.3/contributor-guide/contributing.md
+++ b/src/guides/v2.3/contributor-guide/contributing.md
@@ -84,17 +84,20 @@ Sometimes your pull request may have more than one commit (the main commit, then
 
 ## Magento contributor assistant {#contributor-assist}
 
-The Magento Contributor Assistant is a bot that currently runs on the GitHub `magento` repositories. It helps automate different issue and pull request workflows using commands entered as comments.
+The Magento Contributor Assistant is a bot that runs on all GitHub `magento` repositories. It helps automate issue and pull request workflows using commands entered as comments.
 
-### Assigning the issue
-If you would like to work on some issue and have it assigned to you, just add a simple comment and contribution assistant will do the work.
+### Assigning an issue
 
-**Command:** To assign issue to your GitHub account, add the following command as a comment to the Issue:
+If you would like to have an issue assigned to you, add a comment and the contribution assistant will do the work.
+
+**Command:** To assign issue to your GitHub account, add the following command as a comment to the issue:
+
 ```text
 @magento I am working on this
 ```
 
-This command has several variations for better usability:
+This command has several variations:
+
 ```text
 @magento I am working on this
 @magento I am working on it
@@ -102,16 +105,16 @@ This command has several variations for better usability:
 @magento I'm working on it
 ```
 
-**Actions:** The following actions complete for the command:
+**Actions:** The following actions will occur:
 
--  If the user is a member of Magento GitHub organization, the user will be automatically assigned to the ticket
--  If user is NOT member of Magento GitHub organization yet, the invitation will be sent to user to join. Check your email or accept [Github invitation](https://github.com/orgs/magento/invitation). Once user joined Magento GitHub org, GitHub user can submit this command one more time to get assigned to the ticket
+-  If the user is a member of the Magento GitHub organization, the user will be assigned to the ticket automatically.
+-  If user is not yet a member of the Magento GitHub organization, an invitation will be sent to the user. Check your email or accept the [Github invitation](https://github.com/orgs/magento/invitation). Once the user has joined the Magento GitHub organization, the user should repeat the command to get assigned to the ticket.
 
 **Permissions:**
 
 -  All permissions granted for all users.
 
-Currently, the Magento Contributor Assistant automatically deploys test instances on Magento's hosting based on a contributor's pull request or provide a vanilla Magento instance on the `magento/magento2` repository. This gives a GitHub user an instance to test pull requests or reported issues. We plan on adding features in the future.
+Currently, the Magento Contributor Assistant automatically deploys a test instance based on a contributor's pull request, or, it provides a vanilla Magento instance on the `magento/magento2` repository. This is used to test pull requests or reported issues. We plan on adding features in the future.
 
 -  [Deploy vanilla Magento instance](#vanilla-pr)
 -  [Deploy instance based on PR changes](#deploy-pr)
@@ -119,17 +122,17 @@ Currently, the Magento Contributor Assistant automatically deploys test instance
 
 ### Deploy vanilla Magento instance {#vanilla-pr}
 
-When you need to verify an issue or pull request, enter a command to generate an issue verification instance, or vanilla Magento. This instance is a clean Magento installation of a specified version tag or the develop branch of a specified release line.
+When you want to verify an issue or pull request, use the instance command to generate a Magento instance. This instance is a clean installation of a specified version tag or branch of a specified release line.
 
-**Command:** To deploy a vanilla Magento instance, add the following command as a comment to the GitHub Pull Request or Issue:
+**Command:** To deploy a Magento instance, add the following command as a comment to the GitHub pull request or issue:
 
 ```text
 @magento give me {$version} instance
 ```
 
-For `version`, the currently supported values are latest [version tags](https://github.com/magento/magento2/tags) and 2.4-develop branch.
+For `version`, the currently supported values are latest [version tags](https://github.com/magento/magento2/tags) and the 2.4-develop branch.
 
-**Actions:** The following actions complete for the command:
+**Actions:** The following actions complete the command:
 
 -  If the instance does not exist, it will be deployed. Deployment takes ~2 minutes.
 -  If the instance exists, a fresh instance will be redeployed.
@@ -145,9 +148,9 @@ Admins access will be shared via comment on GitHub
 
 ### Deploy instance based on PR changes {#deploy-pr}
 
-To verify and test changes completed in a pull request, enter a command to generate a Magento instance using the code based in the PR.
+To verify and test changes within a pull request, enter a command to generate a Magento instance using the code based in the PR.
 
-**Command:** To deploy, [Community Maintainers](https://github.com/orgs/magento/teams/open-source-maintainers/members), a [Magento EngCom Team](https://github.com/orgs/magento/teams/core-maintainers/members) member, or contributor under the existing Pull Request enters the following command as a comment to the pull request:
+**Command:** To deploy, [Community Maintainers](https://github.com/orgs/magento/teams/open-source-maintainers/members), a [Magento EngCom Team](https://github.com/orgs/magento/teams/core-maintainers/members) member, or a contributor under the existing Pull Request enters the following command as a comment to the pull request:
 
 ```text
 @magento give me test instance
@@ -160,6 +163,7 @@ To verify and test changes completed in a pull request, enter a command to gener
 -  By default, instances have a lifetime of 3 hours. All deployments are terminated after that.
 
 **Admin access:**
+
 Admins access will be shared via comment on GitHub
 
 **Permissions:**
@@ -172,13 +176,13 @@ Admins access will be shared via comment on GitHub
 
 To optimize the pull request queue, enter a command with a series of related pull requests to verify and combine the code. If all tests pass, the entered PRs are merged into the current PR.
 
-**Command:** To combine pull requests, a member of the [Community Maintainers](https://github.com/orgs/magento/teams/open-source-maintainers/members) or [Magento EngCom Team](https://github.com/orgs/magento/teams/core-maintainers/members) under the existing Pull Request enters the following command:
+**Command:** To combine pull requests, a member of the [Community Maintainers](https://github.com/orgs/magento/teams/open-source-maintainers/members) or [Magento EngCom Team](https://github.com/orgs/magento/teams/core-maintainers/members) under the existing Pull Request will enter the following command:
 
 ```text
 @magento combine {xxx} {yyy} {zzz}
 ```
 
-The command merges the listed related pull requests (`xxx`, `yyy`, `zzz`) into the current pull request. For example: `@magento combine 1234 1238 1239`
+The command merges the listed related pull requests (`xxx`, `yyy`, `zzz`) into the current pull request. For example: `@magento combine 1234 1238 1239`.
 
 **actions:** When all conditions are passed, all related pull requests will be closed and merged to the current PR:
 

--- a/src/guides/v2.3/contributor-guide/contributing.md
+++ b/src/guides/v2.3/contributor-guide/contributing.md
@@ -84,13 +84,13 @@ Sometimes your pull request may have more than one commit (the main commit, then
 
 ## Magento contributor assistant {#contributor-assist}
 
-The Magento Contributor Assistant is a bot that runs on all GitHub `magento` repositories. It helps automate issue and pull request workflows using commands entered as comments.
+The Magento Contributor Assistant is a bot that runs on all GitHub `magento` repositories. It helps automate issue and pull request workflows by using commands entered as comments.
 
 ### Assigning an issue
 
 If you would like to have an issue assigned to you, add a comment and the contribution assistant will do the work.
 
-**Command:** To assign issue to your GitHub account, add the following command as a comment to the issue:
+**Command:** To assign as issue to your GitHub account, add the following command as a comment to the issue:
 
 ```text
 @magento I am working on this
@@ -105,16 +105,16 @@ This command has several variations:
 @magento I'm working on it
 ```
 
-**Actions:** The following actions will occur:
+**Actions:** The following actions occur:
 
 -  If the user is a member of the Magento GitHub organization, the user will be assigned to the ticket automatically.
--  If user is not yet a member of the Magento GitHub organization, an invitation will be sent to the user. Check your email or accept the [Github invitation](https://github.com/orgs/magento/invitation). Once the user has joined the Magento GitHub organization, the user should repeat the command to get assigned to the ticket.
+-  If the user is not yet a member of the Magento GitHub organization, an invitation will be sent to the user. Check your email or accept the [Github invitation](https://github.com/orgs/magento/invitation). Once the user has joined the Magento GitHub organization, the user should repeat the command to get assigned to the ticket.
 
 **Permissions:**
 
 -  All permissions granted for all users.
 
-Currently, the Magento Contributor Assistant automatically deploys a test instance based on a contributor's pull request, or, it provides a vanilla Magento instance on the `magento/magento2` repository. This is used to test pull requests or reported issues. We plan on adding features in the future.
+Currently, the Magento Contributor Assistant automatically deploys a test instance based on a contributor's pull request, or, it provides a vanilla Magento instance on the `magento/magento2` repository. This is used to test pull requests or reported issues.
 
 -  [Deploy vanilla Magento instance](#vanilla-pr)
 -  [Deploy instance based on PR changes](#deploy-pr)
@@ -122,7 +122,7 @@ Currently, the Magento Contributor Assistant automatically deploys a test instan
 
 ### Deploy vanilla Magento instance {#vanilla-pr}
 
-When you want to verify an issue or pull request, use the instance command to generate a Magento instance. This instance is a clean installation of a specified version tag or branch of a specified release line.
+When you want to verify an issue or pull request, use the `instance` command to generate a Magento instance. This is a clean installation of a specified version tag or branch of a specified release line.
 
 **Command:** To deploy a Magento instance, add the following command as a comment to the GitHub pull request or issue:
 
@@ -134,13 +134,13 @@ For `version`, the currently supported values are latest [version tags](https://
 
 **Actions:** The following actions complete the command:
 
--  If the instance does not exist, it will be deployed. Deployment takes ~2 minutes.
--  If the instance exists, a fresh instance will be redeployed.
--  By default, instances have a lifetime of 3 hours. All deployments are terminated after that.
+-  If the instance does not exist, it is deployed. Deployment takes approximately 2 minutes.
+-  If the instance exists, a fresh instance is redeployed.
+-  By default, instances have a lifetime of 3 hours. All deployments are then terminated.
 
 **Admin access:**
 
-Admins access will be shared via comment on GitHub
+Admins access is shared via comment on GitHub.
 
 **Permissions:**
 
@@ -148,7 +148,7 @@ Admins access will be shared via comment on GitHub
 
 ### Deploy instance based on PR changes {#deploy-pr}
 
-To verify and test changes within a pull request, enter a command to generate a Magento instance using the code based in the PR.
+To verify and test changes within a pull request, enter a command to generate a Magento instance using code based on the PR.
 
 **Command:** To deploy, [Community Maintainers](https://github.com/orgs/magento/teams/open-source-maintainers/members), a [Magento EngCom Team](https://github.com/orgs/magento/teams/core-maintainers/members) member, or a contributor under the existing Pull Request enters the following command as a comment to the pull request:
 
@@ -159,12 +159,12 @@ To verify and test changes within a pull request, enter a command to generate a 
 **Actions:**
 
 -  It deploys a new Magento instance based on Pull Request changes.
--  Deployment takes ~2 minutes.
--  By default, instances have a lifetime of 3 hours. All deployments are terminated after that.
+-  Deployment takes approximately 2 minutes.
+-  By default, instances have a lifetime of 3 hours. All deployments are then terminated.
 
 **Admin access:**
 
-Admins access will be shared via comment on GitHub
+Admins access will be shared via comment on GitHub.
 
 **Permissions:**
 
@@ -174,7 +174,7 @@ Admins access will be shared via comment on GitHub
 
 ### Combine multiple pull requests {#combine-pr}
 
-To optimize the pull request queue, enter a command with a series of related pull requests to verify and combine the code. If all tests pass, the entered PRs are merged into the current PR.
+To optimize the pull request queue, enter a command with a series of related pull request numbers to merge and test the code. If all tests pass, the entered PRs are merged into the current PR.
 
 **Command:** To combine pull requests, a member of the [Community Maintainers](https://github.com/orgs/magento/teams/open-source-maintainers/members) or [Magento EngCom Team](https://github.com/orgs/magento/teams/core-maintainers/members) under the existing Pull Request will enter the following command:
 

--- a/src/guides/v2.3/contributor-guide/contributing.md
+++ b/src/guides/v2.3/contributor-guide/contributing.md
@@ -93,6 +93,7 @@ If you would like to work on some issue and have it assigned to you, just add a 
 ```text
 @magento I am working on this
 ```
+
 This command has several variations for better usability:
 ```text
 @magento I am working on this
@@ -102,8 +103,8 @@ This command has several variations for better usability:
 ```
 
 **Actions:** The following actions complete for the command:
-- If the user is a member of Magento GitHub organization, the user will be automatically assigned to the ticket
-- If user is NOT member of Magento GitHub organization yet, the invitation will be sent to user to join. Check your email or accept [Github invitation](https://github.com/orgs/magento/invitation). Once user joined Magento GitHub org, GitHub user can submit this command one more time to get assigned to the ticket 
+-  If the user is a member of Magento GitHub organization, the user will be automatically assigned to the ticket
+-  If user is NOT member of Magento GitHub organization yet, the invitation will be sent to user to join. Check your email or accept [Github invitation](https://github.com/orgs/magento/invitation). Once user joined Magento GitHub org, GitHub user can submit this command one more time to get assigned to the ticket 
 
 **Permissions:**
 
@@ -158,7 +159,6 @@ To verify and test changes completed in a pull request, enter a command to gener
 -  By default, instances have a lifetime of 3 hours. All deployments are terminated after that.
 
 **Admin access:**
-
 Admins access will be shared via comment on GitHub 
 
 **Permissions:**

--- a/src/guides/v2.3/contributor-guide/contributing.md
+++ b/src/guides/v2.3/contributor-guide/contributing.md
@@ -84,9 +84,25 @@ Sometimes your pull request may have more than one commit (the main commit, then
 
 ## Magento contributor assistant {#contributor-assist}
 
-The Magento Contributor Assistant is a bot that currently runs on the GitHub `magento/magento2` repository. It helps automate different issue and pull request workflows using commands entered as comments.
+The Magento Contributor Assistant is a bot that currently runs on the GitHub `magento` repositories. It helps automate different issue and pull request workflows using commands entered as comments.
 
-Currently, the Magento Contributor Assistant automatically deploys test instances on Magento's hosting based on a contributor's pull request or provide a vanilla Magento instance. This gives a GitHub user an instance to test pull requests or reported issues. We plan on adding features in the future.
+### Assigning the issue
+If you would like to work on some issue and have it assigned to you, just add a simple comment and contribution assistant will do the work.
+
+**Command:** To assign issue to your GitHub account, add the following command as a comment to the Issue:
+```text
+@magento I am working on this
+```
+
+**Actions:** The following actions complete for the command:
+- If the user is a member of Magento GitHub organization, the user will be automatically assigned to the ticket
+- If user is NOT member of Magento GitHub organization yet, the invitation will be sent to user to join. Check your email or accept [Github invitation](https://github.com/orgs/magento/invitation). Once user joined Magento GitHub org, GitHub user can submit this command one more time to get assigned to the ticket 
+
+**Permissions:**
+
+-  All permissions granted for all users.
+
+Currently, the Magento Contributor Assistant automatically deploys test instances on Magento's hosting based on a contributor's pull request or provide a vanilla Magento instance on the `magento/magento2` repository. This gives a GitHub user an instance to test pull requests or reported issues. We plan on adding features in the future.
 
 -  [Deploy vanilla Magento instance](#vanilla-pr)
 -  [Deploy instance based on PR changes](#deploy-pr)
@@ -112,10 +128,7 @@ For `version`, the currently supported values are latest [version tags](https://
 
 **Admin access:**
 
--  https://i-{$issue_number}.{branch}.instances.magento-community.engineering/admin
--  Admin Credentials:
-   -  Username: admin
-   -  Password: 123123q
+Admins access will be shared via comment on GitHub
 
 **Permissions:**
 
@@ -135,13 +148,11 @@ To verify and test changes completed in a pull request, enter a command to gener
 
 -  It deploys a new Magento instance based on Pull Request changes.
 -  Deployment takes ~2 minutes.
+-  By default, instances have a lifetime of 3 hours. All deployments are terminated after that.
 
 **Admin access:**
 
--  http://pr-xxx.engcom.dev.magento.com/admin
--  Admin Credentials:
-   -  Username: admin
-   -  Password: 123123q
+Admins access will be shared via comment on GitHub 
 
 **Permissions:**
 

--- a/src/guides/v2.3/contributor-guide/contributing.md
+++ b/src/guides/v2.3/contributor-guide/contributing.md
@@ -93,6 +93,13 @@ If you would like to work on some issue and have it assigned to you, just add a 
 ```text
 @magento I am working on this
 ```
+This command has several variations for better usability:
+```text
+@magento I am working on this
+@magento I am working on it
+@magento I'm working on this
+@magento I'm working on it
+```
 
 **Actions:** The following actions complete for the command:
 - If the user is a member of Magento GitHub organization, the user will be automatically assigned to the ticket

--- a/src/guides/v2.3/contributor-guide/contributing.md
+++ b/src/guides/v2.3/contributor-guide/contributing.md
@@ -103,8 +103,9 @@ This command has several variations for better usability:
 ```
 
 **Actions:** The following actions complete for the command:
+
 -  If the user is a member of Magento GitHub organization, the user will be automatically assigned to the ticket
--  If user is NOT member of Magento GitHub organization yet, the invitation will be sent to user to join. Check your email or accept [Github invitation](https://github.com/orgs/magento/invitation). Once user joined Magento GitHub org, GitHub user can submit this command one more time to get assigned to the ticket 
+-  If user is NOT member of Magento GitHub organization yet, the invitation will be sent to user to join. Check your email or accept [Github invitation](https://github.com/orgs/magento/invitation). Once user joined Magento GitHub org, GitHub user can submit this command one more time to get assigned to the ticket
 
 **Permissions:**
 
@@ -159,7 +160,7 @@ To verify and test changes completed in a pull request, enter a command to gener
 -  By default, instances have a lifetime of 3 hours. All deployments are terminated after that.
 
 **Admin access:**
-Admins access will be shared via comment on GitHub 
+Admins access will be shared via comment on GitHub
 
 **Permissions:**
 


### PR DESCRIPTION
## Purpose of this pull request

- magento/devdocs#7069: Update Contributor Assistance Documentation on issue self-assign automation

## Affected DevDocs pages
- src/guides/v2.3/contributor-guide/contributing.md

whatsnew
Added the 'Assigning an issue' to the [Code Contributions](https://devdocs.magento.com/guides/v2.3/contributor-guide/contributing.html) topic.