### PR TITLE
Update References to Elasticsearch

### DIFF
--- a/src/guides/v2.4/architecture/tech-stack.md
+++ b/src/guides/v2.4/architecture/tech-stack.md
@@ -23,6 +23,10 @@ Magento's highly modular structure includes the following open-source technologi
 *  MySQL
 *  MySQL Percona
 
+### Search
+
+*  Elasticsearch
+
 ### HTTP accelerator
 
 *  Varnish
@@ -30,10 +34,6 @@ Magento's highly modular structure includes the following open-source technologi
 ### Cache Storage
 
 *  Redis
-
-### Search
-
-*  Elasticsearch ({{site.data.var.ee}} in Magento Open Source version 2.3.x)
 
 ### Additional technologies
 
@@ -51,7 +51,6 @@ For Magento 2.3.5, we have started porting unsupported Zend components to the [L
 
 *  Varnish (caching)
 *  Redis (used for page caching)
-*  Elasticsearch (search engine)
 *  RabbitMQ (message queue)
 
 ### Automated testing

--- a/src/guides/v2.4/extension-dev-guide/indexer-batch.md
+++ b/src/guides/v2.4/extension-dev-guide/indexer-batch.md
@@ -129,16 +129,12 @@ The indexer table switching mechanism requires additional database storage.
 The Product EAV indexer reorganizes the EAV product structure to a flat structure.
 As of Magento 2.3, under certain circumstances, you can disable this indexer to improve performance. (Its indexation takes about 5 minutes on a large Magento 2 Commerce performance profile.)
 
-The following conditions must apply to disable Product EAV indexer:
-
-*  You are using a search engine other than MySQL (such as Elasticsearch). If you are using MySQL as the search engine, you cannot disable the Product EAV indexer.
-
-*  You have not installed any 3rd-party extensions that rely on the Product EAV indexer.
+To disable the Product EAV indexer, you have not installed any 3rd-party extensions that rely on the Product EAV indexer.
 
 {:.bs-callout-info}
 To determine whether any 3rd-party extensions are using the Product EAV indexer, check the `catalog_product_index_eav` table for reading/writing activity.
 
-To disable the Product EAV indexer in the Admin, go to **Stores** > Settings > **Configuration** > **Catalog** > **Catalog** > **Catalog Search** and make sure the **Search Engine** field has a value other than MySQL.  Then set the value of **Enable EAV Indexer** to No.
+To disable the Product EAV indexer in the Admin, go to **Stores** > Settings > **Configuration** > **Catalog** > **Catalog** > **Catalog Search** and set the value of **Enable EAV Indexer** to No.
 
 {:.ref-header}
 Related topics

--- a/src/guides/v2.4/extension-dev-guide/indexer-batch.md
+++ b/src/guides/v2.4/extension-dev-guide/indexer-batch.md
@@ -129,7 +129,7 @@ The indexer table switching mechanism requires additional database storage.
 The Product EAV indexer reorganizes the EAV product structure to a flat structure.
 As of Magento 2.3, under certain circumstances, you can disable this indexer to improve performance. (Its indexation takes about 5 minutes on a large Magento 2 Commerce performance profile.)
 
-To disable the Product EAV indexer, you have not installed any 3rd-party extensions that rely on the Product EAV indexer.
+You cannot disable the Product EAV indexer if you have installed any 3rd-party extensions that rely on the Product EAV indexer.
 
 {:.bs-callout-info}
 To determine whether any 3rd-party extensions are using the Product EAV indexer, check the `catalog_product_index_eav` table for reading/writing activity.

--- a/src/guides/v2.4/extension-dev-guide/searching-with-repositories.md
+++ b/src/guides/v2.4/extension-dev-guide/searching-with-repositories.md
@@ -116,7 +116,7 @@ This object is an instance of a class that implements the interface [`SearchResu
 
 Search Result objects hold the Search Criteria object and the retrieved entities along with information about the total count of found entities regardless of any limitations set in the criteria.
 
-The search engine determines the maximum number of results that a query can return. For SQL searches, the maximum is the value  of the `PHP_INT_MAX` environment variable. For Elasticsearch, the value is defined in the `Elasticsearch/etc/di.xml` file. The default is 10000.
+The search engine determines the maximum number of results that a query can return. For Elasticsearch, the default value of 10000 is defined in the module's `etc/di.xml` file.
 
 The example below uses **getList** with the [`ProductRepositoryInterface`]({{ site.mage2bloburl }}/{{ page.guide_version }}/app/code/Magento/Catalog/Api/ProductRepositoryInterface.php).
 We use the [`FilterBuilder`]({{ site.mage2bloburl }}/{{ page.guide_version }}/lib/internal/Magento/Framework/Api/FilterBuilder.php) and the [`SearchCriteriaBuilder`]({{ site.mage2bloburl }}/{{ page.guide_version }}/lib/internal/Magento/Framework/Api/SearchCriteriaBuilder.php) to avoid shared instances.

--- a/src/guides/v2.4/graphql/queries/products.md
+++ b/src/guides/v2.4/graphql/queries/products.md
@@ -130,9 +130,6 @@ Attribute | Data type | Description
 `price` | SortEnum | Sorts by Price
 `relevance` | SortEnum | (Default) Sorts by the search relevance score
 
-{:.bs-callout-info}
-If you use MySQL for searches and you specify `relevance` and another sorting attribute, the `relevance` results are always listed first. This limitation does not apply to [Elasticsearch]({{page.baseurl}}/config-guide/elasticsearch/configure-magento.html).
-
 To enable sorting by an attribute that is not in the `ProductAttributeSortInput` object, set the **Stores** > Attributes > **Product** > <Attribute Name> > **Storefront Properties** > **Use in Search** and **Used in Sorting in Product Listing** fields to Yes.
 
 ## Deprecated input attributes

--- a/src/guides/v2.4/performance-best-practices/advanced-setup.md
+++ b/src/guides/v2.4/performance-best-practices/advanced-setup.md
@@ -9,12 +9,6 @@ functional_areas:
 
 Magento 2 is a highly flexible and scalable product containing solutions for merchants of all sizes. This section covers best practices and recommendations on configuring Magento to work with large amounts of data, extreme load, and other enterprise cases.
 
-## Search with Elasticsearch
-
-By default, Magento uses MySQL for all search operations. {{site.data.var.ee}} allows you to use Elasticsearch as a more optimized search solution. With Elasticsearch, the time on query processing will not change with the growth of search results (the way it does with MySQL). Elasticsearch can provide scaling opportunities when you experience increased loads on your store.
-
-To run Magento with Elasticsearch, you don’t need any specific configuration--just install the server and select the Elasticsearch search engine option in Magento admin.
-
 ## Calibrate index performance
 
 When dealing with large amounts of data, re-indexing can become a concern. The Magento team selected the most loaded indexes and enabled batch indexing, which  allows you to set a portion of data to be processed on each iteration. This way, the user can tune batch sizes based on the type and size of data in the database.

--- a/src/guides/v2.4/performance-best-practices/reference-architecture.md
+++ b/src/guides/v2.4/performance-best-practices/reference-architecture.md
@@ -52,7 +52,6 @@ The following sections provide recommendations and considerations for each secti
 
 ### Search
 
-*  Consider using Elasticsearch to perform searches
 *  Tune the number of instances based on search traffic
 
 ### Storage


### PR DESCRIPTION
## Purpose of this pull request

This pull request (PR) updates instances in the 2.4 doc set that suggest MySQL can be used as a search engine or that Elasticsearch is optional.

Related PRs: #7039, #7105 

## Affected DevDocs pages

-  Several

## Links to Magento source code

<!--  OPTIONAL - REMOVE THIS SECTION IF NOT USED. If this pull request references a file in a Magento codebase repository, add it here. -->

-  ...

<!--
If you are fixing a GitHub issue, note it using GitHub keyword format (https://help.github.com/en/articles/closing-issues-using-keywords#closing-an-issue-in-a-different-repository) to close the issue when this pull request is merged. Example: `Fixes #1234`

`master` is the default branch. Merged pull requests to `master` go live on the site automatically. Any requested changes to content on the `master` branch must be related to the released codebase. Any content related to future releases goes in the `develop` branch.

See Contribution guidelines (https://github.com/magento/devdocs/blob/master/.github/CONTRIBUTING.md) for more information.
-->
