### PR TITLE
Removed deprecated attribute from graphql query

### DIFF
--- a/src/guides/v2.3/graphql/queries/customer.md
+++ b/src/guides/v2.3/graphql/queries/customer.md
@@ -28,7 +28,6 @@ The following call returns information about the logged-in customer. Provide the
     lastname
     suffix
     email
-    id
     addresses {
       firstname
       lastname
@@ -56,7 +55,6 @@ The following call returns information about the logged-in customer. Provide the
       "lastname": "Doe",
       "suffix": null,
       "email": "jdoe@example.com",
-      "id": 3,
       "addresses": [
        {
          "firstname": "John",


### PR DESCRIPTION
## Purpose of this pull request

This pull request (PR) - id attribute is deprecated in customer object. So it should be removed.

## Affected DevDocs pages

<!-- REQUIRED List the affected pages on devdocs.magento.com (URLs). Not needed for large numbers of files. -->

-  https://devdocs.magento.com/guides/v2.3/graphql/queries/customer.html

## Links to Magento source code

https://github.com/magento/magento2/blob/5f3b86ab4bd3e3b94e65429fed33f748d29c1bbe/app/code/Magento/CustomerGraphQl/etc/schema.graphqls#L95
