### PR TITLE
Updated MFTF reference data after 2.3.5 release

### DIFF
--- a/src/_data/codebase/v2_3/mftf/action-groups.yml
+++ b/src/_data/codebase/v2_3/mftf/action-groups.yml
@@ -1,709 +1,692 @@
- 
-- filename: "AdminElasticConnectionTestActionGroup.xml"
-  repo: "https://github.com/magento/magento2/blob/2.3/app/code/Magento/Elasticsearch6/Test/Mftf/ActionGroup/AdminElasticConnectionTestActionGroup.xml"
-  module: "Elasticsearch6"
+- filename: "OpenMyAccountPageActionGroup.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/Customer/Test/Mftf/ActionGroup/OpenMyAccountPageActionGroup.xml"
+  module: "Customer"
   actiongroups:
-     - name: "AdminElasticConnectionTestActionGroup"
-       description: "Check ElasticSearch connection after enabling."
- 
-- filename: "AdminGridFilterResetActionGroup.xml"
-  repo: "https://github.com/magento/magento2/blob/2.3/app/code/Magento/Ui/Test/Mftf/ActionGroup/AdminGridFilterResetActionGroup.xml"
-  module: "Ui"
+     - name: "OpenMyAccountPageActionGroup"
+       description: "Clicks on the Storefront Customer menu in the Header. Clicks on 'My Account'."
+- filename: "AdminAssertCustomerInCustomersGridActionGroup.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/Customer/Test/Mftf/ActionGroup/AdminAssertCustomerInCustomersGridActionGroup.xml"
+  module: "Customer"
   actiongroups:
-     - name: "AdminGridFilterResetActionGroup"
-       description: "Scrolls to the top of the page. Clicks on the 'Clear Filters' link, if present, in the Admin Grid 'Filters' section."
- 
-- filename: "AdminGridFilterFillInputFieldActionGroup.xml"
-  repo: "https://github.com/magento/magento2/blob/2.3/app/code/Magento/Ui/Test/Mftf/ActionGroup/AdminGridFilterFillInputFieldActionGroup.xml"
-  module: "Ui"
+     - name: "AdminAssertCustomerInCustomersGrid"
+       description: "Validates that the provided Customer is present and correct in the Backend Customer grid page."
+- filename: "StorefrontAssertSuccessLoginToStorefrontActionGroup.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/Customer/Test/Mftf/ActionGroup/StorefrontAssertSuccessLoginToStorefrontActionGroup.xml"
+  module: "Customer"
   actiongroups:
-     - name: "AdminGridFilterFillInputFieldActionGroup"
-       description: "Expands the 'Filters' section of an Admin Grid page. Fills in the provided Filter Value for the provided Filter Name."
- 
-- filename: "AdminSaveAndCloseActionGroup.xml"
-  repo: "https://github.com/magento/magento2/blob/2.3/app/code/Magento/Ui/Test/Mftf/ActionGroup/AdminSaveAndCloseActionGroup.xml"
-  module: "Ui"
+     - name: "StorefrontAssertSuccessLoginToStorefront"
+       description: "EXTENDS: LoginToStorefrontActionGroup. Validates that the provided Customer name is present and correct."
+- filename: "AdminAssertCustomerGroupOnCustomerFormActionGroup.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/Customer/Test/Mftf/ActionGroup/AdminAssertCustomerGroupOnCustomerFormActionGroup.xml"
+  module: "Customer"
   actiongroups:
-     - name: "AdminFormSaveAndClose"
-       description: "Clicks on 'Save and Close'. Validates that the Success Message is present."
-
-     - name: "AdminFormSaveAndDuplicate"
-       description: "Clicks on 'Save and Duplicate'. Validates that the Success Message is present and correct."
- 
-- filename: "AdminGridFilterSearchResultsActionGroup.xml"
-  repo: "https://github.com/magento/magento2/blob/2.3/app/code/Magento/Ui/Test/Mftf/ActionGroup/AdminGridFilterSearchResultsActionGroup.xml"
-  module: "Ui"
-  actiongroups:
-     - name: "AdminGridFilterSearchResultsByInput"
-       description: "Filters an Admin Grid page using the provided Filter Selector and Search Value."
- 
-- filename: "AdminDataGridFilterActionGroup.xml"
-  repo: "https://github.com/magento/magento2/blob/2.3/app/code/Magento/Ui/Test/Mftf/ActionGroup/AdminDataGridFilterActionGroup.xml"
-  module: "Ui"
-  actiongroups:
-     - name: "searchAdminDataGridByKeyword"
-       description: "Fills 'Search by keyword' on an Admin Grid page. Clicks on Submit Search."
-
-     - name: "resetAdminDataGridToDefaultView"
-       description: "Resets an Admin Grid page to the 'Default View'."
-
-     - name: "clearFiltersAdminDataGrid"
-       description: "Clicks on 'Clear Filters' on an Admin Grid page."
- 
-- filename: "AdminDataGridPaginationActionGroup.xml"
-  repo: "https://github.com/magento/magento2/blob/2.3/app/code/Magento/Ui/Test/Mftf/ActionGroup/AdminDataGridPaginationActionGroup.xml"
-  module: "Ui"
-  actiongroups:
-     - name: "adminDataGridSelectPerPage"
-       description: "Sets the provided preset 'per page' display setting on an Admin Grid page."
-
-     - name: "adminDataGridSelectCustomPerPage"
-       description: "Sets the provided custom 'per page' display setting on an Admin Grid page."
-
-     - name: "adminDataGridDeleteCustomPerPage"
-       description: "Sets the provided custom 'per page' display setting on an Admin Grid page. Deletes the Items listed in a grid. Validates that the 'per page' count in NOT present."
- 
-- filename: "AdminClickSearchInGridActionGroup.xml"
-  repo: "https://github.com/magento/magento2/blob/2.3/app/code/Magento/Ui/Test/Mftf/ActionGroup/AdminClickSearchInGridActionGroup.xml"
-  module: "Ui"
-  actiongroups:
-     - name: "AdminClickSearchInGridActionGroup"
+     - name: "AdminAssertCustomerGroupOnCustomerForm"
        description: ""
- 
-- filename: "AdminGridFilterApplyActionGroup.xml"
-  repo: "https://github.com/magento/magento2/blob/2.3/app/code/Magento/Ui/Test/Mftf/ActionGroup/AdminGridFilterApplyActionGroup.xml"
-  module: "Ui"
+- filename: "AssertCustomerResetPasswordActionGroup.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/Customer/Test/Mftf/ActionGroup/AssertCustomerResetPasswordActionGroup.xml"
+  module: "Customer"
   actiongroups:
-     - name: "AdminGridFilterApplyActionGroup"
-       description: "Clicks on 'Apply Filters' in the 'Filters' section of an Admin Grid page."
- 
-- filename: "AdminFillInputFilterFieldActionGroup.xml"
-  repo: "https://github.com/magento/magento2/blob/2.3/app/code/Magento/Ui/Test/Mftf/ActionGroup/AdminFillInputFilterFieldActionGroup.xml"
-  module: "Ui"
+     - name: "AssertCustomerResetPasswordActionGroup"
+       description: "Validates that the provided URL is present and correct. Validates that the provided Message/Message Type is present and correct."
+- filename: "AdminUpdateCustomerGroupActionGroup.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/Customer/Test/Mftf/ActionGroup/AdminUpdateCustomerGroupActionGroup.xml"
+  module: "Customer"
   actiongroups:
-     - name: "AdminFillInputFilterFieldActionGroup"
+     - name: "AdminUpdateCustomerGroupByEmailActionGroup"
+       description: "Goes to the Admin Customers grid page. Filters the grid for the provided Email Address. Edits the Customer. Updates the Customer Group with the provided Customer Group. Clicks on Save."
+- filename: "AdminDeleteCustomerGroupActionGroup.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/Customer/Test/Mftf/ActionGroup/AdminDeleteCustomerGroupActionGroup.xml"
+  module: "Customer"
+  actiongroups:
+     - name: "AdminDeleteCustomerGroupActionGroup"
+       description: "Goes to the Customer Groups grid page. Filter results based on provided Customer Group Name. Delete Customer from grid page."
+- filename: "AssertStorefrontPasswordAutocompleteOffActionGroup.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/Customer/Test/Mftf/ActionGroup/AssertStorefrontPasswordAutocompleteOffActionGroup.xml"
+  module: "Customer"
+  actiongroups:
+     - name: "AssertStorefrontPasswordAutoCompleteOffActionGroup"
+       description: "Goes to the Storefront Customer Sign-In page. Validates that the Password field does NOT contain the 'autocomplete' attribute."
+- filename: "StorefrontFillCustomerAccountCreationFormActionGroup.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/Customer/Test/Mftf/ActionGroup/StorefrontFillCustomerAccountCreationFormActionGroup.xml"
+  module: "Customer"
+  actiongroups:
+     - name: "StorefrontFillCustomerAccountCreationFormActionGroup"
+       description: "Fills in the provided Customer details on the Storefront Customer creation page."
+- filename: "AdminFilterCustomerGridByEmailActionGroup.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/Customer/Test/Mftf/ActionGroup/AdminFilterCustomerGridByEmailActionGroup.xml"
+  module: "Customer"
+  actiongroups:
+     - name: "AdminFilterCustomerGridByEmail"
+       description: "Filters the Admin Customers grid by the provided Email Address."
+- filename: "FillNewCustomerAddressRequiredFieldsActionGroup.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/Customer/Test/Mftf/ActionGroup/FillNewCustomerAddressRequiredFieldsActionGroup.xml"
+  module: "Customer"
+  actiongroups:
+     - name: "FillNewCustomerAddressRequiredFieldsActionGroup"
        description: ""
- 
-- filename: "AdminUserActionGroup.xml"
-  repo: "https://github.com/magento/magento2/blob/2.3/app/code/Magento/Braintree/Test/Mftf/ActionGroup/AdminUserActionGroup.xml"
-  module: "Braintree"
+- filename: "LoginToStorefrontActionGroup.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/Customer/Test/Mftf/ActionGroup/LoginToStorefrontActionGroup.xml"
+  module: "Customer"
   actiongroups:
-     - name: "GoToAllUsers"
-       description: "Navigate to the Users page via Backend Admin Side Menu. PLEASE NOTE: Use the amOnPage action instead."
+     - name: "LoginToStorefrontActionGroup"
+       description: "Goes to the Storefront Customer Sign In page. Logs in using the provided Customer."
+- filename: "AssertMessageCustomerCreateAccountActionGroup.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/Customer/Test/Mftf/ActionGroup/AssertMessageCustomerCreateAccountActionGroup.xml"
+  module: "Customer"
+  actiongroups:
+     - name: "AssertMessageCustomerCreateAccountActionGroup"
+       description: "Validates that the provided Message/Message Type are present and correct."
+- filename: "AssertCustomerAccountPageTitleActionGroup.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/Customer/Test/Mftf/ActionGroup/AssertCustomerAccountPageTitleActionGroup.xml"
+  module: "Customer"
+  actiongroups:
+     - name: "AssertCustomerAccountPageTitleActionGroup"
+       description: "Validates that the provided Page Title is present and correct on the Storefront Customer Dashboard."
+- filename: "StorefrontCustomerChangeEmailActionGroup.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/Customer/Test/Mftf/ActionGroup/StorefrontCustomerChangeEmailActionGroup.xml"
+  module: "Customer"
+  actiongroups:
+     - name: "StorefrontCustomerChangeEmailActionGroup"
+       description: "Change the Customer Email Address for a Customer Account via the Storefront Customer Dashboard page."
+- filename: "VerifyGroupCustomerActionGroup.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/Customer/Test/Mftf/ActionGroup/VerifyGroupCustomerActionGroup.xml"
+  module: "Customer"
+  actiongroups:
+     - name: "VerifyCustomerGroupForCustomer"
+       description: "Clicks on the Edit link for the provided Customer Email Address."
+- filename: "StorefrontCustomerLogoutActionGroup.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/Customer/Test/Mftf/ActionGroup/StorefrontCustomerLogoutActionGroup.xml"
+  module: "Customer"
+  actiongroups:
+     - name: "StorefrontCustomerLogoutActionGroup"
+       description: "Goes to the Storefront Customer Logout page."
 
-     - name: "AdminCreateUserAction"
-       description: "Creates a User using the NewAdmin User Entity and User Role Entity. PLEASE NOTE: The Action Group values are Hardcoded."
- 
-- filename: "StorefrontFillCartDataActionGroup.xml"
-  repo: "https://github.com/magento/magento2/blob/2.3/app/code/Magento/Braintree/Test/Mftf/ActionGroup/StorefrontFillCartDataActionGroup.xml"
-  module: "Braintree"
+     - name: "StorefrontSignOutActionGroup"
+       description: "Clicks on Customer Account. Clicks on 'Sign-Out'. Validates that the success message is present and correct. PLEASE NOTE: The Success Message is hardcoded."
+- filename: "AdminResetFilterInCustomerAddressGridActionGroup.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/Customer/Test/Mftf/ActionGroup/AdminResetFilterInCustomerAddressGridActionGroup.xml"
+  module: "Customer"
   actiongroups:
-     - name: "StorefrontFillCartDataActionGroup"
-       description: "Fills Cart Data with Braintree using the provided Data Entity."
- 
-- filename: "ConfigureBraintreeActionGroup.xml"
-  repo: "https://github.com/magento/magento2/blob/2.3/app/code/Magento/Braintree/Test/Mftf/ActionGroup/ConfigureBraintreeActionGroup.xml"
-  module: "Braintree"
+     - name: "AdminResetFilterInCustomerAddressGrid"
+       description: "Clears the Admin Customer Address grid Filters. Sets the grid view to 'Default View'."
+- filename: "AssertAdminCustomerGenderInCustomersGridActionGroup.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/Customer/Test/Mftf/ActionGroup/AssertAdminCustomerGenderInCustomersGridActionGroup.xml"
+  module: "Customer"
   actiongroups:
-     - name: "ConfigureBraintree"
-       description: "Sets up the Braintree configuration setting using the BraintreeConfigurationSection Data Entity. PLEASE NOTE: The Action Group values are Hardcoded."
-
-     - name: "DisableBrainTree"
-       description: "Disables the Braintree and BraintreePaypal configuration settings via the CLI."
- 
-- filename: "AdminRoleActionGroup.xml"
-  repo: "https://github.com/magento/magento2/blob/2.3/app/code/Magento/Braintree/Test/Mftf/ActionGroup/AdminRoleActionGroup.xml"
-  module: "Braintree"
+     - name: "AssertAdminCustomerGenderInCustomersGridActionGroup"
+       description: "Assert customer 'Gender' attribute value on customer grid page"
+- filename: "SetGroupCustomerActionGroup.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/Customer/Test/Mftf/ActionGroup/SetGroupCustomerActionGroup.xml"
+  module: "Customer"
   actiongroups:
-     - name: "GoToUserRoles"
-       description: "Navigate to the User Roles page via Backend Admin Side Menu. PLEASE NOTE: Use the amOnPage action instead."
-
-     - name: "AdminCreateNewRole"
-       description: "Creates a User Role using the provided Data."
-
-     - name: "AdminDeleteRoleActionGroup"
-       description: "Deletes a User Role that contains the text 'Role'. PLEASE NOTE: The Action Group values are Hardcoded."
- 
-- filename: "AdminOrderBraintreeFillActionGroup.xml"
-  repo: "https://github.com/magento/magento2/blob/2.3/app/code/Magento/Braintree/Test/Mftf/ActionGroup/AdminOrderBraintreeFillActionGroup.xml"
-  module: "Braintree"
+     - name: "SetCustomerGroupForSelectedCustomersViaGrid"
+       description: "Clicks on the 'Actions' dropdown menu. Clicks on 'Assign a Customer Group'. Clicks on 'Ok'."
+- filename: "AdminAssertNumberOfRecordsInCustomersAddressGridActionGroup.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/Customer/Test/Mftf/ActionGroup/AdminAssertNumberOfRecordsInCustomersAddressGridActionGroup.xml"
+  module: "Customer"
   actiongroups:
-     - name: "AdminOrderBraintreeFillActionGroup"
-       description: "Fills in the Payment Method using Braintree details. PLEASE NOTE: The Braintree details are Hardcoded using 'PaymentAndShippingInfo'."
- 
-- filename: "AdminProductAddFPTValueActionGroup.xml"
-  repo: "https://github.com/magento/magento2/blob/2.3/app/code/Magento/Weee/Test/Mftf/ActionGroup/AdminProductAddFPTValueActionGroup.xml"
-  module: "Weee"
+     - name: "AdminAssertNumberOfRecordsInCustomersAddressGrid"
+       description: "Validates that the Number of Records listed on the Customer grid page is present and correct."
+- filename: "StorefrontFillCustomerLoginFormActionGroup.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/Customer/Test/Mftf/ActionGroup/StorefrontFillCustomerLoginFormActionGroup.xml"
+  module: "Customer"
   actiongroups:
-     - name: "AdminProductAddFPTValueActionGroup"
-       description: "Adds the provided FPT details (Attribute Code, Country, State and Value) on the Admin Product creation/edit page."
- 
-- filename: "StorefrontFillContactUsFormActionGroup.xml"
-  repo: "https://github.com/magento/magento2/blob/2.3/app/code/Magento/Contact/Test/Mftf/ActionGroup/StorefrontFillContactUsFormActionGroup.xml"
-  module: "Contact"
+     - name: "StorefrontFillCustomerLoginFormActionGroup"
+       description: "Fills Storefront Customer Login Email Address. Fills Storefront Customer Login Password."
+- filename: "AdminDeleteAddressInCustomersAddressGridActionGroup.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/Customer/Test/Mftf/ActionGroup/AdminDeleteAddressInCustomersAddressGridActionGroup.xml"
+  module: "Customer"
   actiongroups:
-     - name: "StorefrontFillContactUsFormActionGroup"
-       description: "Fills Name, Email and Comment on the Storefront 'Contact Us' page."
- 
-- filename: "StorefrontSubmitContactUsFormActionGroup.xml"
-  repo: "https://github.com/magento/magento2/blob/2.3/app/code/Magento/Contact/Test/Mftf/ActionGroup/StorefrontSubmitContactUsFormActionGroup.xml"
-  module: "Contact"
+     - name: "AdminDeleteAddressInCustomersAddressGrid"
+       description: "Deletes a Customer Address from the Customer creation/edit page under the 'Addresses' section."
+- filename: "StorefrontCustomerAddressBookNotContainsActionGroup.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/Customer/Test/Mftf/ActionGroup/StorefrontCustomerAddressBookNotContainsActionGroup.xml"
+  module: "Customer"
   actiongroups:
-     - name: "StorefrontSubmitContactUsFormActionGroup"
-       description: "Clicks on the 'Submit' button on the Storefront 'Contact Us' page."
- 
-- filename: "AssertMessageContactUsFormActionGroup.xml"
-  repo: "https://github.com/magento/magento2/blob/2.3/app/code/Magento/Contact/Test/Mftf/ActionGroup/AssertMessageContactUsFormActionGroup.xml"
-  module: "Contact"
+     - name: "StorefrontCustomerAddressBookNotContains"
+       description: "Validate that the provided Address does NOT appear in the Storefront Customer Address list."
+- filename: "AdminAssertCustomerNoDefaultShippingAddressActionGroup.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/Customer/Test/Mftf/ActionGroup/AdminAssertCustomerNoDefaultShippingAddressActionGroup.xml"
+  module: "Customer"
   actiongroups:
-     - name: "AssertMessageContactUsFormActionGroup"
-       description: "Validates that the provided Message appears in the correct Message Type on the Storefront 'Contact Us' page."
- 
-- filename: "StorefrontOpenContactUsPageActionGroup.xml"
-  repo: "https://github.com/magento/magento2/blob/2.3/app/code/Magento/Contact/Test/Mftf/ActionGroup/StorefrontOpenContactUsPageActionGroup.xml"
-  module: "Contact"
+     - name: "AdminAssertCustomerNoDefaultShippingAddress"
+       description: "Validates that a Customer does NOT have a Default Shipping Address assigned. PLEASE NOTE: The error message is hardcoded."
+- filename: "AssertCustomerGroupOnCustomerFormActionGroup.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/Customer/Test/Mftf/ActionGroup/AssertCustomerGroupOnCustomerFormActionGroup.xml"
+  module: "Customer"
   actiongroups:
-     - name: "StorefrontOpenContactUsPageActionGroup"
-       description: "Goes to the Storefront 'Contact Us' page."
- 
-- filename: "AdminCreateWidgetActionGroup.xml"
-  repo: "https://github.com/magento/magento2/blob/2.3/app/code/Magento/Widget/Test/Mftf/ActionGroup/AdminCreateWidgetActionGroup.xml"
-  module: "Widget"
+     - name: "AssertCustomerGroupOnCustomerFormActionGroup"
+       description: "Validates that the provided Customer Group is selected on the Admin Customer edit page."
+- filename: "AssertStorefrontCustomerSavedCardActionGroup.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/Customer/Test/Mftf/ActionGroup/AssertStorefrontCustomerSavedCardActionGroup.xml"
+  module: "Customer"
   actiongroups:
-     - name: "AdminCreateWidgetActionGroup"
-       description: "Goes to the Admin Widget creation page. Creates the provided Widget."
-
-     - name: "AdminFillSpecificPageWidgetMainFieldsActionGroup"
-       description: "Fill widget main fields and widget layout by index for specified page DisplayOn option"
-
-     - name: "AdminCreateProductsListWidgetActionGroup"
-       description: "EXTENDS: AdminCreateWidgetActionGroup. Creates a Product List Widget. Validates that the Success Message is present and correct."
-
-     - name: "AdminCreateDynamicBlocksRotatorWidgetActionGroup"
-       description: "EXTENDS: AdminCreateWidgetActionGroup. Creates a Dynamic Block Rotate Widget."
-
-     - name: "AdminDeleteWidgetActionGroup"
-       description: "Goes to the Admin Widget grid page. Deletes the provided Widget. Validates that the Success Message is present and correct."
-
-     - name: "AdminCreateProductLinkWidgetActionGroup"
-       description: "EXTENDS: AdminCreateWidgetActionGroup. Creates a Product List Widget using the provided Product. Validates that the Success Message is present and correct."
- 
-- filename: "AdminWidgetActionGroup.xml"
-  repo: "https://github.com/magento/magento2/blob/2.3/app/code/Magento/Widget/Test/Mftf/ActionGroup/AdminWidgetActionGroup.xml"
-  module: "Widget"
-  actiongroups:
-     - name: "AdminCreateWidgetWithBlockActionGroup"
-       description: "Goes to the Admin Widgets creation page. Creates the provided Widget which includes the provided Block. Clicks on Save. Validates that the Success Message is preset and correct."
- 
-- filename: "AdminCreateAndSaveWidgetActionGroup.xml"
-  repo: "https://github.com/magento/magento2/blob/2.3/app/code/Magento/Widget/Test/Mftf/ActionGroup/AdminCreateAndSaveWidgetActionGroup.xml"
-  module: "Widget"
-  actiongroups:
-     - name: "AdminCreateAndSaveWidgetActionGroup"
-       description: "EXTENDS: AdminCreateWidgetActionGroup. Clicks on Save. Validates that the Success Message is present and correct."
- 
-- filename: "ClearCacheActionGroup.xml"
-  repo: "https://github.com/magento/magento2/blob/2.3/app/code/Magento/PageCache/Test/Mftf/ActionGroup/ClearCacheActionGroup.xml"
-  module: "PageCache"
-  actiongroups:
-     - name: "ClearCacheActionGroup"
-       description: "Goes to the Admin Cache Management page. Clicks on 'Flush Magento Cache'."
-
-     - name: "clearPageCache"
-       description: "Goes to the Admin Cache Management page. Selects 'Refresh'. Checks the 'Page Cache' row. Clicks on Submit."
- 
-- filename: "ClearPageCacheActionGroup.xml"
-  repo: "https://github.com/magento/magento2/blob/2.3/app/code/Magento/PageCache/Test/Mftf/ActionGroup/ClearPageCacheActionGroup.xml"
-  module: "PageCache"
-  actiongroups:
-     - name: "ClearPageCacheActionGroup"
-       description: "Goes to the Admin Cache Management page. Selects 'Refresh'. Checks the 'Page Cache' row. Clicks on Submit."
- 
-- filename: "CreateOrderToPrintPageActionGroup.xml"
-  repo: "https://github.com/magento/magento2/blob/2.3/app/code/Magento/Sales/Test/Mftf/ActionGroup/CreateOrderToPrintPageActionGroup.xml"
-  module: "Sales"
-  actiongroups:
-     - name: "CreateOrderToPrintPageActionGroup"
-       description: "Goes to the provided Storefront Category page. Adds the Product to the Cart. Places the Order. Clicks on Print Order."
-
-     - name: "CreateOrderToPrintPageWithSelectedPaymentMethodActionGroup"
-       description: "EXTENDS: CreateOrderToPrintPageActionGroup. Clicks on 'Check / Money Order'."
- 
-- filename: "AdminMoveProductToItemsOrderedFromShoppingCartActionGroup.xml"
-  repo: "https://github.com/magento/magento2/blob/2.3/app/code/Magento/Sales/Test/Mftf/ActionGroup/AdminMoveProductToItemsOrderedFromShoppingCartActionGroup.xml"
-  module: "Sales"
-  actiongroups:
-     - name: "AdminMoveProductToItemsOrderedFromShoppingCartActionGroup"
-       description: "Move product to the \"Items Ordered\" section from shopping cart."
- 
-- filename: "AdminAddToOrderConfigurableProductActionGroup.xml"
-  repo: "https://github.com/magento/magento2/blob/2.3/app/code/Magento/Sales/Test/Mftf/ActionGroup/AdminAddToOrderConfigurableProductActionGroup.xml"
-  module: "Sales"
-  actiongroups:
-     - name: "AdminAddToOrderConfigurableProductActionGroup"
+     - name: "AssertStorefrontCustomerSavedCardActionGroup"
        description: ""
- 
-- filename: "AssertOrderButtonsAvailableActionGroup.xml"
-  repo: "https://github.com/magento/magento2/blob/2.3/app/code/Magento/Sales/Test/Mftf/ActionGroup/AssertOrderButtonsAvailableActionGroup.xml"
-  module: "Sales"
+- filename: "DeleteCustomerActionGroup.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/Customer/Test/Mftf/ActionGroup/DeleteCustomerActionGroup.xml"
+  module: "Customer"
   actiongroups:
-     - name: "AssertOrderButtonsAvailableActionGroup"
-       description: "Validates that the primary buttons appear on the Admin Order edit page."
- 
-- filename: "AdminSubmitOrderActionGroup.xml"
-  repo: "https://github.com/magento/magento2/blob/2.3/app/code/Magento/Sales/Test/Mftf/ActionGroup/AdminSubmitOrderActionGroup.xml"
-  module: "Sales"
+     - name: "DeleteCustomerActionGroup"
+       description: "Goes to the Admin Customers grid page. Deletes a Customer based on the provided Last Name."
+
+     - name: "DeleteCustomerByEmailActionGroup"
+       description: "Goes to the Admin Customers grid page. Deletes a Customer based on the provided Email Address."
+- filename: "StorefrontAddCustomerAddressActionGroup.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/Customer/Test/Mftf/ActionGroup/StorefrontAddCustomerAddressActionGroup.xml"
+  module: "Customer"
   actiongroups:
-     - name: "AdminSubmitOrderActionGroup"
+     - name: "StorefrontAddNewCustomerAddressActionGroup"
+       description: "Goes to the Storefront Customer Add New Address page. Fills in the provided Address details. Clicks on Save."
+
+     - name: "StorefrontAddCustomerDefaultAddressActionGroup"
+       description: "Goes to the Storefront Customer Add New Default Address page. Fills in the provided Address details. Clicks on Save."
+- filename: "OpenStorefrontStoredPaymentMethodsPageActionGroup.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/Customer/Test/Mftf/ActionGroup/OpenStorefrontStoredPaymentMethodsPageActionGroup.xml"
+  module: "Customer"
+  actiongroups:
+     - name: "OpenStorefrontCustomerStoredPaymentMethodsPageActionGroup"
        description: ""
- 
-- filename: "AdminAssertRefundOrderStatusInCommentsHistoryActionGroup.xml"
-  repo: "https://github.com/magento/magento2/blob/2.3/app/code/Magento/Sales/Test/Mftf/ActionGroup/AdminAssertRefundOrderStatusInCommentsHistoryActionGroup.xml"
-  module: "Sales"
+- filename: "AdminEditCustomerAddressNoZipNoStateActionGroup.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/Customer/Test/Mftf/ActionGroup/AdminEditCustomerAddressNoZipNoStateActionGroup.xml"
+  module: "Customer"
   actiongroups:
-     - name: "AdminAssertRefundOrderStatusCommentsHistoryActionGroup"
-       description: "Clicks on the 'Comments History' on Admin View Order page. Validates that the provided Order Status and Refund message are present and correct."
- 
-- filename: "AdminCreditMemoActionGroup.xml"
-  repo: "https://github.com/magento/magento2/blob/2.3/app/code/Magento/Sales/Test/Mftf/ActionGroup/AdminCreditMemoActionGroup.xml"
-  module: "Sales"
+     - name: "AdminEditCustomerAddressNoZipNoState"
+       description: "EXTENDS: AdminEditCustomerAddressesFrom. Removes 'selectState' and 'fillZipCode'. Clicks on 'Set Default' for Billing/Shipping."
+- filename: "EditCustomerAddressesFromAdminActionGroup.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/Customer/Test/Mftf/ActionGroup/EditCustomerAddressesFromAdminActionGroup.xml"
+  module: "Customer"
   actiongroups:
-     - name: "verifyBasicCreditMemoInformation"
-       description: "Validates that the provided Customer, Shipping/Billing Address and Customer Group are present and correct on the Admin Credit Memo view page."
-
-     - name: "seeProductInItemsRefunded"
-       description: "Validates that the provided Product appears in the 'Product' column on the Admin Credit Memo view page."
-
-     - name: "StartToCreateCreditMemoActionGroup"
+     - name: "EditCustomerAddressesFromAdminActionGroup"
+       description: "Adds the provided Address to a Customer from the Admin Customers creation/edit page."
+- filename: "AdminAssertCustomerNoDefaultBillingAddressActionGroup.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/Customer/Test/Mftf/ActionGroup/AdminAssertCustomerNoDefaultBillingAddressActionGroup.xml"
+  module: "Customer"
+  actiongroups:
+     - name: "AdminAssertCustomerNoDefaultBillingAddress"
+       description: "Validates that a Customer does NOT have a Default Billing Address assigned. PLEASE NOTE: The error message is hardcoded."
+- filename: "SwitchAccountActionGroup.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/Customer/Test/Mftf/ActionGroup/SwitchAccountActionGroup.xml"
+  module: "Customer"
+  actiongroups:
+     - name: "SignOut"
+       description: "Click on the Backend Admin current Admin User menu. Click on 'Logout'. Validate that you are logged out."
+- filename: "AdminAssertErrorMessageCustomerGroupAlreadyExistsActionGroup.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/Customer/Test/Mftf/ActionGroup/AdminAssertErrorMessageCustomerGroupAlreadyExistsActionGroup.xml"
+  module: "Customer"
+  actiongroups:
+     - name: "AdminAssertErrorMessageCustomerGroupAlreadyExists"
        description: ""
-
-     - name: "SubmitCreditMemoActionGroup"
+- filename: "AdminFilterCustomerAddressGridByPhoneNumberActionGroup.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/Customer/Test/Mftf/ActionGroup/AdminFilterCustomerAddressGridByPhoneNumberActionGroup.xml"
+  module: "Customer"
+  actiongroups:
+     - name: "AdminFilterCustomerAddressGridByPhoneNumber"
+       description: "Filters the Admin Customers grid by the provided Phone Number."
+- filename: "AdminAssertCustomerDefaultShippingAddressActionGroup.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/Customer/Test/Mftf/ActionGroup/AdminAssertCustomerDefaultShippingAddressActionGroup.xml"
+  module: "Customer"
+  actiongroups:
+     - name: "AdminAssertCustomerDefaultShippingAddress"
+       description: "Validates that the provided Default Customer Shipping Address details are present and correct on the Customer creation/edit page. Under the section 'Addresses'."
+- filename: "NavigateCustomerGroupActionGroup.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/Customer/Test/Mftf/ActionGroup/NavigateCustomerGroupActionGroup.xml"
+  module: "Customer"
+  actiongroups:
+     - name: "NavigateToCustomerGroupPage"
+       description: "Goes to the Admin Customer Groups page."
+- filename: "AssertMessageCustomerLoginActionGroup.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/Customer/Test/Mftf/ActionGroup/AssertMessageCustomerLoginActionGroup.xml"
+  module: "Customer"
+  actiongroups:
+     - name: "AssertMessageCustomerLoginActionGroup"
+       description: "Validates that the provided Message/Message Type are present and correct."
+- filename: "AdminAssertCustomerGroupOnProductFormActionGroup.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/Customer/Test/Mftf/ActionGroup/AdminAssertCustomerGroupOnProductFormActionGroup.xml"
+  module: "Customer"
+  actiongroups:
+     - name: "AdminAssertCustomerGroupOnProductForm"
        description: ""
-
-     - name: "UpdateCreditMemoTotalsActionGroup"
+- filename: "StorefrontOpenMyAccountPageActionGroup.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/Customer/Test/Mftf/ActionGroup/StorefrontOpenMyAccountPageActionGroup.xml"
+  module: "Customer"
+  actiongroups:
+     - name: "StorefrontOpenMyAccountPageActionGroup"
        description: ""
- 
-- filename: "AdminSelectFlatRateShippingMethodActionGroup.xml"
-  repo: "https://github.com/magento/magento2/blob/2.3/app/code/Magento/Sales/Test/Mftf/ActionGroup/AdminSelectFlatRateShippingMethodActionGroup.xml"
-  module: "Sales"
+- filename: "AdminDeleteCustomerActionGroup.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/Customer/Test/Mftf/ActionGroup/AdminDeleteCustomerActionGroup.xml"
+  module: "Customer"
   actiongroups:
-     - name: "AdminSelectFlatRateShippingMethodActionGroup"
-       description: ""
- 
-- filename: "FilterShipmentGridByOrderIdActionGroup.xml"
-  repo: "https://github.com/magento/magento2/blob/2.3/app/code/Magento/Sales/Test/Mftf/ActionGroup/FilterShipmentGridByOrderIdActionGroup.xml"
-  module: "Sales"
+     - name: "AdminDeleteCustomerActionGroup"
+       description: "Goes to the Customers grid page. Check the row for the provided Customer Email Address. Delete the Customer."
+- filename: "AdminCreateCustomerGroupActionGroup.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/Customer/Test/Mftf/ActionGroup/AdminCreateCustomerGroupActionGroup.xml"
+  module: "Customer"
   actiongroups:
-     - name: "FilterShipmentGridByOrderIdActionGroup"
-       description: ""
- 
-- filename: "StorefrontFillOrdersAndReturnsFormActionGroup.xml"
-  repo: "https://github.com/magento/magento2/blob/2.3/app/code/Magento/Sales/Test/Mftf/ActionGroup/StorefrontFillOrdersAndReturnsFormActionGroup.xml"
-  module: "Sales"
+     - name: "AdminCreateCustomerGroupActionGroup"
+       description: "Goes to the Customer Groups creation page. Fills Name. Selects Tax Class. Clicks on Save. Validate that the Success Message is present and correct."
+- filename: "AdminEditCustomerAddressesFromActionGroup.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/Customer/Test/Mftf/ActionGroup/AdminEditCustomerAddressesFromActionGroup.xml"
+  module: "Customer"
   actiongroups:
-     - name: "StorefrontFillOrdersAndReturnsFormActionGroup"
-       description: ""
- 
-- filename: "AdminOrderFilterByOrderIdAndStatusActionGroup.xml"
-  repo: "https://github.com/magento/magento2/blob/2.3/app/code/Magento/Sales/Test/Mftf/ActionGroup/AdminOrderFilterByOrderIdAndStatusActionGroup.xml"
-  module: "Sales"
-  actiongroups:
-     - name: "AdminOrderFilterByOrderIdAndStatusActionGroup"
-       description: ""
- 
-- filename: "AssertStorefrontShippingDescriptionInOrderViewActionGroup.xml"
-  repo: "https://github.com/magento/magento2/blob/2.3/app/code/Magento/Sales/Test/Mftf/ActionGroup/AssertStorefrontShippingDescriptionInOrderViewActionGroup.xml"
-  module: "Sales"
-  actiongroups:
-     - name: "AssertStorefrontShippingDescriptionInOrderViewActionGroup"
-       description: "Validates that the Shipping Description will shown in Shipping total description."
- 
-- filename: "AdminOrderActionOnGridActionGroup.xml"
-  repo: "https://github.com/magento/magento2/blob/2.3/app/code/Magento/Sales/Test/Mftf/ActionGroup/AdminOrderActionOnGridActionGroup.xml"
-  module: "Sales"
-  actiongroups:
-     - name: "AdminOrderActionOnGridActionGroup"
-       description: ""
+     - name: "AdminEditCustomerAddressesFrom"
+       description: "Adds the provided Address to a Customer from the Admin Customers creation/edit page."
 
-     - name: "AdminTwoOrderActionOnGridActionGroup"
-       description: ""
- 
-- filename: "AdminOrderGridActionGroup.xml"
-  repo: "https://github.com/magento/magento2/blob/2.3/app/code/Magento/Sales/Test/Mftf/ActionGroup/AdminOrderGridActionGroup.xml"
-  module: "Sales"
-  actiongroups:
-     - name: "filterOrderGridById"
-       description: "Goes to the Admin Orders page. Filters the grid based on the provided Order ID."
+     - name: "AdminEditCustomerAddressSetDefaultShippingAndBilling"
+       description: "EXTENDS: AdminEditCustomerAddressesFrom. Clicks on 'Set Default' for Billing/Shipping."
 
-     - name: "filterOrderGridByBillingName"
-       description: "Goes to the Admin Orders page. Filters the grid based on the provided Customer."
+     - name: "AdminEditCustomerAddressNoZipNoState"
+       description: "EXTENDS: AdminEditCustomerAddressesFrom. Removes 'selectState' and 'fillZipCode'. Clicks on 'Set Default' for Billing/Shipping."
 
-     - name: "filterOrderGridByBaseTotalRange"
-       description: "Goes to the Admin Orders page. Filters the grid based on the provided Grand Total From/To values."
+     - name: "SelectDropdownCustomerAddressAttributeValueActionGroup"
+       description: "Selects the provided Option in the provided Customer Address Attribute drop down menu. Clicks on Save."
+- filename: "AssertCustomerGroupNotOnProductFormActionGroup.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/Customer/Test/Mftf/ActionGroup/AssertCustomerGroupNotOnProductFormActionGroup.xml"
+  module: "Customer"
+  actiongroups:
+     - name: "AssertCustomerGroupNotOnProductFormActionGroup"
+       description: "Clicks on 'Advanced Pricing' on the Admin Customers creation/edit page. Validates that the provided Customer Group does NOT appear in the dropdown menu."
+- filename: "StorefrontCustomerAddressBookContainsActionGroup.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/Customer/Test/Mftf/ActionGroup/StorefrontCustomerAddressBookContainsActionGroup.xml"
+  module: "Customer"
+  actiongroups:
+     - name: "StorefrontCustomerAddressBookContains"
+       description: "Validate that the provided Address appears in the Storefront Customer Address list."
+- filename: "AdminAssertAddressInCustomersAddressGridActionGroup.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/Customer/Test/Mftf/ActionGroup/AdminAssertAddressInCustomersAddressGridActionGroup.xml"
+  module: "Customer"
+  actiongroups:
+     - name: "AdminAssertAddressInCustomersAddressGrid"
+       description: "Validates that the provided Customer Address is present in the Customer Address grid on the Customer creation/edit page. Under the 'Addresses' section."
+- filename: "StorefrontOpenCustomerAccountCreatePageActionGroup.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/Customer/Test/Mftf/ActionGroup/StorefrontOpenCustomerAccountCreatePageActionGroup.xml"
+  module: "Customer"
+  actiongroups:
+     - name: "StorefrontOpenCustomerAccountCreatePageActionGroup"
+       description: "Goes to the Storefront Customer Create page."
 
-     - name: "filterOrderGridByPurchaseDate"
-       description: "Goes to the Admin Orders page. Filters the grid based on the provided Purchased Date From/To values."
+     - name: "StorefrontOpenCustomerAccountCreatePageUsingStoreCodeInUrlActionGroup"
+       description: "Goes to the Storefront Customer Create page using Store code in URL option."
+- filename: "StorefrontFillCustomerLoginFormWithWrongPasswordActionGroup.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/Customer/Test/Mftf/ActionGroup/StorefrontFillCustomerLoginFormWithWrongPasswordActionGroup.xml"
+  module: "Customer"
+  actiongroups:
+     - name: "StorefrontFillCustomerLoginFormWithWrongPasswordActionGroup"
+       description: "EXTENDS: StorefrontFillCustomerLoginFormActionGroup. Removes 'fillPassword'. Fills in an invalid Password."
+- filename: "SignUpNewUserFromStorefrontActionGroup.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/Customer/Test/Mftf/ActionGroup/SignUpNewUserFromStorefrontActionGroup.xml"
+  module: "Customer"
+  actiongroups:
+     - name: "SignUpNewUserFromStorefrontActionGroup"
+       description: "Goes to the Storefront. Clicks on 'Create Account'. Fills in the provided Customer details, excluding Newsletter Sign-Up. Clicks on 'Create Account' button. Validate that the Customer details are present and correct."
 
-     - name: "filterOrderGridByStatus"
-       description: "Filters the Admin Orders grid based on the provided Order Status."
+     - name: "StorefrontCreateCustomerSignedUpNewsletterActionGroup"
+       description: "Goes to the Storefront. Clicks on 'Create Account'. Fills in the provided Customer details, including Newsletter Sign-Up. Clicks on 'Create Account' button."
 
-     - name: "AdminOrdersGridClearFiltersActionGroup"
-       description: "Goes to the Admin Orders grid page. Clicks on 'Clear Filters', if present."
-
-     - name: "OpenOrderById"
-       description: "EXTENDS: filterOrderGridById. Clicks on the 1st row of the Admin Orders grid."
- 
-- filename: "AdminOrderStatusFormFillAndSaveActionGroup.xml"
-  repo: "https://github.com/magento/magento2/blob/2.3/app/code/Magento/Sales/Test/Mftf/ActionGroup/AdminOrderStatusFormFillAndSaveActionGroup.xml"
-  module: "Sales"
-  actiongroups:
-     - name: "AdminOrderStatusFormFillAndSave"
-       description: "Fills in the provided Status and Label on the Admin Order Status section."
- 
-- filename: "AdminAssertRefundInRefundsGridActionGroup.xml"
-  repo: "https://github.com/magento/magento2/blob/2.3/app/code/Magento/Sales/Test/Mftf/ActionGroup/AdminAssertRefundInRefundsGridActionGroup.xml"
-  module: "Sales"
-  actiongroups:
-     - name: "AdminAssertRefundInRefundsGridActionGroup"
-       description: "Goes to the Admin Credit Memo grid page. Filters the grid for the provided Order ID, Memo ID, Refund Status and Refunded Total. Validates that the provided details are present and correct."
- 
-- filename: "CreateNewOrderActionGroup.xml"
-  repo: "https://github.com/magento/magento2/blob/2.3/app/code/Magento/Sales/Test/Mftf/ActionGroup/CreateNewOrderActionGroup.xml"
-  module: "Sales"
-  actiongroups:
-     - name: "useBraintreeForMasterCard"
-       description: "Selects 'Braintree' as the Payment Method on the Admin New Order creation page. Enters Credit Card details. PLEASE NOTE: The Credit Card details used are Hardcoded using 'PaymentAndShippingInfo'."
- 
-- filename: "StorefrontAssertSalesPrintOrderBillingAddressActionGroup.xml"
-  repo: "https://github.com/magento/magento2/blob/2.3/app/code/Magento/Sales/Test/Mftf/ActionGroup/StorefrontAssertSalesPrintOrderBillingAddressActionGroup.xml"
-  module: "Sales"
-  actiongroups:
-     - name: "AssertSalesPrintOrderBillingAddress"
-       description: ""
- 
-- filename: "AdminAddToOrderDownloadableProductActionGroup.xml"
-  repo: "https://github.com/magento/magento2/blob/2.3/app/code/Magento/Sales/Test/Mftf/ActionGroup/AdminAddToOrderDownloadableProductActionGroup.xml"
-  module: "Sales"
-  actiongroups:
-     - name: "AdminAddToOrderDownloadableProductActionGroup"
-       description: ""
- 
-- filename: "AssertOrderStatusFormSaveSuccessActionGroup.xml"
-  repo: "https://github.com/magento/magento2/blob/2.3/app/code/Magento/Sales/Test/Mftf/ActionGroup/AssertOrderStatusFormSaveSuccessActionGroup.xml"
-  module: "Sales"
-  actiongroups:
-     - name: "AssertOrderStatusFormSaveSuccess"
-       description: "Validates that the Success Message is present and correct."
- 
-- filename: "FilterOrderStatusByLabelAndCodeActionGroup.xml"
-  repo: "https://github.com/magento/magento2/blob/2.3/app/code/Magento/Sales/Test/Mftf/ActionGroup/FilterOrderStatusByLabelAndCodeActionGroup.xml"
-  module: "Sales"
-  actiongroups:
-     - name: "FilterOrderStatusByLabelAndCodeActionGroup"
-       description: ""
- 
-- filename: "AssertOrderStatusExistsInGridActionGroup.xml"
-  repo: "https://github.com/magento/magento2/blob/2.3/app/code/Magento/Sales/Test/Mftf/ActionGroup/AssertOrderStatusExistsInGridActionGroup.xml"
-  module: "Sales"
-  actiongroups:
-     - name: "AssertOrderStatusExistsInGrid"
-       description: "Validates that the provided Order Status and Label are present in the Admin Orders grid."
- 
-- filename: "AdminApplyCouponToOrderActionGroup.xml"
-  repo: "https://github.com/magento/magento2/blob/2.3/app/code/Magento/Sales/Test/Mftf/ActionGroup/AdminApplyCouponToOrderActionGroup.xml"
-  module: "Sales"
-  actiongroups:
-     - name: "AdminApplyCouponToOrderActionGroup"
-       description: ""
- 
-- filename: "SelectActionForOrdersActionGroup.xml"
-  repo: "https://github.com/magento/magento2/blob/2.3/app/code/Magento/Sales/Test/Mftf/ActionGroup/SelectActionForOrdersActionGroup.xml"
-  module: "Sales"
-  actiongroups:
-     - name: "SelectActionForOrdersActionGroup"
-       description: ""
- 
-- filename: "AdminAssertOrderAvailableButtonsActionGroup.xml"
-  repo: "https://github.com/magento/magento2/blob/2.3/app/code/Magento/Sales/Test/Mftf/ActionGroup/AdminAssertOrderAvailableButtonsActionGroup.xml"
-  module: "Sales"
-  actiongroups:
-     - name: "AdminAssertOrderAvailableButtonsActionGroup"
-       description: ""
- 
-- filename: "AdminOrderActionGroup.xml"
-  repo: "https://github.com/magento/magento2/blob/2.3/app/code/Magento/Sales/Test/Mftf/ActionGroup/AdminOrderActionGroup.xml"
-  module: "Sales"
-  actiongroups:
-     - name: "navigateToNewOrderPageNewCustomer"
-       description: "Goes to the Admin Orders grid page. Clicks on 'Create New Order'. Clicks on 'Create New Customer'. Select the provided Store View, if present. Validates that Page Title is present and correct."
-
-     - name: "navigateToNewOrderPageNewCustomerSingleStore"
-       description: "Goes to the Admin Orders grid page. Clicks on 'Create New Order'. Clicks on 'Create New Customer'. Validates that Page Title is present and correct."
-
-     - name: "navigateToNewOrderPageExistingCustomer"
-       description: "Goes tot he Admin Orders grid page. Clicks on 'Create New Order'. Filters the grid for the provided Customer. Clicks on the Customer. Selects the provided Store View, if present. Validates that the Page Title is present and correct."
-
-     - name: "NavigateToNewOrderPageExistingCustomerAndStoreActionGroup"
-       description: "EXTENDS: navigateToNewOrderPageExistingCustomer. Clicks on the provided Store View."
-
-     - name: "checkRequiredFieldsNewOrderForm"
-       description: "Clears the Email, First Name, Last Name, Street Line 1, City, Postal Code and Phone fields when adding an Order and then verifies that they are required after attempting to Save."
-
-     - name: "addSimpleProductToOrder"
-       description: "Adds the provided Simple Product to an Order. Fills in the provided Product Qty. Clicks on 'Add Selected Product(s) to Order'."
-
-     - name: "AddSimpleProductWithQtyToOrderActionGroup"
+     - name: "StorefrontFillRegistrationFormActionGroup"
        description: ""
 
-     - name: "addConfigurableProductToOrder"
-       description: "Adds the provided Configurable Product with the provided Option to an Order. Fills in the provided Product Qty. Clicks on 'Add Selected Product(s) to Order'."
-
-     - name: "newAddConfigurableProductToOrder"
+     - name: "SaveRegistrationFormActionGroup"
        description: ""
 
-     - name: "addConfigurableProductToOrderFromAdmin"
-       description: "EXTENDS: addConfigurableProductToOrder. Selects the provided Option to the Configurable Product."
+     - name: "AssertSignedUpNewsletterActionGroup"
+       description: "Validates that the provided Customer details are present and correct on the Storefront Customer Dashboard page."
 
-     - name: "configureOrderedConfigurableProduct"
-       description: "Clicks on 'Configure' for a Product in the 'Please select products' under the 'Create New Order for' page. Selects the provided Option and Attribute. Fills in the provided Qty. Clicks on Ok."
+     - name: "EnterCustomerAddressInfo"
+       description: "Fills in the provided Customer details (First/Last Name, Company, Phone # and Address) on the Admin Customer creation/edit page. Clicks on the Save button."
 
-     - name: "addBundleProductToOrder"
-       description: "Adds the provided Bundled Product with the provided Option to an Order. Fills in the provided Product Qty. Clicks on 'Add Selected Product(s) to Order'."
+     - name: "EnterCustomerAddressInfoFillState"
+       description: "EXTENDS: EnterCustomerAddressInfo. Fills the State field."
 
-     - name: "addBundleProductToOrderAndCheckPriceInGrid"
-       description: "EXTENDS: addBundleProductToOrder. Validates that the provided Product Price is present and correct in the 'Items Ordered' section."
+     - name: "VerifyCustomerBillingAddress"
+       description: "Goes to the Storefront Customer Dashboard Address area. Validates that the provided Customer Billing Address is present and correct on the Storefront Customer Dashboard Address section."
 
-     - name: "addDownloadableProductToOrder"
-       description: "Adds a Downloadable Product to an Order. Clicks on 'Add Selected Product(s) to Order'."
+     - name: "VerifyCustomerShippingAddress"
+       description: "Goes to the Storefront Customer Dashboard Address area. Validates that the provided Customer Shipping Address is present and correct."
 
-     - name: "addGroupedProductOptionToOrder"
-       description: "Adds the provided Grouped Product with the provided Option to an Order. Fills in the provided Product Qty. Clicks on 'Add Selected Product(s) to Order'."
+     - name: "VerifyCustomerBillingAddressWithState"
+       description: "Goes to the Storefront Customer Dashboard Address area. Validates that the provided Customer Billing Address, including the State, is present and correct."
 
-     - name: "fillOrderCustomerInformation"
-       description: "Fills in the provided Customer and Address details on the Admin 'Create New Order for' page."
+     - name: "VerifyCustomerShippingAddressWithState"
+       description: "Goes to the Storefront Customer Dashboard Address area. Validates that the provided Customer Shipping Address, including the State, is present and correct."
 
-     - name: "orderSelectFlatRateShipping"
-       description: "Selects the 'Flat Rate' Shipping Method on the Admin 'Create New Order for' page."
+     - name: "VerifyCustomerNameOnFrontend"
+       description: "Goes to the Storefront Customer Dashboard page. Validates that the Customer First/Last Name is present and correct."
 
-     - name: "changeShippingMethod"
-       description: "Change Shipping Method on the Admin 'Create New Order for' page."
-
-     - name: "orderSelectFreeShipping"
-       description: "Selects the 'Free Shipping' Shipping Method on the Admin 'Create New Order for' page."
-
-     - name: "verifyBasicOrderInformation"
-       description: "Validates that the provided Customer, Shipping/Billing Address and Customer Group are present and correct on the Admin Orders view page."
-
-     - name: "AssertOrderAddressInformationActionGroup"
-       description: ""
-
-     - name: "verifyCreatedOrderInformation"
-       description: "Validates that the Success Message, Order Status (Pending) and Order ID are present and correct."
-
-     - name: "seeProductInItemsOrdered"
-       description: "Validates that the provided Product is present and correct in the 'Items Ordered' section on the Admin Orders view page."
-
-     - name: "CreateOrderInStoreActionGroup"
-       description: "Goes to the Admin Create Order page. Creates an Order based on the provided Customer, Store View and Product. Validates that the Success Message is present and correct."
-
-     - name: "CreateOrderInStoreChoosingPaymentMethodActionGroup"
-       description: "Goes to the Admin Create Order page. Creates an Order based on the provided Customer, Store View and Product. Validates that the Success Message is present and correct."
-
-     - name: "cancelPendingOrder"
-       description: "Cancels the Pending Order on the Admin Orders view page. Validates that the provided Order Status is present and correct."
-
-     - name: "dontSeeProductInItemsOrdered"
-       description: ""
-
-     - name: "SelectCheckMoneyPaymentMethod"
-       description: "Selects the 'Check / Money Order' Payment Method on the Admin Create New Order page."
-
-     - name: "SelectBankTransferPaymentMethodActionGroup"
-       description: ""
-
-     - name: "SelectCashOnDeliveryPaymentMethodActionGroup"
-       description: ""
-
-     - name: "SelectPurchaseOrderPaymentMethodActionGroup"
-       description: ""
-
-     - name: "CreateOrderActionGroup"
-       description: "Goes to the Admin Create New Order page. Selects the provided Customer. Adds the provided Product to the Order. Clicks on Submit Order. Validates that the Success Message is present and correct."
-
-     - name: "CreateOrderFilteringCustomerByEmailActionGroup"
-       description: ""
- 
-- filename: "AssertAdminShippingDescriptionInOrderViewActionGroup.xml"
-  repo: "https://github.com/magento/magento2/blob/2.3/app/code/Magento/Sales/Test/Mftf/ActionGroup/AssertAdminShippingDescriptionInOrderViewActionGroup.xml"
-  module: "Sales"
+     - name: "SignUpNewCustomerStorefrontActionGroup"
+       description: "EXTENDS: SignUpNewUserFromStorefrontActionGroup. Adds a waitForPageLoad action to the Action Group. Removes the action for 'seeThankYouMessage'."
+- filename: "StorefrontCustomerResetPasswordActionGroup.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/Customer/Test/Mftf/ActionGroup/StorefrontCustomerResetPasswordActionGroup.xml"
+  module: "Customer"
   actiongroups:
-     - name: "AssertAdminShippingDescriptionInOrderViewActionGroup"
-       description: "Validates that the Shipping Description will shown in Shipping total description."
- 
-- filename: "AdminAssertProductQtyInGridActionGroup.xml"
-  repo: "https://github.com/magento/magento2/blob/2.3/app/code/Magento/Sales/Test/Mftf/ActionGroup/AdminAssertProductQtyInGridActionGroup.xml"
-  module: "Sales"
+     - name: "StorefrontCustomerResetPasswordActionGroup"
+       description: "Goes to the Storefront Customer Sign-In page. Clicks on 'Forgot Password'. Fills Email Address. Clicks on Reset Password."
+- filename: "StorefrontClickSignInButtonActionGroup.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/Customer/Test/Mftf/ActionGroup/StorefrontClickSignInButtonActionGroup.xml"
+  module: "Customer"
   actiongroups:
-     - name: "AdminAssertProductQtyInGridActionGroup"
-       description: "Goes tot he Admin Catalog Product grid page. Filters the grid based on the provided Product SKU. Validates that the provided Product Qty is present."
- 
-- filename: "AdminAssertProductInShoppingCartSectionActionGroup.xml"
-  repo: "https://github.com/magento/magento2/blob/2.3/app/code/Magento/Sales/Test/Mftf/ActionGroup/AdminAssertProductInShoppingCartSectionActionGroup.xml"
-  module: "Sales"
+     - name: "StorefrontClickSignInButtonActionGroup"
+       description: "Click on the Storefront Header 'Sign-In' link."
+- filename: "AdminAssertDefaultValueDisableAutoGroupInCustomerFormActionGroup.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/Customer/Test/Mftf/ActionGroup/AdminAssertDefaultValueDisableAutoGroupInCustomerFormActionGroup.xml"
+  module: "Customer"
   actiongroups:
-     - name: "AdminAssertProductInShoppingCartSectionActionGroup"
-       description: "Assert product in Shopping cart section in Customer's Activities block on Create Order Page."
- 
-- filename: "AdminCreateInvoiceActionGroup.xml"
-  repo: "https://github.com/magento/magento2/blob/2.3/app/code/Magento/Sales/Test/Mftf/ActionGroup/AdminCreateInvoiceActionGroup.xml"
-  module: "Sales"
+     - name: "AdminAssertDefaultValueDisableAutoGroupInCustomerFormActionGroup"
+       description: "Check Default Value for Disable Automatic Group Changes Based on VAT ID in Create Customer form."
+- filename: "AssertAdminCustomerGenderOnCustomerFormActionGroup.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/Customer/Test/Mftf/ActionGroup/AssertAdminCustomerGenderOnCustomerFormActionGroup.xml"
+  module: "Customer"
   actiongroups:
-     - name: "AdminCreateInvoiceActionGroup"
+     - name: "AssertAdminCustomerGenderOnCustomerFormActionGroup"
+       description: "Validates that the provided Customer Gender is selected on the Admin Customer edit page."
+- filename: "StorefrontAssertRegistrationPageFieldsActionGroup.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/Customer/Test/Mftf/ActionGroup/StorefrontAssertRegistrationPageFieldsActionGroup.xml"
+  module: "Customer"
+  actiongroups:
+     - name: "StorefrontAssertRegistrationPageFields"
        description: ""
-
-     - name: "AdminCreateInvoiceAndShipmentActionGroup"
+- filename: "AdminFilterCustomerGroupByNameActionGroup.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/Customer/Test/Mftf/ActionGroup/AdminFilterCustomerGroupByNameActionGroup.xml"
+  module: "Customer"
+  actiongroups:
+     - name: "AdminFilterCustomerGroupByNameActionGroup"
+       description: "Filters the Admin Customers grid by the provided Customer Group Name."
+- filename: "AssertStorefrontDefaultWelcomeMessageActionGroup.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/Customer/Test/Mftf/ActionGroup/AssertStorefrontDefaultWelcomeMessageActionGroup.xml"
+  module: "Customer"
+  actiongroups:
+     - name: "AssertStorefrontDefaultWelcomeMessageActionGroup"
+       description: "Validates that the Welcome message is present and correct and not you link absent."
+- filename: "AdminNavigateNewCustomerActionGroup.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/Customer/Test/Mftf/ActionGroup/AdminNavigateNewCustomerActionGroup.xml"
+  module: "Customer"
+  actiongroups:
+     - name: "AdminNavigateNewCustomerActionGroup"
+       description: "Goes to the New Customer page."
+- filename: "StorefrontOpenCustomerLoginPageActionGroup.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/Customer/Test/Mftf/ActionGroup/StorefrontOpenCustomerLoginPageActionGroup.xml"
+  module: "Customer"
+  actiongroups:
+     - name: "StorefrontOpenCustomerLoginPageActionGroup"
+       description: "Goes to the Storefront Customer Sign-In page."
+- filename: "AssertCustomerLoggedInActionGroup.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/Customer/Test/Mftf/ActionGroup/AssertCustomerLoggedInActionGroup.xml"
+  module: "Customer"
+  actiongroups:
+     - name: "AssertCustomerWelcomeMessageActionGroup"
+       description: "Validates that the Welcome message is present and correct, including the provided Customers Full Name."
+- filename: "StorefrontClickCreateAnAccountCustomerAccountCreationFormActionGroup.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/Customer/Test/Mftf/ActionGroup/StorefrontClickCreateAnAccountCustomerAccountCreationFormActionGroup.xml"
+  module: "Customer"
+  actiongroups:
+     - name: "StorefrontClickCreateAnAccountCustomerAccountCreationFormActionGroup"
+       description: "Clicks on the Storefront Header 'Create Account' link."
+- filename: "NavigateThroughCustomerTabsActionGroup.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/Customer/Test/Mftf/ActionGroup/NavigateThroughCustomerTabsActionGroup.xml"
+  module: "Customer"
+  actiongroups:
+     - name: "NavigateThroughCustomerTabsActionGroup"
+       description: "Clicks on the provided Storefront Customer Dashboard Side Bar tab names."
+- filename: "StorefrontCustomerAddressBookNumberOfAddressesActionGroup.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/Customer/Test/Mftf/ActionGroup/StorefrontCustomerAddressBookNumberOfAddressesActionGroup.xml"
+  module: "Customer"
+  actiongroups:
+     - name: "StorefrontCustomerAddressBookNumberOfAddresses"
+       description: "Validate that the Customer Address count is present and correct on the Storefront Customer Dashboard page."
+- filename: "CreateCustomerActionGroup.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/Customer/Test/Mftf/ActionGroup/CreateCustomerActionGroup.xml"
+  module: "Customer"
+  actiongroups:
+     - name: "CreateCustomerActionGroup"
+       description: "Goes to the Add Customers page via the Admin Nav Menu. Fills in the Customer details. Clicks on Save. PLEASE NOTE: The Customer data is Hardcoded using 'NewCustomerData'."
+- filename: "AdminOpenCustomerEditPageActionGroup.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/Customer/Test/Mftf/ActionGroup/AdminOpenCustomerEditPageActionGroup.xml"
+  module: "Customer"
+  actiongroups:
+     - name: "AdminOpenCustomerEditPageActionGroup"
+       description: "Goes to the Admin Customer Edit page for the provided Customer ID #."
+- filename: "AdminCustomerSaveAndContinueActionGroup.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/Customer/Test/Mftf/ActionGroup/AdminCustomerSaveAndContinueActionGroup.xml"
+  module: "Customer"
+  actiongroups:
+     - name: "AdminCustomerSaveAndContinue"
+       description: "Clicks on 'Save and Continue' on the Customer creation/edit page."
+- filename: "AdminCreateCustomerWithDefaultAddressWithoutPhoneActionGroup.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/Customer/Test/Mftf/ActionGroup/AdminCreateCustomerWithDefaultAddressWithoutPhoneActionGroup.xml"
+  module: "Customer"
+  actiongroups:
+     - name: "AdminCreateCustomerWithDefaultAddressWithoutPhoneActionGroup"
        description: ""
-
-     - name: "AdminCreateInvoiceAndCreditMemoActionGroup"
+- filename: "StorefrontRegisterCustomerFromOrderSuccessPageActionGroup.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/Customer/Test/Mftf/ActionGroup/StorefrontRegisterCustomerFromOrderSuccessPageActionGroup.xml"
+  module: "Customer"
+  actiongroups:
+     - name: "StorefrontRegisterCustomerFromOrderSuccessPage"
+       description: "Clicks on 'Create Account' on the Storefront Checkout Success page. Fills in the provided Customer details. Clicks on 'Create Account'. Validates that the Success Message is present and correct."
+- filename: "AdminAssertCustomerGroupPresentInGridActionGroup.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/Customer/Test/Mftf/ActionGroup/AdminAssertCustomerGroupPresentInGridActionGroup.xml"
+  module: "Customer"
+  actiongroups:
+     - name: "AdminAssertCustomerGroupPresentInGrid"
        description: ""
- 
-- filename: "AdminInvoiceActionGroup.xml"
-  repo: "https://github.com/magento/magento2/blob/2.3/app/code/Magento/Sales/Test/Mftf/ActionGroup/AdminInvoiceActionGroup.xml"
-  module: "Sales"
+- filename: "AdminCustomerShopingCartActionGroup.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/Customer/Test/Mftf/ActionGroup/AdminCustomerShopingCartActionGroup.xml"
+  module: "Customer"
   actiongroups:
-     - name: "verifyBasicInvoiceInformation"
-       description: "Validates that the provided Customer, Address and Customer Group details are present and correct on the Admin View Invoice page."
-
-     - name: "seeProductInInvoiceItems"
-       description: "Validates that the provided Product appears under the 'SKU' column in the Admin Invoices edit page."
-
-     - name: "adminFastCreateInvoice"
-       description: "Clicks on 'Invoice' on the Admin Orders view page. Clicks on 'Submit Invoice'. Clicks on 'View Invoice'."
-
-     - name: "clearInvoicesGridFilters"
-       description: "Goes to the Admin Invoices grid page. Clicks on 'Clear Filters', if present."
-
-     - name: "goToInvoiceIntoOrder"
-       description: "Clicks on 'Invoice' on the Admin Orders view page. Validates that the URL and Page Title are correct."
-
-     - name: "StartCreateInvoiceFromOrderPage"
-       description: "Clicks on 'Invoice' on the Admin Orders view page. Validates that the URL and Page Title are correct."
-
-     - name: "SubmitInvoice"
-       description: "Clicks on 'Submit Invoice' on the Admin 'New Invoice' page. Validates that the Success Message is present and correct. Validates that the Order ID appears in the URL."
-
-     - name: "filterInvoiceGridByOrderId"
-       description: "Goes to the Admin Invoices grid page. Filters the grid for the provided Order ID."
-
-     - name: "FilterInvoiceGridByOrderIdWithCleanFiltersActionGroup"
+     - name: "AdminAddProductToShoppingCartActionGroup"
+       description: "Adds the provided Product Name to the Cart on the Admin Customer creation/edit page."
+- filename: "StorefrontCustomerElementNotVisibleActionGroup.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/Customer/Test/Mftf/ActionGroup/StorefrontCustomerElementNotVisibleActionGroup.xml"
+  module: "Customer"
+  actiongroups:
+     - name: "StorefrontCustomerReorderButtonNotVisibleActionGroup"
        description: ""
- 
-- filename: "AdminAddToOrderCouponCodeActionGroup.xml"
-  repo: "https://github.com/magento/magento2/blob/2.3/app/code/Magento/Sales/Test/Mftf/ActionGroup/AdminAddToOrderCouponCodeActionGroup.xml"
-  module: "Sales"
+- filename: "AdminConfigCustomerActionGroup.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/Customer/Test/Mftf/ActionGroup/AdminConfigCustomerActionGroup.xml"
+  module: "Customer"
   actiongroups:
-     - name: "AdminAddToOrderCouponCodeActionGroup"
+     - name: "SetCustomerDataLifetimeActionGroup"
+       description: "Goes to the Customer Configuration page. Fills Customer Data Lifetime. Clicks on Save. Validates that the Success message is present."
+- filename: "AdminAssertCustomerDefaultBillingAddressActionGroup.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/Customer/Test/Mftf/ActionGroup/AdminAssertCustomerDefaultBillingAddressActionGroup.xml"
+  module: "Customer"
+  actiongroups:
+     - name: "AdminAssertCustomerDefaultBillingAddress"
+       description: "Validates that the provided Default Customer Billing Address details are present and correct on the Customer creation/edit page. Under the section 'Addresses'."
+- filename: "StorefrontNavigateToCustomerOrdersHistoryPageActionGroup.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/Customer/Test/Mftf/ActionGroup/StorefrontNavigateToCustomerOrdersHistoryPageActionGroup.xml"
+  module: "Customer"
+  actiongroups:
+     - name: "StorefrontNavigateToCustomerOrdersHistoryPageActionGroup"
        description: ""
- 
-- filename: "AdminShipThePendingOrderActionGroup.xml"
-  repo: "https://github.com/magento/magento2/blob/2.3/app/code/Magento/Sales/Test/Mftf/ActionGroup/AdminShipThePendingOrderActionGroup.xml"
-  module: "Sales"
+- filename: "StorefrontCustomerGoToSidebarMenuActionGroup.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/Customer/Test/Mftf/ActionGroup/StorefrontCustomerGoToSidebarMenuActionGroup.xml"
+  module: "Customer"
   actiongroups:
-     - name: "AdminShipThePendingOrderActionGroup"
-       description: ""
- 
-- filename: "AssertOrderStatusFormSaveDuplicateErrorActionGroup.xml"
-  repo: "https://github.com/magento/magento2/blob/2.3/app/code/Magento/Sales/Test/Mftf/ActionGroup/AssertOrderStatusFormSaveDuplicateErrorActionGroup.xml"
-  module: "Sales"
+     - name: "StorefrontCustomerGoToSidebarMenu"
+       description: "Click on the Storefront Customer Account Dashboard sub-menu based on the provided Menu Name."
+- filename: "StorefrontClickSignOnCustomerLoginFormActionGroup.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/Customer/Test/Mftf/ActionGroup/StorefrontClickSignOnCustomerLoginFormActionGroup.xml"
+  module: "Customer"
   actiongroups:
-     - name: "AssertOrderStatusFormSaveDuplicateError"
-       description: "Validates that the 'Duplicate Order' Error Message is present and correct."
- 
-- filename: "AdminOpenAndFillCreditMemoRefundActionGroup.xml"
-  repo: "https://github.com/magento/magento2/blob/2.3/app/code/Magento/Sales/Test/Mftf/ActionGroup/AdminOpenAndFillCreditMemoRefundActionGroup.xml"
-  module: "Sales"
+     - name: "StorefrontClickSignOnCustomerLoginFormActionGroup"
+       description: "Click on the Customer Sign In button on the Storefront Customer Sign-In page."
+- filename: "AdminUpdateCustomerGenderInCustomersGridActionGroup.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/Customer/Test/Mftf/ActionGroup/AdminUpdateCustomerGenderInCustomersGridActionGroup.xml"
+  module: "Customer"
   actiongroups:
-     - name: "AdminOpenAndFillCreditMemoRefundActionGroup"
-       description: "Clicks on the 'Credit Memos' section on the Admin Orders edit page. Fills in the provided Refund details (Qty to Refund, Shipping Refund, Adjustment Refund, Adjustment Fee and Row number)."
+     - name: "AdminUpdateCustomerGenderInCustomersGridActionGroup"
+       description: "Update customer gender attribute value on customers grid page"
+- filename: "StorefrontOpenCustomerAccountInfoEditPageActionGroup.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/Customer/Test/Mftf/ActionGroup/StorefrontOpenCustomerAccountInfoEditPageActionGroup.xml"
+  module: "Customer"
+  actiongroups:
+     - name: "StorefrontOpenCustomerAccountInfoEditPageActionGroup"
+       description: "Goes to the Storefront Customer Edit page."
+- filename: "StoreFrontClickEditDefaultShippingAddressActionGroup.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/Customer/Test/Mftf/ActionGroup/StoreFrontClickEditDefaultShippingAddressActionGroup.xml"
+  module: "Customer"
+  actiongroups:
+     - name: "StoreFrontClickEditDefaultShippingAddressActionGroup"
+       description: "Click on the edit default shipping address link."
+- filename: "AdminCustomerGridActionGroup.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/Customer/Test/Mftf/ActionGroup/AdminCustomerGridActionGroup.xml"
+  module: "Customer"
+  actiongroups:
+     - name: "AdminFilterCustomerByEmail"
+       description: "Goes to the Customer grid page. Filter results based on provided Customer Email Address."
+- filename: "AdminSaveCustomerAndAssertSuccessMessageActionGroup.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/Customer/Test/Mftf/ActionGroup/AdminSaveCustomerAndAssertSuccessMessageActionGroup.xml"
+  module: "Customer"
+  actiongroups:
+     - name: "AdminSaveCustomerAndAssertSuccessMessage"
+       description: "Clicks on the Save button. Validates that the Success Message is present and correct. PLEASE NOTE: The message is Hardcoded."
+- filename: "FillCustomerSignInPopupFormActionGroup.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/Customer/Test/Mftf/ActionGroup/FillCustomerSignInPopupFormActionGroup.xml"
+  module: "Customer"
+  actiongroups:
+     - name: "FillCustomerSignInPopupFormActionGroup"
+       description: "Fills in the provided Customer details (Email and Password) in the Customer Sign In modal on the Storefront Checkout page. Clicks on Sign In."
+- filename: "AssertAuthorizationPopUpPasswordAutoCompleteOffActionGroup.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/Customer/Test/Mftf/ActionGroup/AssertAuthorizationPopUpPasswordAutoCompleteOffActionGroup.xml"
+  module: "Customer"
+  actiongroups:
+     - name: "AssertAuthorizationPopUpPasswordAutoCompleteOffActionGroup"
+       description: "Validates that the Storefront Customer Sign-In popup form does NOT contain the 'autocomplete=off' attribute."
+- filename: "AdminSelectCustomerByEmailActionGroup.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/Customer/Test/Mftf/ActionGroup/AdminSelectCustomerByEmailActionGroup.xml"
+  module: "Customer"
+  actiongroups:
+     - name: "AdminSelectCustomerByEmail"
+       description: "Checks the Customer for the provided Customer Email Address in the Admin Customers grid."
+- filename: "AdminFilterCustomerByNameActionGroup.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/Customer/Test/Mftf/ActionGroup/AdminFilterCustomerByNameActionGroup.xml"
+  module: "Customer"
+  actiongroups:
+     - name: "AdminFilterCustomerByName"
+       description: "Filters the Admin Customers grid by the provided Name."
+- filename: "AdminResetFilterInCustomerGridActionGroup.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/Customer/Test/Mftf/ActionGroup/AdminResetFilterInCustomerGridActionGroup.xml"
+  module: "Customer"
+  actiongroups:
+     - name: "AdminResetFilterInCustomerGrid"
+       description: "Clears the Admin Customer grid Filters. Sets the grid view to 'Default View'."
+- filename: "AdminCreateCustomerWithWebsiteAndStoreViewActionGroup.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/Customer/Test/Mftf/ActionGroup/AdminCreateCustomerWithWebsiteAndStoreViewActionGroup.xml"
+  module: "Customer"
+  actiongroups:
+     - name: "AdminCreateCustomerWithWebsiteAndStoreViewActionGroup"
+       description: "Goes to the Customer grid page. Click on 'Add New Customer'. Fills provided Customer Data. Fill provided Customer Address data. Assigns Product to Website and Store View. Click on Save Address."
 
-     - name: "AdminOpenAndFillCreditMemoRefundAndBackToStockActionGroup"
-       description: "EXTENDS: AdminOpenAndFillCreditMemoRefundActionGroup. Checks 'Return to Stock'."
- 
-- filename: "AdminFilterProductInCreateOrderActionGroup.xml"
-  repo: "https://github.com/magento/magento2/blob/2.3/app/code/Magento/Sales/Test/Mftf/ActionGroup/AdminFilterProductInCreateOrderActionGroup.xml"
-  module: "Sales"
+     - name: "AdminCreateCustomerWithWebSiteAndGroup"
+       description: "Goes to the Customer grid page. Click on 'Add New Customer'. Fills provided Customer Data. Fill provided Customer Address data. Assigns Product to Website and Store View. Clicks on Save."
+- filename: "StorefrontFillBillingAddressActionGroup.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/Customer/Test/Mftf/ActionGroup/StorefrontFillBillingAddressActionGroup.xml"
+  module: "Customer"
   actiongroups:
-     - name: "AdminFilterProductInCreateOrderActionGroup"
+     - name: "StorefrontFillBillingAddressActionGroup"
        description: ""
- 
-- filename: "StorefrontCustomerReorderActionGroup.xml"
-  repo: "https://github.com/magento/magento2/blob/2.3/app/code/Magento/Sales/Test/Mftf/ActionGroup/StorefrontCustomerReorderActionGroup.xml"
-  module: "Sales"
+- filename: "AdminNavigateCustomerEditPageAddressesTabActionGroup.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/Customer/Test/Mftf/ActionGroup/AdminNavigateCustomerEditPageAddressesTabActionGroup.xml"
+  module: "Customer"
   actiongroups:
-     - name: "StorefrontCustomerReorderActionGroup"
-       description: "Navigate to customer dashboard -&gt; orders. Press 'reorder' button for specified order id. Notice: customer should be logged in."
- 
-- filename: "AdminOrderSelectShippingMethodActionGroup.xml"
-  repo: "https://github.com/magento/magento2/blob/2.3/app/code/Magento/Sales/Test/Mftf/ActionGroup/AdminOrderSelectShippingMethodActionGroup.xml"
-  module: "Sales"
+     - name: "AdminNavigateCustomerEditPageAddressesTabActionGroup"
+       description: "EXTENDS: AdminOpenCustomerEditPageActionGroup. Navigates to Addresses Tab in Admin Customer Edit page for the provided Customer ID #."
+- filename: "StorefrontCustomerActionGroup.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/Customer/Test/Mftf/ActionGroup/StorefrontCustomerActionGroup.xml"
+  module: "Customer"
   actiongroups:
-     - name: "AdminOrderSelectShippingMethodActionGroup"
-       description: "Select Shipping method from admin order page."
- 
-- filename: "AdminAddToOrderBundleProductActionGroup.xml"
-  repo: "https://github.com/magento/magento2/blob/2.3/app/code/Magento/Sales/Test/Mftf/ActionGroup/AdminAddToOrderBundleProductActionGroup.xml"
-  module: "Sales"
+     - name: "CustomerLogoutStorefrontByMenuItemsActionGroup"
+       description: "Click on the Storefront Current Customer menu. Click on Logout."
+- filename: "AdminSelectAllCustomersActionGroup.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/Customer/Test/Mftf/ActionGroup/AdminSelectAllCustomersActionGroup.xml"
+  module: "Customer"
   actiongroups:
-     - name: "AdminAddToOrderBundleProductActionGroup"
+     - name: "AdminSelectAllCustomers"
+       description: "Selects All of the Customers in the Admin Customers grid."
+- filename: "AdminSaveCustomerAddressActionGroup.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/Customer/Test/Mftf/ActionGroup/AdminSaveCustomerAddressActionGroup.xml"
+  module: "Customer"
+  actiongroups:
+     - name: "AdminSaveCustomerAddressActionGroup"
        description: ""
- 
-- filename: "StorefrontOrderActionGroupActionGroup.xml"
-  repo: "https://github.com/magento/magento2/blob/2.3/app/code/Magento/Sales/Test/Mftf/ActionGroup/StorefrontOrderActionGroupActionGroup.xml"
-  module: "Sales"
+- filename: "OpenEditCustomerFromAdminActionGroup.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/Customer/Test/Mftf/ActionGroup/OpenEditCustomerFromAdminActionGroup.xml"
+  module: "Customer"
   actiongroups:
-     - name: "StorefrontSearchGuestOrderActionGroup"
-       description: "Goes to the Storefront Customer Orders and Returns page. Fills in the provided Order ID, Billing Last Name and Email. Clicks on Continue. Validates that the URL is correct."
- 
-- filename: "AssertAdminVideoValidationErrorActionGroup.xml"
-  repo: "https://github.com/magento/magento2/blob/2.3/app/code/Magento/ProductVideo/Test/Mftf/ActionGroup/AssertAdminVideoValidationErrorActionGroup.xml"
+     - name: "OpenEditCustomerFromAdminActionGroup"
+       description: "Goes to the Admin Customers grid page. Filters the grid based on the provided Customer. Clicks on Edit."
+
+     - name: "OpenEditCustomerAddressFromAdminActionGroup"
+       description: "Filters the Admin Customers Addresses based on the provided Address. Clicks on Edit."
+
+     - name: "DeleteCustomerFromAdminActionGroup"
+       description: "Goes to the Admin Customers grid page. Deletes the provided Customer from the grid. Validates that the Success message is present and correct."
+
+     - name: "AdminClearCustomersFiltersActionGroup"
+       description: "Goes to the Admin Customers grid page. Clicks on 'Clear Filters'."
+- filename: "AdminEditCustomerAddressSetDefaultShippingAndBillingActionGroup.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/Customer/Test/Mftf/ActionGroup/AdminEditCustomerAddressSetDefaultShippingAndBillingActionGroup.xml"
+  module: "Customer"
+  actiongroups:
+     - name: "AdminEditCustomerAddressSetDefaultShippingAndBilling"
+       description: "EXTENDS: AdminEditCustomerAddressesFrom. Removes 'selectState' and 'fillZipCode'."
+- filename: "AdminEditCustomerInformationFromActionGroup.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/Customer/Test/Mftf/ActionGroup/AdminEditCustomerInformationFromActionGroup.xml"
+  module: "Customer"
+  actiongroups:
+     - name: "AdminEditCustomerAccountInformationActionGroup"
+       description: "Fills in the Customer First Name, Last Name and Email. Clicks on Save and Continue."
+- filename: "AssertCustomerGroupNotInGridActionGroup.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/Customer/Test/Mftf/ActionGroup/AssertCustomerGroupNotInGridActionGroup.xml"
+  module: "Customer"
+  actiongroups:
+     - name: "AssertCustomerGroupNotInGridActionGroup"
+       description: "Filters the Admin Customers grid for the Customer Group (Code). Validates that the grid is empty."
+- filename: "AdminAssertCustomerAccountInformationActionGroup.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/Customer/Test/Mftf/ActionGroup/AdminAssertCustomerAccountInformationActionGroup.xml"
+  module: "Customer"
+  actiongroups:
+     - name: "AdminAssertCustomerAccountInformation"
+       description: "Validates that the provided Customer details are present and correct on the Customer creation/edit page. Under the 'Account Information' section."
+- filename: "AssertMessageCustomerChangeAccountInfoActionGroup.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/Customer/Test/Mftf/ActionGroup/AssertMessageCustomerChangeAccountInfoActionGroup.xml"
+  module: "Customer"
+  actiongroups:
+     - name: "AssertMessageCustomerChangeAccountInfoActionGroup"
+       description: "Validates that the provided Message/Message Type are present and correct."
+- filename: "StorefrontAssertCustomerAddressItemsActionGroup.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/Customer/Test/Mftf/ActionGroup/StorefrontAssertCustomerAddressItemsActionGroup.xml"
+  module: "Customer"
+  actiongroups:
+     - name: "StorefrontAssertCustomerAddressItemsActionGroup"
+       description: "Validate that the Storefront Customer Address contains correct items."
+- filename: "NavigateCustomerActionGroup.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/Customer/Test/Mftf/ActionGroup/NavigateCustomerActionGroup.xml"
+  module: "Customer"
+  actiongroups:
+     - name: "NavigateToAllCustomerPage"
+       description: "Goes to the Admin Customers grid page."
+- filename: "LoginToStorefrontWithEmailAndPasswordActionGroup.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/Customer/Test/Mftf/ActionGroup/LoginToStorefrontWithEmailAndPasswordActionGroup.xml"
+  module: "Customer"
+  actiongroups:
+     - name: "LoginToStorefrontWithEmailAndPassword"
+       description: "Goes to the Storefront Customer Sign In page. Logs in using the provided Email and Password."
+- filename: "AdminOpenProductVideoModalActionGroup.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/ProductVideo/Test/Mftf/ActionGroup/AdminOpenProductVideoModalActionGroup.xml"
   module: "ProductVideo"
   actiongroups:
-     - name: "AssertAdminVideoValidationErrorActionGroup"
+     - name: "AdminOpenProductVideoModalActionGroup"
        description: ""
- 
-- filename: "AdminFillProductVideoFieldActionGroup.xml"
-  repo: "https://github.com/magento/magento2/blob/2.3/app/code/Magento/ProductVideo/Test/Mftf/ActionGroup/AdminFillProductVideoFieldActionGroup.xml"
-  module: "ProductVideo"
-  actiongroups:
-     - name: "AdminFillProductVideoFieldActionGroup"
-       description: ""
- 
-- filename: "AdminGetVideoInformationActionGroup.xml"
-  repo: "https://github.com/magento/magento2/blob/2.3/app/code/Magento/ProductVideo/Test/Mftf/ActionGroup/AdminGetVideoInformationActionGroup.xml"
-  module: "ProductVideo"
-  actiongroups:
-     - name: "AdminGetVideoInformationActionGroup"
-       description: ""
- 
-- filename: "StorefrontProductVideoActionGroup.xml"
-  repo: "https://github.com/magento/magento2/blob/2.3/app/code/Magento/ProductVideo/Test/Mftf/ActionGroup/StorefrontProductVideoActionGroup.xml"
-  module: "ProductVideo"
-  actiongroups:
-     - name: "assertProductVideoStorefrontProductPage"
-       description: "Validates that the provided Video is present on the Storefront Product page."
-
-     - name: "assertProductVideoNotInStorefrontProductPage"
-       description: "Validates that the provided Video is NOT present on the Storefront Product page."
- 
 - filename: "AdminAssertVideoNoValidationErrorActionGroup.xml"
-  repo: "https://github.com/magento/magento2/blob/2.3/app/code/Magento/ProductVideo/Test/Mftf/ActionGroup/AdminAssertVideoNoValidationErrorActionGroup.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/ProductVideo/Test/Mftf/ActionGroup/AdminAssertVideoNoValidationErrorActionGroup.xml"
   module: "ProductVideo"
   actiongroups:
      - name: "AdminAssertVideoNoValidationErrorActionGroup"
        description: ""
- 
 - filename: "AdminProductVideoActionGroup.xml"
-  repo: "https://github.com/magento/magento2/blob/2.3/app/code/Magento/ProductVideo/Test/Mftf/ActionGroup/AdminProductVideoActionGroup.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/ProductVideo/Test/Mftf/ActionGroup/AdminProductVideoActionGroup.xml"
   module: "ProductVideo"
   actiongroups:
      - name: "addProductVideo"
@@ -717,473 +700,1630 @@
 
      - name: "assertProductVideoNotInAdminProductPage"
        description: "Validates that the provided Video is NOT present on the Admin Product creation/edit page."
- 
-- filename: "AdminOpenProductVideoModalActionGroup.xml"
-  repo: "https://github.com/magento/magento2/blob/2.3/app/code/Magento/ProductVideo/Test/Mftf/ActionGroup/AdminOpenProductVideoModalActionGroup.xml"
+- filename: "AssertAdminVideoValidationErrorActionGroup.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/ProductVideo/Test/Mftf/ActionGroup/AssertAdminVideoValidationErrorActionGroup.xml"
   module: "ProductVideo"
   actiongroups:
-     - name: "AdminOpenProductVideoModalActionGroup"
+     - name: "AssertAdminVideoValidationErrorActionGroup"
        description: ""
- 
-- filename: "AdminChangeInstantPurchaseButtonTextActionGroup.xml"
-  repo: "https://github.com/magento/magento2/blob/2.3/app/code/Magento/InstantPurchase/Test/Mftf/ActionGroup/AdminChangeInstantPurchaseButtonTextActionGroup.xml"
-  module: "InstantPurchase"
+- filename: "AdminGetVideoInformationActionGroup.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/ProductVideo/Test/Mftf/ActionGroup/AdminGetVideoInformationActionGroup.xml"
+  module: "ProductVideo"
   actiongroups:
-     - name: "AdminChangeInstantPurchaseButtonTextActionGroup"
+     - name: "AdminGetVideoInformationActionGroup"
        description: ""
- 
-- filename: "AdminOpenInstantPurchaseConfigPageActionGroup.xml"
-  repo: "https://github.com/magento/magento2/blob/2.3/app/code/Magento/InstantPurchase/Test/Mftf/ActionGroup/AdminOpenInstantPurchaseConfigPageActionGroup.xml"
-  module: "InstantPurchase"
+- filename: "StorefrontProductVideoActionGroup.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/ProductVideo/Test/Mftf/ActionGroup/StorefrontProductVideoActionGroup.xml"
+  module: "ProductVideo"
   actiongroups:
-     - name: "AdminOpenInstantPurchaseConfigPageActionGroup"
-       description: ""
- 
-- filename: "AdminChangeInstantPurchaseStatusActionGroup.xml"
-  repo: "https://github.com/magento/magento2/blob/2.3/app/code/Magento/InstantPurchase/Test/Mftf/ActionGroup/AdminChangeInstantPurchaseStatusActionGroup.xml"
-  module: "InstantPurchase"
-  actiongroups:
-     - name: "AdminChangeInstantPurchaseStatusActionGroup"
-       description: ""
- 
-- filename: "StorefrontPersistentAssertCustomerWelcomeMessageActionGroup.xml"
-  repo: "https://github.com/magento/magento2/blob/2.3/app/code/Magento/Persistent/Test/Mftf/ActionGroup/StorefrontPersistentAssertCustomerWelcomeMessageActionGroup.xml"
-  module: "Persistent"
-  actiongroups:
-     - name: "StorefrontAssertPersistentCustomerWelcomeMessageActionGroup"
-       description: ""
+     - name: "assertProductVideoStorefrontProductPage"
+       description: "Validates that the provided Video is present on the Storefront Product page."
 
-     - name: "StorefrontAssertPersistentCustomerWelcomeMessageNotPresentActionGroup"
+     - name: "assertProductVideoNotInStorefrontProductPage"
+       description: "Validates that the provided Video is NOT present on the Storefront Product page."
+- filename: "AdminFillProductVideoFieldActionGroup.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/ProductVideo/Test/Mftf/ActionGroup/AdminFillProductVideoFieldActionGroup.xml"
+  module: "ProductVideo"
+  actiongroups:
+     - name: "AdminFillProductVideoFieldActionGroup"
        description: ""
- 
-- filename: "StorefrontAssertPersistentRegistrationPageFieldsActionGroup.xml"
-  repo: "https://github.com/magento/magento2/blob/2.3/app/code/Magento/Persistent/Test/Mftf/ActionGroup/StorefrontAssertPersistentRegistrationPageFieldsActionGroup.xml"
-  module: "Persistent"
-  actiongroups:
-     - name: "StorefrontAssertPersistentRegistrationPageFields"
-       description: ""
- 
-- filename: "StorefrontCustomerActionGroup.xml"
-  repo: "https://github.com/magento/magento2/blob/2.3/app/code/Magento/Persistent/Test/Mftf/ActionGroup/StorefrontCustomerActionGroup.xml"
-  module: "Persistent"
-  actiongroups:
-     - name: "CustomerLoginOnStorefrontWithRememberMeChecked"
-       description: "EXTENDS: LoginToStorefrontActionGroup. Checks the 'Remember Me' checkbox."
-
-     - name: "CustomerLoginOnStorefrontWithRememberMeUnChecked"
-       description: "EXTENDS: LoginToStorefrontActionGroup. Uncheck the 'Remember Me' checkbox."
-
-     - name: "StorefrontRegisterCustomerRememberMe"
-       description: ""
-
-     - name: "StorefrontCreateCustomerOnRegisterPageDoNotRememberMe"
-       description: ""
- 
-- filename: "AssertElementInTranslateInlineModeActionGroup.xml"
-  repo: "https://github.com/magento/magento2/blob/2.3/app/code/Magento/Translation/Test/Mftf/ActionGroup/AssertElementInTranslateInlineModeActionGroup.xml"
-  module: "Translation"
-  actiongroups:
-     - name: "AssertElementInTranslateInlineModeActionGroup"
-       description: ""
- 
-- filename: "AdminTranslateElementActionGroup.xml"
-  repo: "https://github.com/magento/magento2/blob/2.3/app/code/Magento/Translation/Test/Mftf/ActionGroup/AdminTranslateElementActionGroup.xml"
-  module: "Translation"
-  actiongroups:
-     - name: "AdminTranslateElementActionGroup"
-       description: ""
- 
-- filename: "AdminOpenNewVariablePageActionGroup.xml"
-  repo: "https://github.com/magento/magento2/blob/2.3/app/code/Magento/Variable/Test/Mftf/ActionGroup/AdminOpenNewVariablePageActionGroup.xml"
-  module: "Variable"
-  actiongroups:
-     - name: "AdminOpenNewVariablePageActionGroup"
-       description: ""
- 
-- filename: "AdminFilterVariableGridActionGroup.xml"
-  repo: "https://github.com/magento/magento2/blob/2.3/app/code/Magento/Variable/Test/Mftf/ActionGroup/AdminFilterVariableGridActionGroup.xml"
-  module: "Variable"
-  actiongroups:
-     - name: "AdminFilterVariableGridActionGroup"
-       description: ""
- 
-- filename: "AdminNavigateToVariablePageActionGroup.xml"
-  repo: "https://github.com/magento/magento2/blob/2.3/app/code/Magento/Variable/Test/Mftf/ActionGroup/AdminNavigateToVariablePageActionGroup.xml"
-  module: "Variable"
-  actiongroups:
-     - name: "AdminNavigateToVariablePageByCodeActionGroup"
-       description: ""
- 
-- filename: "AdminOpenVariablesGridPageActionGroup.xml"
-  repo: "https://github.com/magento/magento2/blob/2.3/app/code/Magento/Variable/Test/Mftf/ActionGroup/AdminOpenVariablesGridPageActionGroup.xml"
-  module: "Variable"
-  actiongroups:
-     - name: "AdminOpenVariablesGridPageActionGroup"
-       description: ""
- 
-- filename: "CreateCustomVariableActionGroup.xml"
-  repo: "https://github.com/magento/magento2/blob/2.3/app/code/Magento/Variable/Test/Mftf/ActionGroup/CreateCustomVariableActionGroup.xml"
-  module: "Variable"
-  actiongroups:
-     - name: "CreateCustomVariableActionGroup"
-       description: "Goes to the Custom Variable creation page. Fills in the Custom Variable details. PLEASE NOTE: The Custom Variable details are Hardcoded using 'customVariable'."
-
-     - name: "DeleteCustomVariableActionGroup"
-       description: "Goes to the Custom Variable grid page. Deletes the Custom Variable. PLEASE NOTE: The Custom Variable that is deleted is Hardcoded using 'customVariable'."
- 
-- filename: "AdminFillVariableFormActionGroup.xml"
-  repo: "https://github.com/magento/magento2/blob/2.3/app/code/Magento/Variable/Test/Mftf/ActionGroup/AdminFillVariableFormActionGroup.xml"
-  module: "Variable"
-  actiongroups:
-     - name: "AdminFillVariableFormActionGroup"
-       description: ""
- 
-- filename: "AssertAdminCustomVariableFormActionGroup.xml"
-  repo: "https://github.com/magento/magento2/blob/2.3/app/code/Magento/Variable/Test/Mftf/ActionGroup/AssertAdminCustomVariableFormActionGroup.xml"
-  module: "Variable"
-  actiongroups:
-     - name: "AssertAdminCustomVariableFormActionGroup"
-       description: ""
- 
-- filename: "AssertAdminCustomVariableInGridActionGroup.xml"
-  repo: "https://github.com/magento/magento2/blob/2.3/app/code/Magento/Variable/Test/Mftf/ActionGroup/AssertAdminCustomVariableInGridActionGroup.xml"
-  module: "Variable"
-  actiongroups:
-     - name: "AssertAdminCustomVariableInGridActionGroup"
-       description: ""
- 
-- filename: "AdminOpenStoreConfigDeveloperPageActionGroup.xml"
-  repo: "https://github.com/magento/magento2/blob/2.3/app/code/Magento/Config/Test/Mftf/ActionGroup/AdminOpenStoreConfigDeveloperPageActionGroup.xml"
-  module: "Config"
-  actiongroups:
-     - name: "AdminOpenStoreConfigDeveloperPageActionGroup"
-       description: "Go to admin store configuration developer page."
- 
-- filename: "ConfigWebUrlOptionsActionGroup.xml"
-  repo: "https://github.com/magento/magento2/blob/2.3/app/code/Magento/Config/Test/Mftf/ActionGroup/ConfigWebUrlOptionsActionGroup.xml"
-  module: "Config"
-  actiongroups:
-     - name: "EnableWebUrlOptions"
-       description: "Goes to the 'Configuration' page for 'Url Options'. Enables 'Add Store Code to Urls'. Clicks on the Save button."
-
-     - name: "ResetWebUrlOptions"
-       description: "Goes to the 'Configuration' page for 'Url Options'. Disables 'Add Store Code to Urls'. Clicks on the Save button."
- 
-- filename: "AdminOpenStoreConfigPageActionGroup.xml"
-  repo: "https://github.com/magento/magento2/blob/2.3/app/code/Magento/Config/Test/Mftf/ActionGroup/AdminOpenStoreConfigPageActionGroup.xml"
-  module: "Config"
-  actiongroups:
-     - name: "AdminOpenStoreConfigPageActionGroup"
-       description: "Go to admin store configuration page."
- 
-- filename: "AdminConfigCreateNewAccountActionGroup.xml"
-  repo: "https://github.com/magento/magento2/blob/2.3/app/code/Magento/Config/Test/Mftf/ActionGroup/AdminConfigCreateNewAccountActionGroup.xml"
-  module: "Config"
-  actiongroups:
-     - name: "SetGroupForValidVATIdIntraUnionActionGroup"
-       description: "Goes to the 'Configuration' page for 'Customer Configuration'. Sets the 'Group For Valid VAT ID Intra Union' option. Clicks on the Save button. Validates the Save message is present."
- 
-- filename: "SwitcherActionGroup.xml"
-  repo: "https://github.com/magento/magento2/blob/2.3/app/code/Magento/Config/Test/Mftf/ActionGroup/SwitcherActionGroup.xml"
-  module: "Config"
-  actiongroups:
-     - name: "SwitchToVersion4ActionGroup"
-       description: "Goes to the 'Configuration' page for 'Content Management'. Sets the 'WYSIWYG Editor' to 'TinyMCE 4'. Clicks on the Save button. PLEASE NOTE: The value is Hardcoded."
- 
-- filename: "AdminExpandSecurityTabActionGroup.xml"
-  repo: "https://github.com/magento/magento2/blob/2.3/app/code/Magento/Config/Test/Mftf/ActionGroup/AdminExpandSecurityTabActionGroup.xml"
-  module: "Config"
-  actiongroups:
-     - name: "AdminExpandSecurityTabActionGroup"
-       description: ""
- 
-- filename: "GeneralConfigurationActionGroup.xml"
-  repo: "https://github.com/magento/magento2/blob/2.3/app/code/Magento/Config/Test/Mftf/ActionGroup/GeneralConfigurationActionGroup.xml"
-  module: "Config"
-  actiongroups:
-     - name: "NavigateToDefaultLayoutsSetting"
-       description: "Goes to the 'Configuration' page for 'Web'. Expands the 'Default Layouts' section."
-
-     - name: "NavigateToConfigurationGeneralPage"
-       description: "Goes to the 'Configuration' page for 'General'."
-
-     - name: "SelectTopDestinationsCountry"
-       description: "Selects the provided Countries under 'Top destinations' on the 'General' section of the 'Configuration' page. Clicks on the Save button."
-
-     - name: "UnSelectTopDestinationsCountry"
-       description: "Un-selects the provided Countries under 'Top destinations' on the 'General' section of the 'Configuration' page. Clicks on the Save button."
-
-     - name: "SelectCountriesWithRequiredRegion"
-       description: "Goes to the 'Configuration' page for 'General'. Selects the provided Countries under 'State is Required for'. Clicks on the Save button."
- 
-- filename: "ConfigWYSIWYGActionGroup.xml"
-  repo: "https://github.com/magento/magento2/blob/2.3/app/code/Magento/Config/Test/Mftf/ActionGroup/ConfigWYSIWYGActionGroup.xml"
-  module: "Config"
-  actiongroups:
-     - name: "EnabledWYSIWYG"
-       description: "Enables the WYSIWYG Editor via the CLI."
-
-     - name: "SwitchToTinyMCE3"
-       description: "Goes to the 'Configuration' page for 'Content Management'. Sets 'WYSIWYG Editor' to 'TinyMCE 3'. Clicks on the Save button. PLEASE NOTE: The value is Hardcoded."
-
-     - name: "DisabledWYSIWYG"
-       description: "Disables the WYSIWYG Editor via the CLI."
-
-     - name: "UseStaticURLForMediaContentInWYSIWYG"
-       description: "Goes to the 'Configuration' page for 'Content Management'. Sets 'Use Static URLs for Media Content in WYSIWYG' to the provided value. Clicks on the Save button."
-
-     - name: "EnabledWYSIWYGEditor"
-       description: "Goes to the 'Configuration' page for 'Content Management'. Sets 'Enable WYSIWYG Editor' to 'Enabled by Default'. Clicks on the Save button. PLEASE NOTE: The value is Hardcoded."
- 
-- filename: "RestoreLayoutSettingActionGroup.xml"
-  repo: "https://github.com/magento/magento2/blob/2.3/app/code/Magento/Config/Test/Mftf/ActionGroup/RestoreLayoutSettingActionGroup.xml"
-  module: "Config"
-  actiongroups:
-     - name: "RestoreLayoutSetting"
-       description: "Goes to the 'Configuration' page for 'Web'. Clicks on the Save button."
- 
-- filename: "AdminOpenConfigAdminPageActionGroup.xml"
-  repo: "https://github.com/magento/magento2/blob/2.3/app/code/Magento/Config/Test/Mftf/ActionGroup/AdminOpenConfigAdminPageActionGroup.xml"
-  module: "Config"
-  actiongroups:
-     - name: "AdminOpenConfigAdminPageActionGroup"
-       description: ""
- 
-- filename: "AdminSetMaximumLoginFailuresToLockoutAccountActionGroup.xml"
-  repo: "https://github.com/magento/magento2/blob/2.3/app/code/Magento/Config/Test/Mftf/ActionGroup/AdminSetMaximumLoginFailuresToLockoutAccountActionGroup.xml"
-  module: "Config"
-  actiongroups:
-     - name: "AdminSetMaximumLoginFailuresToLockoutAccountActionGroup"
-       description: ""
- 
-- filename: "AdminOpenConfigNavItemActionGroup.xml"
-  repo: "https://github.com/magento/magento2/blob/2.3/app/code/Magento/Config/Test/Mftf/ActionGroup/AdminOpenConfigNavItemActionGroup.xml"
-  module: "Config"
-  actiongroups:
-     - name: "AdminOpenConfigNavItemActionGroup"
-       description: "Clicks on config nav item selected by passed argument."
- 
-- filename: "AdminSaveConfigActionGroup.xml"
-  repo: "https://github.com/magento/magento2/blob/2.3/app/code/Magento/Config/Test/Mftf/ActionGroup/AdminSaveConfigActionGroup.xml"
-  module: "Config"
-  actiongroups:
-     - name: "AdminSaveConfigActionGroup"
-       description: ""
- 
-- filename: "ConfigSalesTaxClassActionGroup.xml"
-  repo: "https://github.com/magento/magento2/blob/2.3/app/code/Magento/Config/Test/Mftf/ActionGroup/ConfigSalesTaxClassActionGroup.xml"
-  module: "Config"
-  actiongroups:
-     - name: "SetTaxClassForShipping"
-       description: "Goes to the 'Configuration' page for 'Tax'. Sets 'Tax Class for Shipping' to 'Taxable Goods'. Clicks on the Save button. PLEASE NOTE: The value is Hardcoded."
-
-     - name: "ResetTaxClassForShipping"
-       description: "Goes to the 'Configuration' page for 'Tax'. Sets 'Tax Class for Shipping' to 'None'. Clicks on the Save button. PLEASE NOTE: The value is Hardcoded."
-
-     - name: "SetTaxApplyOnSetting"
-       description: "Goes to the 'Configuration' page for 'Tax'. Sets 'Apply Tax On' to the provided value. Clicks on the Save button"
-
-     - name: "DisableTaxApplyOnOriginalPrice"
-       description: "Goes to the 'Configuration' page for 'Tax'. Sets 'Apply Tax On' to the provided value. Clicks on the Save button."
- 
-- filename: "AdminExpandConfigTabActionGroup.xml"
-  repo: "https://github.com/magento/magento2/blob/2.3/app/code/Magento/Config/Test/Mftf/ActionGroup/AdminExpandConfigTabActionGroup.xml"
-  module: "Config"
-  actiongroups:
-     - name: "AdminExpandConfigTabActionGroup"
-       description: "Goes to the 'Configuration' page and expands main level configuration tab passed via argument as Tab Name."
- 
-- filename: "ConfigAdminCatalogSearchActionGroup.xml"
-  repo: "https://github.com/magento/magento2/blob/2.3/app/code/Magento/Config/Test/Mftf/ActionGroup/ConfigAdminCatalogSearchActionGroup.xml"
-  module: "Config"
-  actiongroups:
-     - name: "ChooseElasticSearchAsSearchEngine"
-       description: "Goes to the 'Configuration' page for 'Catalog'. Sets the 'Search Engine' to 'elasticsearch5'. Clicks on the Save button. PLEASE NOTE: The value is Hardcoded."
-
-     - name: "ResetSearchEngineConfiguration"
-       description: "Goes to the 'Configuration' page for 'Catalog'. Sets the 'Search Engine' to 'mysql'. Clicks on the Save button. PLEASE NOTE: The value is Hardcoded."
- 
-- filename: "ConfigAdminAccountSharingActionGroup.xml"
-  repo: "https://github.com/magento/magento2/blob/2.3/app/code/Magento/Config/Test/Mftf/ActionGroup/ConfigAdminAccountSharingActionGroup.xml"
-  module: "Config"
-  actiongroups:
-     - name: "ConfigAdminAccountSharingActionGroup"
-       description: "Goes to the 'Configuration' page for 'Admin'. Enables 'Admin Account Sharing'. Clicks on the Save button."
-
-     - name: "EnableAdminAccountSharingActionGroup"
-       description: "Enabled 'Admin Account Sharing' via the API."
-
-     - name: "DisableAdminAccountSharingActionGroup"
-       description: "Disables 'Admin Account Sharing' via the API."
- 
-- filename: "AdminFillIntegrationFormActionGroup.xml"
-  repo: "https://github.com/magento/magento2/blob/2.3/app/code/Magento/Integration/Test/Mftf/ActionGroup/AdminFillIntegrationFormActionGroup.xml"
-  module: "Integration"
-  actiongroups:
-     - name: "AdminFillIntegrationFormActionGroup"
-       description: ""
- 
-- filename: "AdminOpenNewIntegrationPageActionGroup.xml"
-  repo: "https://github.com/magento/magento2/blob/2.3/app/code/Magento/Integration/Test/Mftf/ActionGroup/AdminOpenNewIntegrationPageActionGroup.xml"
-  module: "Integration"
-  actiongroups:
-     - name: "AdminOpenNewIntegrationPageActionGroup"
-       description: ""
- 
-- filename: "AdminSaveIntegrationActionGroup.xml"
-  repo: "https://github.com/magento/magento2/blob/2.3/app/code/Magento/Integration/Test/Mftf/ActionGroup/AdminSaveIntegrationActionGroup.xml"
-  module: "Integration"
-  actiongroups:
-     - name: "AdminClickSaveButtonIntegrationFormActionGroup"
-       description: ""
- 
 - filename: "ApplyCouponOnPaymentPageActionGroup.xml"
-  repo: "https://github.com/magento/magento2/blob/2.3/app/code/Magento/Payment/Test/Mftf/ActionGroup/ApplyCouponOnPaymentPageActionGroup.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/Payment/Test/Mftf/ActionGroup/ApplyCouponOnPaymentPageActionGroup.xml"
   module: "Payment"
   actiongroups:
      - name: "ApplyCouponOnPaymentPageActionGroup"
        description: "Adds the provided Coupon Code on the Storefront Shopping Cart page. Validates that the Discount Verification Message is present and correct."
- 
-- filename: "StorefrontCurrencyRatesActionGroup.xml"
-  repo: "https://github.com/magento/magento2/blob/2.3/app/code/Magento/CurrencySymbol/Test/Mftf/ActionGroup/StorefrontCurrencyRatesActionGroup.xml"
-  module: "CurrencySymbol"
+- filename: "AdminNavigateToNewRatingFormActionGroup.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/Review/Test/Mftf/ActionGroup/AdminNavigateToNewRatingFormActionGroup.xml"
+  module: "Review"
   actiongroups:
-     - name: "StorefrontSwitchCurrencyActionGroup"
+     - name: "AdminNavigateToNewRatingFormActionGroup"
+       description: "Open New Rating Form"
+- filename: "AdminOpenPendingReviewsPageActionGroup.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/Review/Test/Mftf/ActionGroup/AdminOpenPendingReviewsPageActionGroup.xml"
+  module: "Review"
+  actiongroups:
+     - name: "AdminOpenPendingReviewsPageActionGroup"
+       description: ""
+- filename: "AdminDeleteReviewsByUserNicknameActionGroup.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/Review/Test/Mftf/ActionGroup/AdminDeleteReviewsByUserNicknameActionGroup.xml"
+  module: "Review"
+  actiongroups:
+     - name: "AdminDeleteReviewsByUserNicknameActionGroup"
+       description: ""
+- filename: "AdminSaveReviewActionGroup.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/Review/Test/Mftf/ActionGroup/AdminSaveReviewActionGroup.xml"
+  module: "Review"
+  actiongroups:
+     - name: "AdminSaveReviewActionGroup"
+       description: ""
+- filename: "AdminAssertStoreViewRatingTitleWhenSingleStoreModeIsNoActionGroup.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/Review/Test/Mftf/ActionGroup/AdminAssertStoreViewRatingTitleWhenSingleStoreModeIsNoActionGroup.xml"
+  module: "Review"
+  actiongroups:
+     - name: "AdminAssertStoreViewRatingTitleWhenSingleStoreModeIsNoActionGroup"
+       description: "If Single Store Mode is disabled, default store view title label should be displayed."
+- filename: "StorefrontAssertReviewAtProductPageActionGroup.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/Review/Test/Mftf/ActionGroup/StorefrontAssertReviewAtProductPageActionGroup.xml"
+  module: "Review"
+  actiongroups:
+     - name: "StorefrontAssertReviewAtProductPageActionGroup"
+       description: ""
+- filename: "AdminChangeReviewStatusActionGroup.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/Review/Test/Mftf/ActionGroup/AdminChangeReviewStatusActionGroup.xml"
+  module: "Review"
+  actiongroups:
+     - name: "AdminChangeReviewStatusActionGroup"
+       description: ""
+- filename: "AdminOpenReviewByUserNicknameActionGroup.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/Review/Test/Mftf/ActionGroup/AdminOpenReviewByUserNicknameActionGroup.xml"
+  module: "Review"
+  actiongroups:
+     - name: "AdminOpenReviewByUserNicknameActionGroup"
+       description: ""
+- filename: "AdminAssertStoreViewRatingTitleWhenSingleStoreModeIsYesActionGroup.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/Review/Test/Mftf/ActionGroup/AdminAssertStoreViewRatingTitleWhenSingleStoreModeIsYesActionGroup.xml"
+  module: "Review"
+  actiongroups:
+     - name: "AdminAssertStoreViewRatingTitleWhenSingleStoreModeIsYesActionGroup"
+       description: "If Single Store Mode is enabled, default store view title label should not be displayed."
+- filename: "AdminOpenReviewsPageActionGroup.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/Review/Test/Mftf/ActionGroup/AdminOpenReviewsPageActionGroup.xml"
+  module: "Review"
+  actiongroups:
+     - name: "AdminOpenReviewsPageActionGroup"
+       description: ""
+- filename: "AdminEncryptionKeyChangeKeyManualActionGroup.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/EncryptionKey/Test/Mftf/ActionGroup/AdminEncryptionKeyChangeKeyManualActionGroup.xml"
+  module: "EncryptionKey"
+  actiongroups:
+     - name: "AdminEncryptionKeyChangeKeyManualActionGroup"
+       description: "Change Encryption Key - No-Auto Generate Action Group."
+- filename: "AdminEncryptionKeyChangeKeyAutoActionGroup.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/EncryptionKey/Test/Mftf/ActionGroup/AdminEncryptionKeyChangeKeyAutoActionGroup.xml"
+  module: "EncryptionKey"
+  actiongroups:
+     - name: "AdminEncryptionKeyChangeKeyAutoActionGroup"
+       description: "Change Encryption Key Auto Generate Action Group."
+- filename: "AdminEncryptionKeyNavigateToChangePageActionGroup.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/EncryptionKey/Test/Mftf/ActionGroup/AdminEncryptionKeyNavigateToChangePageActionGroup.xml"
+  module: "EncryptionKey"
+  actiongroups:
+     - name: "AdminEncryptionKeyNavigateToChangePageActionGroup"
+       description: "Navigate to change encryption key page."
+- filename: "AssertShoppingCartIsEmptyActionGroup.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/Checkout/Test/Mftf/ActionGroup/AssertShoppingCartIsEmptyActionGroup.xml"
+  module: "Checkout"
+  actiongroups:
+     - name: "AssertShoppingCartIsEmptyActionGroup"
+       description: "Goes to the Storefront Shopping Cart page. Validates that the Empty Shopping Cart message is present and correct. PLEASE NOTE: The message is Hardcoded."
+- filename: "StorefrontOpenCartPageActionGroup.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/Checkout/Test/Mftf/ActionGroup/StorefrontOpenCartPageActionGroup.xml"
+  module: "Checkout"
+  actiongroups:
+     - name: "StorefrontOpenCartPageActionGroup"
+       description: ""
+- filename: "StorefrontAddBundleProductToTheCartActionGroup.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/Checkout/Test/Mftf/ActionGroup/StorefrontAddBundleProductToTheCartActionGroup.xml"
+  module: "Checkout"
+  actiongroups:
+     - name: "StorefrontAddBundleProductToTheCartActionGroup"
+       description: "Clicks on 'Customize and Add to Cart' button on a Storefront Bundled product page. Adds the provided Product Name/Quantity. Clicks on Add to Cart."
+- filename: "AssertStorefrontEmailNoteMessageOnCheckoutActionGroup.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/Checkout/Test/Mftf/ActionGroup/AssertStorefrontEmailNoteMessageOnCheckoutActionGroup.xml"
+  module: "Checkout"
+  actiongroups:
+     - name: "AssertStorefrontEmailNoteMessageOnCheckoutActionGroup"
+       description: "Validates that the provided 'Email Address' message is present on the Storefront Checkout page under the 'Email Address' field."
+- filename: "StorefrontCheckoutAndAssertOrderSummaryDisplayActionGroup.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/Checkout/Test/Mftf/ActionGroup/StorefrontCheckoutAndAssertOrderSummaryDisplayActionGroup.xml"
+  module: "Checkout"
+  actiongroups:
+     - name: "StorefrontCheckoutAndAssertOrderSummaryDisplayActionGroup"
+       description: "Clicks on 'Go To Checkout' in the Storefront Mini Shopping Cart modal. Validates that the provided Items in Cart Text is present and correct on the Storefront Checkout page under the 'Summary' section."
+- filename: "GuestCheckoutFillNewShippingAddressActionGroup.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/Checkout/Test/Mftf/ActionGroup/GuestCheckoutFillNewShippingAddressActionGroup.xml"
+  module: "Checkout"
+  actiongroups:
+     - name: "GuestCheckoutFillNewShippingAddressActionGroup"
+       description: "Fills in the provided Customer/Address details in the 'Shipping Address' section on the Storefront Checkout page."
+- filename: "StorefrontSelectOptionRadioButtonActionGroup.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/Checkout/Test/Mftf/ActionGroup/StorefrontSelectOptionRadioButtonActionGroup.xml"
+  module: "Checkout"
+  actiongroups:
+     - name: "StorefrontSelectOptionRadioButtonActionGroup"
+       description: "DEPRECATED. Please use StorefrontProductPageSelectRadioButtonOptionValueActionGroup instead. Checks the provided Product Option radio button for the provided Product Option Price on a Storefront Product page."
+- filename: "StorefrontRemoveCartItemActionGroup.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/Checkout/Test/Mftf/ActionGroup/StorefrontRemoveCartItemActionGroup.xml"
+  module: "Checkout"
+  actiongroups:
+     - name: "StorefrontRemoveCartItemActionGroup"
+       description: ""
+- filename: "StorefrontCheckCartDiscountAndSummaryActionGroup.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/Checkout/Test/Mftf/ActionGroup/StorefrontCheckCartDiscountAndSummaryActionGroup.xml"
+  module: "Checkout"
+  actiongroups:
+     - name: "StorefrontCheckCartDiscountAndSummaryActionGroup"
+       description: "Validates that the provided Order Total and Discount Totals are present and correct under the 'Summary' section of the Storefront Shopping Cart page."
+- filename: "AssertStorefrontShoppingCartSummaryItemsActionGroup.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/Checkout/Test/Mftf/ActionGroup/AssertStorefrontShoppingCartSummaryItemsActionGroup.xml"
+  module: "Checkout"
+  actiongroups:
+     - name: "AssertStorefrontShoppingCartSummaryItemsActionGroup"
+       description: "Goes to the Storefront Shopping Cart page. Validates that the provided Subtotal/Total are present and correct."
+- filename: "StorefrontAssertNoValidationErrorForCheckoutAddressFieldsActionGroup.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/Checkout/Test/Mftf/ActionGroup/StorefrontAssertNoValidationErrorForCheckoutAddressFieldsActionGroup.xml"
+  module: "Checkout"
+  actiongroups:
+     - name: "StorefrontAssertNoValidationErrorForCheckoutAddressFieldsActionGroup"
+       description: ""
+- filename: "StorefrontAddProductToCartFromCategoryActionGroup.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/Checkout/Test/Mftf/ActionGroup/StorefrontAddProductToCartFromCategoryActionGroup.xml"
+  module: "Checkout"
+  actiongroups:
+     - name: "StorefrontAddProductToCartFromCategoryActionGroup"
+       description: ""
+- filename: "StorefrontClickOnMiniCartActionGroup.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/Checkout/Test/Mftf/ActionGroup/StorefrontClickOnMiniCartActionGroup.xml"
+  module: "Checkout"
+  actiongroups:
+     - name: "StorefrontClickOnMiniCartActionGroup"
+       description: "Scrolls to the Top of the Page. Clicks on the Mini Shopping Cart icon in the Storefront Header."
+- filename: "StorefrontCartEstimateShippingAndTaxActionGroup.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/Checkout/Test/Mftf/ActionGroup/StorefrontCartEstimateShippingAndTaxActionGroup.xml"
+  module: "Checkout"
+  actiongroups:
+     - name: "StorefrontCartEstimateShippingAndTaxActionGroup"
+       description: "Fills in the provided Address details (Country, State and Zip Code) under the 'Summary' section on the Storefront Shopping Cart page."
+- filename: "StorefrontCustomerSignInPopUpActionGroup.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/Checkout/Test/Mftf/ActionGroup/StorefrontCustomerSignInPopUpActionGroup.xml"
+  module: "Checkout"
+  actiongroups:
+     - name: "StorefrontCustomerSignInPopUpActionGroup"
+       description: ""
+- filename: "AssertStorefrontCheckoutCartEstimateShippingAndTaxAddressActionGroup.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/Checkout/Test/Mftf/ActionGroup/AssertStorefrontCheckoutCartEstimateShippingAndTaxAddressActionGroup.xml"
+  module: "Checkout"
+  actiongroups:
+     - name: "AssertStorefrontCheckoutCartEstimateShippingAndTaxAddressActionGroup"
+       description: "Check address data in Estimate Shipping And Tax section of shopping cart on storefront"
+- filename: "StorefrontCheckoutCartFillEstimateShippingAndTaxActionGroup.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/Checkout/Test/Mftf/ActionGroup/StorefrontCheckoutCartFillEstimateShippingAndTaxActionGroup.xml"
+  module: "Checkout"
+  actiongroups:
+     - name: "StorefrontCheckoutCartFillEstimateShippingAndTaxActionGroup"
+       description: "Fill address data in Estimate Shipping And Tax section of shopping cart on storefront"
+- filename: "StorefrontSelectOptionMultiSelectActionGroup.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/Checkout/Test/Mftf/ActionGroup/StorefrontSelectOptionMultiSelectActionGroup.xml"
+  module: "Checkout"
+  actiongroups:
+     - name: "StorefrontSelectOptionMultiSelectActionGroup"
+       description: "Selects the provided Product Option under the provided Product Option Title on a Storefront Product page."
+- filename: "CheckoutFillEstimateShippingAndTaxActionGroup.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/Checkout/Test/Mftf/ActionGroup/CheckoutFillEstimateShippingAndTaxActionGroup.xml"
+  module: "Checkout"
+  actiongroups:
+     - name: "CheckoutFillEstimateShippingAndTaxActionGroup"
+       description: ""
+- filename: "LoginAsCustomerOnCheckoutPageActionGroup.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/Checkout/Test/Mftf/ActionGroup/LoginAsCustomerOnCheckoutPageActionGroup.xml"
+  module: "Checkout"
+  actiongroups:
+     - name: "LoginAsCustomerOnCheckoutPageActionGroup"
+       description: "Fills in the provided Customer (Email and Password) details in the 'Sign In' modal on the Storefront Checkout page."
+- filename: "AssertStorefrontShoppingCartSummaryWithShippingActionGroup.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/Checkout/Test/Mftf/ActionGroup/AssertStorefrontShoppingCartSummaryWithShippingActionGroup.xml"
+  module: "Checkout"
+  actiongroups:
+     - name: "AssertStorefrontShoppingCartSummaryWithShippingActionGroup"
+       description: "EXTENDS: AssertStorefrontShoppingCartSummaryItemsActionGroup. Waits for the Storefront Checkout 'Shipping Methods' section to appear."
+- filename: "StorefrontSelectOptionCheckBoxActionGroup.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/Checkout/Test/Mftf/ActionGroup/StorefrontSelectOptionCheckBoxActionGroup.xml"
+  module: "Checkout"
+  actiongroups:
+     - name: "StorefrontSelectOptionCheckBoxActionGroup"
+       description: "Checks the provided Product Option Title on a Storefront Product page."
+- filename: "CheckoutActionGroup.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/Checkout/Test/Mftf/ActionGroup/CheckoutActionGroup.xml"
+  module: "Checkout"
+  actiongroups:
+     - name: "CheckoutSelectFlatRateShippingMethodActionGroup"
+       description: "Clicks on the 'Flat Rate' Shipping Method on the Storefront Checkout page."
+
+     - name: "GoToCheckoutFromMinicartActionGroup"
+       description: "Clicks on the Storefront Mini Shopping Cart icon. Clicks on 'Proceed to Checkout'."
+
+     - name: "GoToCheckoutFromCartActionGroup"
+       description: "Clicks on the 'View and Edit Cart' link in the Storefront Mini Shopping Cart. Validates that the Storefront Shopping Cart URL is present and correct. Clicks on 'Proceed to Checkout'."
+
+     - name: "GuestCheckoutFillingShippingSectionActionGroup"
+       description: "Fills in the provided Customer/Address (Including Region) details on the Storefront Checkout page under the 'Shipping Address' section. Selects the provided Shipping Method. Clicks on Next. Validates that the URL is present and correct."
+
+     - name: "GuestCheckoutFillShippingNoWaitForPaymentActionGroup"
+       description: "EXTENDS: GuestCheckoutFillingShippingSectionActionGroup. Removed 'waitForPaymentSectionLoaded' and 'assertCheckoutPaymentUrl'."
+
+     - name: "GuestCheckoutFillingShippingSectionWithoutRegionActionGroup"
+       description: "Fills in the provided Customer/Address (Excluding Region) details on the Storefront Checkout page under the 'Shipping Address' section. Selects the provided Shipping Method. Clicks on Next. Validates that the URL is present and correct."
+
+     - name: "GuestCheckoutFillingShippingSectionUnavailablePaymentActionGroup"
+       description: "Fills in the provided Customer/Address (Including Region) details on the Storefront Checkout page under the 'Shipping Address' section. Selects the 1st Shipping Method. Clicks on Next. Validates that the Payment Error Message and URL are present and correct."
+
+     - name: "GuestCheckoutWithSpecificCountryOptionForPaymentMethodActionGroup"
+       description: "EXTENDS: GuestCheckoutFillingShippingSectionUnavailablePaymentActionGroup. Removes 'checkMessage'. Validates that the provided Payment Method Name is NOT present on the Storefront Checkout page."
+
+     - name: "LoggedInUserCheckoutFillingShippingSectionActionGroup"
+       description: "Fills in the provided Customer/Address (Including Region) details on the Storefront Checkout page under the 'Shipping Address' section. Selects the 1st Shipping Method. Clicks on Next. Validates that the Payment Error Message and URL are present and correct."
+
+     - name: "StorefrontCheckoutForwardFromShippingStep"
+       description: "Clicks next on Checkout Shipping step"
+
+     - name: "LoggedInUserCheckoutAddNewShippingSectionWithoutRegionActionGroup"
+       description: "Fills in the provided Customer/Address (Excluding Region) details on the Storefront Checkout page under the 'Shipping Address' section. Selects the 1st Shipping Method. Clicks on Next. Validates that the Payment Error Message and URL are present and correct."
+
+     - name: "PlaceOrderWithLoggedUserActionGroup"
+       description: "Clicks on 'Proceed to Checkout' on the Storefront Shopping Cart page. Selects the provided Shipping Method. Clicks on Next. Clicks on Place Order. Validates that the Success Message is present and correct."
+
+     - name: "CheckProductInCheckoutCartItemsActionGroup"
+       description: "Validates the provided Product appears in the Storefront Checkout 'Order Summary' section."
+
+     - name: "CheckOrderSummaryInCheckoutActionGroup"
+       description: "Validates that the provided Subtotal, Shipping Total, Shipping Method and Total are present and correct on the Storefront Checkout page under the 'Order Summary' section."
+
+     - name: "CheckTotalsSortOrderInSummarySection"
+       description: "Validates that the provided Element Name appears at the provided Position in the Storefront Checkout 'Order Summary' section."
+
+     - name: "CheckShipToInformationInCheckoutActionGroup"
+       description: "Validates that the provided Customer and Address details are present and correct on the Storefront Checkout page under the 'Ship To' section."
+
+     - name: "CheckShippingMethodInCheckoutActionGroup"
+       description: "Validates that the provided Shipping Method Name is present on the Storefront Checkout page under the 'Shipping Method' section."
+
+     - name: "CheckoutSelectCheckMoneyOrderPaymentActionGroup"
+       description: "Selects the 'Check / Money Order' Payment Method on the Storefront Checkout page."
+
+     - name: "CheckSelectedShippingAddressInCheckoutActionGroup"
+       description: "Validates that the provided Customer and Address details are listed on the Storefront Checkout page under the 'Shipping Address' section when multiple Addresses are present for a Customer."
+
+     - name: "CheckBillingAddressInCheckoutActionGroup"
+       description: "Validates that the provided Customer and Address details are present on the Storefront Checkout page under the 'Payment Method' section."
+
+     - name: "CheckBillingAddressInCheckoutWithBillingAddressOnPaymentPageActionGroup"
+       description: "Validates that the provided Customer and Address details appear on the Storefront Checkout page under the 'Billing Address' section."
+
+     - name: "CheckoutPlaceOrderActionGroup"
+       description: "Clicks on 'Place Order'. Validates that the provided Order ID and Email You messages are present and correct."
+
+     - name: "VerifyTopDestinationsCountry"
+       description: "Validates that the provided Country is listed at the provided Index in 'Country' drop down menu on the Storefront Shopping Cart page under the 'Summary' section."
+
+     - name: "StorefrontSignOutActionGroup"
+       description: "Clicks on the Customer Account link. Clicks on 'Sign Out'. Validates that the Signed Out message is present and correct."
+
+     - name: "ClickPlaceOrderActionGroup"
+       description: "Clicks on the 'Place Order' button. Validates that the Success Message is present and correct."
+- filename: "IdentityOfDefaultBillingAndShippingAddressActionGroup.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/Checkout/Test/Mftf/ActionGroup/IdentityOfDefaultBillingAndShippingAddressActionGroup.xml"
+  module: "Checkout"
+  actiongroups:
+     - name: "AssertThatShippingAndBillingAddressTheSame"
+       description: "Validates that the Shipping and Billing Addresses are the same."
+- filename: "StorefrontFillEmailFieldOnCheckoutActionGroup.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/Checkout/Test/Mftf/ActionGroup/StorefrontFillEmailFieldOnCheckoutActionGroup.xml"
+  module: "Checkout"
+  actiongroups:
+     - name: "StorefrontFillEmailFieldOnCheckoutActionGroup"
+       description: "Fills in the provided Email Address on the Storefront Checkout page. Double clicks on the Email tooltip."
+- filename: "AssertStorefrontShippingLabelDescriptionInOrderSummaryActionGroup.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/Checkout/Test/Mftf/ActionGroup/AssertStorefrontShippingLabelDescriptionInOrderSummaryActionGroup.xml"
+  module: "Checkout"
+  actiongroups:
+     - name: "AssertStorefrontShippingLabelDescriptionInOrderSummaryActionGroup"
+       description: "Validates that the Shipping label description is present and correct."
+- filename: "StorefrontAssertCartEstimateShippingAndTaxActionGroup.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/Checkout/Test/Mftf/ActionGroup/StorefrontAssertCartEstimateShippingAndTaxActionGroup.xml"
+  module: "Checkout"
+  actiongroups:
+     - name: "StorefrontAssertCartEstimateShippingAndTaxActionGroup"
+       description: "Validates that the provided Customer details (Country, State and Zip Code) are present and correct in the 'Estimate Shipping and Tax' section on the Storefront Shopping Cart page."
+- filename: "StorefrontCheckoutCheckOutOfStockProductActionGroup.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/Checkout/Test/Mftf/ActionGroup/StorefrontCheckoutCheckOutOfStockProductActionGroup.xml"
+  module: "Checkout"
+  actiongroups:
+     - name: "StorefrontCheckoutCheckOutOfStockProductActionGroup"
+       description: "Validates that the 'Out of Stock' Error Message is present and correct on the Storefront Checkout page for the provided Product."
+- filename: "StorefrontFillOptionTextAreaActionGroup.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/Checkout/Test/Mftf/ActionGroup/StorefrontFillOptionTextAreaActionGroup.xml"
+  module: "Checkout"
+  actiongroups:
+     - name: "StorefrontFillOptionTextAreaActionGroup"
+       description: "Fills in the provided Option Title with the provided Value on a Storefront product page."
+- filename: "VerifyCheckoutPaymentOrderSummaryActionGroup.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/Checkout/Test/Mftf/ActionGroup/VerifyCheckoutPaymentOrderSummaryActionGroup.xml"
+  module: "Checkout"
+  actiongroups:
+     - name: "VerifyCheckoutPaymentOrderSummaryActionGroup"
+       description: "Validates that the provided Subtotal, Shipping Total and Summary Total prices are present and correct on the Storefront Checkout page."
+
+     - name: "AssertStorefrontCheckoutPaymentSummarySubtotalActionGroup"
        description: ""
 
-     - name: "StorefrontSwitchCurrency"
-       description: ""
- 
-- filename: "AdminSetBaseCurrencyActionGroup.xml"
-  repo: "https://github.com/magento/magento2/blob/2.3/app/code/Magento/CurrencySymbol/Test/Mftf/ActionGroup/AdminSetBaseCurrencyActionGroup.xml"
-  module: "CurrencySymbol"
-  actiongroups:
-     - name: "AdminSetBaseCurrencyActionGroup"
-       description: ""
- 
-- filename: "AdminCurrencyRatesActionGroup.xml"
-  repo: "https://github.com/magento/magento2/blob/2.3/app/code/Magento/CurrencySymbol/Test/Mftf/ActionGroup/AdminCurrencyRatesActionGroup.xml"
-  module: "CurrencySymbol"
-  actiongroups:
-     - name: "AdminImportCurrencyRatesActionGroup"
+     - name: "AssertStorefrontCheckoutPaymentSummaryTotalActionGroup"
        description: ""
 
-     - name: "AdminSaveCurrencyRatesActionGroup"
+     - name: "AssertStorefrontCheckoutPaymentSummaryTotalMissingActionGroup"
+       description: ""
+- filename: "StorefrontProductCartActionGroup.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/Checkout/Test/Mftf/ActionGroup/StorefrontProductCartActionGroup.xml"
+  module: "Checkout"
+  actiongroups:
+     - name: "StorefrontAddCategoryProductToCartActionGroup"
+       description: "Adds the provided Product to the Cart from a Storefront Category page. Validates that the Success Message is present and correct. Validates that the Mini Shopping Cart contains the provided Product Count."
+
+     - name: "StorefrontAddCategoryProductToCartWithQuantityActionGroup"
+       description: "Adds the provided Product to the Cart from a Storefront Category page. Validates that the Success Message is present and correct. Updates the Product Quantity using the provided Product Quantity. Validates that the provided Quantity is present and correct in the Mini Shopping Cart."
+
+     - name: "StorefrontAddProductToCartActionGroup"
+       description: "Clicks on Add to Cart on a Storefront Product page. Validates that the Success Message is present and correct. Validates that the provided Product Count is present and correct in the Mini Shopping Cart."
+
+     - name: "StorefrontOpenMinicartAndCheckSimpleProductActionGroup"
+       description: "Clicks on the Storefront Mini Shopping Cart icon. Validates that the provided Product is present and correct in the Mini Shopping Cart."
+
+     - name: "StorefrontCheckCartSimpleProductActionGroup"
+       description: "Validates that the provided Product details (Name and Price) are present and correct in the Mini Shopping Cart. Validates that the provided Product Quantity is present and correct in the Mini Shopping Cart."
+
+     - name: "StorefrontCheckCartActionGroup"
+       description: "Goes to the Storefront Shopping Cart page. Validates that the provided Subtotal, Shipping, Shipping Method and Total are present and correct."
+
+     - name: "StorefrontOpenCartFromMinicartActionGroup"
+       description: "Clicks on the Storefront Mini Shopping Cart icon. Click on 'View and Edit Cart'."
+
+     - name: "changeSummaryQuoteAddress"
+       description: "Fills in the provided Address details (Country, State and Zip Code) under the 'Summary' section on the Storefront Shopping Cart page."
+
+     - name: "StorefrontCheckCartTotalWithDiscountCategoryActionGroup"
+       description: "EXTENDS: StorefrontCheckCartActionGroup. Validates that the provided Discount is present in the Storefront Shopping Cart."
+- filename: "StorefrontRegisterCustomerAfterCheckoutActionGroup.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/Checkout/Test/Mftf/ActionGroup/StorefrontRegisterCustomerAfterCheckoutActionGroup.xml"
+  module: "Checkout"
+  actiongroups:
+     - name: "StorefrontRegisterCustomerAfterCheckoutActionGroup"
+       description: ""
+- filename: "StorefrontAssertCartShippingMethodSelectedActionGroup.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/Checkout/Test/Mftf/ActionGroup/StorefrontAssertCartShippingMethodSelectedActionGroup.xml"
+  module: "Checkout"
+  actiongroups:
+     - name: "StorefrontAssertCartShippingMethodSelectedActionGroup"
+       description: "Validates that the provided Shipping Method Carrier/Method Code is checked on the Storefront Shopping Cart page."
+- filename: "AssertAdminEmailValidationMessageOnCheckoutActionGroup.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/Checkout/Test/Mftf/ActionGroup/AssertAdminEmailValidationMessageOnCheckoutActionGroup.xml"
+  module: "Checkout"
+  actiongroups:
+     - name: "AssertAdminEmailValidationMessageOnCheckoutActionGroup"
+       description: ""
+- filename: "CustomerCheckoutFillNewShippingAddressActionGroup.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/Checkout/Test/Mftf/ActionGroup/CustomerCheckoutFillNewShippingAddressActionGroup.xml"
+  module: "Checkout"
+  actiongroups:
+     - name: "CustomerCheckoutFillNewShippingAddressActionGroup"
+       description: "Fills in the provided Address details in the 'Shipping Address' section on the Storefront Checkout page."
+- filename: "StorefrontAddToTheCartActionGroup.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/Checkout/Test/Mftf/ActionGroup/StorefrontAddToTheCartActionGroup.xml"
+  module: "Checkout"
+  actiongroups:
+     - name: "StorefrontAddToTheCartActionGroup"
+       description: "Scrolls to the Add To Cart button. Clicks on Add To Cart."
+- filename: "StorefrontAddProductWithSelectedOptionToCartActionGroup.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/Checkout/Test/Mftf/ActionGroup/StorefrontAddProductWithSelectedOptionToCartActionGroup.xml"
+  module: "Checkout"
+  actiongroups:
+     - name: "StorefrontAddProductWithSelectedConfigurableOptionToCartActionGroup"
+       description: "Selects the provided Product Option in the drop down on a Storefront Configurable product page. Clicks on Add to Cart. Validates that the Success Message is present and correct."
+- filename: "StorefrontAssertCheckoutShippingMethodSelectedActionGroup.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/Checkout/Test/Mftf/ActionGroup/StorefrontAssertCheckoutShippingMethodSelectedActionGroup.xml"
+  module: "Checkout"
+  actiongroups:
+     - name: "StorefrontAssertCheckoutShippingMethodSelectedActionGroup"
+       description: "Validates that the provided Shipping Method is checked on the Storefront Checkout page."
+- filename: "StorefrontAddProductWithSelectedConfigurableAndCustomOptionsToCartActionGroup.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/Checkout/Test/Mftf/ActionGroup/StorefrontAddProductWithSelectedConfigurableAndCustomOptionsToCartActionGroup.xml"
+  module: "Checkout"
+  actiongroups:
+     - name: "StorefrontAddProductWithSelectedConfigurableAndCustomOptionsToCartActionGroup"
+       description: "Selects the provided Customizable Option in the Product Options drop down on a Storefront Configurable product page. Clicks on Add to Cart. Validates that the Success Message is present and correct."
+- filename: "AssertStorefrontOrderCannotBePlacedActionGroup.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/Checkout/Test/Mftf/ActionGroup/AssertStorefrontOrderCannotBePlacedActionGroup.xml"
+  module: "Checkout"
+  actiongroups:
+     - name: "AssertStorefrontOrderCannotBePlacedActionGroup"
+       description: "Validates order cannot be placed and checks error message."
+- filename: "GuestCheckoutFillNewBillingAddressActionGroup.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/Checkout/Test/Mftf/ActionGroup/GuestCheckoutFillNewBillingAddressActionGroup.xml"
+  module: "Checkout"
+  actiongroups:
+     - name: "GuestCheckoutFillNewBillingAddressActionGroup"
+       description: "Fills in the provided Customer and Address details on the Storefront Checkout page."
+
+     - name: "StorefrontCheckoutFillNewBillingAddressActionGroup"
        description: ""
 
-     - name: "AdminSetCurrencyRatesActionGroup"
+     - name: "LoggedInCheckoutFillNewBillingAddressActionGroup"
+       description: "Fills in the provided Address details on the Storefront Checkout Address sections based on the provided Class Prefix (i.e. '._show', '[aria-hidden=false]')."
+
+     - name: "LoggedInCheckoutWithOneAddressFieldWithoutStateField"
+       description: "EXTENDS: LoggedInCheckoutFillNewBillingAddressActionGroup. Removes 'fillStreetAddress2' and 'selectState'."
+
+     - name: "clearCheckoutAddressPopupFieldsActionGroup"
+       description: "Clears the fields for the Customer/Address fields on the Storefront Checkout Address sections based on the provided Class Prefix (i.e. '._show', '[aria-hidden=false]')."
+
+     - name: "GuestCheckoutSelectPaymentAndFillNewBillingAddressActionGroup"
+       description: "EXTENDS: GuestCheckoutFillNewBillingAddressActionGroup. Clicks on the provided Payment Method on the Storefront Checkout page."
+- filename: "StorefrontAssertCheckoutEstimateShippingInformationActionGroup.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/Checkout/Test/Mftf/ActionGroup/StorefrontAssertCheckoutEstimateShippingInformationActionGroup.xml"
+  module: "Checkout"
+  actiongroups:
+     - name: "StorefrontAssertCheckoutEstimateShippingInformationActionGroup"
+       description: "Validates that the provided Customer details (Country, State and Zip Code) are present and correct on the Storefront Checkout page."
+- filename: "StorefrontCheckThatCartIsEmptyActionGroup.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/Checkout/Test/Mftf/ActionGroup/StorefrontCheckThatCartIsEmptyActionGroup.xml"
+  module: "Checkout"
+  actiongroups:
+     - name: "StorefrontCheckThatCartIsEmptyActionGroup"
+       description: "Clicks on the Mini Shopping Cart icon in the Storefront Header. Validates that the 'Empty Cart' message is present and correct."
+- filename: "StorefrontFillOptionFieldInputActionGroup.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/Checkout/Test/Mftf/ActionGroup/StorefrontFillOptionFieldInputActionGroup.xml"
+  module: "Checkout"
+  actiongroups:
+     - name: "StorefrontFillOptionFieldInputActionGroup"
+       description: "Fills in the provided Option Title with the provided Value on a Storefront product page."
+- filename: "AssertStorefrontMiniCartSubtotalActionGroup.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/Checkout/Test/Mftf/ActionGroup/AssertStorefrontMiniCartSubtotalActionGroup.xml"
+  module: "Checkout"
+  actiongroups:
+     - name: "AssertStorefrontMiniCartSubtotalActionGroup"
        description: ""
- 
-- filename: "StorefrontQuickSearchWithPaginationActionGroup.xml"
-  repo: "https://github.com/magento/magento2/blob/2.3/app/code/Magento/CatalogSearch/Test/Mftf/ActionGroup/StorefrontQuickSearchWithPaginationActionGroup.xml"
-  module: "CatalogSearch"
+- filename: "StorefrontAssertGuestShippingInfoActionGroup.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/Checkout/Test/Mftf/ActionGroup/StorefrontAssertGuestShippingInfoActionGroup.xml"
+  module: "Checkout"
   actiongroups:
-     - name: "StorefrontQuickSearchWithPaginationActionGroup"
-       description: "Navigate to catalog search page with prepared GET params to get search results with particular page number."
- 
-- filename: "AdminCatalogSearchTermActionGroup.xml"
-  repo: "https://github.com/magento/magento2/blob/2.3/app/code/Magento/CatalogSearch/Test/Mftf/ActionGroup/AdminCatalogSearchTermActionGroup.xml"
-  module: "CatalogSearch"
+     - name: "StorefrontAssertGuestShippingInfoActionGroup"
+       description: "Validates that the provided Customer details are present and correct in the 'Shipping Address' section on the Storefront Check page."
+- filename: "StorefrontMiniCartActionGroup.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/Checkout/Test/Mftf/ActionGroup/StorefrontMiniCartActionGroup.xml"
+  module: "Checkout"
   actiongroups:
-     - name: "AssertSearchTermSaveSuccessMessage"
-       description: "Goes to the Catalog Search Term grid page. Adds the provided Search Term. Validates that the Success Message is present and correct."
+     - name: "clickViewAndEditCartFromMiniCart"
+       description: "Clicks on the Storefront Mini Shopping Cart icon. Clicks on the 'View and Edit Cart' link. Validates that the URL is present and correct. PLEASE NOTE: The URL is Hardcoded."
 
-     - name: "AssertSearchTermSuccessDeleteMessage"
-       description: "Goes to the Catalog Search Term grid page. Deletes the provided Search Term. Validates that the Success Message is present and correct."
+     - name: "assertOneProductNameInMiniCart"
+       description: "Validates that the provided Product Name is present in the Storefront Mini Shopping Cart."
 
-     - name: "AssertSearchTermNotInGrid"
-       description: "Goes to the Catalog Search Term grid page. Searches for the provided Search Term. Validates that it is NOT present in the grid."
- 
-- filename: "StorefrontFillFormAdvancedSearchActionGroup.xml"
-  repo: "https://github.com/magento/magento2/blob/2.3/app/code/Magento/CatalogSearch/Test/Mftf/ActionGroup/StorefrontFillFormAdvancedSearchActionGroup.xml"
-  module: "CatalogSearch"
+     - name: "removeProductFromMiniCart"
+       description: "Removed the provided Product from the Storefront Mini Shopping Cart."
+
+     - name: "assertMiniCartEmpty"
+       description: "Validates that the provided Product Count appears in the Storefront Header next to the Shopping Cart icon. Clicks on the Mini Shopping Cart icon. Validates that the 'No Items' message is present and correct in the Storefront Mini Shopping Cart."
+- filename: "StorefrontAssertShippingAddressPageDisplayActionGroup.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/Checkout/Test/Mftf/ActionGroup/StorefrontAssertShippingAddressPageDisplayActionGroup.xml"
+  module: "Checkout"
   actiongroups:
-     - name: "StorefrontFillFormAdvancedSearchActionGroup"
+     - name: "StorefrontAssertShippingAddressPageDisplayActionGroup"
+       description: "Goes to the Storefront Checkout page. Validates that the 'Shipping Address' Title and Main Area are present."
+- filename: "AssertStorefrontCheckoutCartItemsActionGroup.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/Checkout/Test/Mftf/ActionGroup/AssertStorefrontCheckoutCartItemsActionGroup.xml"
+  module: "Checkout"
+  actiongroups:
+     - name: "AssertStorefrontCheckoutCartItemsActionGroup"
+       description: "Validates that the provided Product details (Name, SKU, Price, Subtotal and Quantity) are present and correct on the Storefront Shopping Cart page."
+- filename: "StorefrontCheckoutClickNextOnShippingStepActionGroup.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/Checkout/Test/Mftf/ActionGroup/StorefrontCheckoutClickNextOnShippingStepActionGroup.xml"
+  module: "Checkout"
+  actiongroups:
+     - name: "StorefrontCheckoutClickNextOnShippingStepActionGroup"
        description: ""
- 
-- filename: "AdminSetMinimalQueryLengthActionGroup.xml"
-  repo: "https://github.com/magento/magento2/blob/2.3/app/code/Magento/CatalogSearch/Test/Mftf/ActionGroup/AdminSetMinimalQueryLengthActionGroup.xml"
-  module: "CatalogSearch"
+- filename: "AssertStorefrontElementInvisibleActionGroup.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/Checkout/Test/Mftf/ActionGroup/AssertStorefrontElementInvisibleActionGroup.xml"
+  module: "Checkout"
   actiongroups:
-     - name: "SetMinimalQueryLengthActionGroup"
-       description: "Goes to the 'Configuration' page for 'Catalog'. Sets the Minimal Query Length. CLicks on the Save button."
- 
-- filename: "StorefrontCatalogSearchTermActionGroup.xml"
-  repo: "https://github.com/magento/magento2/blob/2.3/app/code/Magento/CatalogSearch/Test/Mftf/ActionGroup/StorefrontCatalogSearchTermActionGroup.xml"
-  module: "CatalogSearch"
+     - name: "AssertStorefrontElementInvisibleActionGroup"
+       description: ""
+- filename: "StorefrontSelectOptionTimeActionGroup.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/Checkout/Test/Mftf/ActionGroup/StorefrontSelectOptionTimeActionGroup.xml"
+  module: "Checkout"
   actiongroups:
-     - name: "AssertSearchTermNotOnFrontend"
-       description: "Goes to the Storefront. Fills the Search field with the provided Search Query. Clicks on Search. Validates that there are no results."
-
-     - name: "AssertSearchTermOnFrontend"
-       description: "Fills the Storefront Search field with the provided Search Query. Clicks on Search. Validates that the URL is correct."
- 
-- filename: "StorefrontCatalogSearchActionGroup.xml"
-  repo: "https://github.com/magento/magento2/blob/2.3/app/code/Magento/CatalogSearch/Test/Mftf/ActionGroup/StorefrontCatalogSearchActionGroup.xml"
-  module: "CatalogSearch"
+     - name: "StorefrontSelectOptionTimeActionGroup"
+       description: "Selects the provided Hour, Minute and Part of Day under the provided Product Option Title on a Storefront Product page."
+- filename: "StorefrontUpdateProductQtyMiniShoppingCartActionGroup.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/Checkout/Test/Mftf/ActionGroup/StorefrontUpdateProductQtyMiniShoppingCartActionGroup.xml"
+  module: "Checkout"
   actiongroups:
-     - name: "StorefrontCheckQuickSearchActionGroup"
-       description: "Submits Form POST for the Storefront Search feature. Validates that the URL is correct. Validates that the Title is present and correct."
-
-     - name: "StorefrontCheckQuickSearchStringActionGroup"
-       description: "Fill the Storefront Search field. Submits the Form. Validates that the provided Search Phrase is present and correct."
-
-     - name: "StorefrontQuickSearchTooShortStringActionGroup"
-       description: "Fill the Storefront Search field. Submits the Form. Validates that 'Minimum Search query length' warning appears."
-
-     - name: "StorefrontQuickSearchRelatedSearchTermsAppearsActionGroup"
+     - name: "StorefrontUpdateProductQtyMiniShoppingCartActionGroup"
+       description: "Clicks on the Storefront Mini Shopping Cart icon in the Header. Fills in the provided Quantity for the provided Product in the Mini Shopping Cart. Clicks on Update."
+- filename: "AdminCheckoutActionGroup.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/Checkout/Test/Mftf/ActionGroup/AdminCheckoutActionGroup.xml"
+  module: "Checkout"
+  actiongroups:
+     - name: "AdminCheckoutSelectCheckMoneyOrderBillingMethodActionGroup"
+       description: "Selects the Billing Method 'Check / Money order' on the Admin 'Create New Order for' page."
+- filename: "AssertStorefrontCheckoutSuccessActionGroup.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/Checkout/Test/Mftf/ActionGroup/AssertStorefrontCheckoutSuccessActionGroup.xml"
+  module: "Checkout"
+  actiongroups:
+     - name: "AssertStorefrontCheckoutSuccessActionGroup"
+       description: "Verifies if the order is placed successfully on the 'one page checkout' page."
+- filename: "StorefrontOpenOrderFromSuccessPageActionGroup.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/Checkout/Test/Mftf/ActionGroup/StorefrontOpenOrderFromSuccessPageActionGroup.xml"
+  module: "Checkout"
+  actiongroups:
+     - name: "StorefrontOpenOrderFromSuccessPageActionGroup"
+       description: "Click order number link from checkout success page and check order number on order view page."
+- filename: "StorefrontSelectOptionDropDownActionGroup.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/Checkout/Test/Mftf/ActionGroup/StorefrontSelectOptionDropDownActionGroup.xml"
+  module: "Checkout"
+  actiongroups:
+     - name: "StorefrontSelectOptionDropDownActionGroup"
+       description: "DEPRECATED. Please use StorefrontProductPageSelectDropDownOptionValueActionGroup instead. Selects the provided Product Option Value under the provided Product Option Title on a Storefront Product page."
+- filename: "DeleteProductFromShoppingCartActionGroup.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/Checkout/Test/Mftf/ActionGroup/DeleteProductFromShoppingCartActionGroup.xml"
+  module: "Checkout"
+  actiongroups:
+     - name: "DeleteProductFromShoppingCartActionGroup"
+       description: "Removes the provided Product Name from the Storefront Mini Shopping Cart. Validates that the Success Message is present and correct."
+- filename: "StorefrontAttachOptionFileActionGroup.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/Checkout/Test/Mftf/ActionGroup/StorefrontAttachOptionFileActionGroup.xml"
+  module: "Checkout"
+  actiongroups:
+     - name: "StorefrontAttachOptionFileActionGroup"
+       description: "Attaches the provided File to the provided Product Option on a Storefront Product page."
+- filename: "AssertToolbarTextIsVisibleInCartActionGroup.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/Checkout/Test/Mftf/ActionGroup/AssertToolbarTextIsVisibleInCartActionGroup.xml"
+  module: "Checkout"
+  actiongroups:
+     - name: "AssertToolbarTextIsVisibleInCartActionGroup"
+       description: ""
+- filename: "AssertStorefrontOrderIsNotPlacedActionGroup.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/Checkout/Test/Mftf/ActionGroup/AssertStorefrontOrderIsNotPlacedActionGroup.xml"
+  module: "Checkout"
+  actiongroups:
+     - name: "AssertStorefrontOrderIsNotPlacedActionGroup"
+       description: ""
+- filename: "AssertStorefrontSeeElementActionGroup.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/Checkout/Test/Mftf/ActionGroup/AssertStorefrontSeeElementActionGroup.xml"
+  module: "Checkout"
+  actiongroups:
+     - name: "AssertStorefrontSeeElementActionGroup"
+       description: "Scrolls to the provided Selector. Validates that the provided Selector is present."
+- filename: "StorefrontAssertProductDetailsInOrderSummaryActionGroup.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/Checkout/Test/Mftf/ActionGroup/StorefrontAssertProductDetailsInOrderSummaryActionGroup.xml"
+  module: "Checkout"
+  actiongroups:
+     - name: "StorefrontAssertProductDetailsInOrderSummaryActionGroup"
+       description: "Validates that the provided Product Name, Quantity and Price are present in the 'Order Summary' section on the Storefront Checkout page."
+- filename: "StorefrontOpenMiniCartActionGroup.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/Checkout/Test/Mftf/ActionGroup/StorefrontOpenMiniCartActionGroup.xml"
+  module: "Checkout"
+  actiongroups:
+     - name: "StorefrontOpenMiniCartActionGroup"
+       description: "Clicks on the Mini Shopping Cart icon in the Storefront Header."
+- filename: "AssertStorefrontNotCalculatedValueInShippingTotalInOrderSummaryActionGroup.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/Checkout/Test/Mftf/ActionGroup/AssertStorefrontNotCalculatedValueInShippingTotalInOrderSummaryActionGroup.xml"
+  module: "Checkout"
+  actiongroups:
+     - name: "AssertStorefrontNotCalculatedValueInShippingTotalInOrderSummaryActionGroup"
+       description: "Validates value of the Shipping total is not calculated."
+- filename: "AssertStorefrontEmailTooltipContentOnCheckoutActionGroup.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/Checkout/Test/Mftf/ActionGroup/AssertStorefrontEmailTooltipContentOnCheckoutActionGroup.xml"
+  module: "Checkout"
+  actiongroups:
+     - name: "AssertStorefrontEmailTooltipContentOnCheckoutActionGroup"
+       description: "Clicks on the Email Address tooltip. Validates that the provided Message appears in the Email Address Tooltip."
+- filename: "StorefrontOpenCheckoutPageActionGroup.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/Checkout/Test/Mftf/ActionGroup/StorefrontOpenCheckoutPageActionGroup.xml"
+  module: "Checkout"
+  actiongroups:
+     - name: "StorefrontOpenCheckoutPageActionGroup"
+       description: "Goes to the Storefront Checkout page."
+- filename: "ClearShippingAddressActionGroup.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/Checkout/Test/Mftf/ActionGroup/ClearShippingAddressActionGroup.xml"
+  module: "Checkout"
+  actiongroups:
+     - name: "ClearShippingAddressActionGroup"
+       description: "Clears all of the fields for the Shipping Address section on the Storefront Checkout page."
+- filename: "StorefrontAssertMiniCartItemCountActionGroup.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/Checkout/Test/Mftf/ActionGroup/StorefrontAssertMiniCartItemCountActionGroup.xml"
+  module: "Checkout"
+  actiongroups:
+     - name: "StorefrontAssertMiniCartItemCountActionGroup"
+       description: "Validates that the provided Product Count appears in the Storefront Header next to the Shopping Cart icon. Validates that the provided Product Count Text appears in the Storefront Mini Shopping Cart."
+- filename: "FillGuestCheckoutShippingAddressFormActionGroup.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/Checkout/Test/Mftf/ActionGroup/FillGuestCheckoutShippingAddressFormActionGroup.xml"
+  module: "Checkout"
+  actiongroups:
+     - name: "FillGuestCheckoutShippingAddressFormActionGroup"
        description: ""
 
-     - name: "StorefrontOpenProductFromQuickSearch"
-       description: "Clicks on the provided Product Name from the Storefront Quick Search Results page."
+     - name: "FillGuestCheckoutShippingAddressWithCountryActionGroup"
+       description: ""
+- filename: "FillShippingAddressOneStreetActionGroup.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/Checkout/Test/Mftf/ActionGroup/FillShippingAddressOneStreetActionGroup.xml"
+  module: "Checkout"
+  actiongroups:
+     - name: "FillShippingAddressOneStreetActionGroup"
+       description: "Fills in the provided Address details in the 'Shipping Address' (Fills in Street Address 1 only) section of the Storefront Checkout page."
+- filename: "LoginAsCustomerUsingSignInLinkActionGroup.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/Checkout/Test/Mftf/ActionGroup/LoginAsCustomerUsingSignInLinkActionGroup.xml"
+  module: "Checkout"
+  actiongroups:
+     - name: "LoginAsCustomerUsingSignInLinkActionGroup"
+       description: "Clicks on 'Sign In' on the Storefront Checkout page. Fills in the provided Customer details (Email and Password). Clicks on Sign In."
+- filename: "FillNewShippingAddressModalActionGroup.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/Checkout/Test/Mftf/ActionGroup/FillNewShippingAddressModalActionGroup.xml"
+  module: "Checkout"
+  actiongroups:
+     - name: "FillNewShippingAddressModalActionGroup"
+       description: "EXTENDS: FillShippingAddressOneStreetActionGroup. Selects the provided State in the 'Shipping Address' section of the Storefront Checkout page."
+- filename: "StorefrontSelectOptionDateTimeActionGroup.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/Checkout/Test/Mftf/ActionGroup/StorefrontSelectOptionDateTimeActionGroup.xml"
+  module: "Checkout"
+  actiongroups:
+     - name: "StorefrontSelectOptionDateTimeActionGroup"
+       description: "Selects the provided Month, Day, Year, Hour, Minute and Part of Day for the provided Product Option on a Storefront product page."
+- filename: "StorefrontAssertShippingMethodPresentInCartActionGroup.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/Checkout/Test/Mftf/ActionGroup/StorefrontAssertShippingMethodPresentInCartActionGroup.xml"
+  module: "Checkout"
+  actiongroups:
+     - name: "StorefrontAssertShippingMethodPresentInCartActionGroup"
+       description: "Validates that the provided Shipping Method Name is present in the 'Summary' section of the Storefront Shopping Cart page."
+- filename: "AssertStorefrontEmailValidationMessageOnCheckoutActionGroup.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/Checkout/Test/Mftf/ActionGroup/AssertStorefrontEmailValidationMessageOnCheckoutActionGroup.xml"
+  module: "Checkout"
+  actiongroups:
+     - name: "AssertStorefrontEmailValidationMessageOnCheckoutActionGroup"
+       description: "Validates that the provided Error Message appears on the Storefront Checkout page after an invalid Email Addressed is inputted."
+- filename: "OpenStoreFrontCheckoutShippingPageActionGroup.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/Checkout/Test/Mftf/ActionGroup/OpenStoreFrontCheckoutShippingPageActionGroup.xml"
+  module: "Checkout"
+  actiongroups:
+     - name: "OpenStoreFrontCheckoutShippingPageActionGroup"
+       description: ""
+- filename: "StorefrontFillGuestShippingInfoActionGroup.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/Checkout/Test/Mftf/ActionGroup/StorefrontFillGuestShippingInfoActionGroup.xml"
+  module: "Checkout"
+  actiongroups:
+     - name: "StorefrontFillGuestShippingInfoActionGroup"
+       description: "Fills in the provided Customer details on the Storefront Checkout page under the 'Shipping Address' section."
+- filename: "StorefrontShippmentFromActionGroup.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/Checkout/Test/Mftf/ActionGroup/StorefrontShippmentFromActionGroup.xml"
+  module: "Checkout"
+  actiongroups:
+     - name: "ShipmentFormFreeShippingActionGroup"
+       description: "Fills in the Customer details for the 'Shipping Address' section of the Storefront Checkout page. Selects 'Free Shipping'. Clicks on Next. Validates that the URL is present and correct."
+- filename: "StorefrontCheckoutCheckProductActionGroup.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/Checkout/Test/Mftf/ActionGroup/StorefrontCheckoutCheckProductActionGroup.xml"
+  module: "Checkout"
+  actiongroups:
+     - name: "StorefrontCheckoutCheckProductActionGroup"
+       description: "Validates that the provided Product and Cart Item are present and correct on the Storefront Shopping Cart page."
+- filename: "FillShippingZipFormActionGroup.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/Checkout/Test/Mftf/ActionGroup/FillShippingZipFormActionGroup.xml"
+  module: "Checkout"
+  actiongroups:
+     - name: "FillShippingZipForm"
+       description: "Fills in the provided Address details (Country, State and Zip Code) in the 'Estimate Shipping and Tax' section of the Storefront Shopping Cart page."
+- filename: "StorefrontAddSimpleProductToCartActionGroup.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/Checkout/Test/Mftf/ActionGroup/StorefrontAddSimpleProductToCartActionGroup.xml"
+  module: "Checkout"
+  actiongroups:
+     - name: "StorefrontAddSimpleProductToCartActionGroup"
+       description: "Adds the provided Product to the Storefront Shopping Cart from a Storefront Category page. Validates that the provided Success Message is present and correct."
+- filename: "StorefrontSelectOptionDateActionGroup.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/Checkout/Test/Mftf/ActionGroup/StorefrontSelectOptionDateActionGroup.xml"
+  module: "Checkout"
+  actiongroups:
+     - name: "StorefrontSelectOptionDateActionGroup"
+       description: "Selects the provided Month, Day and Year for the provided Product Option on a Storefront Product page."
+- filename: "StorefrontAssertShippingMethodOptionPresentInCartActionGroup.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/Checkout/Test/Mftf/ActionGroup/StorefrontAssertShippingMethodOptionPresentInCartActionGroup.xml"
+  module: "Checkout"
+  actiongroups:
+     - name: "StorefrontAssertShippingMethodOptionPresentInCartActionGroup"
+       description: ""
+- filename: "AssertMiniShoppingCartSubTotalActionGroup.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/Checkout/Test/Mftf/ActionGroup/AssertMiniShoppingCartSubTotalActionGroup.xml"
+  module: "Checkout"
+  actiongroups:
+     - name: "AssertMiniShoppingCartSubTotalActionGroup"
+       description: "Validates that the provided Subtotal (Price and Store Currency) is present and correct."
+- filename: "AssertIsNotVisibleCartPagerTextActionGroup.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/Checkout/Test/Mftf/ActionGroup/AssertIsNotVisibleCartPagerTextActionGroup.xml"
+  module: "Checkout"
+  actiongroups:
+     - name: "AssertPagerTextIsNotVisibleActionGroup"
+       description: ""
+- filename: "StorefrontEnterProductQuantityAndAddToTheCartActionGroup.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/Checkout/Test/Mftf/ActionGroup/StorefrontEnterProductQuantityAndAddToTheCartActionGroup.xml"
+  module: "Checkout"
+  actiongroups:
+     - name: "StorefrontEnterProductQuantityAndAddToTheCartActionGroup"
+       description: "Fills in the provided Product Quantity on a Storefront Bundled product page. Clicks on Add to Cart."
+- filename: "AssertStorefrontMiniCartItemsActionGroup.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/Checkout/Test/Mftf/ActionGroup/AssertStorefrontMiniCartItemsActionGroup.xml"
+  module: "Checkout"
+  actiongroups:
+     - name: "AssertStorefrontMiniCartItemsActionGroup"
+       description: "Validates that the provided Product details (Name, Price, Subtotal and Quantity) are present and correct in the Storefront Mini Shopping Cart."
 
-     - name: "StorefrontAddToCartFromQuickSearch"
-       description: "Adds the provided Product Name to the Shopping Cart from the Storefront Quick Search Results page. Validates that the Success Message is present and correct."
+     - name: "AssertStorefrontMiniCartProductDetailsAbsentActionGroup"
+       description: "Validates that the provided Product details (Name, Price) are
+                not present in the Storefront Mini Shopping Cart."
+- filename: "StorefrontAddSimpleProductToShopingCartActionGroup.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/Checkout/Test/Mftf/ActionGroup/StorefrontAddSimpleProductToShopingCartActionGroup.xml"
+  module: "Checkout"
+  actiongroups:
+     - name: "StorefrontAddSimpleProductToShoppingCartActionGroup"
+       description: ""
+- filename: "AssertStorefronElementVisibleActionGroup.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/Checkout/Test/Mftf/ActionGroup/AssertStorefronElementVisibleActionGroup.xml"
+  module: "Checkout"
+  actiongroups:
+     - name: "AssertStorefrontElementVisibleActionGroup"
+       description: "Validates that the provided Selector contains the provided Value on a Storefront page."
+- filename: "ClearPageCacheActionGroup.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/PageCache/Test/Mftf/ActionGroup/ClearPageCacheActionGroup.xml"
+  module: "PageCache"
+  actiongroups:
+     - name: "ClearPageCacheActionGroup"
+       description: "Goes to the Admin Cache Management page. Selects 'Refresh'. Checks the 'Page Cache' row. Clicks on Submit."
+- filename: "ClearCacheActionGroup.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/PageCache/Test/Mftf/ActionGroup/ClearCacheActionGroup.xml"
+  module: "PageCache"
+  actiongroups:
+     - name: "ClearCacheActionGroup"
+       description: "Goes to the Admin Cache Management page. Clicks on 'Flush Magento Cache'."
 
-     - name: "StorefrontQuickSearchCheckProductNameInGrid"
-       description: "Validates that the provided Product Name appears at the correct index on the Storefront Quick Search page."
+     - name: "clearPageCache"
+       description: "Goes to the Admin Cache Management page. Selects 'Refresh'. Checks the 'Page Cache' row. Clicks on Submit."
+- filename: "StorefrontAssertProductAbsentOnCategoryPageActionGroup.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/Catalog/Test/Mftf/ActionGroup/StorefrontAssertProductAbsentOnCategoryPageActionGroup.xml"
+  module: "Catalog"
+  actiongroups:
+     - name: "StorefrontAssertProductAbsentOnCategoryPageActionGroup"
+       description: "DEPRECATED. Please use AssertStorefrontProductAbsentOnCategoryPageActionGroup instead.
+                Navigate to category page and verify product is absent."
+- filename: "AdminAssignProductInWebsiteActionGroup.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/Catalog/Test/Mftf/ActionGroup/AdminAssignProductInWebsiteActionGroup.xml"
+  module: "Catalog"
+  actiongroups:
+     - name: "AdminAssignProductInWebsiteActionGroup"
+       description: ""
+- filename: "AssertProductInStorefrontProductPageActionGroup.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/Catalog/Test/Mftf/ActionGroup/AssertProductInStorefrontProductPageActionGroup.xml"
+  module: "Catalog"
+  actiongroups:
+     - name: "AssertProductInStorefrontProductPageActionGroup"
+       description: "Goes to the Storefront page. Validates that the provided Product details are present."
 
-     - name: "StorefrontQuickSearchSeeProductByName"
+     - name: "AssertProductInStorefrontProductPage"
+       description: "Goes to the Storefront page. Validates that the provided Product details are present."
+
+     - name: "AssertProductNameAndSkuInStorefrontProductPage"
+       description: "Goes to the Storefront Product page for the provided Product. Validates that the Product details are present and correct."
+
+     - name: "AssertProductNameAndSkuInStorefrontProductPageByCustomAttributeUrlKey"
+       description: "Goes to the Storefront Product page for the provided Product. Validates that the Product details are present and correct."
+- filename: "StorefrontAssertCustomOptionByTitleActionGroup.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/Catalog/Test/Mftf/ActionGroup/StorefrontAssertCustomOptionByTitleActionGroup.xml"
+  module: "Catalog"
+  actiongroups:
+     - name: "StorefrontAssertCustomOptionByTitleActionGroup"
+       description: "Validates that the provided Product Option Title is present on the Storefront Product page."
+- filename: "SaveCategoryFormActionGroup.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/Catalog/Test/Mftf/ActionGroup/SaveCategoryFormActionGroup.xml"
+  module: "Catalog"
+  actiongroups:
+     - name: "SaveCategoryFormActionGroup"
+       description: "DEPRECATED. Use AdminSaveCategoryFormActionGroup instead. Requires navigation to the Category creation/edit page. Checks that the url contains the AdminCategoryPage url. Saves the Category."
+- filename: "StorefrontProductPageSelectRadioButtonOptionValueActionGroup.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/Catalog/Test/Mftf/ActionGroup/StorefrontProductPageSelectRadioButtonOptionValueActionGroup.xml"
+  module: "Catalog"
+  actiongroups:
+     - name: "StorefrontProductPageSelectRadioButtonOptionValueActionGroup"
+       description: "Selects the provided Product Option Value under the provided Radio Button Product Option Title on a Storefront Product page."
+- filename: "DeleteProductAttributeByAttributeCodeActionGroup.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/Catalog/Test/Mftf/ActionGroup/DeleteProductAttributeByAttributeCodeActionGroup.xml"
+  module: "Catalog"
+  actiongroups:
+     - name: "DeleteProductAttributeByAttributeCodeActionGroup"
+       description: "Delete a Product Attribute from the Product Attribute creation/edit page."
+- filename: "DeleteProductBySkuActionGroup.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/Catalog/Test/Mftf/ActionGroup/DeleteProductBySkuActionGroup.xml"
+  module: "Catalog"
+  actiongroups:
+     - name: "DeleteProductBySkuActionGroup"
+       description: "Goes to the Admin Products grid page. Deletes the provided Product SKU."
+- filename: "AdminCategoryPageOpenProductsInCategorySectionActionGroup.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/Catalog/Test/Mftf/ActionGroup/AdminCategoryPageOpenProductsInCategorySectionActionGroup.xml"
+  module: "Catalog"
+  actiongroups:
+     - name: "AdminCategoryPageOpenProductsInCategorySectionActionGroup"
+       description: "Open 'Products in Category' section on category edit page in Admin."
+- filename: "AssertProductAttributePresenceInCatalogProductGridActionGroup.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/Catalog/Test/Mftf/ActionGroup/AssertProductAttributePresenceInCatalogProductGridActionGroup.xml"
+  module: "Catalog"
+  actiongroups:
+     - name: "AssertProductAttributePresenceInCatalogProductGridActionGroup"
+       description: "Validates that the provided Attributes Sets is present on the Backend Attribute Sets grid."
+- filename: "FillProductNameAndSkuInProductFormActionGroup.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/Catalog/Test/Mftf/ActionGroup/FillProductNameAndSkuInProductFormActionGroup.xml"
+  module: "Catalog"
+  actiongroups:
+     - name: "FillProductNameAndSkuInProductFormActionGroup"
+       description: "Fills in the provided Product details (Name and SKU) on the Admin Products creation and edit page."
+- filename: "AdminAddMinimumAdvertisedPriceActionGroup.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/Catalog/Test/Mftf/ActionGroup/AdminAddMinimumAdvertisedPriceActionGroup.xml"
+  module: "Catalog"
+  actiongroups:
+     - name: "AdminAddMinimumAdvertisedPriceActionGroup"
+       description: "Clicks 'Advanced Pricing' on the Admin Product creation/edit page. Fills in the provided MSRP details. Clicks on Done."
+- filename: "StorefrontProductPageActionGroup.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/Catalog/Test/Mftf/ActionGroup/StorefrontProductPageActionGroup.xml"
+  module: "Catalog"
+  actiongroups:
+     - name: "addToCartFromStorefrontProductPage"
+       description: "Click on the Add to Cart button. Validates that the Success Message is present."
+
+     - name: "AddProductWithQtyToCartFromStorefrontProductPage"
+       description: "EXTENDS: addToCartFromStorefrontProductPage. Fills in the provided Product Quantity for the provided Product Name."
+
+     - name: "testDynamicValidationHint"
+       description: "Validates that the Product Text Option Text Length Hint displays the correct Count for multiple inputs based on the provided Character Limit."
+
+     - name: "checkAttributeInMoreInformationTab"
+       description: "Validates that the Product More Information area contains the provided Text."
+
+     - name: "checkAttributeNotInMoreInformationTab"
+       description: "Validate that the More Information area does not contain the provided Text."
+- filename: "AdminAssignImageRolesActionGroup.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/Catalog/Test/Mftf/ActionGroup/AdminAssignImageRolesActionGroup.xml"
+  module: "Catalog"
+  actiongroups:
+     - name: "AdminAssignImageRolesActionGroup"
+       description: "Requires the navigation to the Product Creation page. Checks the Base, Small, Thumbnail, and Swatch Roles areas for images."
+
+     - name: "AdminAssignImageRolesIfUnassignedActionGroup"
+       description: "Requires the navigation to the Product Creation page. Assign the Base, Small, Thumbnail, and Swatch Roles to image."
+- filename: "AdminUnassignCategoryOnProductAndSaveActionGroup.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/Catalog/Test/Mftf/ActionGroup/AdminUnassignCategoryOnProductAndSaveActionGroup.xml"
+  module: "Catalog"
+  actiongroups:
+     - name: "AdminUnassignCategoryOnProductAndSaveActionGroup"
+       description: ""
+- filename: "StorefrontCategoryPageSortProductActionGroup.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/Catalog/Test/Mftf/ActionGroup/StorefrontCategoryPageSortProductActionGroup.xml"
+  module: "Catalog"
+  actiongroups:
+     - name: "StorefrontCategoryPageSortProductActionGroup"
+       description: "Select 'Sort by' parameter for sorting Products on Category page"
+
+     - name: "StorefrontCategoryPageSortAscendingActionGroup"
+       description: "Set Ascending Direction for sorting Products on Category page"
+
+     - name: "StorefrontCategoryPageSortDescendingActionGroup"
+       description: "Set Descending Direction for sorting Products on Category page"
+- filename: "AssertStorefrontProductAbsentOnCategoryPageActionGroup.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/Catalog/Test/Mftf/ActionGroup/AssertStorefrontProductAbsentOnCategoryPageActionGroup.xml"
+  module: "Catalog"
+  actiongroups:
+     - name: "AssertStorefrontProductAbsentOnCategoryPageActionGroup"
+       description: "Navigate to category page and verify product is absent."
+- filename: "AdminOpenNewProductFormPageActionGroup.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/Catalog/Test/Mftf/ActionGroup/AdminOpenNewProductFormPageActionGroup.xml"
+  module: "Catalog"
+  actiongroups:
+     - name: "AdminOpenNewProductFormPageActionGroup"
+       description: "Goes to the Product creation/edit page for the provided Product Type and Attribute Set ID."
+- filename: "AdminAssignCategoryToProductAndSaveActionGroup.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/Catalog/Test/Mftf/ActionGroup/AdminAssignCategoryToProductAndSaveActionGroup.xml"
+  module: "Catalog"
+  actiongroups:
+     - name: "AdminAssignCategoryToProductAndSaveActionGroup"
+       description: ""
+- filename: "StorefrontSelectCustomOptionRadioAndAssertPricesActionGroup.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/Catalog/Test/Mftf/ActionGroup/StorefrontSelectCustomOptionRadioAndAssertPricesActionGroup.xml"
+  module: "Catalog"
+  actiongroups:
+     - name: "StorefrontSelectCustomOptionRadioAndAssertPricesActionGroup"
+       description: "EXTENDS: AssertStorefrontProductPricesActionGroup. Clicks on the provided Custom Option on a Storefront Product page."
+- filename: "AssertAdminProductStockStatusActionGroup.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/Catalog/Test/Mftf/ActionGroup/AssertAdminProductStockStatusActionGroup.xml"
+  module: "Catalog"
+  actiongroups:
+     - name: "AssertAdminProductStockStatusActionGroup"
+       description: ""
+- filename: "AdminCreateWidgetActionGroup.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/Catalog/Test/Mftf/ActionGroup/AdminCreateWidgetActionGroup.xml"
+  module: "Catalog"
+  actiongroups:
+     - name: "AdminCreateRecentlyProductsWidgetActionGroup"
+       description: "EXTENDS: AdminCreateWidgetActionGroup. Adds Product Attributes/Buttons to a Widget. Clicks on the Save button."
+
+     - name: "AdminCreateCatalogProductWidgetActionGroup"
+       description: "EXTENDS: AdminCreateWidgetActionGroup. Creates Catalog Category Link Widget."
+- filename: "AssertProductOnAdminGridActionGroup.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/Catalog/Test/Mftf/ActionGroup/AssertProductOnAdminGridActionGroup.xml"
+  module: "Catalog"
+  actiongroups:
+     - name: "AssertProductOnAdminGridActionGroup"
+       description: "EXTENDS: viewProductInAdminGrid. Removes the 'clickClearFiltersAfter' step from the Action Group."
+- filename: "AssertErrorMessageAfterDeletingWebsiteActionGroup.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/Catalog/Test/Mftf/ActionGroup/AssertErrorMessageAfterDeletingWebsiteActionGroup.xml"
+  module: "Catalog"
+  actiongroups:
+     - name: "AssertErrorMessageAfterDeletingWebsiteActionGroup"
+       description: "Goes to the Admin Products grid page. Clicks on Ok. Validates that the provided Error Message is present and correct."
+- filename: "StorefrontAssertPageNotFoundErrorOnProductDetailPageActionGroup.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/Catalog/Test/Mftf/ActionGroup/StorefrontAssertPageNotFoundErrorOnProductDetailPageActionGroup.xml"
+  module: "Catalog"
+  actiongroups:
+     - name: "StorefrontAssertPageNotFoundErrorOnProductDetailPageActionGroup"
+       description: ""
+- filename: "StorefrontNavigateCategoryPageActionGroup.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/Catalog/Test/Mftf/ActionGroup/StorefrontNavigateCategoryPageActionGroup.xml"
+  module: "Catalog"
+  actiongroups:
+     - name: "StorefrontNavigateCategoryPageActionGroup"
+       description: ""
+- filename: "AdminFillProductAttributePropertiesActionGroup.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/Catalog/Test/Mftf/ActionGroup/AdminFillProductAttributePropertiesActionGroup.xml"
+  module: "Catalog"
+  actiongroups:
+     - name: "AdminFillProductAttributePropertiesActionGroup"
        description: ""
 
-     - name: "StorefrontQuickSearchCheckProductNameNotInGrid"
-       description: "Validates that the provided Product Name does NOT appear on the Storefront Quick Search page."
+     - name: "AdminSwitchScopeForProductAttributeActionGroup"
+       description: ""
+- filename: "AdminSwitchProductGiftMessageStatusActionGroup.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/Catalog/Test/Mftf/ActionGroup/AdminSwitchProductGiftMessageStatusActionGroup.xml"
+  module: "Catalog"
+  actiongroups:
+     - name: "AdminSwitchProductGiftMessageStatusActionGroup"
+       description: ""
+- filename: "StorefrontCheckProductPriceInCategoryActionGroup.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/Catalog/Test/Mftf/ActionGroup/StorefrontCheckProductPriceInCategoryActionGroup.xml"
+  module: "Catalog"
+  actiongroups:
+     - name: "StorefrontCheckProductPriceInCategoryActionGroup"
+       description: "EXTENDS: StorefrontCheckCategorySimpleProduct. Removes 'AssertProductPrice'. Validates that the provided Product Price is present and correct on a Storefront Product page."
 
-     - name: "StorefrontOpenAdvancedSearchActionGroup"
-       description: "Clicks on 'Advanced Search' in the Storefront Footer. Validates that the URL and Title are present and correct."
+     - name: "StorefrontAssertProductPriceOnCategoryPageActionGroup"
+       description: "Validate that the provided Product Price is correct on category page."
+- filename: "NavigateToMediaGalleryActionGroup.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/Catalog/Test/Mftf/ActionGroup/NavigateToMediaGalleryActionGroup.xml"
+  module: "Catalog"
+  actiongroups:
+     - name: "NavigateToMediaGalleryActionGroup"
+       description: "Navigates to the category page and Opens the Media Gallery."
+- filename: "AdminProductFormCloseAdvancedPricingDialogActionGroup.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/Catalog/Test/Mftf/ActionGroup/AdminProductFormCloseAdvancedPricingDialogActionGroup.xml"
+  module: "Catalog"
+  actiongroups:
+     - name: "AdminProductFormCloseAdvancedPricingDialogActionGroup"
+       description: "Close Advanced Pricing dialog from product form."
+- filename: "AdminProductAttributeSetActionGroup.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/Catalog/Test/Mftf/ActionGroup/AdminProductAttributeSetActionGroup.xml"
+  module: "Catalog"
+  actiongroups:
+     - name: "AssignAttributeToGroup"
+       description: "Assign the provided Attribute to an Attribute Set from the Attribute Sets creation/edit page."
 
-     - name: "StorefrontCheckAdvancedSearchResultActionGroup"
-       description: "Validates that the URL and Title are present and correct on the Storefront Advanced Search Results page."
+     - name: "UnassignAttributeFromGroup"
+       description: "Unassign the provided Attribute from an Attribute Set from the Attribute Sets creation/edit page."
 
-     - name: "StorefrontSelectSearchFilterCategoryActionGroup"
-       description: "Clicks on Category Filter. Clicks on the provided Category."
+     - name: "SaveAttributeSet"
+       description: "Save an Attribute Set on the Attribute Set creation/edit page."
 
-     - name: "GoToStoreViewAdvancedCatalogSearchActionGroup"
-       description: "Goes to the Storefront 'Advanced Search' page."
+     - name: "CreateDefaultAttributeSet"
+       description: "Goes to the Attribute Sets grid page. Clicks on Add. Fill Name. Clicks on Save."
 
-     - name: "StorefrontAdvancedCatalogSearchByProductNameActionGroup"
-       description: "Fills the Product Name field on the Storefront 'Advanced Search' page. Clicks on the Submit button."
+     - name: "AdminAddUnassignedAttributeToGroup"
+       description: ""
 
-     - name: "StorefrontAdvancedCatalogSearchByProductSkuActionGroup"
-       description: "Fills the Product SKU field on the Storefront 'Advanced Search' page. Clicks on the Submit button."
+     - name: "goToAttributeGridPage"
+       description: "Goes to the Attribute Sets grid page."
 
-     - name: "StorefrontAdvancedCatalogSearchByDescriptionActionGroup"
-       description: "Fills the Product Description field on the Storefront 'Advanced Search' page. Clicks on the Submit button."
+     - name: "goToAttributeSetByName"
+       description: "Searches for the provided Attribute Sets Name. Clicks on the 1st row."
 
-     - name: "StorefrontAdvancedCatalogSearchByShortDescriptionActionGroup"
-       description: "Fills the Product Short Description field on the Storefront 'Advanced Search' page. Clicks on the Submit button."
+     - name: "filterProductAttributeByAttributeLabel"
+       description: "Searches the Attribute Sets grid page for the provided Attribute Set Name."
 
-     - name: "StorefrontAdvancedCatalogSearchByProductNameAndPriceActionGroup"
-       description: "Fills the Product Name, Price From and Price To fields on the Storefront 'Advanced Search' page. Clicks on the Submit button."
+     - name: "FilterProductAttributeSetGridByAttributeSetName"
+       description: "Filters the Attribute Sets grid page for the provided Attribute Set Name."
 
-     - name: "StorefrontAdvancedCatalogSearchByProductNameAndDescriptionActionGroup"
-       description: "Fills the Product Name and Description fields on the Storefront 'Advanced Search' page. Clicks on the Submit button."
+     - name: "deleteAttributeSetByLabel"
+       description: "Deletes the provided Attribute Set Name from the Attribute Sets grid page."
+- filename: "ConfirmChangeInputTypeModalActionGroup.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/Catalog/Test/Mftf/ActionGroup/ConfirmChangeInputTypeModalActionGroup.xml"
+  module: "Catalog"
+  actiongroups:
+     - name: "ConfirmChangeInputTypeModalActionGroup"
+       description: "Clicks on the Confirm button for the 'Product Data My Be Lost' modal."
+- filename: "AdminChangeProductSEOSettingsActionGroup.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/Catalog/Test/Mftf/ActionGroup/AdminChangeProductSEOSettingsActionGroup.xml"
+  module: "Catalog"
+  actiongroups:
+     - name: "AdminChangeProductSEOSettingsActionGroup"
+       description: ""
+- filename: "MoveCategoryActionGroup.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/Catalog/Test/Mftf/ActionGroup/MoveCategoryActionGroup.xml"
+  module: "Catalog"
+  actiongroups:
+     - name: "MoveCategoryActionGroup"
+       description: "Move a Category on the Backend Category page."
+- filename: "StorefrontAssertProductPriceOnProductPageActionGroup.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/Catalog/Test/Mftf/ActionGroup/StorefrontAssertProductPriceOnProductPageActionGroup.xml"
+  module: "Catalog"
+  actiongroups:
+     - name: "StorefrontAssertProductPriceOnProductPageActionGroup"
+       description: "Validate that the provided Product Price is present and correct."
+- filename: "AddProductToCartActionGroup.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/Catalog/Test/Mftf/ActionGroup/AddProductToCartActionGroup.xml"
+  module: "Catalog"
+  actiongroups:
+     - name: "AddSimpleProductToCart"
+       description: "Navigates to the Storefront Product page. Then adds the Product to the Cart. Validates that the Success Message is present and correct."
 
-     - name: "StorefrontCheckSearchIsEmpty"
-       description: "Validates that the 'No Results' message is present and correct on the Storefront Search Results page. PLEASE NOTE: The expected message is Hardcoded."
- 
+     - name: "StorefrontAddSimpleProductWithQtyActionGroup"
+       description: ""
+- filename: "AddUpSellProductBySkuActionGroup.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/Catalog/Test/Mftf/ActionGroup/AddUpSellProductBySkuActionGroup.xml"
+  module: "Catalog"
+  actiongroups:
+     - name: "AddUpSellProductBySkuActionGroup"
+       description: "EXTENDS: AddRelatedProductBySkuActionGroup. Add the provided Product as an Up Sell Product."
+- filename: "ResetProductGridToDefaultViewActionGroup.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/Catalog/Test/Mftf/ActionGroup/ResetProductGridToDefaultViewActionGroup.xml"
+  module: "Catalog"
+  actiongroups:
+     - name: "ResetProductGridToDefaultViewActionGroup"
+       description: "Sets the Admin Products grid view to the 'Default View'."
+- filename: "AssertAdminProductFormAdvancedPricingCheckTierPriceActionGroup.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/Catalog/Test/Mftf/ActionGroup/AssertAdminProductFormAdvancedPricingCheckTierPriceActionGroup.xml"
+  module: "Catalog"
+  actiongroups:
+     - name: "AssertAdminProductFormAdvancedPricingCheckTierPriceActionGroup"
+       description: "Check AdvancedPricing tier price row."
+- filename: "DeleteProductAttributeByLabelActionGroup.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/Catalog/Test/Mftf/ActionGroup/DeleteProductAttributeByLabelActionGroup.xml"
+  module: "Catalog"
+  actiongroups:
+     - name: "DeleteProductAttributeByLabelActionGroup"
+       description: "Goes to the Admin Product Attributes grid page. Filters the grid for the provided Product Attribute (Label). Deletes the Product Attribute from the grid. Validates that the Success Message is present."
+- filename: "NavigateToCreatedProductAttributeActionGroup.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/Catalog/Test/Mftf/ActionGroup/NavigateToCreatedProductAttributeActionGroup.xml"
+  module: "Catalog"
+  actiongroups:
+     - name: "NavigateToCreatedProductAttributeActionGroup"
+       description: "Goes to the Product Attributes grid page. Filters the grid based on the provided Product Attribute. Clicks on the 1st row."
+- filename: "StorefrontProductActionGroup.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/Catalog/Test/Mftf/ActionGroup/StorefrontProductActionGroup.xml"
+  module: "Catalog"
+  actiongroups:
+     - name: "StorefrontCheckSimpleProduct"
+       description: "Validates that the provided Simple Product information is present and correct."
+
+     - name: "assertProductImageStorefrontProductPage"
+       description: "Validates that the provided Product Image is present."
+
+     - name: "assertProductImageStorefrontProductPage2"
+       description: "Validates that the provided Product Image is present."
+
+     - name: "assertProductImageNotInStorefrontProductPage"
+       description: "Validates that the provided Product Image is not present."
+
+     - name: "assertProductImageNotInStorefrontProductPage2"
+       description: "Validates that the provided Product Image is not present."
+- filename: "AdminOpenAttributeSetByNameActionGroup.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/Catalog/Test/Mftf/ActionGroup/AdminOpenAttributeSetByNameActionGroup.xml"
+  module: "Catalog"
+  actiongroups:
+     - name: "AdminOpenAttributeSetByNameActionGroup"
+       description: ""
+- filename: "AdminProductFormAdvancedPricingAddTierPriceActionGroup.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/Catalog/Test/Mftf/ActionGroup/AdminProductFormAdvancedPricingAddTierPriceActionGroup.xml"
+  module: "Catalog"
+  actiongroups:
+     - name: "AdminProductFormAdvancedPricingAddTierPriceActionGroup"
+       description: "Add new tier price on Advanced Pricing dialog on the Admin Product creation/edit page."
+- filename: "AdminProductAttributeMassUpdateActionGroup.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/Catalog/Test/Mftf/ActionGroup/AdminProductAttributeMassUpdateActionGroup.xml"
+  module: "Catalog"
+  actiongroups:
+     - name: "AdminUpdateProductNameAndDescriptionAttributes"
+       description: ""
+- filename: "AdminAddAdvancedPricingToTheProductActionGroup.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/Catalog/Test/Mftf/ActionGroup/AdminAddAdvancedPricingToTheProductActionGroup.xml"
+  module: "Catalog"
+  actiongroups:
+     - name: "AdminAddAdvancedPricingToTheProductActionGroup"
+       description: "Clicks 'Advanced Pricing' on the Admin Product creation/edit page. Fills in the provided Group Price at the provided Index for CE/EE. Clicks on Done."
+
+     - name: "AdminAddAdvancedPricingToTheProductExtendedActionGroup"
+       description: "EXTENDS: AdminAddAdvancedPricingToTheProductActionGroup. Removes 'selectProductTierPriceCustomerGroupInput'. Selects the provided Group Price at the provided Index for B2B."
+- filename: "VerifyProductTypeOrderActionGroup.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/Catalog/Test/Mftf/ActionGroup/VerifyProductTypeOrderActionGroup.xml"
+  module: "Catalog"
+  actiongroups:
+     - name: "VerifyProductTypeOrder"
+       description: "Clicks on the 'Add Product' toggle. Validates that the Simple/Virtual Products are listed in the correct order."
+- filename: "FillNewProductCategoryActionGroup.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/Catalog/Test/Mftf/ActionGroup/FillNewProductCategoryActionGroup.xml"
+  module: "Catalog"
+  actiongroups:
+     - name: "FillNewProductCategoryActionGroup"
+       description: "Actions to fill out a new category from the product page with specified category and parent category names."
+- filename: "AssertStorefrontCategorySimpleProductShownActionGroup.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/Catalog/Test/Mftf/ActionGroup/AssertStorefrontCategorySimpleProductShownActionGroup.xml"
+  module: "Catalog"
+  actiongroups:
+     - name: "AssertStorefrontCategorySimpleProductShownActionGroup"
+       description: "Validate that the provided Simple Product is present and correct on a Category page."
+- filename: "OpenProductAttributeFromSearchResultInGridActionGroup.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/Catalog/Test/Mftf/ActionGroup/OpenProductAttributeFromSearchResultInGridActionGroup.xml"
+  module: "Catalog"
+  actiongroups:
+     - name: "OpenProductAttributeFromSearchResultInGridActionGroup"
+       description: "EXTENDS: SearchAttributeByCodeOnProductAttributeGridActionGroup. Click on Edit for the provided Product Attribute Code."
+- filename: "AdminOpenProductAttributePageActionGroup.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/Catalog/Test/Mftf/ActionGroup/AdminOpenProductAttributePageActionGroup.xml"
+  module: "Catalog"
+  actiongroups:
+     - name: "AdminOpenProductAttributePageActionGroup"
+       description: ""
+- filename: "AdminAnchorCategoryActionGroup.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/Catalog/Test/Mftf/ActionGroup/AdminAnchorCategoryActionGroup.xml"
+  module: "Catalog"
+  actiongroups:
+     - name: "AdminAnchorCategoryActionGroup"
+       description: ""
+- filename: "NavigateToCreatedCategoryActionGroup.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/Catalog/Test/Mftf/ActionGroup/NavigateToCreatedCategoryActionGroup.xml"
+  module: "Catalog"
+  actiongroups:
+     - name: "NavigateToCreatedCategoryActionGroup"
+       description: "Navigates to category page, selects a category by specified category."
+- filename: "StorefrontAssertProductImagesOnProductPageActionGroup.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/Catalog/Test/Mftf/ActionGroup/StorefrontAssertProductImagesOnProductPageActionGroup.xml"
+  module: "Catalog"
+  actiongroups:
+     - name: "StorefrontAssertProductImagesOnProductPageActionGroup"
+       description: "Validate that the Product Image is present and correct. Validate that the Fullscreen Product Image is present and correct."
+
+     - name: "StorefrontAssertFotoramaImageAvailablity"
+       description: ""
+- filename: "StorefrontAddProductReviewActionGroup.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/Catalog/Test/Mftf/ActionGroup/StorefrontAddProductReviewActionGroup.xml"
+  module: "Catalog"
+  actiongroups:
+     - name: "StorefrontAddProductReviewActionGroup"
+       description: ""
+- filename: "AdminProductFormDoneAdvancedPricingDialogActionGroup.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/Catalog/Test/Mftf/ActionGroup/AdminProductFormDoneAdvancedPricingDialogActionGroup.xml"
+  module: "Catalog"
+  actiongroups:
+     - name: "AdminProductFormDoneAdvancedPricingDialogActionGroup"
+       description: "Done Advanced Pricing dialog from product form."
+- filename: "ExpandAdminProductSectionActionGroup.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/Catalog/Test/Mftf/ActionGroup/ExpandAdminProductSectionActionGroup.xml"
+  module: "Catalog"
+  actiongroups:
+     - name: "ExpandAdminProductSectionActionGroup"
+       description: "Expand the provided Section Selector based on the provided dependant Section Selector."
+- filename: "AssertProductInfoOnEditPageActionGroup.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/Catalog/Test/Mftf/ActionGroup/AssertProductInfoOnEditPageActionGroup.xml"
+  module: "Catalog"
+  actiongroups:
+     - name: "AssertProductInfoOnEditPageActionGroup"
+       description: "Validate that the provided Product details are correct on the Product creation/edit page."
+- filename: "AdminSaveCategoryFormActionGroup.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/Catalog/Test/Mftf/ActionGroup/AdminSaveCategoryFormActionGroup.xml"
+  module: "Catalog"
+  actiongroups:
+     - name: "AdminSaveCategoryFormActionGroup"
+       description: "Save category edit form in Admin and check success message."
+- filename: "AdminAssertProductsGridIsEmptyActionGroup.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/Catalog/Test/Mftf/ActionGroup/AdminAssertProductsGridIsEmptyActionGroup.xml"
+  module: "Catalog"
+  actiongroups:
+     - name: "AdminAssertProductsGridIsEmptyActionGroup"
+       description: ""
+- filename: "StorefrontAssertProductInWidgetActionGroup.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/Catalog/Test/Mftf/ActionGroup/StorefrontAssertProductInWidgetActionGroup.xml"
+  module: "Catalog"
+  actiongroups:
+     - name: "StorefrontAssertProductInRecentlyViewedWidgetActionGroup"
+       description: "Validate that the provided Product appears in the Recently Viewed Products widget."
+
+     - name: "StorefrontAssertProductInRecentlyComparedWidgetActionGroup"
+       description: "Validate that the provided Product appears in the Recently Compared Products widget."
+
+     - name: "StorefrontAssertProductInRecentlyOrderedWidgetActionGroup"
+       description: "Validate that the provided Product appears in the Recently Ordered Products widget."
+- filename: "SaveProductAttributeActionGroup.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/Catalog/Test/Mftf/ActionGroup/SaveProductAttributeActionGroup.xml"
+  module: "Catalog"
+  actiongroups:
+     - name: "SaveProductAttributeActionGroup"
+       description: "Clicks on Save. Validates that the Success Message is present."
+- filename: "AssertProductNameAndSkuInStorefrontProductPageActionGroup.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/Catalog/Test/Mftf/ActionGroup/AssertProductNameAndSkuInStorefrontProductPageActionGroup.xml"
+  module: "Catalog"
+  actiongroups:
+     - name: "AssertProductNameAndSkuInStorefrontProductPageActionGroup"
+       description: "Goes to the Storefront Product page for the provided Product. Validates that the Product details are present and correct."
+- filename: "AssertStorefrontProductPriceInCategoryPageActionGroup.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/Catalog/Test/Mftf/ActionGroup/AssertStorefrontProductPriceInCategoryPageActionGroup.xml"
+  module: "Catalog"
+  actiongroups:
+     - name: "AssertStorefrontProductPriceInCategoryPageActionGroup"
+       description: "Goes to Storefront Category page for the provided Category. Validates that the Product price is present and correct."
+- filename: "FilterProductGridByNameActionGroup.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/Catalog/Test/Mftf/ActionGroup/FilterProductGridByNameActionGroup.xml"
+  module: "Catalog"
+  actiongroups:
+     - name: "FilterProductGridByNameActionGroup"
+       description: "Filters the Admin Products grid by the provided Product (Name)."
+- filename: "AddRelatedProductBySkuActionGroup.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/Catalog/Test/Mftf/ActionGroup/AddRelatedProductBySkuActionGroup.xml"
+  module: "Catalog"
+  actiongroups:
+     - name: "AddRelatedProductBySkuActionGroup"
+       description: "Adds the provided Product SKU as a Related Product on the Admin Product creation/edit page."
+- filename: "AssertProductDetailsOnStorefrontActionGroup.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/Catalog/Test/Mftf/ActionGroup/AssertProductDetailsOnStorefrontActionGroup.xml"
+  module: "Catalog"
+  actiongroups:
+     - name: "AssertProductDetailsOnStorefrontActionGroup"
+       description: "Validates that the provided Product Info does NOT appear in the Product Number on a Storefront Category page."
+- filename: "StorefrontCompareActionGroup.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/Catalog/Test/Mftf/ActionGroup/StorefrontCompareActionGroup.xml"
+  module: "Catalog"
+  actiongroups:
+     - name: "StorefrontAddCategoryProductToCompareActionGroup"
+       description: "Add a Product to the Compare Product list from a Category page."
+
+     - name: "StorefrontAddProductToCompareActionGroup"
+       description: "Add a Product to the Compare Product list. Validate that the Success Message is present."
+
+     - name: "StorefrontCheckCompareSidebarProductActionGroup"
+       description: "Validate that the Product Name is present and correct in the Compare Product list."
+
+     - name: "StorefrontOpenAndCheckComparisionActionGroup"
+       description: "Open the Storefront Compare Product page. Validate that the Compare Product fields are present."
+
+     - name: "StorefrontCheckCompareSimpleProductActionGroup"
+       description: "Validate that the Simple Product is present and correct in the Compare Product area."
+
+     - name: "StorefrontClearCompareActionGroup"
+       description: "Clear the Compare Products list. Validate that the Compare Products list is empty."
+- filename: "AssertStorefrontAttributeOptionPresentInLayeredNavigationActionGroup.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/Catalog/Test/Mftf/ActionGroup/AssertStorefrontAttributeOptionPresentInLayeredNavigationActionGroup.xml"
+  module: "Catalog"
+  actiongroups:
+     - name: "AssertStorefrontAttributeOptionPresentInLayeredNavigationActionGroup"
+       description: "Clicks on the attribute label. Checks for attribute option presence."
+- filename: "StorefrontOpenProductPageActionGroup.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/Catalog/Test/Mftf/ActionGroup/StorefrontOpenProductPageActionGroup.xml"
+  module: "Catalog"
+  actiongroups:
+     - name: "StorefrontOpenProductPageActionGroup"
+       description: "Goes to the Storefront Product page for the provided Product URL."
+
+     - name: "StorefrontOpenProductPageOnSecondStore"
+       description: "Goes to the Storefront Product page for the provided store code and Product URL."
+- filename: "AdminProductFormOpenAdvancedPricingDialogActionGroup.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/Catalog/Test/Mftf/ActionGroup/AdminProductFormOpenAdvancedPricingDialogActionGroup.xml"
+  module: "Catalog"
+  actiongroups:
+     - name: "AdminProductFormOpenAdvancedPricingDialogActionGroup"
+       description: "Open Advanced Pricing dialog from product form."
+- filename: "DeleteProductUsingProductGridActionGroup.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/Catalog/Test/Mftf/ActionGroup/DeleteProductUsingProductGridActionGroup.xml"
+  module: "Catalog"
+  actiongroups:
+     - name: "DeleteProductUsingProductGridActionGroup"
+       description: "Deletes the provided Product from the Admin Products grid page."
+- filename: "SaveProductFormActionGroup.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/Catalog/Test/Mftf/ActionGroup/SaveProductFormActionGroup.xml"
+  module: "Catalog"
+  actiongroups:
+     - name: "SaveProductFormActionGroup"
+       description: "Clicks on the Save button. Validates that the Success Message is present and correct."
+- filename: "AdminSetProductDesignSettingsActionGroup.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/Catalog/Test/Mftf/ActionGroup/AdminSetProductDesignSettingsActionGroup.xml"
+  module: "Catalog"
+  actiongroups:
+     - name: "AdminSetProductDesignSettingsActionGroup"
+       description: ""
+- filename: "AssertStorefrontProductPricesActionGroup.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/Catalog/Test/Mftf/ActionGroup/AssertStorefrontProductPricesActionGroup.xml"
+  module: "Catalog"
+  actiongroups:
+     - name: "AssertStorefrontProductPricesActionGroup"
+       description: "Validates that the provided Product Price and Final Product Price are present on the Storefront Product page."
+- filename: "StorefrontAddProductToCartFromProductPageActionGroup.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/Catalog/Test/Mftf/ActionGroup/StorefrontAddProductToCartFromProductPageActionGroup.xml"
+  module: "Catalog"
+  actiongroups:
+     - name: "StorefrontAddProductToCartFromProductPageActionGroup"
+       description: "Click on the Add to Cart button. Validates that the Success Message is present."
+- filename: "StorefrontOpenHomePageActionGroup.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/Catalog/Test/Mftf/ActionGroup/StorefrontOpenHomePageActionGroup.xml"
+  module: "Catalog"
+  actiongroups:
+     - name: "StorefrontOpenHomePageActionGroup"
+       description: "Goes to the Storefront Homepage."
+- filename: "StorefrontAssertProductSpecialPriceOnProductPageActionGroup.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/Catalog/Test/Mftf/ActionGroup/StorefrontAssertProductSpecialPriceOnProductPageActionGroup.xml"
+  module: "Catalog"
+  actiongroups:
+     - name: "StorefrontAssertProductSpecialPriceOnProductPageActionGroup"
+       description: "Goes to the provided Storefront Product page. Validates that the provided Special Price is present and correct."
+- filename: "AdminProductAttributeActionGroup.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/Catalog/Test/Mftf/ActionGroup/AdminProductAttributeActionGroup.xml"
+  module: "Catalog"
+  actiongroups:
+     - name: "navigateToCreatedProductAttribute"
+       description: "Goes to the Product Attributes grid page. Filters the grid based on the provided Product Attribute. Clicks on the 1st row."
+
+     - name: "navigateToEditProductAttribute"
+       description: "Goes to the Product Attributes grid page. Filters the grid based on the provided Product Attribute. Clicks on the 1st row."
+
+     - name: "AdminCreateAttributeFromProductPage"
+       description: "From the Product creation/edit page, under 'Configurations', Clicks on 'Create Configurations'. Clicks on 'Create New Attribute'. Fills Label. Selects Type. Clicks on Save."
+
+     - name: "AdminCreateAttributeFromProductPageWithScope"
+       description: ""
+
+     - name: "AdminCreateAttributeWithValueWithTwoStoreViesFromProductPage"
+       description: "EXTENDS: AdminCreateAttributeFromProductPage. Adds the 2 provided Store Views to a Product. Clicks on Save."
+
+     - name: "AdminProductPageCreateAttributeSetWithAttribute"
+       description: "Adds the provided Product Attribute Set to a Product on the Product creation/edit page."
+
+     - name: "AdminCreateAttributeWithSearchWeight"
+       description: "EXTENDS: AdminProductPageCreateAttributeSetWithAttribute. Sets the provided Search Weight and Default Values."
+
+     - name: "AdminProductPageSelectAttributeSet"
+       description: "Selects the provided Attribute Set from the Admin Product creation/edit page."
+
+     - name: "AdminProductPageFillTextAttributeValueByName"
+       description: "Fills in the Attribute Name field with the provided value."
+
+     - name: "changeUseForPromoRuleConditionsProductAttribute"
+       description: "Select the provided value for the 'Use for Promo Rule Conditions' dropdown menu. Clicks on Save. Validates that the Save message is present."
+
+     - name: "deleteProductAttribute"
+       description: "EXTENDS: navigateToCreatedProductAttribute. Deletes the Product Attribute. Validates that the success message is present."
+
+     - name: "deleteProductAttributeByLabel"
+       description: "Goes to the Admin Product Attributes grid page. Filters the grid for the provided Product Attribute (Label). Deletes the Product Attribute from the grid. Validates that the Success Message is present."
+
+     - name: "deleteProductAttributeByAttributeCode"
+       description: "Goes to the Admin Product Attributes grid page. Filters the grid for the provided Product Attribute Code. Deletes the Product Attribute from the grid. Validates that the Success Message is present."
+
+     - name: "filterProductAttributeByAttributeCode"
+       description: "Filters the Product Attributes grid by the provided Product Attribute Code."
+
+     - name: "filterProductAttributeByDefaultLabel"
+       description: "Filters the Product Attributes grid by the provided Product Attribute Label."
+
+     - name: "saveProductAttribute"
+       description: "Clicks on Save. Validates that the Success Message is present."
+
+     - name: "confirmChangeInputTypeModal"
+       description: "Clicks on the Confirm button for the 'Product Data My Be Lost' modal."
+
+     - name: "saveProductAttributeInUse"
+       description: "Clicks on Save. Validates that the Success Message is present."
+
+     - name: "addProductAttributeInProductModal"
+       description: "Adds the provided Attribute Code to the Product on the Admin Product creation/edit page."
+
+     - name: "createProductAttribute"
+       description: "Clicks on 'Add New Attribute'. Fills in the Attribute Details (Label, Input Type and Value Required). Clicks on Save."
+
+     - name: "AdminCreateSearchableProductAttribute"
+       description: ""
+
+     - name: "createProductAttributeWithTextField"
+       description: "EXTENDS: createProductAttribute. Fills in the Attribute Code and Default Value (Attribute Type: Text Field)."
+
+     - name: "createProductAttributeWithDateField"
+       description: "EXTENDS: createProductAttribute. Fills in the Attribute Code and Default Value (Attribute Type: Date Field)."
+
+     - name: "createAttributeDropdownNthOption"
+       description: "Creates an Option for a Product Attribute (Attribute Type: Dropdown)."
+
+     - name: "createAttributeDropdownNthOptionAsDefault"
+       description: "EXTENDS: createAttributeDropdownNthOption. Checks the 'Is Default' option."
+- filename: "CustomOptionsActionGroup.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/Catalog/Test/Mftf/ActionGroup/CustomOptionsActionGroup.xml"
+  module: "Catalog"
+  actiongroups:
+     - name: "CreateCustomRadioOptions"
+       description: "Adds a custom Radio Product Option with 3 Radio Options to a Product based on the provided Options."
+
+     - name: "AddProductCustomOptionFile"
+       description: "Add a custom File Product Option to a Product based on the provided File."
+
+     - name: "AddProductCustomOptionField"
+       description: "Add a custom Field Product Option to a Product based on the provided Option."
+
+     - name: "importProductCustomizableOptions"
+       description: "Import custom Product Options for the provided Product Name."
+
+     - name: "resetImportOptionFilter"
+       description: "Click on the Reset Filters button for the Import Options filters on the Product grid page."
+
+     - name: "checkCustomizableOptionImport"
+       description: "Validate that the Custom Product Option Import value is present and correct."
+
+     - name: "AdminDeleteAllProductCustomOptions"
+       description: ""
+
+     - name: "AdminAssertProductHasNoCustomOptions"
+       description: ""
+
+     - name: "AdminAssertProductHasNoCustomOption"
+       description: ""
+
+     - name: "AdminAssertProductCustomOptionVisible"
+       description: ""
+
+     - name: "AdminDeleteProductCustomOption"
+       description: ""
+- filename: "AssertAttributeDeletionErrorMessageActionGroup.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/Catalog/Test/Mftf/ActionGroup/AssertAttributeDeletionErrorMessageActionGroup.xml"
+  module: "Catalog"
+  actiongroups:
+     - name: "AssertAttributeDeletionErrorMessageActionGroup"
+       description: "Validates that the Error Message is present and correct on the Backend Admin Attribute Sets creation/edit page when you try to delete an Attribute Set assigned to a Configurable Product. PLEASE NOTE: The Error Message is hardcoded."
+- filename: "OpenProductFromCategoryPageActionGroup.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/Catalog/Test/Mftf/ActionGroup/OpenProductFromCategoryPageActionGroup.xml"
+  module: "Catalog"
+  actiongroups:
+     - name: "OpenProductFromCategoryPageActionGroup"
+       description: "Goto the provided Category page. Click on the provided Product page."
+- filename: "AdminClickOnAdvancedInventoryLinkActionGroup.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/Catalog/Test/Mftf/ActionGroup/AdminClickOnAdvancedInventoryLinkActionGroup.xml"
+  module: "Catalog"
+  actiongroups:
+     - name: "AdminClickOnAdvancedInventoryLinkActionGroup"
+       description: "Clicks on the 'Advanced Inventory' link on the Admin Product creation/edit page."
+
+     - name: "AdminClickOnAdvancedInventoryButtonActionGroup"
+       description: "Clicks on the 'Advanced Inventory' link on the Admin Product creation/edit page."
+- filename: "AdminFillAttributeDataProductFormNewAttributeActionGroup.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/Catalog/Test/Mftf/ActionGroup/AdminFillAttributeDataProductFormNewAttributeActionGroup.xml"
+  module: "Catalog"
+  actiongroups:
+     - name: "AdminFillAttributeDataProductFormNewAttributeActionGroup"
+       description: "Fill attribute data on 'Create New Attribute' page  Admin Product creation/edit page ."
+- filename: "AdminClickAddAttributeOnProductEditPageActionGroup.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/Catalog/Test/Mftf/ActionGroup/AdminClickAddAttributeOnProductEditPageActionGroup.xml"
+  module: "Catalog"
+  actiongroups:
+     - name: "AdminClickAddAttributeOnProductEditPageActionGroup"
+       description: "Clicks on 'Add Attribute'.  Admin Product creation/edit page ."
+- filename: "AssertStorefrontCustomProductAttributeActionGroup.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/Catalog/Test/Mftf/ActionGroup/AssertStorefrontCustomProductAttributeActionGroup.xml"
+  module: "Catalog"
+  actiongroups:
+     - name: "AssertStorefrontCustomProductAttributeActionGroup"
+       description: ""
+- filename: "StorefrontGoToCategoryPageActionGroup.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/Catalog/Test/Mftf/ActionGroup/StorefrontGoToCategoryPageActionGroup.xml"
+  module: "Catalog"
+  actiongroups:
+     - name: "StorefrontGoToCategoryPageActionGroup"
+       description: ""
+
+     - name: "StorefrontGoToSubCategoryPageActionGroup"
+       description: ""
+- filename: "StorefrontClickAddToCartOnProductPageActionGroup.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/Catalog/Test/Mftf/ActionGroup/StorefrontClickAddToCartOnProductPageActionGroup.xml"
+  module: "Catalog"
+  actiongroups:
+     - name: "StorefrontClickAddToCartOnProductPageActionGroup"
+       description: "Adds a Product to the Cart. Validate that the Success Message is present."
+- filename: "NavigateToAndResetProductAttributeGridToDefaultViewActionGroup.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/Catalog/Test/Mftf/ActionGroup/NavigateToAndResetProductAttributeGridToDefaultViewActionGroup.xml"
+  module: "Catalog"
+  actiongroups:
+     - name: "NavigateToAndResetProductAttributeGridToDefaultViewActionGroup"
+       description: "Goes to the Product Attributes grid. Clicks on 'Clear Filters'."
+- filename: "AdminFillAdvancedInventoryOutOfStockThresholdActionGroup.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/Catalog/Test/Mftf/ActionGroup/AdminFillAdvancedInventoryOutOfStockThresholdActionGroup.xml"
+  module: "Catalog"
+  actiongroups:
+     - name: "AdminFillAdvancedInventoryOutOfStockThresholdActionGroup"
+       description: "Unchecks 'Use Config Setting' for the 'Minimum Qty Allowed in Shopping Cart' option in 'Advanced Inventory' panel on the Admin Product creation/edit page. Fills in the provided Quantity."
+- filename: "AdminCreateCustomDropDownOptionsActionGroup.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/Catalog/Test/Mftf/ActionGroup/AdminCreateCustomDropDownOptionsActionGroup.xml"
+  module: "Catalog"
+  actiongroups:
+     - name: "AdminCreateCustomDropDownOptionsActionGroup"
+       description: "Clicks on 'Add Option'. Adds the 2 provided Options under the provided Custom Option Name to a Product on the Admin Product creation/edit page under the 'Customizable Options' section."
+- filename: "CheckProductsOrderActionGroup.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/Catalog/Test/Mftf/ActionGroup/CheckProductsOrderActionGroup.xml"
+  module: "Catalog"
+  actiongroups:
+     - name: "CompareTwoProductsOrder"
+       description: "Goes to the Storefront. Validates that the 2 provided Products appear in the correct order."
+- filename: "OpenStorefrontProductPageByProductNameActionGroup.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/Catalog/Test/Mftf/ActionGroup/OpenStorefrontProductPageByProductNameActionGroup.xml"
+  module: "Catalog"
+  actiongroups:
+     - name: "OpenStorefrontProductPageByProductNameActionGroup"
+       description: ""
+- filename: "AdminAddProductCustomOptionActionGroup.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/Catalog/Test/Mftf/ActionGroup/AdminAddProductCustomOptionActionGroup.xml"
+  module: "Catalog"
+  actiongroups:
+     - name: "AdminAddProductCustomOptionActionGroup"
+       description: "Adds the provided Custom Option Title/Type to a Product on the Admin Product creation/edit page under the 'Customizable Options' section."
+- filename: "AddSimpleProductToCartActionGroup.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/Catalog/Test/Mftf/ActionGroup/AddSimpleProductToCartActionGroup.xml"
+  module: "Catalog"
+  actiongroups:
+     - name: "AddSimpleProductToCartActionGroup"
+       description: "Navigates to the Storefront Product page. Then adds the Product to the Cart. Validates that the Success Message is present and correct."
+- filename: "AssertSeeProductDetailsOnStorefrontRecentlyViewedWidgetActionGroup.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/Catalog/Test/Mftf/ActionGroup/AssertSeeProductDetailsOnStorefrontRecentlyViewedWidgetActionGroup.xml"
+  module: "Catalog"
+  actiongroups:
+     - name: "AssertSeeProductDetailsOnStorefrontRecentlyViewedWidgetActionGroup"
+       description: "Goes to the home Page Recently VIewed Product and Grab the Prdouct name and Position from it."
+- filename: "FillMainProductFormByStringActionGroup.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/Catalog/Test/Mftf/ActionGroup/FillMainProductFormByStringActionGroup.xml"
+  module: "Catalog"
+  actiongroups:
+     - name: "FillMainProductFormByStringActionGroup"
+       description: "Fills in the provided Product Name, SKU, Price, Quantity, Stock Status and Weight on the Admin Products creation/edit page."
+- filename: "StorefrontSelectCustomOptionDropDownAndAssertPricesActionGroup.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/Catalog/Test/Mftf/ActionGroup/StorefrontSelectCustomOptionDropDownAndAssertPricesActionGroup.xml"
+  module: "Catalog"
+  actiongroups:
+     - name: "StorefrontSelectCustomOptionDropDownAndAssertPricesActionGroup"
+       description: "EXTENDS: AssertStorefrontProductPricesActionGroup. Selects the provided Custom Product Option on a Storefront Product page."
+- filename: "FillAdminSimpleProductFormActionGroup.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/Catalog/Test/Mftf/ActionGroup/FillAdminSimpleProductFormActionGroup.xml"
+  module: "Catalog"
+  actiongroups:
+     - name: "FillAdminSimpleProductFormActionGroup"
+       description: "Goes to the Admin Product grid page. Clicks on Add. Fills the provided Product details (Name, SKU, Price, Quantity, Category and URL). Clicks on Save. Validates that the Product details are present and correct."
 - filename: "AdminProductGridActionGroup.xml"
-  repo: "https://github.com/magento/magento2/blob/2.3/app/code/Magento/Catalog/Test/Mftf/ActionGroup/AdminProductGridActionGroup.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/Catalog/Test/Mftf/ActionGroup/AdminProductGridActionGroup.xml"
   module: "Catalog"
   actiongroups:
      - name: "resetProductGridToDefaultView"
@@ -1266,67 +2406,50 @@
 
      - name: "deleteAllProductsUsingProductGrid"
        description: "Deletes all products in Admin Products grid page."
- 
-- filename: "DeleteProductActionGroup.xml"
-  repo: "https://github.com/magento/magento2/blob/2.3/app/code/Magento/Catalog/Test/Mftf/ActionGroup/DeleteProductActionGroup.xml"
+- filename: "CreateNewProductActionGroup.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/Catalog/Test/Mftf/ActionGroup/CreateNewProductActionGroup.xml"
   module: "Catalog"
   actiongroups:
-     - name: "DeleteProductActionGroup"
-       description: "Deletes the provided Product Name from the Product grid page."
- 
-- filename: "AssertDontSeeProductDetailsOnStorefrontActionGroup.xml"
-  repo: "https://github.com/magento/magento2/blob/2.3/app/code/Magento/Catalog/Test/Mftf/ActionGroup/AssertDontSeeProductDetailsOnStorefrontActionGroup.xml"
+     - name: "CreateNewProductActionGroup"
+       description: "Goes to the Product creation/edit page. Fills in Product Name, Price and Quantity. Then Saves the work."
+- filename: "AdminSubmitAdvancedInventoryFormActionGroup.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/Catalog/Test/Mftf/ActionGroup/AdminSubmitAdvancedInventoryFormActionGroup.xml"
   module: "Catalog"
   actiongroups:
-     - name: "AssertDontSeeProductDetailsOnStorefrontActionGroup"
-       description: "Validates that the provided Product Info does NOT appear in the Product Number on a Storefront Category page."
- 
-- filename: "StorefrontAssertProductNameOnProductMainPageActionGroup.xml"
-  repo: "https://github.com/magento/magento2/blob/2.3/app/code/Magento/Catalog/Test/Mftf/ActionGroup/StorefrontAssertProductNameOnProductMainPageActionGroup.xml"
+     - name: "AdminSubmitAdvancedInventoryFormActionGroup"
+       description: "Clicks on Done on the Admin Product creation/edit page on the 'Advanced Inventory' panel."
+- filename: "AssertStorefrontProductControlsAreVisibleOnHoverActionGroup.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/Catalog/Test/Mftf/ActionGroup/AssertStorefrontProductControlsAreVisibleOnHoverActionGroup.xml"
   module: "Catalog"
   actiongroups:
-     - name: "StorefrontAssertProductNameOnProductMainPageActionGroup"
-       description: "Validates that the provided Product Name is present and correct on a Storefront Category page."
- 
-- filename: "CustomOptionsActionGroup.xml"
-  repo: "https://github.com/magento/magento2/blob/2.3/app/code/Magento/Catalog/Test/Mftf/ActionGroup/CustomOptionsActionGroup.xml"
+     - name: "AssertStorefrontProductControlsAreVisibleOnHoverActionGroup"
+       description: "Validate that the Product Controls Are Visible on Category Page on Hover on Product"
+- filename: "GoToProductPageViaIDActionGroup.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/Catalog/Test/Mftf/ActionGroup/GoToProductPageViaIDActionGroup.xml"
   module: "Catalog"
   actiongroups:
-     - name: "CreateCustomRadioOptions"
-       description: "Adds a custom Radio Product Option with 3 Radio Options to a Product based on the provided Options."
-
-     - name: "AddProductCustomOptionFile"
-       description: "Add a custom File Product Option to a Product based on the provided File."
-
-     - name: "AddProductCustomOptionField"
-       description: "Add a custom Field Product Option to a Product based on the provided Option."
-
-     - name: "importProductCustomizableOptions"
-       description: "Import custom Product Options for the provided Product Name."
-
-     - name: "resetImportOptionFilter"
-       description: "Click on the Reset Filters button for the Import Options filters on the Product grid page."
-
-     - name: "checkCustomizableOptionImport"
-       description: "Validate that the Custom Product Option Import value is present and correct."
-
-     - name: "AdminDeleteAllProductCustomOptions"
+     - name: "GoToProductPageViaIDActionGroup"
+       description: "Goes to the Product edit page for the provided Product ID."
+- filename: "AssertStorefrontProductIsPresentOnCategoryPageActionGroup.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/Catalog/Test/Mftf/ActionGroup/AssertStorefrontProductIsPresentOnCategoryPageActionGroup.xml"
+  module: "Catalog"
+  actiongroups:
+     - name: "AssertStorefrontProductIsPresentOnCategoryPageActionGroup"
+       description: "Validate that the provided Product is present and has correct name on a Category page."
+- filename: "AdminOpenAttributeSetGridPageActionGroup.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/Catalog/Test/Mftf/ActionGroup/AdminOpenAttributeSetGridPageActionGroup.xml"
+  module: "Catalog"
+  actiongroups:
+     - name: "AdminOpenAttributeSetGridPageActionGroup"
        description: ""
-
-     - name: "AdminAssertProductHasNoCustomOptions"
+- filename: "StorefrontAssertGiftMessageFieldsActionGroup.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/Catalog/Test/Mftf/ActionGroup/StorefrontAssertGiftMessageFieldsActionGroup.xml"
+  module: "Catalog"
+  actiongroups:
+     - name: "StorefrontAssertGiftMessageFieldsActionGroup"
        description: ""
-
-     - name: "AdminAssertProductHasNoCustomOption"
-       description: ""
-
-     - name: "AdminAssertProductCustomOptionVisible"
-       description: ""
-
-     - name: "AdminDeleteProductCustomOption"
-       description: ""
- 
 - filename: "StorefrontCategoryActionGroup.xml"
-  repo: "https://github.com/magento/magento2/blob/2.3/app/code/Magento/Catalog/Test/Mftf/ActionGroup/StorefrontCategoryActionGroup.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/Catalog/Test/Mftf/ActionGroup/StorefrontCategoryActionGroup.xml"
   module: "Catalog"
   actiongroups:
      - name: "GoToStorefrontCategoryPageByParameters"
@@ -1339,10 +2462,10 @@
        description: "Validate that the Storefront Category is present and correct."
 
      - name: "StorefrontCheckCategorySimpleProduct"
-       description: "Validate that the provided Simple Product is present and correct on a Category page."
+       description: "DEPRECATED Use AssertStorefrontCategorySimpleProductShownActionGroup. Validate that the provided Simple Product is present and correct on a Category page."
 
      - name: "AssertProductOnCategoryPageActionGroup"
-       description: "EXTENDS:StorefrontCheckCategorySimpleProduct. Removes 'AssertProductPrice', 'moveMouseOverProduct', 'AssertAddToCart'"
+       description: "DEPRECATED Use AssertStorefrontProductIsPresentOnCategoryPageActionGroup. EXTENDS:StorefrontCheckCategorySimpleProduct. Removes 'AssertProductPrice', 'moveMouseOverProduct', 'AssertAddToCart'"
 
      - name: "StorefrontCheckAddToCartButtonAbsence"
        description: ""
@@ -1352,205 +2475,65 @@
 
      - name: "GoToSubCategoryPage"
        description: "Goes to the Storefront page. Open the Parent Category menu in the Top Nav Menu. Click on a Subcategory. Validate that the Subcategory is present and correct."
- 
-- filename: "AssertProductInStorefrontProductPageActionGroup.xml"
-  repo: "https://github.com/magento/magento2/blob/2.3/app/code/Magento/Catalog/Test/Mftf/ActionGroup/AssertProductInStorefrontProductPageActionGroup.xml"
+- filename: "FilterProductGridBySku2ActionGroup.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/Catalog/Test/Mftf/ActionGroup/FilterProductGridBySku2ActionGroup.xml"
   module: "Catalog"
   actiongroups:
-     - name: "AssertProductInStorefrontProductPage"
-       description: "Goes to the Storefront page. Validates that the provided Product details are present."
-
-     - name: "AssertProductNameAndSkuInStorefrontProductPage"
-       description: "Goes to the Storefront Product page for the provided Product. Validates that the Product details are present and correct."
-
-     - name: "AssertProductNameAndSkuInStorefrontProductPageByCustomAttributeUrlKey"
-       description: "Goes to the Storefront Product page for the provided Product. Validates that the Product details are present and correct."
- 
-- filename: "AssertProductInStorefrontCategoryPageActionGroup.xml"
-  repo: "https://github.com/magento/magento2/blob/2.3/app/code/Magento/Catalog/Test/Mftf/ActionGroup/AssertProductInStorefrontCategoryPageActionGroup.xml"
+     - name: "FilterProductGridBySku2ActionGroup"
+       description: "Filters the Admin Products grid by the provided Product SKU."
+- filename: "OpenEditProductOnBackendActionGroup.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/Catalog/Test/Mftf/ActionGroup/OpenEditProductOnBackendActionGroup.xml"
   module: "Catalog"
   actiongroups:
-     - name: "AssertProductInStorefrontCategoryPage"
-       description: "Goes to Storefront Category page for the provided Category. Validates that the Product details are present and correct."
- 
-- filename: "OpenStoreFrontProductPageActionGroup.xml"
-  repo: "https://github.com/magento/magento2/blob/2.3/app/code/Magento/Catalog/Test/Mftf/ActionGroup/OpenStoreFrontProductPageActionGroup.xml"
+     - name: "OpenEditProductOnBackendActionGroup"
+       description: "Click on Edit for the provided Product SKU."
+- filename: "AdminAssertProductEditPageCreateAttributeSaveInAttributeSetPopUpShownActionGroup.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/Catalog/Test/Mftf/ActionGroup/AdminAssertProductEditPageCreateAttributeSaveInAttributeSetPopUpShownActionGroup.xml"
   module: "Catalog"
   actiongroups:
-     - name: "OpenStoreFrontProductPageActionGroup"
-       description: ""
- 
-- filename: "AddProductToCartActionGroup.xml"
-  repo: "https://github.com/magento/magento2/blob/2.3/app/code/Magento/Catalog/Test/Mftf/ActionGroup/AddProductToCartActionGroup.xml"
-  module: "Catalog"
-  actiongroups:
-     - name: "AddSimpleProductToCart"
-       description: "Navigates to the Storefront Product page. Then adds the Product to the Cart. Validates that the Success Message is present and correct."
-
-     - name: "StorefrontAddSimpleProductWithQtyActionGroup"
-       description: ""
- 
-- filename: "AdminAddTitleAndPriceValueToCustomOptionActionGroup.xml"
-  repo: "https://github.com/magento/magento2/blob/2.3/app/code/Magento/Catalog/Test/Mftf/ActionGroup/AdminAddTitleAndPriceValueToCustomOptionActionGroup.xml"
-  module: "Catalog"
-  actiongroups:
-     - name: "AdminAddTitleAndPriceValueToCustomOptionActionGroup"
-       description: "Clicks on 'Add Option'. Fills in the provided Custom Option Title/Type on the Admin Product creation/edit page under the 'Customizable Options' section."
- 
+     - name: "AdminAssertProductEditPageCreateAttributeSaveInAttributeSetPopUpShownActionGroup"
+       description: "Asserts that after click on 'Save In New Attribute Set' poup shown  ."
 - filename: "StorefrontOpenProductPageUsingStoreCodeInUrlActionGroup.xml"
-  repo: "https://github.com/magento/magento2/blob/2.3/app/code/Magento/Catalog/Test/Mftf/ActionGroup/StorefrontOpenProductPageUsingStoreCodeInUrlActionGroup.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/Catalog/Test/Mftf/ActionGroup/StorefrontOpenProductPageUsingStoreCodeInUrlActionGroup.xml"
   module: "Catalog"
   actiongroups:
      - name: "StorefrontOpenProductPageUsingStoreCodeInUrlActionGroup"
        description: ""
- 
-- filename: "StorefrontCategoryPageSortProductActionGroup.xml"
-  repo: "https://github.com/magento/magento2/blob/2.3/app/code/Magento/Catalog/Test/Mftf/ActionGroup/StorefrontCategoryPageSortProductActionGroup.xml"
+- filename: "StorefrontAssertProductNameOnProductPageActionGroup.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/Catalog/Test/Mftf/ActionGroup/StorefrontAssertProductNameOnProductPageActionGroup.xml"
   module: "Catalog"
   actiongroups:
-     - name: "StorefrontCategoryPageSortProductActionGroup"
-       description: "Select \"Sort by\" parameter for sorting Products on Category page"
+     - name: "StorefrontAssertProductNameOnProductPageActionGroup"
+       description: "Validate that the provided Product Price is present and correct."
+- filename: "AdminCheckProductsInGridActionGroup.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/Catalog/Test/Mftf/ActionGroup/AdminCheckProductsInGridActionGroup.xml"
+  module: "Catalog"
+  actiongroups:
+     - name: "AdminCheckProductIsMissingInCategoryProductsGrid"
+       description: ""
 
-     - name: "StorefrontCategoryPageSortAscendingActionGroup"
-       description: "Set Ascending Direction for sorting Products on Category page"
-
-     - name: "StorefrontCategoryPageSortDescendingActionGroup"
-       description: "Set Descending Direction for sorting Products on Category page"
- 
-- filename: "AdminOpenAttributeSetGridPageActionGroup.xml"
-  repo: "https://github.com/magento/magento2/blob/2.3/app/code/Magento/Catalog/Test/Mftf/ActionGroup/AdminOpenAttributeSetGridPageActionGroup.xml"
-  module: "Catalog"
-  actiongroups:
-     - name: "AdminOpenAttributeSetGridPageActionGroup"
+     - name: "AdminCheckProductPositionInCategoryProductsGrid"
        description: ""
- 
-- filename: "AssertSubTotalOnStorefrontMinicartActionGroup.xml"
-  repo: "https://github.com/magento/magento2/blob/2.3/app/code/Magento/Catalog/Test/Mftf/ActionGroup/AssertSubTotalOnStorefrontMinicartActionGroup.xml"
+- filename: "AssertStorefrontProductControlsAreNotVisibleWithoutHoverActionGroup.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/Catalog/Test/Mftf/ActionGroup/AssertStorefrontProductControlsAreNotVisibleWithoutHoverActionGroup.xml"
   module: "Catalog"
   actiongroups:
-     - name: "AssertSubTotalOnStorefrontMiniCartActionGroup"
-       description: "Validates that the provided Sub Total is present in the Storefront Mini Shopping Cart."
- 
-- filename: "AdminSetProductDesignSettingsActionGroup.xml"
-  repo: "https://github.com/magento/magento2/blob/2.3/app/code/Magento/Catalog/Test/Mftf/ActionGroup/AdminSetProductDesignSettingsActionGroup.xml"
+     - name: "AssertStorefrontProductControlsAreNotVisibleWithoutHoverActionGroup"
+       description: "Validate that the Product Controls Are Not Visible On Category Page Without Hover on Product"
+- filename: "AssertDontSeeProductDetailsOnStorefrontActionGroup.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/Catalog/Test/Mftf/ActionGroup/AssertDontSeeProductDetailsOnStorefrontActionGroup.xml"
   module: "Catalog"
   actiongroups:
-     - name: "AdminSetProductDesignSettingsActionGroup"
-       description: ""
- 
-- filename: "AdminCreateRootCategoryActionGroup.xml"
-  repo: "https://github.com/magento/magento2/blob/2.3/app/code/Magento/Catalog/Test/Mftf/ActionGroup/AdminCreateRootCategoryActionGroup.xml"
+     - name: "AssertDontSeeProductDetailsOnStorefrontActionGroup"
+       description: "Validates that the provided Product Info does NOT appear in the Product Number on a Storefront Category page."
+- filename: "AdminExpandProductAttributesTabActionGroup.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/Catalog/Test/Mftf/ActionGroup/AdminExpandProductAttributesTabActionGroup.xml"
   module: "Catalog"
   actiongroups:
-     - name: "AdminCreateRootCategory"
-       description: "Requires navigation to Category creation. Adds a new root category and asserts on creation."
- 
-- filename: "AssertAdminProductStockStatusActionGroup.xml"
-  repo: "https://github.com/magento/magento2/blob/2.3/app/code/Magento/Catalog/Test/Mftf/ActionGroup/AssertAdminProductStockStatusActionGroup.xml"
-  module: "Catalog"
-  actiongroups:
-     - name: "AssertAdminProductStockStatusActionGroup"
-       description: ""
- 
-- filename: "StorefrontSelectCustomOptionDropDownAndAssertPricesActionGroup.xml"
-  repo: "https://github.com/magento/magento2/blob/2.3/app/code/Magento/Catalog/Test/Mftf/ActionGroup/StorefrontSelectCustomOptionDropDownAndAssertPricesActionGroup.xml"
-  module: "Catalog"
-  actiongroups:
-     - name: "StorefrontSelectCustomOptionDropDownAndAssertPricesActionGroup"
-       description: "EXTENDS: AssertStorefrontProductPricesActionGroup. Selects the provided Custom Product Option on a Storefront Product page."
- 
-- filename: "AdminUnassignProductInWebsiteActionGroup.xml"
-  repo: "https://github.com/magento/magento2/blob/2.3/app/code/Magento/Catalog/Test/Mftf/ActionGroup/AdminUnassignProductInWebsiteActionGroup.xml"
-  module: "Catalog"
-  actiongroups:
-     - name: "AdminUnassignProductInWebsiteActionGroup"
-       description: ""
- 
-- filename: "AdminAddAdvancedPricingToTheProductActionGroup.xml"
-  repo: "https://github.com/magento/magento2/blob/2.3/app/code/Magento/Catalog/Test/Mftf/ActionGroup/AdminAddAdvancedPricingToTheProductActionGroup.xml"
-  module: "Catalog"
-  actiongroups:
-     - name: "AdminAddAdvancedPricingToTheProductActionGroup"
-       description: "Clicks 'Advanced Pricing' on the Admin Product creation/edit page. Fills in the provided Group Price at the provided Index for CE/EE. Clicks on Done."
-
-     - name: "AdminAddAdvancedPricingToTheProductExtendedActionGroup"
-       description: "EXTENDS: AdminAddAdvancedPricingToTheProductActionGroup. Removes 'selectProductTierPriceCustomerGroupInput'. Selects the provided Group Price at the provided Index for B2B."
- 
-- filename: "AssertStorefrontProductPricesActionGroup.xml"
-  repo: "https://github.com/magento/magento2/blob/2.3/app/code/Magento/Catalog/Test/Mftf/ActionGroup/AssertStorefrontProductPricesActionGroup.xml"
-  module: "Catalog"
-  actiongroups:
-     - name: "AssertStorefrontProductPricesActionGroup"
-       description: "Validates that the provided Product Price and Final Product Price are present on the Storefront Product page."
- 
-- filename: "StorefrontAssertProductSpecialPriceOnProductPageActionGroup.xml"
-  repo: "https://github.com/magento/magento2/blob/2.3/app/code/Magento/Catalog/Test/Mftf/ActionGroup/StorefrontAssertProductSpecialPriceOnProductPageActionGroup.xml"
-  module: "Catalog"
-  actiongroups:
-     - name: "StorefrontAssertProductSpecialPriceOnProductPageActionGroup"
-       description: "Goes to the provided Storefront Product page. Validates that the provided Special Price is present and correct."
- 
-- filename: "StorefrontOpenProductPageActionGroup.xml"
-  repo: "https://github.com/magento/magento2/blob/2.3/app/code/Magento/Catalog/Test/Mftf/ActionGroup/StorefrontOpenProductPageActionGroup.xml"
-  module: "Catalog"
-  actiongroups:
-     - name: "StorefrontOpenProductPageActionGroup"
-       description: "Goes to the Storefront Product page for the provided Product URL."
-
-     - name: "StorefrontOpenProductPageOnSecondStore"
-       description: "Goes to the Storefront Product page for the provided store code and Product URL."
- 
-- filename: "AdminClickAddAttributeOnProductEditPageActionGroup.xml"
-  repo: "https://github.com/magento/magento2/blob/2.3/app/code/Magento/Catalog/Test/Mftf/ActionGroup/AdminClickAddAttributeOnProductEditPageActionGroup.xml"
-  module: "Catalog"
-  actiongroups:
-     - name: "AdminClickAddAttributeOnProductEditPageActionGroup"
-       description: "Clicks on 'Add Attribute'.  Admin Product creation/edit page ."
- 
-- filename: "AssertErrorMessageAfterDeletingWebsiteActionGroup.xml"
-  repo: "https://github.com/magento/magento2/blob/2.3/app/code/Magento/Catalog/Test/Mftf/ActionGroup/AssertErrorMessageAfterDeletingWebsiteActionGroup.xml"
-  module: "Catalog"
-  actiongroups:
-     - name: "AssertErrorMessageAfterDeletingWebsiteActionGroup"
-       description: "Goes to the Admin Products grid page. Clicks on Ok. Validates that the provided Error Message is present and correct."
- 
-- filename: "AdminCreateCustomDropDownOptionsActionGroup.xml"
-  repo: "https://github.com/magento/magento2/blob/2.3/app/code/Magento/Catalog/Test/Mftf/ActionGroup/AdminCreateCustomDropDownOptionsActionGroup.xml"
-  module: "Catalog"
-  actiongroups:
-     - name: "AdminCreateCustomDropDownOptionsActionGroup"
-       description: "Clicks on 'Add Option'. Adds the 2 provided Options under the provided Custom Option Name to a Product on the Admin Product creation/edit page under the 'Customizable Options' section."
- 
-- filename: "AssertProductOnAdminGridActionGroup.xml"
-  repo: "https://github.com/magento/magento2/blob/2.3/app/code/Magento/Catalog/Test/Mftf/ActionGroup/AssertProductOnAdminGridActionGroup.xml"
-  module: "Catalog"
-  actiongroups:
-     - name: "AssertProductOnAdminGridActionGroup"
-       description: "EXTENDS: viewProductInAdminGrid. Removes the 'clickClearFiltersAfter' step from the Action Group."
- 
-- filename: "AdminAddProductCustomOptionActionGroup.xml"
-  repo: "https://github.com/magento/magento2/blob/2.3/app/code/Magento/Catalog/Test/Mftf/ActionGroup/AdminAddProductCustomOptionActionGroup.xml"
-  module: "Catalog"
-  actiongroups:
-     - name: "AdminAddProductCustomOptionActionGroup"
-       description: "Adds the provided Custom Option Title/Type to a Product on the Admin Product creation/edit page under the 'Customizable Options' section."
- 
-- filename: "AdminAddMinimumAdvertisedPriceActionGroup.xml"
-  repo: "https://github.com/magento/magento2/blob/2.3/app/code/Magento/Catalog/Test/Mftf/ActionGroup/AdminAddMinimumAdvertisedPriceActionGroup.xml"
-  module: "Catalog"
-  actiongroups:
-     - name: "AdminAddMinimumAdvertisedPriceActionGroup"
-       description: "Clicks 'Advanced Pricing' on the Admin Product creation/edit page. Fills in the provided MSRP details. Clicks on Done."
- 
-- filename: "StorefrontNavigateCategoryPageActionGroup.xml"
-  repo: "https://github.com/magento/magento2/blob/2.3/app/code/Magento/Catalog/Test/Mftf/ActionGroup/StorefrontNavigateCategoryPageActionGroup.xml"
-  module: "Catalog"
-  actiongroups:
-     - name: "StorefrontNavigateCategoryPageActionGroup"
-       description: ""
- 
+     - name: "AdminExpandProductAttributesTabActionGroup"
+       description: "Expands the 'Attributes' tab on the Admin Product page."
 - filename: "SearchForProductOnBackendActionGroup.xml"
-  repo: "https://github.com/magento/magento2/blob/2.3/app/code/Magento/Catalog/Test/Mftf/ActionGroup/SearchForProductOnBackendActionGroup.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/Catalog/Test/Mftf/ActionGroup/SearchForProductOnBackendActionGroup.xml"
   module: "Catalog"
   actiongroups:
      - name: "SearchForProductOnBackendActionGroup"
@@ -1561,249 +2544,209 @@
 
      - name: "ClearProductsFilterActionGroup"
        description: "Goto the Product grid page. Clear the Search Filters for the grid."
- 
-- filename: "AdminSubmitAdvancedInventoryFormActionGroup.xml"
-  repo: "https://github.com/magento/magento2/blob/2.3/app/code/Magento/Catalog/Test/Mftf/ActionGroup/AdminSubmitAdvancedInventoryFormActionGroup.xml"
+- filename: "StorefrontAssertProductSkuOnProductPageActionGroup.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/Catalog/Test/Mftf/ActionGroup/StorefrontAssertProductSkuOnProductPageActionGroup.xml"
   module: "Catalog"
   actiongroups:
-     - name: "AdminSubmitAdvancedInventoryFormActionGroup"
-       description: "Clicks on Done on the Admin Product creation/edit page on the 'Advanced Inventory' panel."
- 
-- filename: "StorefrontOpenHomePageActionGroup.xml"
-  repo: "https://github.com/magento/magento2/blob/2.3/app/code/Magento/Catalog/Test/Mftf/ActionGroup/StorefrontOpenHomePageActionGroup.xml"
+     - name: "StorefrontAssertProductSkuOnProductPageActionGroup"
+       description: "Validate that the provided Product Sku is present and correct."
+- filename: "AdminOpenProductIndexPageActionGroup.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/Catalog/Test/Mftf/ActionGroup/AdminOpenProductIndexPageActionGroup.xml"
   module: "Catalog"
   actiongroups:
-     - name: "StorefrontOpenHomePageActionGroup"
-       description: "Goes to the Storefront Homepage."
- 
-- filename: "AdminUnassignCategoryOnProductAndSaveActionGroup.xml"
-  repo: "https://github.com/magento/magento2/blob/2.3/app/code/Magento/Catalog/Test/Mftf/ActionGroup/AdminUnassignCategoryOnProductAndSaveActionGroup.xml"
-  module: "Catalog"
-  actiongroups:
-     - name: "AdminUnassignCategoryOnProductAndSaveActionGroup"
+     - name: "AdminOpenProductIndexPageActionGroup"
        description: ""
- 
-- filename: "OpenProductFromCategoryPageActionGroup.xml"
-  repo: "https://github.com/magento/magento2/blob/2.3/app/code/Magento/Catalog/Test/Mftf/ActionGroup/OpenProductFromCategoryPageActionGroup.xml"
+- filename: "StorefrontCheckProductIsMissingInCategoryProductsPageActionGroup.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/Catalog/Test/Mftf/ActionGroup/StorefrontCheckProductIsMissingInCategoryProductsPageActionGroup.xml"
   module: "Catalog"
   actiongroups:
-     - name: "OpenProductFromCategoryPageActionGroup"
-       description: "Goto the provided Category page. Click on the provided Product page."
- 
-- filename: "StorefrontProductActionGroup.xml"
-  repo: "https://github.com/magento/magento2/blob/2.3/app/code/Magento/Catalog/Test/Mftf/ActionGroup/StorefrontProductActionGroup.xml"
-  module: "Catalog"
-  actiongroups:
-     - name: "StorefrontCheckSimpleProduct"
-       description: "Validates that the provided Simple Product information is present and correct."
-
-     - name: "assertProductImageStorefrontProductPage"
-       description: "Validates that the provided Product Image is present."
-
-     - name: "assertProductImageStorefrontProductPage2"
-       description: "Validates that the provided Product Image is present."
-
-     - name: "assertProductImageNotInStorefrontProductPage"
-       description: "Validates that the provided Product Image is not present."
-
-     - name: "assertProductImageNotInStorefrontProductPage2"
-       description: "Validates that the provided Product Image is not present."
- 
-- filename: "AdminCreateWidgetActionGroup.xml"
-  repo: "https://github.com/magento/magento2/blob/2.3/app/code/Magento/Catalog/Test/Mftf/ActionGroup/AdminCreateWidgetActionGroup.xml"
-  module: "Catalog"
-  actiongroups:
-     - name: "AdminCreateRecentlyProductsWidgetActionGroup"
-       description: "EXTENDS: AdminCreateWidgetActionGroup. Adds Product Attributes/Buttons to a Widget. Clicks on the Save button."
-
-     - name: "AdminCreateCatalogProductWidgetActionGroup"
-       description: "EXTENDS: AdminCreateWidgetActionGroup. Creates Catalog Category Link Widget."
- 
-- filename: "AdminProductAttributeSetActionGroup.xml"
-  repo: "https://github.com/magento/magento2/blob/2.3/app/code/Magento/Catalog/Test/Mftf/ActionGroup/AdminProductAttributeSetActionGroup.xml"
-  module: "Catalog"
-  actiongroups:
-     - name: "AssignAttributeToGroup"
-       description: "Assign the provided Attribute to an Attribute Set from the Attribute Sets creation/edit page."
-
-     - name: "UnassignAttributeFromGroup"
-       description: "Unassign the provided Attribute from an Attribute Set from the Attribute Sets creation/edit page."
-
-     - name: "SaveAttributeSet"
-       description: "Save an Attribute Set on the Attribute Set creation/edit page."
-
-     - name: "CreateDefaultAttributeSet"
-       description: "Goes to the Attribute Sets grid page. Clicks on Add. Fill Name. Clicks on Save."
-
-     - name: "AdminAddUnassignedAttributeToGroup"
+     - name: "StorefrontCheckProductIsMissingInCategoryProductsPageActionGroup"
        description: ""
 
-     - name: "goToAttributeGridPage"
-       description: "Goes to the Attribute Sets grid page."
-
-     - name: "goToAttributeSetByName"
-       description: "Searches for the provided Attribute Sets Name. Clicks on the 1st row."
-
-     - name: "filterProductAttributeByAttributeLabel"
-       description: "Searches the Attribute Sets grid page for the provided Attribute Set Name."
-
-     - name: "FilterProductAttributeSetGridByAttributeSetName"
-       description: "Filters the Attribute Sets grid page for the provided Attribute Set Name."
-
-     - name: "deleteAttributeSetByLabel"
-       description: "Deletes the provided Attribute Set Name from the Attribute Sets grid page."
- 
-- filename: "CreateNewProductActionGroup.xml"
-  repo: "https://github.com/magento/magento2/blob/2.3/app/code/Magento/Catalog/Test/Mftf/ActionGroup/CreateNewProductActionGroup.xml"
-  module: "Catalog"
-  actiongroups:
-     - name: "CreateNewProductActionGroup"
-       description: "Goes to the Product creation/edit page. Fills in Product Name, Price and Quantity. Then Saves the work."
- 
-- filename: "OpenStorefrontProductPageByProductNameActionGroup.xml"
-  repo: "https://github.com/magento/magento2/blob/2.3/app/code/Magento/Catalog/Test/Mftf/ActionGroup/OpenStorefrontProductPageByProductNameActionGroup.xml"
-  module: "Catalog"
-  actiongroups:
-     - name: "OpenStorefrontProductPageByProductNameActionGroup"
+     - name: "StorefrontCheckProductPositionActionGroup"
        description: ""
- 
-- filename: "AdminOpenNewProductFormPageActionGroup.xml"
-  repo: "https://github.com/magento/magento2/blob/2.3/app/code/Magento/Catalog/Test/Mftf/ActionGroup/AdminOpenNewProductFormPageActionGroup.xml"
+- filename: "SearchAttributeByCodeOnProductAttributeGridActionGroup.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/Catalog/Test/Mftf/ActionGroup/SearchAttributeByCodeOnProductAttributeGridActionGroup.xml"
   module: "Catalog"
   actiongroups:
-     - name: "AdminOpenNewProductFormPageActionGroup"
-       description: "Goes to the Product creation/edit page for the provided Product Type and Attribute Set ID."
- 
-- filename: "AdminClickCreateNewAttributeFromProductEditPageActionGroup.xml"
-  repo: "https://github.com/magento/magento2/blob/2.3/app/code/Magento/Catalog/Test/Mftf/ActionGroup/AdminClickCreateNewAttributeFromProductEditPageActionGroup.xml"
+     - name: "SearchAttributeByCodeOnProductAttributeGridActionGroup"
+       description: "Goto the Product Attribute grid page. Search for the provided Product Attribute Code."
+- filename: "AdminAddTitleAndPriceValueToCustomOptionActionGroup.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/Catalog/Test/Mftf/ActionGroup/AdminAddTitleAndPriceValueToCustomOptionActionGroup.xml"
   module: "Catalog"
   actiongroups:
-     - name: "AdminClickCreateNewAttributeFromProductEditPageActionGroup"
-       description: "Clicks on 'Create New Attribute'.  Admin Product creation/edit page ."
- 
-- filename: "AssertProductDetailsOnStorefrontActionGroup.xml"
-  repo: "https://github.com/magento/magento2/blob/2.3/app/code/Magento/Catalog/Test/Mftf/ActionGroup/AssertProductDetailsOnStorefrontActionGroup.xml"
+     - name: "AdminAddTitleAndPriceValueToCustomOptionActionGroup"
+       description: "Clicks on 'Add Option'. Fills in the provided Custom Option Title/Type on the Admin Product creation/edit page under the 'Customizable Options' section."
+- filename: "OpenStoreFrontProductPageActionGroup.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/Catalog/Test/Mftf/ActionGroup/OpenStoreFrontProductPageActionGroup.xml"
   module: "Catalog"
   actiongroups:
-     - name: "AssertProductDetailsOnStorefrontActionGroup"
-       description: "Validates that the provided Product Info does NOT appear in the Product Number on a Storefront Category page."
- 
-- filename: "RestoreLayoutSettingActionGroup.xml"
-  repo: "https://github.com/magento/magento2/blob/2.3/app/code/Magento/Catalog/Test/Mftf/ActionGroup/RestoreLayoutSettingActionGroup.xml"
-  module: "Catalog"
-  actiongroups:
-     - name: "RestoreLayoutSetting"
-       description: "Goes to the 'Configuration' page for 'Web'. Selects 'No layout updates' for the Default Product/Category Layouts."
- 
-- filename: "AdminFillAttributeDataProductFormNewAttributeActionGroup.xml"
-  repo: "https://github.com/magento/magento2/blob/2.3/app/code/Magento/Catalog/Test/Mftf/ActionGroup/AdminFillAttributeDataProductFormNewAttributeActionGroup.xml"
-  module: "Catalog"
-  actiongroups:
-     - name: "AdminFillAttributeDataProductFormNewAttributeActionGroup"
-       description: "Fill attribute data on 'Create New Attribute' page  Admin Product creation/edit page ."
- 
-- filename: "AdminProductAttributeActionGroup.xml"
-  repo: "https://github.com/magento/magento2/blob/2.3/app/code/Magento/Catalog/Test/Mftf/ActionGroup/AdminProductAttributeActionGroup.xml"
-  module: "Catalog"
-  actiongroups:
-     - name: "navigateToCreatedProductAttribute"
-       description: "Goes to the Product Attributes grid page. Filters the grid based on the provided Product Attribute. Clicks on the 1st row."
-
-     - name: "navigateToEditProductAttribute"
-       description: "Goes to the Product Attributes grid page. Filters the grid based on the provided Product Attribute. Clicks on the 1st row."
-
-     - name: "AdminCreateAttributeFromProductPage"
-       description: "From the Product creation/edit page, under 'Configurations', Clicks on 'Create Configurations'. Clicks on 'Create New Attribute'. Fills Label. Selects Type. Clicks on Save."
-
-     - name: "AdminCreateAttributeFromProductPageWithScope"
+     - name: "OpenStoreFrontProductPageActionGroup"
        description: ""
-
-     - name: "AdminCreateAttributeWithValueWithTwoStoreViesFromProductPage"
-       description: "EXTENDS: AdminCreateAttributeFromProductPage. Adds the 2 provided Store Views to a Product. Clicks on Save."
-
-     - name: "AdminProductPageCreateAttributeSetWithAttribute"
-       description: "Adds the provided Product Attribute Set to a Product on the Product creation/edit page."
-
-     - name: "AdminCreateAttributeWithSearchWeight"
-       description: "EXTENDS: AdminProductPageCreateAttributeSetWithAttribute. Sets the provided Search Weight and Default Values."
-
-     - name: "AdminProductPageSelectAttributeSet"
-       description: "Selects the provided Attribute Set from the Admin Product creation/edit page."
-
-     - name: "AdminProductPageFillTextAttributeValueByName"
-       description: "Fills in the Attribute Name field with the provided value."
-
-     - name: "changeUseForPromoRuleConditionsProductAttribute"
-       description: "Select the provided value for the 'Use for Promo Rule Conditions' dropdown menu. Clicks on Save. Validates that the Save message is present."
-
-     - name: "deleteProductAttribute"
-       description: "EXTENDS: navigateToCreatedProductAttribute. Deletes the Product Attribute. Validates that the success message is present."
-
-     - name: "deleteProductAttributeByLabel"
-       description: "Goes to the Admin Product Attributes grid page. Filters the grid for the provided Product Attribute (Label). Deletes the Product Attribute from the grid. Validates that the Success Message is present."
-
-     - name: "deleteProductAttributeByAttributeCode"
-       description: "Goes to the Admin Product Attributes grid page. Filters the grid for the provided Product Attribute Code. Deletes the Product Attribute from the grid. Validates that the Success Message is present."
-
-     - name: "filterProductAttributeByAttributeCode"
-       description: "Filters the Product Attributes grid by the provided Product Attribute Code."
-
-     - name: "filterProductAttributeByDefaultLabel"
-       description: "Filters the Product Attributes grid by the provided Product Attribute Label."
-
-     - name: "saveProductAttribute"
-       description: "Clicks on Save. Validates that the Success Message is present."
-
-     - name: "confirmChangeInputTypeModal"
-       description: "Clicks on the Confirm button for the 'Product Data My Be Lost' modal."
-
-     - name: "saveProductAttributeInUse"
-       description: "Clicks on Save. Validates that the Success Message is present."
-
-     - name: "addProductAttributeInProductModal"
-       description: "Adds the provided Attribute Code to the Product on the Admin Product creation/edit page."
-
-     - name: "createProductAttribute"
-       description: "Clicks on 'Add New Attribute'. Fills in the Attribute Details (Label, Input Type and Value Required). Clicks on Save."
-
-     - name: "AdminCreateSearchableProductAttribute"
-       description: ""
-
-     - name: "createProductAttributeWithTextField"
-       description: "EXTENDS: createProductAttribute. Fills in the Attribute Code and Default Value (Attribute Type: Text Field)."
-
-     - name: "createProductAttributeWithDateField"
-       description: "EXTENDS: createProductAttribute. Fills in the Attribute Code and Default Value (Attribute Type: Date Field)."
-
-     - name: "createAttributeDropdownNthOption"
-       description: "Creates an Option for a Product Attribute (Attribute Type: Dropdown)."
-
-     - name: "createAttributeDropdownNthOptionAsDefault"
-       description: "EXTENDS: createAttributeDropdownNthOption. Checks the 'Is Default' option."
- 
-- filename: "AdminProductAttributeMassUpdateActionGroup.xml"
-  repo: "https://github.com/magento/magento2/blob/2.3/app/code/Magento/Catalog/Test/Mftf/ActionGroup/AdminProductAttributeMassUpdateActionGroup.xml"
+- filename: "AdminSetUseInSearchValueForProductAttributeActionGroup.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/Catalog/Test/Mftf/ActionGroup/AdminSetUseInSearchValueForProductAttributeActionGroup.xml"
   module: "Catalog"
   actiongroups:
-     - name: "AdminUpdateProductNameAndDescriptionAttributes"
-       description: ""
- 
-- filename: "StorefrontAddProductToCartWithQtyActionGroup.xml"
-  repo: "https://github.com/magento/magento2/blob/2.3/app/code/Magento/Catalog/Test/Mftf/ActionGroup/StorefrontAddProductToCartWithQtyActionGroup.xml"
+     - name: "AdminSetUseInSearchValueForProductAttributeActionGroup"
+       description: "Set 'Use In Search' value for product attribute"
+- filename: "DisableProductLabelActionGroup.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/Catalog/Test/Mftf/ActionGroup/DisableProductLabelActionGroup.xml"
   module: "Catalog"
   actiongroups:
-     - name: "StorefrontAddProductToCartWithQtyActionGroup"
-       description: "Fills in the provided Product Quantity. Clicks on Add To Cart. Validates that the Success Message is present."
- 
+     - name: "DisableProductLabelActionGroup"
+       description: "Disable Product Label and Change Attribute Set."
+- filename: "StorefrontAddToCartCustomOptionsProductPageActionGroup.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/Catalog/Test/Mftf/ActionGroup/StorefrontAddToCartCustomOptionsProductPageActionGroup.xml"
+  module: "Catalog"
+  actiongroups:
+     - name: "StorefrontAddToCartCustomOptionsProductPageActionGroup"
+       description: "Add a Product to the Cart. Validate that the Success Message is present."
+- filename: "AdminCreateRootCategoryActionGroup.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/Catalog/Test/Mftf/ActionGroup/AdminCreateRootCategoryActionGroup.xml"
+  module: "Catalog"
+  actiongroups:
+     - name: "AdminCreateRootCategory"
+       description: "Requires navigation to Category creation. Adds a new root category and asserts on creation."
+- filename: "AssertSubTotalOnStorefrontMinicartActionGroup.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/Catalog/Test/Mftf/ActionGroup/AssertSubTotalOnStorefrontMinicartActionGroup.xml"
+  module: "Catalog"
+  actiongroups:
+     - name: "AssertSubTotalOnStorefrontMiniCartActionGroup"
+       description: "Validates that the provided Sub Total is present in the Storefront Mini Shopping Cart."
+- filename: "AdminUnassignProductInWebsiteActionGroup.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/Catalog/Test/Mftf/ActionGroup/AdminUnassignProductInWebsiteActionGroup.xml"
+  module: "Catalog"
+  actiongroups:
+     - name: "AdminUnassignProductInWebsiteActionGroup"
+       description: ""
 - filename: "SearchAndMultiselectActionGroup.xml"
-  repo: "https://github.com/magento/magento2/blob/2.3/app/code/Magento/Catalog/Test/Mftf/ActionGroup/SearchAndMultiselectActionGroup.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/Catalog/Test/Mftf/ActionGroup/SearchAndMultiselectActionGroup.xml"
   module: "Catalog"
   actiongroups:
      - name: "searchAndMultiSelectActionGroup"
        description: "Search for and select multiple items in the Magento dropdown UI component."
- 
+- filename: "FillMainProductFormNoWeightActionGroup.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/Catalog/Test/Mftf/ActionGroup/FillMainProductFormNoWeightActionGroup.xml"
+  module: "Catalog"
+  actiongroups:
+     - name: "FillMainProductFormNoWeightActionGroup"
+       description: "Fills in the provided Product details (Name, SKU, Price, Quantity, Stock Status and Weight Type) on the Admin Products creation/edit page."
+- filename: "AssertStorefrontProductSpecialPriceInCategoryPageActionGroup.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/Catalog/Test/Mftf/ActionGroup/AssertStorefrontProductSpecialPriceInCategoryPageActionGroup.xml"
+  module: "Catalog"
+  actiongroups:
+     - name: "AssertStorefrontProductSpecialPriceInCategoryPageActionGroup"
+       description: "Goes to Storefront Category page for the provided Category. Validates that the Product price and special price are correct."
+- filename: "DeleteProductActionGroup.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/Catalog/Test/Mftf/ActionGroup/DeleteProductActionGroup.xml"
+  module: "Catalog"
+  actiongroups:
+     - name: "DeleteProductActionGroup"
+       description: "Deletes the provided Product Name from the Product grid page."
+- filename: "CheckItemInLayeredNavigationActionGroup.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/Catalog/Test/Mftf/ActionGroup/CheckItemInLayeredNavigationActionGroup.xml"
+  module: "Catalog"
+  actiongroups:
+     - name: "CheckItemInLayeredNavigationActionGroup"
+       description: "Expands the Product Filters on a Storefront Category page if it is not expanded."
+- filename: "NavigateToCreatedProductEditPageActionGroup.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/Catalog/Test/Mftf/ActionGroup/NavigateToCreatedProductEditPageActionGroup.xml"
+  module: "Catalog"
+  actiongroups:
+     - name: "NavigateToCreatedProductEditPageActionGroup"
+       description: "Goes to the Admin Product grid page. Filters the Product grid based on the provided Product details (SKU). Edits the provided Product. Validates that the Product SKU is present and correct."
+- filename: "StorefrontAddProductToCartWithQtyActionGroup.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/Catalog/Test/Mftf/ActionGroup/StorefrontAddProductToCartWithQtyActionGroup.xml"
+  module: "Catalog"
+  actiongroups:
+     - name: "StorefrontAddProductToCartWithQtyActionGroup"
+       description: "Fills in the provided Product Quantity. Clicks on Add To Cart. Validates that the Success Message is present."
+- filename: "AdminFillAdvancedInventoryQtyActionGroup.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/Catalog/Test/Mftf/ActionGroup/AdminFillAdvancedInventoryQtyActionGroup.xml"
+  module: "Catalog"
+  actiongroups:
+     - name: "AdminFillAdvancedInventoryQtyActionGroup"
+       description: "Fills in the provided Quantity for the 'Qty' option in 'Advanced Inventory' panel on the Admin Product creation/edit page."
+- filename: "StorefrontAssertProductNameOnProductMainPageActionGroup.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/Catalog/Test/Mftf/ActionGroup/StorefrontAssertProductNameOnProductMainPageActionGroup.xml"
+  module: "Catalog"
+  actiongroups:
+     - name: "StorefrontAssertProductNameOnProductMainPageActionGroup"
+       description: "Validates that the provided Product Name is present and correct on a Storefront Category page."
+- filename: "StorefrontProductPageSelectDropDownOptionValueActionGroup.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/Catalog/Test/Mftf/ActionGroup/StorefrontProductPageSelectDropDownOptionValueActionGroup.xml"
+  module: "Catalog"
+  actiongroups:
+     - name: "StorefrontProductPageSelectDropDownOptionValueActionGroup"
+       description: "Selects the provided Product Option Value under the provided DropDown Product Option Title on a Storefront Product page."
+- filename: "GoToCreateProductPageActionGroup.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/Catalog/Test/Mftf/ActionGroup/GoToCreateProductPageActionGroup.xml"
+  module: "Catalog"
+  actiongroups:
+     - name: "GoToCreateProductPageActionGroup"
+       description: "Clicks on the 'Add Product' toggle on the Admin Products grid page. Clicks on the provided Product (Type)."
+- filename: "FilterProductGridBySkuActionGroup.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/Catalog/Test/Mftf/ActionGroup/FilterProductGridBySkuActionGroup.xml"
+  module: "Catalog"
+  actiongroups:
+     - name: "FilterProductGridBySkuActionGroup"
+       description: "Filters the Admin Products grid by the provided Product (SKU)."
+- filename: "RestoreLayoutSettingActionGroup.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/Catalog/Test/Mftf/ActionGroup/RestoreLayoutSettingActionGroup.xml"
+  module: "Catalog"
+  actiongroups:
+     - name: "RestoreLayoutSetting"
+       description: "Goes to the 'Configuration' page for 'Web'. Selects 'No layout updates' for the Default Product/Category Layouts."
+- filename: "AdminClickCreateNewAttributeFromProductEditPageActionGroup.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/Catalog/Test/Mftf/ActionGroup/AdminClickCreateNewAttributeFromProductEditPageActionGroup.xml"
+  module: "Catalog"
+  actiongroups:
+     - name: "AdminClickCreateNewAttributeFromProductEditPageActionGroup"
+       description: "Clicks on 'Create New Attribute'.  Admin Product creation/edit page ."
+- filename: "AssertProductInStorefrontCategoryPageActionGroup.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/Catalog/Test/Mftf/ActionGroup/AssertProductInStorefrontCategoryPageActionGroup.xml"
+  module: "Catalog"
+  actiongroups:
+     - name: "AssertProductInStorefrontCategoryPage"
+       description: "Goes to Storefront Category page for the provided Category. Validates that the Product details are present and correct."
+- filename: "AssertStorefrontProductDetailPageNameAndUrlActionGroup.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/Catalog/Test/Mftf/ActionGroup/AssertStorefrontProductDetailPageNameAndUrlActionGroup.xml"
+  module: "Catalog"
+  actiongroups:
+     - name: "AssertStorefrontProductDetailPageNameAndUrlActionGroup"
+       description: "Validates that the Product name and Url are correct."
+- filename: "AddWebsiteToProductActionGroup.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/Catalog/Test/Mftf/ActionGroup/AddWebsiteToProductActionGroup.xml"
+  module: "Catalog"
+  actiongroups:
+     - name: "AddWebsiteToProductActionGroup"
+       description: "Adds the provided Website to a Product on the Admin Product creation/edit page. Clicks on Save. Validates that the Success Message is present and correct."
+- filename: "OpenProductForEditByClickingRowXColumnYInProductGridActionGroup.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/Catalog/Test/Mftf/ActionGroup/OpenProductForEditByClickingRowXColumnYInProductGridActionGroup.xml"
+  module: "Catalog"
+  actiongroups:
+     - name: "OpenProductForEditByClickingRowXColumnYInProductGridActionGroup"
+       description: "Clicks on the 'Edit' button in the Admin Products grid by the provided Grid coordinates (X, Y)."
+- filename: "FillMainProductFormActionGroup.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/Catalog/Test/Mftf/ActionGroup/FillMainProductFormActionGroup.xml"
+  module: "Catalog"
+  actiongroups:
+     - name: "FillMainProductFormActionGroup"
+       description: "Fills in the provided Product details (Name, SKU, Price, Quantity, Stock Status, Weight Type and Weight) on the Admin Products creation/edit page."
+- filename: "NavigateToAndResetProductGridToDefaultViewActionGroup.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/Catalog/Test/Mftf/ActionGroup/NavigateToAndResetProductGridToDefaultViewActionGroup.xml"
+  module: "Catalog"
+  actiongroups:
+     - name: "NavigateToAndResetProductGridToDefaultViewActionGroup"
+       description: "EXTENDS: resetProductGridToDefaultView. Adds an action to go to the Admin Products grid page."
+- filename: "FilterProductInGridByStoreViewAndNameActionGroup.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/Catalog/Test/Mftf/ActionGroup/FilterProductInGridByStoreViewAndNameActionGroup.xml"
+  module: "Catalog"
+  actiongroups:
+     - name: "FilterProductInGridByStoreViewAndNameActionGroup"
+       description: "Goes to the Admin Products grid page. Filters the grid based on the provided Store View. Validates that the Product Name is present in the 1st row of the grid."
 - filename: "AdminCategoryActionGroup.xml"
-  repo: "https://github.com/magento/magento2/blob/2.3/app/code/Magento/Catalog/Test/Mftf/ActionGroup/AdminCategoryActionGroup.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/Catalog/Test/Mftf/ActionGroup/AdminCategoryActionGroup.xml"
   module: "Catalog"
   actiongroups:
      - name: "CreateCategory"
@@ -1819,7 +2762,7 @@
        description: "Requires navigation to the Subcategory creation/edit page. Fills the Subcategory Name. Fills the Search Engine Optimization."
 
      - name: "saveCategoryForm"
-       description: "Requires navigation to the Category creation/edit page. Checks that the url contains the AdminCategoryPage url. Saves the Category."
+       description: "DEPRECATED. Use AdminSaveCategoryFormActionGroup instead. Requires navigation to the Category creation/edit page. Checks that the url contains the AdminCategoryPage url. Saves the Category."
 
      - name: "addCategoryImage"
        description: "Requires navigation to the Category creation/edit page. Adds the provided image to a Category. Validates that the Image exists."
@@ -1879,51 +2822,18 @@
        description: "Requires navigation to subcategory creation/edit. Fills the name, and sets the Search Engine Optimization for the category."
 
      - name: "AdminCategoryAssignProduct"
-       description: "Requires navigation to category creation/edit page. Assign products to category - using \"Products in Category\" tab."
+       description: "Requires navigation to category creation/edit page. Assign products to category - using 'Products in Category' tab."
 
      - name: "DeleteDefaultCategoryChildren"
        description: "Deletes all children categories of Default Root Category."
- 
-- filename: "AssertAttributeDeletionErrorMessageActionGroup.xml"
-  repo: "https://github.com/magento/magento2/blob/2.3/app/code/Magento/Catalog/Test/Mftf/ActionGroup/AssertAttributeDeletionErrorMessageActionGroup.xml"
+- filename: "DeleteCategoryActionGroup.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/Catalog/Test/Mftf/ActionGroup/DeleteCategoryActionGroup.xml"
   module: "Catalog"
   actiongroups:
-     - name: "AssertAttributeDeletionErrorMessageActionGroup"
-       description: "Validates that the Error Message is present and correct on the Backend Admin Attribute Sets creation/edit page when you try to delete an Attribute Set assigned to a Configurable Product. PLEASE NOTE: The Error Message is hardcoded."
- 
-- filename: "AssertStorefrontCustomProductAttributeActionGroup.xml"
-  repo: "https://github.com/magento/magento2/blob/2.3/app/code/Magento/Catalog/Test/Mftf/ActionGroup/AssertStorefrontCustomProductAttributeActionGroup.xml"
-  module: "Catalog"
-  actiongroups:
-     - name: "AssertStorefrontCustomProductAttributeActionGroup"
-       description: ""
- 
-- filename: "StorefrontCheckProductIsMissingInCategoryProductsPageActionGroup.xml"
-  repo: "https://github.com/magento/magento2/blob/2.3/app/code/Magento/Catalog/Test/Mftf/ActionGroup/StorefrontCheckProductIsMissingInCategoryProductsPageActionGroup.xml"
-  module: "Catalog"
-  actiongroups:
-     - name: "StorefrontCheckProductIsMissingInCategoryProductsPageActionGroup"
-       description: ""
-
-     - name: "StorefrontCheckProductPositionActionGroup"
-       description: ""
- 
-- filename: "DeleteProductAttributeByAttributeCodeActionGroup.xml"
-  repo: "https://github.com/magento/magento2/blob/2.3/app/code/Magento/Catalog/Test/Mftf/ActionGroup/DeleteProductAttributeByAttributeCodeActionGroup.xml"
-  module: "Catalog"
-  actiongroups:
-     - name: "DeleteProductAttributeByAttributeCodeActionGroup"
-       description: "Delete a Product Attribute from the Product Attribute creation/edit page."
- 
-- filename: "AssertProductAttributePresenceInCatalogProductGridActionGroup.xml"
-  repo: "https://github.com/magento/magento2/blob/2.3/app/code/Magento/Catalog/Test/Mftf/ActionGroup/AssertProductAttributePresenceInCatalogProductGridActionGroup.xml"
-  module: "Catalog"
-  actiongroups:
-     - name: "AssertProductAttributePresenceInCatalogProductGridActionGroup"
-       description: "Validates that the provided Attributes Sets is present on the Backend Attribute Sets grid."
- 
+     - name: "DeleteCategoryActionGroup"
+       description: "Navigates to the category page and deletes the specified category."
 - filename: "AdminProductActionGroup.xml"
-  repo: "https://github.com/magento/magento2/blob/2.3/app/code/Magento/Catalog/Test/Mftf/ActionGroup/AdminProductActionGroup.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/Catalog/Test/Mftf/ActionGroup/AdminProductActionGroup.xml"
   module: "Catalog"
   actiongroups:
      - name: "goToCreateProductPage"
@@ -2078,413 +2988,386 @@
 
      - name: "StorefrontAssertActiveProductImage"
        description: ""
- 
-- filename: "AdminFillAdvancedInventoryQtyActionGroup.xml"
-  repo: "https://github.com/magento/magento2/blob/2.3/app/code/Magento/Catalog/Test/Mftf/ActionGroup/AdminFillAdvancedInventoryQtyActionGroup.xml"
+- filename: "StorefrontCategoryPageOpenProductActionGroup.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/Catalog/Test/Mftf/ActionGroup/StorefrontCategoryPageOpenProductActionGroup.xml"
   module: "Catalog"
   actiongroups:
-     - name: "AdminFillAdvancedInventoryQtyActionGroup"
-       description: "Fills in the provided Quantity for the 'Qty' option in 'Advanced Inventory' panel on the Admin Product creation/edit page."
- 
-- filename: "AdminFillProductAttributePropertiesActionGroup.xml"
-  repo: "https://github.com/magento/magento2/blob/2.3/app/code/Magento/Catalog/Test/Mftf/ActionGroup/AdminFillProductAttributePropertiesActionGroup.xml"
-  module: "Catalog"
+     - name: "StorefrontCategoryPageOpenProductActionGroup"
+       description: "Click on the provided product on category page."
+- filename: "CloseAllDialogBoxesActionGroup.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/AdminAnalytics/Test/Mftf/ActionGroup/CloseAllDialogBoxesActionGroup.xml"
+  module: "AdminAnalytics"
   actiongroups:
-     - name: "AdminFillProductAttributePropertiesActionGroup"
+     - name: "CloseAllDialogBoxes"
        description: ""
+- filename: "LoginAdminWithCredentialsActionGroup.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/AdminAnalytics/Test/Mftf/ActionGroup/LoginAdminWithCredentialsActionGroup.xml"
+  module: "AdminAnalytics"
+  actiongroups:
+     - name: "LoginAdminWithCredentialsActionGroup"
+       description: ""
+- filename: "SelectAdminUsageSettingActionGroup.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/AdminAnalytics/Test/Mftf/ActionGroup/SelectAdminUsageSettingActionGroup.xml"
+  module: "AdminAnalytics"
+  actiongroups:
+     - name: "SelectAdminUsageSetting"
+       description: ""
+- filename: "LoginAsAdminActionGroup.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/AdminAnalytics/Test/Mftf/ActionGroup/LoginAsAdminActionGroup.xml"
+  module: "AdminAnalytics"
+  actiongroups:
+     - name: "LoginAsAdmin"
+       description: ""
+- filename: "StorefrontSalesRuleActionGroup.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/SalesRule/Test/Mftf/ActionGroup/StorefrontSalesRuleActionGroup.xml"
+  module: "SalesRule"
+  actiongroups:
+     - name: "StorefrontApplyCouponActionGroup"
+       description: "Applies the provided Coupon Code to the Storefront Shopping Cart."
 
-     - name: "AdminSwitchScopeForProductAttributeActionGroup"
-       description: ""
- 
-- filename: "AssertProductInfoOnEditPageActionGroup.xml"
-  repo: "https://github.com/magento/magento2/blob/2.3/app/code/Magento/Catalog/Test/Mftf/ActionGroup/AssertProductInfoOnEditPageActionGroup.xml"
-  module: "Catalog"
-  actiongroups:
-     - name: "AssertProductInfoOnEditPageActionGroup"
-       description: "Validate that the provided Product details are correct on the Product creation/edit page."
- 
-- filename: "AdminClickOnAdvancedInventoryLinkActionGroup.xml"
-  repo: "https://github.com/magento/magento2/blob/2.3/app/code/Magento/Catalog/Test/Mftf/ActionGroup/AdminClickOnAdvancedInventoryLinkActionGroup.xml"
-  module: "Catalog"
-  actiongroups:
-     - name: "AdminClickOnAdvancedInventoryLinkActionGroup"
-       description: "Clicks on the 'Advanced Inventory' link on the Admin Product creation/edit page."
+     - name: "StorefrontCancelCouponActionGroup"
+       description: "Cancels the Coupon that is applied to the Storefront Shopping Cart."
 
-     - name: "AdminClickOnAdvancedInventoryButtonActionGroup"
-       description: "Clicks on the 'Advanced Inventory' link on the Admin Product creation/edit page."
- 
-- filename: "StorefrontAssertProductPriceOnProductPageActionGroup.xml"
-  repo: "https://github.com/magento/magento2/blob/2.3/app/code/Magento/Catalog/Test/Mftf/ActionGroup/StorefrontAssertProductPriceOnProductPageActionGroup.xml"
-  module: "Catalog"
-  actiongroups:
-     - name: "StorefrontAssertProductPriceOnProductPageActionGroup"
-       description: "Validate that the provided Product Price is present and correct."
- 
-- filename: "AdminSwitchProductGiftMessageStatusActionGroup.xml"
-  repo: "https://github.com/magento/magento2/blob/2.3/app/code/Magento/Catalog/Test/Mftf/ActionGroup/AdminSwitchProductGiftMessageStatusActionGroup.xml"
-  module: "Catalog"
-  actiongroups:
-     - name: "AdminSwitchProductGiftMessageStatusActionGroup"
-       description: ""
- 
-- filename: "StorefrontCheckProductPriceInCategoryActionGroup.xml"
-  repo: "https://github.com/magento/magento2/blob/2.3/app/code/Magento/Catalog/Test/Mftf/ActionGroup/StorefrontCheckProductPriceInCategoryActionGroup.xml"
-  module: "Catalog"
-  actiongroups:
-     - name: "StorefrontCheckProductPriceInCategoryActionGroup"
-       description: "EXTENDS: StorefrontCheckCategorySimpleProduct. Removes 'AssertProductPrice'. Validates that the provided Product Price is present and correct on a Storefront Product page."
+     - name: "StorefrontCheckCouponAppliedActionGroup"
+       description: "Validates that the provided Rule and Discount Amount is present and correct on the Storefront Checkout page."
 
-     - name: "StorefrontAssertProductPriceOnCategoryPageActionGroup"
-       description: "Validate that the provided Product Price is correct on category page."
- 
-- filename: "StorefrontAssertProductAbsentOnCategoryPageActionGroup.xml"
-  repo: "https://github.com/magento/magento2/blob/2.3/app/code/Magento/Catalog/Test/Mftf/ActionGroup/StorefrontAssertProductAbsentOnCategoryPageActionGroup.xml"
-  module: "Catalog"
+     - name: "VerifyDiscountAmount"
+       description: "Goes to the provided Storefront Product URL. Fills in provided Quantity. Clicks Add to Cart. Goes to Checkout. Validates that the provided Discount Amount is present and correct."
+- filename: "ApplyCartRuleOnStorefrontActionGroup.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/SalesRule/Test/Mftf/ActionGroup/ApplyCartRuleOnStorefrontActionGroup.xml"
+  module: "SalesRule"
   actiongroups:
-     - name: "StorefrontAssertProductAbsentOnCategoryPageActionGroup"
-       description: "Navigate to category page and verify product is absent."
- 
-- filename: "StorefrontAssertProductInWidgetActionGroup.xml"
-  repo: "https://github.com/magento/magento2/blob/2.3/app/code/Magento/Catalog/Test/Mftf/ActionGroup/StorefrontAssertProductInWidgetActionGroup.xml"
-  module: "Catalog"
+     - name: "ApplyCartRuleOnStorefrontActionGroup"
+       description: "Clicks on Add to Cart on a Storefront Product page. Validates that the Success Message is present and correct. Goes to the Storefront Shopping Cart page. Applies the provided Coupon Code to the Shopping Cart."
+- filename: "AssertCustomerGroupNotOnCartPriceRuleFormActionGroup.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/SalesRule/Test/Mftf/ActionGroup/AssertCustomerGroupNotOnCartPriceRuleFormActionGroup.xml"
+  module: "SalesRule"
   actiongroups:
-     - name: "StorefrontAssertProductInRecentlyViewedWidgetActionGroup"
-       description: "Validate that the provided Product appears in the Recently Viewed Products widget."
+     - name: "AssertCustomerGroupNotOnCartPriceRuleFormActionGroup"
+       description: "Validates that the 'Customer Groups' section does NOT contain the provided Customer Group on the Admin Cart Price Rule creation/edit page."
+- filename: "StorefrontClickOnMiniCartActionGroup.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/SalesRule/Test/Mftf/ActionGroup/StorefrontClickOnMiniCartActionGroup.xml"
+  module: "SalesRule"
+  actiongroups:
+     - name: "StorefrontClickOnMiniCartActionGroup"
+       description: ""
+- filename: "AdminFilterCartPriceRuleActionGroup.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/SalesRule/Test/Mftf/ActionGroup/AdminFilterCartPriceRuleActionGroup.xml"
+  module: "SalesRule"
+  actiongroups:
+     - name: "AdminFilterCartPriceRuleActionGroup"
+       description: "Filters the Admin Cart Price Rule grid based on the provided Rule Name. Clicks on the 1st row in the grid."
 
-     - name: "StorefrontAssertProductInRecentlyComparedWidgetActionGroup"
-       description: "Validate that the provided Product appears in the Recently Compared Products widget."
+     - name: "AdminCartPriceRuleNotInGridActionGroup"
+       description: "EXTENDS: AdminFilterCartPriceRuleActionGroup. Removes 'goToEditRulePage'. Validates that the Empty Grid message is present and correct."
+- filename: "AdminCreateCartPriceRuleActionGroup.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/SalesRule/Test/Mftf/ActionGroup/AdminCreateCartPriceRuleActionGroup.xml"
+  module: "SalesRule"
+  actiongroups:
+     - name: "AdminCreateCartPriceRuleActionGroup"
+       description: "Goes to the Admin Cart Price Rule grid page. Adds the provided Rule. Validates that the Success Message is present and correct."
 
-     - name: "StorefrontAssertProductInRecentlyOrderedWidgetActionGroup"
-       description: "Validate that the provided Product appears in the Recently Ordered Products widget."
- 
-- filename: "StorefrontSelectCustomOptionRadioAndAssertPricesActionGroup.xml"
-  repo: "https://github.com/magento/magento2/blob/2.3/app/code/Magento/Catalog/Test/Mftf/ActionGroup/StorefrontSelectCustomOptionRadioAndAssertPricesActionGroup.xml"
-  module: "Catalog"
-  actiongroups:
-     - name: "StorefrontSelectCustomOptionRadioAndAssertPricesActionGroup"
-       description: "EXTENDS: AssertStorefrontProductPricesActionGroup. Clicks on the provided Custom Option on a Storefront Product page."
- 
-- filename: "StorefrontAssertProductSkuOnProductPageActionGroup.xml"
-  repo: "https://github.com/magento/magento2/blob/2.3/app/code/Magento/Catalog/Test/Mftf/ActionGroup/StorefrontAssertProductSkuOnProductPageActionGroup.xml"
-  module: "Catalog"
-  actiongroups:
-     - name: "StorefrontAssertProductSkuOnProductPageActionGroup"
-       description: "Validate that the provided Product Sku is present and correct."
- 
-- filename: "AdminAssignCategoryToProductAndSaveActionGroup.xml"
-  repo: "https://github.com/magento/magento2/blob/2.3/app/code/Magento/Catalog/Test/Mftf/ActionGroup/AdminAssignCategoryToProductAndSaveActionGroup.xml"
-  module: "Catalog"
-  actiongroups:
-     - name: "AdminAssignCategoryToProductAndSaveActionGroup"
-       description: ""
- 
-- filename: "AdminOpenProductAttributePageActionGroup.xml"
-  repo: "https://github.com/magento/magento2/blob/2.3/app/code/Magento/Catalog/Test/Mftf/ActionGroup/AdminOpenProductAttributePageActionGroup.xml"
-  module: "Catalog"
-  actiongroups:
-     - name: "AdminOpenProductAttributePageActionGroup"
-       description: ""
- 
-- filename: "StorefrontAssertCustomOptionByTitleActionGroup.xml"
-  repo: "https://github.com/magento/magento2/blob/2.3/app/code/Magento/Catalog/Test/Mftf/ActionGroup/StorefrontAssertCustomOptionByTitleActionGroup.xml"
-  module: "Catalog"
-  actiongroups:
-     - name: "StorefrontAssertCustomOptionByTitleActionGroup"
-       description: "Validates that the provided Product Option Title is present on the Storefront Product page."
- 
-- filename: "AddWebsiteToProductActionGroup.xml"
-  repo: "https://github.com/magento/magento2/blob/2.3/app/code/Magento/Catalog/Test/Mftf/ActionGroup/AddWebsiteToProductActionGroup.xml"
-  module: "Catalog"
-  actiongroups:
-     - name: "AddWebsiteToProductActionGroup"
-       description: "Adds the provided Website to a Product on the Admin Product creation/edit page. Clicks on Save. Validates that the Success Message is present and correct."
- 
-- filename: "AdminOpenAttributeSetByNameActionGroup.xml"
-  repo: "https://github.com/magento/magento2/blob/2.3/app/code/Magento/Catalog/Test/Mftf/ActionGroup/AdminOpenAttributeSetByNameActionGroup.xml"
-  module: "Catalog"
-  actiongroups:
-     - name: "AdminOpenAttributeSetByNameActionGroup"
-       description: ""
- 
-- filename: "AdminFillAdvancedInventoryOutOfStockThresholdActionGroup.xml"
-  repo: "https://github.com/magento/magento2/blob/2.3/app/code/Magento/Catalog/Test/Mftf/ActionGroup/AdminFillAdvancedInventoryOutOfStockThresholdActionGroup.xml"
-  module: "Catalog"
-  actiongroups:
-     - name: "AdminFillAdvancedInventoryOutOfStockThresholdActionGroup"
-       description: "Unchecks 'Use Config Setting' for the 'Minimum Qty Allowed in Shopping Cart' option in 'Advanced Inventory' panel on the Admin Product creation/edit page. Fills in the provided Quantity."
- 
-- filename: "SearchAttributeByCodeOnProductAttributeGridActionGroup.xml"
-  repo: "https://github.com/magento/magento2/blob/2.3/app/code/Magento/Catalog/Test/Mftf/ActionGroup/SearchAttributeByCodeOnProductAttributeGridActionGroup.xml"
-  module: "Catalog"
-  actiongroups:
-     - name: "SearchAttributeByCodeOnProductAttributeGridActionGroup"
-       description: "Goto the Product Attribute grid page. Search for the provided Product Attribute Code."
- 
-- filename: "StorefrontAssertPageNotFoundErrorOnProductDetailPageActionGroup.xml"
-  repo: "https://github.com/magento/magento2/blob/2.3/app/code/Magento/Catalog/Test/Mftf/ActionGroup/StorefrontAssertPageNotFoundErrorOnProductDetailPageActionGroup.xml"
-  module: "Catalog"
-  actiongroups:
-     - name: "StorefrontAssertPageNotFoundErrorOnProductDetailPageActionGroup"
-       description: ""
- 
-- filename: "AdminAnchorCategoryActionGroup.xml"
-  repo: "https://github.com/magento/magento2/blob/2.3/app/code/Magento/Catalog/Test/Mftf/ActionGroup/AdminAnchorCategoryActionGroup.xml"
-  module: "Catalog"
-  actiongroups:
-     - name: "AdminAnchorCategoryActionGroup"
-       description: ""
- 
-- filename: "AdminChangeProductSEOSettingsActionGroup.xml"
-  repo: "https://github.com/magento/magento2/blob/2.3/app/code/Magento/Catalog/Test/Mftf/ActionGroup/AdminChangeProductSEOSettingsActionGroup.xml"
-  module: "Catalog"
-  actiongroups:
-     - name: "AdminChangeProductSEOSettingsActionGroup"
-       description: ""
- 
-- filename: "CheckItemInLayeredNavigationActionGroup.xml"
-  repo: "https://github.com/magento/magento2/blob/2.3/app/code/Magento/Catalog/Test/Mftf/ActionGroup/CheckItemInLayeredNavigationActionGroup.xml"
-  module: "Catalog"
-  actiongroups:
-     - name: "CheckItemInLayeredNavigationActionGroup"
-       description: "Expands the Product Filters on a Storefront Category page if it is not expanded."
- 
-- filename: "AdminAssignProductInWebsiteActionGroup.xml"
-  repo: "https://github.com/magento/magento2/blob/2.3/app/code/Magento/Catalog/Test/Mftf/ActionGroup/AdminAssignProductInWebsiteActionGroup.xml"
-  module: "Catalog"
-  actiongroups:
-     - name: "AdminAssignProductInWebsiteActionGroup"
-       description: ""
- 
-- filename: "OpenProductAttributeFromSearchResultInGridActionGroup.xml"
-  repo: "https://github.com/magento/magento2/blob/2.3/app/code/Magento/Catalog/Test/Mftf/ActionGroup/OpenProductAttributeFromSearchResultInGridActionGroup.xml"
-  module: "Catalog"
-  actiongroups:
-     - name: "OpenProductAttributeFromSearchResultInGridActionGroup"
-       description: "EXTENDS: SearchAttributeByCodeOnProductAttributeGridActionGroup. Click on Edit for the provided Product Attribute Code."
- 
-- filename: "AdminOpenProductIndexPageActionGroup.xml"
-  repo: "https://github.com/magento/magento2/blob/2.3/app/code/Magento/Catalog/Test/Mftf/ActionGroup/AdminOpenProductIndexPageActionGroup.xml"
-  module: "Catalog"
-  actiongroups:
-     - name: "AdminOpenProductIndexPageActionGroup"
-       description: ""
- 
-- filename: "StorefrontProductPageActionGroup.xml"
-  repo: "https://github.com/magento/magento2/blob/2.3/app/code/Magento/Catalog/Test/Mftf/ActionGroup/StorefrontProductPageActionGroup.xml"
-  module: "Catalog"
-  actiongroups:
-     - name: "addToCartFromStorefrontProductPage"
-       description: "Click on the Add to Cart button. Validates that the Success Message is present."
+     - name: "AdminCreateCartPriceRuleAndStayOnEditActionGroup"
+       description: "EXTENDS: AdminCreateCartPriceRuleActionGroup. Clicks on Save and Continue."
 
-     - name: "AddProductWithQtyToCartFromStorefrontProductPage"
-       description: "EXTENDS: addToCartFromStorefrontProductPage. Fills in the provided Product Quantity for the provided Product Name."
+     - name: "AdminCreateCartPriceRuleWithCouponCode"
+       description: "EXTENDS: AdminCreateCartPriceRuleActionGroup. Removes 'selectActionType' and 'fillDiscountAmount'. Adds the provided Coupon Code to a Cart Price Rule."
 
-     - name: "testDynamicValidationHint"
-       description: "Validates that the Product Text Option Text Length Hint displays the correct Count for multiple inputs based on the provided Character Limit."
+     - name: "AdminDeleteCartPriceRuleForRetailerActionGroup"
+       description: "Goes to the Admin Cart Price Rules grid page. Removes the 1st Cart Price Rule in the Grid."
 
-     - name: "checkAttributeInMoreInformationTab"
-       description: "Validates that the Product More Information area contains the provided Text."
+     - name: "AdminCreateCartPriceRuleWithConditions"
+       description: "EXTENDS: AdminCreateCartPriceRuleActionGroup. Removes 'fillDiscountAmount'. Adds the 2 provided Conditions (Name, Rule, Rule to Change and Category Name) to a Cart Price Rule."
 
-     - name: "checkAttributeNotInMoreInformationTab"
-       description: "Validate that the More Information area does not contain the provided Text."
- 
-- filename: "StorefrontCompareActionGroup.xml"
-  repo: "https://github.com/magento/magento2/blob/2.3/app/code/Magento/Catalog/Test/Mftf/ActionGroup/StorefrontCompareActionGroup.xml"
-  module: "Catalog"
+     - name: "AdminCreateCartPriceRuleActionsWithSubtotalActionGroup"
+       description: "EXTENDS: AdminCreateCartPriceRuleActionGroup. Removes 'fillDiscountAmount'. Adds sub total conditions for free shipping to a Cart Price Rule."
+
+     - name: "AdminCreateMultiWebsiteCartPriceRuleActionGroup"
+       description: "EXTENDS: AdminCreateCartPriceRuleActionGroup. Removes 'clickSaveButton' for the next data changing. Assign cart price rule to 2 websites instead of 1."
+
+     - name: "CreateCartPriceRuleSecondWebsiteActionGroup"
+       description: "Goes to the Admin Cart Price Rule grid page. Clicks on Add New Rule. Fills the provided Rule (Name). Selects 'Second Website' from the 'Websites' menu."
+
+     - name: "AdminInactiveCartPriceRuleActionGroup"
+       description: "EXTENDS: AdminCreateCartPriceRuleActionGroup. Clicks on 'Active'."
+
+     - name: "AdminCreateCartPriceRuleWithConditionIsCategoryActionGroup"
+       description: "EXTENDS: AdminCreateCartPriceRuleActionGroup. Sets the provide Condition (Actions Aggregator/Value, Child Attribute and Action Value) for Actions on the Admin Cart Price Rule creation/edit page."
+- filename: "AssertCartPriceRuleSuccessSaveMessageActionGroup.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/SalesRule/Test/Mftf/ActionGroup/AssertCartPriceRuleSuccessSaveMessageActionGroup.xml"
+  module: "SalesRule"
   actiongroups:
-     - name: "StorefrontAddCategoryProductToCompareActionGroup"
-       description: "Add a Product to the Compare Product list from a Category page."
-
-     - name: "StorefrontAddProductToCompareActionGroup"
-       description: "Add a Product to the Compare Product list. Validate that the Success Message is present."
-
-     - name: "StorefrontCheckCompareSidebarProductActionGroup"
-       description: "Validate that the Product Name is present and correct in the Compare Product list."
-
-     - name: "StorefrontOpenAndCheckComparisionActionGroup"
-       description: "Open the Storefront Compare Product page. Validate that the Compare Product fields are present."
-
-     - name: "StorefrontCheckCompareSimpleProductActionGroup"
-       description: "Validate that the Simple Product is present and correct in the Compare Product area."
-
-     - name: "StorefrontClearCompareActionGroup"
-       description: "Clear the Compare Products list. Validate that the Compare Products list is empty."
- 
-- filename: "StorefrontClickAddToCartOnProductPageActionGroup.xml"
-  repo: "https://github.com/magento/magento2/blob/2.3/app/code/Magento/Catalog/Test/Mftf/ActionGroup/StorefrontClickAddToCartOnProductPageActionGroup.xml"
-  module: "Catalog"
+     - name: "AssertCartPriceRuleSuccessSaveMessageActionGroup"
+       description: "Clicks on the Save button on the Admin Cart Price Rule creation/edit page. Validates that the Success Message is present and correct."
+- filename: "AdminSalesRuleActionGroup.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/SalesRule/Test/Mftf/ActionGroup/AdminSalesRuleActionGroup.xml"
+  module: "SalesRule"
   actiongroups:
-     - name: "StorefrontClickAddToCartOnProductPageActionGroup"
-       description: "Adds a Product to the Cart. Validate that the Success Message is present."
- 
-- filename: "AdminAssertProductsGridIsEmptyActionGroup.xml"
-  repo: "https://github.com/magento/magento2/blob/2.3/app/code/Magento/Catalog/Test/Mftf/ActionGroup/AdminAssertProductsGridIsEmptyActionGroup.xml"
-  module: "Catalog"
+     - name: "DeleteCartPriceRuleByName"
+       description: "Goes to the Admin Cart Price Rules grid page. Filters the grid based on the provided Rule Name. Deletes the Price Rule via the grid."
+- filename: "AdminCreateCartPriceRuleActionsSectionActionGroup.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/SalesRule/Test/Mftf/ActionGroup/AdminCreateCartPriceRuleActionsSectionActionGroup.xml"
+  module: "SalesRule"
   actiongroups:
-     - name: "AdminAssertProductsGridIsEmptyActionGroup"
+     - name: "AdminCreateCartPriceRuleActionsSectionDiscountFieldsActionGroup"
+       description: "Clicks on the 'Actions' section on the Admin Cart Price Rule creation/edit page. Fills in the provided Cart Price Rule details."
+
+     - name: "AdminCreateCartPriceRuleActionsSectionShippingAmountActionGroup"
+       description: "Clicks on the 'Apply to Shipping Amount' toggle."
+
+     - name: "AdminCreateCartPriceRuleActionsSectionSubsequentRulesActionGroup"
+       description: "Clicks on the 'Discard subsequent rules' toggle."
+
+     - name: "AdminCreateCartPriceRuleActionsSectionFreeShippingActionGroup"
+       description: "Selects the provided option in the 'Free Shipping' dropdown menu."
+- filename: "StorefrontAddToTheCartActionGroup.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/SalesRule/Test/Mftf/ActionGroup/StorefrontAddToTheCartActionGroup.xml"
+  module: "SalesRule"
+  actiongroups:
+     - name: "StorefrontAddToTheCartActionGroup"
        description: ""
- 
-- filename: "DisableProductLabelActionGroup.xml"
-  repo: "https://github.com/magento/magento2/blob/2.3/app/code/Magento/Catalog/Test/Mftf/ActionGroup/DisableProductLabelActionGroup.xml"
-  module: "Catalog"
+- filename: "StorefrontApplyDiscountCodeActionGroup.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/SalesRule/Test/Mftf/ActionGroup/StorefrontApplyDiscountCodeActionGroup.xml"
+  module: "SalesRule"
   actiongroups:
-     - name: "DisableProductLabelActionGroup"
-       description: "Disable Product Label and Change Attribute Set."
- 
-- filename: "VerifyProductTypeOrderActionGroup.xml"
-  repo: "https://github.com/magento/magento2/blob/2.3/app/code/Magento/Catalog/Test/Mftf/ActionGroup/VerifyProductTypeOrderActionGroup.xml"
-  module: "Catalog"
-  actiongroups:
-     - name: "VerifyProductTypeOrder"
-       description: "Clicks on the 'Add Product' toggle. Validates that the Simple/Virtual Products are listed in the correct order."
- 
-- filename: "MoveCategoryActionGroup.xml"
-  repo: "https://github.com/magento/magento2/blob/2.3/app/code/Magento/Catalog/Test/Mftf/ActionGroup/MoveCategoryActionGroup.xml"
-  module: "Catalog"
-  actiongroups:
-     - name: "MoveCategoryActionGroup"
-       description: "Move a Category on the Backend Category page."
- 
-- filename: "StorefrontAssertGiftMessageFieldsActionGroup.xml"
-  repo: "https://github.com/magento/magento2/blob/2.3/app/code/Magento/Catalog/Test/Mftf/ActionGroup/StorefrontAssertGiftMessageFieldsActionGroup.xml"
-  module: "Catalog"
-  actiongroups:
-     - name: "StorefrontAssertGiftMessageFieldsActionGroup"
+     - name: "StorefrontApplyDiscountCodeActionGroup"
        description: ""
- 
-- filename: "AdminAssertProductEditPageCreateAttributeSaveInAttributeSetPopUpShownActionGroup.xml"
-  repo: "https://github.com/magento/magento2/blob/2.3/app/code/Magento/Catalog/Test/Mftf/ActionGroup/AdminAssertProductEditPageCreateAttributeSaveInAttributeSetPopUpShownActionGroup.xml"
-  module: "Catalog"
+- filename: "AdminCreateCartPriceRuleRuleInfoSectionActionGroup.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/SalesRule/Test/Mftf/ActionGroup/AdminCreateCartPriceRuleRuleInfoSectionActionGroup.xml"
+  module: "SalesRule"
   actiongroups:
-     - name: "AdminAssertProductEditPageCreateAttributeSaveInAttributeSetPopUpShownActionGroup"
-       description: "Asserts that after click on \"Save In New Attribute Set\" poup shown  ."
- 
-- filename: "FilterProductInGridByStoreViewAndNameActionGroup.xml"
-  repo: "https://github.com/magento/magento2/blob/2.3/app/code/Magento/Catalog/Test/Mftf/ActionGroup/FilterProductInGridByStoreViewAndNameActionGroup.xml"
-  module: "Catalog"
+     - name: "AdminCreateCartPriceRuleRuleInfoSectionActionGroup"
+       description: "Goes to the Admin Cart Price Rule grid page. Clicks on Add New Rule. Fills in the provided Rule details."
+- filename: "AdminOpenNewCartPriceRuleFormPageActionGroup.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/SalesRule/Test/Mftf/ActionGroup/AdminOpenNewCartPriceRuleFormPageActionGroup.xml"
+  module: "SalesRule"
   actiongroups:
-     - name: "FilterProductInGridByStoreViewAndNameActionGroup"
-       description: "Goes to the Admin Products grid page. Filters the grid based on the provided Store View. Validates that the Product Name is present in the 1st row of the grid."
- 
-- filename: "StorefrontAssertProductNameOnProductPageActionGroup.xml"
-  repo: "https://github.com/magento/magento2/blob/2.3/app/code/Magento/Catalog/Test/Mftf/ActionGroup/StorefrontAssertProductNameOnProductPageActionGroup.xml"
-  module: "Catalog"
+     - name: "AdminOpenNewCartPriceRuleFormPageActionGroup"
+       description: "Goes to the Admin Cart Price Rule creation page."
+- filename: "AdminCartPriceRuleActionGroup.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/SalesRule/Test/Mftf/ActionGroup/AdminCartPriceRuleActionGroup.xml"
+  module: "SalesRule"
   actiongroups:
-     - name: "StorefrontAssertProductNameOnProductPageActionGroup"
-       description: "Validate that the provided Product Price is present and correct."
- 
-- filename: "StorefrontAddProductReviewActionGroup.xml"
-  repo: "https://github.com/magento/magento2/blob/2.3/app/code/Magento/Catalog/Test/Mftf/ActionGroup/StorefrontAddProductReviewActionGroup.xml"
-  module: "Catalog"
-  actiongroups:
-     - name: "StorefrontAddProductReviewActionGroup"
-       description: ""
- 
-- filename: "StorefrontAddToCartCustomOptionsProductPageActionGroup.xml"
-  repo: "https://github.com/magento/magento2/blob/2.3/app/code/Magento/Catalog/Test/Mftf/ActionGroup/StorefrontAddToCartCustomOptionsProductPageActionGroup.xml"
-  module: "Catalog"
-  actiongroups:
-     - name: "StorefrontAddToCartCustomOptionsProductPageActionGroup"
-       description: "Add a Product to the Cart. Validate that the Success Message is present."
- 
-- filename: "AdminAssignImageRolesActionGroup.xml"
-  repo: "https://github.com/magento/magento2/blob/2.3/app/code/Magento/Catalog/Test/Mftf/ActionGroup/AdminAssignImageRolesActionGroup.xml"
-  module: "Catalog"
-  actiongroups:
-     - name: "AdminAssignImageRolesActionGroup"
-       description: "Requires the navigation to the Product Creation page. Checks the Base, Small, Thumbnail, and Swatch Roles areas for images."
+     - name: "selectNotLoggedInCustomerGroup"
+       description: "Selects 'NOT LOGGED IN' from the 'Customer Groups' list (Magento 2 B2B). PLEASE NOTE: The value is Hardcoded."
 
-     - name: "AdminAssignImageRolesIfUnassignedActionGroup"
-       description: "Requires the navigation to the Product Creation page. Assign the Base, Small, Thumbnail, and Swatch Roles to image."
- 
-- filename: "CheckProductsOrderActionGroup.xml"
-  repo: "https://github.com/magento/magento2/blob/2.3/app/code/Magento/Catalog/Test/Mftf/ActionGroup/CheckProductsOrderActionGroup.xml"
-  module: "Catalog"
-  actiongroups:
-     - name: "CompareTwoProductsOrder"
-       description: "Goes to the Storefront. Validates that the 2 provided Products appear in the correct order."
- 
-- filename: "AdminCheckProductsInGridActionGroup.xml"
-  repo: "https://github.com/magento/magento2/blob/2.3/app/code/Magento/Catalog/Test/Mftf/ActionGroup/AdminCheckProductsInGridActionGroup.xml"
-  module: "Catalog"
-  actiongroups:
-     - name: "AdminCheckProductIsMissingInCategoryProductsGrid"
-       description: ""
+     - name: "selectRetailerCustomerGroup"
+       description: "Selects 'Retailer' from the 'Customer Groups' list (Magento 2 B2B). PLEASE NOTE: The value is Hardcoded."
 
-     - name: "AdminCheckProductPositionInCategoryProductsGrid"
-       description: ""
- 
-- filename: "StorefrontAssertProductImagesOnProductPageActionGroup.xml"
-  repo: "https://github.com/magento/magento2/blob/2.3/app/code/Magento/Catalog/Test/Mftf/ActionGroup/StorefrontAssertProductImagesOnProductPageActionGroup.xml"
-  module: "Catalog"
-  actiongroups:
-     - name: "StorefrontAssertProductImagesOnProductPageActionGroup"
-       description: "Validate that the Product Image is present and correct. Validate that the Fullscreen Product Image is present and correct."
+     - name: "SetCartAttributeConditionForCartPriceRuleActionGroup"
+       description: "Sets the provided Cart Attribute Condition (Attribute Name, Operator Type and Value) on the Admin Cart Price Rule creation/edit page."
 
-     - name: "StorefrontAssertFotoramaImageAvailablity"
-       description: ""
- 
-- filename: "StorefrontGoToCategoryPageActionGroup.xml"
-  repo: "https://github.com/magento/magento2/blob/2.3/app/code/Magento/Catalog/Test/Mftf/ActionGroup/StorefrontGoToCategoryPageActionGroup.xml"
-  module: "Catalog"
+     - name: "SetConditionForActionsInCartPriceRuleActionGroup"
+       description: "Sets the provided Condition (Actions Aggregator/Value, Child Attribute and Action Value) for Actions on the Admin Cart Price Rule creation/edit page."
+- filename: "AdminCreateCartPriceRuleLabelsSectionActionGroup.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/SalesRule/Test/Mftf/ActionGroup/AdminCreateCartPriceRuleLabelsSectionActionGroup.xml"
+  module: "SalesRule"
   actiongroups:
-     - name: "StorefrontGoToCategoryPageActionGroup"
+     - name: "AdminCreateCartPriceRuleLabelsSectionActionGroup"
+       description: "Fills in the provided Rule details on a Admin Cart Price Rule creation/edit page."
+- filename: "AdminAssertCustomerGroupOnCartPriceRuleFormActionGroup.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/SalesRule/Test/Mftf/ActionGroup/AdminAssertCustomerGroupOnCartPriceRuleFormActionGroup.xml"
+  module: "SalesRule"
+  actiongroups:
+     - name: "AdminAssertCustomerGroupOnCartPriceRuleForm"
        description: ""
+- filename: "AdminDeleteCartPriceRuleActionGroup.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/SalesRule/Test/Mftf/ActionGroup/AdminDeleteCartPriceRuleActionGroup.xml"
+  module: "SalesRule"
+  actiongroups:
+     - name: "AdminDeleteCartPriceRuleActionGroup"
+       description: "Goes to the Admin Cart Price Rules grid page. Filters the grid for the provided Rule Name. Deletes the Rule via the grid."
+- filename: "AssertStorefrontMiniCartItemsActionGroup.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/SalesRule/Test/Mftf/ActionGroup/AssertStorefrontMiniCartItemsActionGroup.xml"
+  module: "SalesRule"
+  actiongroups:
+     - name: "AssertStorefrontMiniCartItemsActionGroup"
+       description: ""
+- filename: "AssertStorefrontCheckoutCartTaxAmountFPTActionGroup.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/Weee/Test/Mftf/ActionGroup/AssertStorefrontCheckoutCartTaxAmountFPTActionGroup.xml"
+  module: "Weee"
+  actiongroups:
+     - name: "AssertStorefrontCheckoutCartTaxAmountFPTActionGroup"
+       description: "EXTENDS: AssertStorefrontCheckoutCartTaxAmountActionGroup. Add check FPT tax summary in Summary section of shopping cart on storefront"
+- filename: "AdminProductAddFPTValueActionGroup.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/Weee/Test/Mftf/ActionGroup/AdminProductAddFPTValueActionGroup.xml"
+  module: "Weee"
+  actiongroups:
+     - name: "AdminProductAddFPTValueActionGroup"
+       description: "Adds the provided FPT details (Attribute Code, Country, State and Value) on the Admin Product creation/edit page."
+- filename: "AdminOpenStoreConfigPageActionGroup.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/Config/Test/Mftf/ActionGroup/AdminOpenStoreConfigPageActionGroup.xml"
+  module: "Config"
+  actiongroups:
+     - name: "AdminOpenStoreConfigPageActionGroup"
+       description: "Go to admin store configuration page."
+- filename: "AdminExpandConfigTabActionGroup.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/Config/Test/Mftf/ActionGroup/AdminExpandConfigTabActionGroup.xml"
+  module: "Config"
+  actiongroups:
+     - name: "AdminExpandConfigTabActionGroup"
+       description: "Goes to the 'Configuration' page and expands main level configuration tab passed via argument as Tab Name."
+- filename: "SwitcherActionGroup.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/Config/Test/Mftf/ActionGroup/SwitcherActionGroup.xml"
+  module: "Config"
+  actiongroups:
+     - name: "SwitchToVersion4ActionGroup"
+       description: "Goes to the 'Configuration' page for 'Content Management'. Sets the 'WYSIWYG Editor' to 'TinyMCE 4'. Clicks on the Save button. PLEASE NOTE: The value is Hardcoded."
+- filename: "AdminOpenConfigNavItemActionGroup.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/Config/Test/Mftf/ActionGroup/AdminOpenConfigNavItemActionGroup.xml"
+  module: "Config"
+  actiongroups:
+     - name: "AdminOpenConfigNavItemActionGroup"
+       description: "Clicks on config nav item selected by passed argument."
+- filename: "ResetSearchEngineConfigurationActionGroup.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/Config/Test/Mftf/ActionGroup/ResetSearchEngineConfigurationActionGroup.xml"
+  module: "Config"
+  actiongroups:
+     - name: "ResetSearchEngineConfigurationActionGroup"
+       description: "Goes to the 'Configuration' page for 'Catalog'. Sets the 'Search Engine' to 'mysql'. Clicks on the Save button. PLEASE NOTE: The value is Hardcoded."
+- filename: "AdminOpenStoreConfigDeveloperPageActionGroup.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/Config/Test/Mftf/ActionGroup/AdminOpenStoreConfigDeveloperPageActionGroup.xml"
+  module: "Config"
+  actiongroups:
+     - name: "AdminOpenStoreConfigDeveloperPageActionGroup"
+       description: "Go to admin store configuration developer page."
+- filename: "ConfigAdminAccountSharingActionGroup.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/Config/Test/Mftf/ActionGroup/ConfigAdminAccountSharingActionGroup.xml"
+  module: "Config"
+  actiongroups:
+     - name: "ConfigAdminAccountSharingActionGroup"
+       description: "Goes to the 'Configuration' page for 'Admin'. Enables 'Admin Account Sharing'. Clicks on the Save button."
 
-     - name: "StorefrontGoToSubCategoryPageActionGroup"
+     - name: "EnableAdminAccountSharingActionGroup"
+       description: "Enabled 'Admin Account Sharing' via the API."
+
+     - name: "DisableAdminAccountSharingActionGroup"
+       description: "Disables 'Admin Account Sharing' via the API."
+- filename: "ConfigWYSIWYGActionGroup.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/Config/Test/Mftf/ActionGroup/ConfigWYSIWYGActionGroup.xml"
+  module: "Config"
+  actiongroups:
+     - name: "EnabledWYSIWYG"
+       description: "Enables the WYSIWYG Editor via the CLI."
+
+     - name: "SwitchToTinyMCE3"
+       description: "Goes to the 'Configuration' page for 'Content Management'. Sets 'WYSIWYG Editor' to 'TinyMCE 3'. Clicks on the Save button. PLEASE NOTE: The value is Hardcoded."
+
+     - name: "DisabledWYSIWYG"
+       description: "Disables the WYSIWYG Editor via the CLI."
+
+     - name: "UseStaticURLForMediaContentInWYSIWYG"
+       description: "Goes to the 'Configuration' page for 'Content Management'. Sets 'Use Static URLs for Media Content in WYSIWYG' to the provided value. Clicks on the Save button."
+
+     - name: "EnabledWYSIWYGEditor"
+       description: "Goes to the 'Configuration' page for 'Content Management'. Sets 'Enable WYSIWYG Editor' to 'Enabled by Default'. Clicks on the Save button. PLEASE NOTE: The value is Hardcoded."
+- filename: "ConfigAdminCatalogSearchActionGroup.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/Config/Test/Mftf/ActionGroup/ConfigAdminCatalogSearchActionGroup.xml"
+  module: "Config"
+  actiongroups:
+     - name: "ChooseElasticSearchAsSearchEngine"
+       description: "Goes to the 'Configuration' page for 'Catalog'. Sets the 'Search Engine' to 'elasticsearch5'. Clicks on the Save button. PLEASE NOTE: The value is Hardcoded."
+
+     - name: "ResetSearchEngineConfiguration"
+       description: "Goes to the 'Configuration' page for 'Catalog'. Sets the 'Search Engine' to 'mysql'. Clicks on the Save button. PLEASE NOTE: The value is Hardcoded."
+- filename: "GeneralConfigurationActionGroup.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/Config/Test/Mftf/ActionGroup/GeneralConfigurationActionGroup.xml"
+  module: "Config"
+  actiongroups:
+     - name: "NavigateToDefaultLayoutsSetting"
+       description: "Goes to the 'Configuration' page for 'Web'. Expands the 'Default Layouts' section."
+
+     - name: "NavigateToConfigurationGeneralPage"
+       description: "Goes to the 'Configuration' page for 'General'."
+
+     - name: "SelectTopDestinationsCountry"
+       description: "Selects the provided Countries under 'Top destinations' on the 'General' section of the 'Configuration' page. Clicks on the Save button."
+
+     - name: "UnSelectTopDestinationsCountry"
+       description: "Un-selects the provided Countries under 'Top destinations' on the 'General' section of the 'Configuration' page. Clicks on the Save button."
+
+     - name: "SelectCountriesWithRequiredRegion"
+       description: "Goes to the 'Configuration' page for 'General'. Selects the provided Countries under 'State is Required for'. Clicks on the Save button."
+- filename: "AdminExpandSecurityTabActionGroup.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/Config/Test/Mftf/ActionGroup/AdminExpandSecurityTabActionGroup.xml"
+  module: "Config"
+  actiongroups:
+     - name: "AdminExpandSecurityTabActionGroup"
        description: ""
- 
-- filename: "OpenEditProductOnBackendActionGroup.xml"
-  repo: "https://github.com/magento/magento2/blob/2.3/app/code/Magento/Catalog/Test/Mftf/ActionGroup/OpenEditProductOnBackendActionGroup.xml"
-  module: "Catalog"
+- filename: "AdminSaveConfigActionGroup.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/Config/Test/Mftf/ActionGroup/AdminSaveConfigActionGroup.xml"
+  module: "Config"
   actiongroups:
-     - name: "OpenEditProductOnBackendActionGroup"
-       description: "Click on Edit for the provided Product SKU."
- 
-- filename: "AssertSiteMapCreateSuccessActionGroup.xml"
-  repo: "https://github.com/magento/magento2/blob/2.3/app/code/Magento/Sitemap/Test/Mftf/ActionGroup/AssertSiteMapCreateSuccessActionGroup.xml"
-  module: "Sitemap"
+     - name: "AdminSaveConfigActionGroup"
+       description: ""
+- filename: "EnabledWYSIWYGActionGroup.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/Config/Test/Mftf/ActionGroup/EnabledWYSIWYGActionGroup.xml"
+  module: "Config"
   actiongroups:
-     - name: "AssertSiteMapCreateSuccessActionGroup"
-       description: "Validate the success message after creating site map."
- 
-- filename: "AdminMarketingSiteMapNavigateNewActionGroup.xml"
-  repo: "https://github.com/magento/magento2/blob/2.3/app/code/Magento/Sitemap/Test/Mftf/ActionGroup/AdminMarketingSiteMapNavigateNewActionGroup.xml"
-  module: "Sitemap"
+     - name: "EnabledWYSIWYGActionGroup"
+       description: "Enables the WYSIWYG Editor via the CLI."
+- filename: "DisabledWYSIWYGActionGroup.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/Config/Test/Mftf/ActionGroup/DisabledWYSIWYGActionGroup.xml"
+  module: "Config"
   actiongroups:
-     - name: "AdminMarketingSiteMapNavigateNewActionGroup"
-       description: "Navigate to New Site Map"
- 
-- filename: "AdminMarketingSiteMapFillFormActionGroup.xml"
-  repo: "https://github.com/magento/magento2/blob/2.3/app/code/Magento/Sitemap/Test/Mftf/ActionGroup/AdminMarketingSiteMapFillFormActionGroup.xml"
-  module: "Sitemap"
+     - name: "DisabledWYSIWYGActionGroup"
+       description: "Disables the WYSIWYG Editor via the CLI."
+- filename: "ConfigWebUrlOptionsActionGroup.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/Config/Test/Mftf/ActionGroup/ConfigWebUrlOptionsActionGroup.xml"
+  module: "Config"
   actiongroups:
-     - name: "AdminMarketingSiteMapFillFormActionGroup"
-       description: "Fill data to Site map form"
- 
-- filename: "AdminMarketingSiteDeleteByNameActionGroup.xml"
-  repo: "https://github.com/magento/magento2/blob/2.3/app/code/Magento/Sitemap/Test/Mftf/ActionGroup/AdminMarketingSiteDeleteByNameActionGroup.xml"
-  module: "Sitemap"
+     - name: "EnableWebUrlOptions"
+       description: "Goes to the 'Configuration' page for 'Url Options'. Enables 'Add Store Code to Urls'. Clicks on the Save button."
+
+     - name: "ResetWebUrlOptions"
+       description: "Goes to the 'Configuration' page for 'Url Options'. Disables 'Add Store Code to Urls'. Clicks on the Save button."
+- filename: "AdminConfigCreateNewAccountActionGroup.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/Config/Test/Mftf/ActionGroup/AdminConfigCreateNewAccountActionGroup.xml"
+  module: "Config"
   actiongroups:
-     - name: "AdminMarketingSiteDeleteByNameActionGroup"
-       description: "Go to the Site map page. Delete a site map based on the provided Name."
- 
-- filename: "AssertSiteMapDeleteSuccessActionGroup.xml"
-  repo: "https://github.com/magento/magento2/blob/2.3/app/code/Magento/Sitemap/Test/Mftf/ActionGroup/AssertSiteMapDeleteSuccessActionGroup.xml"
-  module: "Sitemap"
+     - name: "SetGroupForValidVATIdIntraUnionActionGroup"
+       description: "Goes to the 'Configuration' page for 'Customer Configuration'. Sets the 'Group For Valid VAT ID Intra Union' option. Clicks on the Save button. Validates the Save message is present."
+- filename: "AdminOpenConfigAdminPageActionGroup.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/Config/Test/Mftf/ActionGroup/AdminOpenConfigAdminPageActionGroup.xml"
+  module: "Config"
   actiongroups:
-     - name: "AssertSiteMapDeleteSuccessActionGroup"
-       description: "Validate the success message after delete site map."
- 
+     - name: "AdminOpenConfigAdminPageActionGroup"
+       description: ""
+- filename: "AdminSetMaximumLoginFailuresToLockoutAccountActionGroup.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/Config/Test/Mftf/ActionGroup/AdminSetMaximumLoginFailuresToLockoutAccountActionGroup.xml"
+  module: "Config"
+  actiongroups:
+     - name: "AdminSetMaximumLoginFailuresToLockoutAccountActionGroup"
+       description: ""
+- filename: "RestoreLayoutSettingActionGroup.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/Config/Test/Mftf/ActionGroup/RestoreLayoutSettingActionGroup.xml"
+  module: "Config"
+  actiongroups:
+     - name: "RestoreLayoutSetting"
+       description: "Goes to the 'Configuration' page for 'Web'. Clicks on the Save button."
+- filename: "ConfigSalesTaxClassActionGroup.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/Config/Test/Mftf/ActionGroup/ConfigSalesTaxClassActionGroup.xml"
+  module: "Config"
+  actiongroups:
+     - name: "SetTaxClassForShipping"
+       description: "Goes to the 'Configuration' page for 'Tax'. Sets 'Tax Class for Shipping' to 'Taxable Goods'. Clicks on the Save button. PLEASE NOTE: The value is Hardcoded."
+
+     - name: "ResetTaxClassForShipping"
+       description: "Goes to the 'Configuration' page for 'Tax'. Sets 'Tax Class for Shipping' to 'None'. Clicks on the Save button. PLEASE NOTE: The value is Hardcoded."
+
+     - name: "SetTaxApplyOnSetting"
+       description: "Goes to the 'Configuration' page for 'Tax'. Sets 'Apply Tax On' to the provided value. Clicks on the Save button"
+
+     - name: "DisableTaxApplyOnOriginalPrice"
+       description: "Goes to the 'Configuration' page for 'Tax'. Sets 'Apply Tax On' to the provided value. Clicks on the Save button."
 - filename: "AdminDeleteTaxRuleActionGroup.xml"
-  repo: "https://github.com/magento/magento2/blob/2.3/app/code/Magento/Tax/Test/Mftf/ActionGroup/AdminDeleteTaxRuleActionGroup.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/Tax/Test/Mftf/ActionGroup/AdminDeleteTaxRuleActionGroup.xml"
   module: "Tax"
   actiongroups:
      - name: "AdminDeleteTaxRule"
        description: "Goes to the Admin Tax Rule grid page. Deletes the provided Tax Rule Code."
- 
 - filename: "AdminTaxActionGroup.xml"
-  repo: "https://github.com/magento/magento2/blob/2.3/app/code/Magento/Tax/Test/Mftf/ActionGroup/AdminTaxActionGroup.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/Tax/Test/Mftf/ActionGroup/AdminTaxActionGroup.xml"
   module: "Tax"
   actiongroups:
      - name: "editTaxConfigurationByUI"
@@ -2513,16 +3396,26 @@
 
      - name: "deleteProductTaxClass"
        description: "Goes to the Admin Tax Rule creation page. Deletes the provided Tax Class."
- 
+- filename: "AssertStorefrontCheckoutCartTaxAmountActionGroup.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/Tax/Test/Mftf/ActionGroup/AssertStorefrontCheckoutCartTaxAmountActionGroup.xml"
+  module: "Tax"
+  actiongroups:
+     - name: "AssertStorefrontCheckoutCartTaxAmountActionGroup"
+       description: "Check tax summary data in Summary section of shopping cart on storefront"
+- filename: "AdminCreateTaxRuleCustomProductTaxClassActionGroup.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/Tax/Test/Mftf/ActionGroup/AdminCreateTaxRuleCustomProductTaxClassActionGroup.xml"
+  module: "Tax"
+  actiongroups:
+     - name: "AdminCreateTaxRuleCustomProductTaxClassActionGroup"
+       description: "Admin create tax rule with custom tax rate and product tax class"
 - filename: "AdminCreateTaxRuleActionGroup.xml"
-  repo: "https://github.com/magento/magento2/blob/2.3/app/code/Magento/Tax/Test/Mftf/ActionGroup/AdminCreateTaxRuleActionGroup.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/Tax/Test/Mftf/ActionGroup/AdminCreateTaxRuleActionGroup.xml"
   module: "Tax"
   actiongroups:
      - name: "AdminCreateTaxRuleActionGroup"
        description: ""
- 
 - filename: "AdminCustomerTaxClassActionGroup.xml"
-  repo: "https://github.com/magento/magento2/blob/2.3/app/code/Magento/Tax/Test/Mftf/ActionGroup/AdminCustomerTaxClassActionGroup.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/Tax/Test/Mftf/ActionGroup/AdminCustomerTaxClassActionGroup.xml"
   module: "Tax"
   actiongroups:
      - name: "addCustomerTaxClass"
@@ -2530,673 +3423,86 @@
 
      - name: "deleteCustomerTaxClass"
        description: "Goes to the Admin New Tax Rule page. Deletes the provided Tax Class Name."
- 
-- filename: "StorefrontSelectCustomizeAndAddToTheCartButtonActionGroup.xml"
-  repo: "https://github.com/magento/magento2/blob/2.3/app/code/Magento/Bundle/Test/Mftf/ActionGroup/StorefrontSelectCustomizeAndAddToTheCartButtonActionGroup.xml"
-  module: "Bundle"
+- filename: "EmailTemplateActionGroup.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/Email/Test/Mftf/ActionGroup/EmailTemplateActionGroup.xml"
+  module: "Email"
   actiongroups:
-     - name: "StorefrontSelectCustomizeAndAddToTheCartButtonActionGroup"
-       description: "Clicks 'Customize and Add to Cart' on a Storefront Bundled Product page."
- 
-- filename: "BundleProductFilterActionGroup.xml"
-  repo: "https://github.com/magento/magento2/blob/2.3/app/code/Magento/Bundle/Test/Mftf/ActionGroup/BundleProductFilterActionGroup.xml"
-  module: "Bundle"
-  actiongroups:
-     - name: "BundleProductFilter"
-       description: "Applies a Backend Admin Grid filter for Bundle Products."
- 
-- filename: "StoreFrontAddProductToCartFromBundleActionGroup.xml"
-  repo: "https://github.com/magento/magento2/blob/2.3/app/code/Magento/Bundle/Test/Mftf/ActionGroup/StoreFrontAddProductToCartFromBundleActionGroup.xml"
-  module: "Bundle"
-  actiongroups:
-     - name: "StoreFrontAddProductToCartFromBundleWithCurrencyActionGroup"
-       description: "Adds a Bundled Product to the Cart with a specified Currency Value."
- 
-- filename: "AdminBundleProductActionGroup.xml"
-  repo: "https://github.com/magento/magento2/blob/2.3/app/code/Magento/Bundle/Test/Mftf/ActionGroup/AdminBundleProductActionGroup.xml"
-  module: "Bundle"
-  actiongroups:
-     - name: "fillMainBundleProductForm"
-       description: "Fills the Name, SKU and Stock Status fields."
+     - name: "CreateNewTemplate"
+       description: "Clicks on Add New Template. Fills the Template details. Clicks on Save. PLEASE NOTE: The values are Hardcoded."
 
-     - name: "checkRequiredFieldsInBundleProductForm"
-       description: "Clears the Name and SKU fields when adding a Product and then verifies that they are required after attempting to Save."
-
-     - name: "viewBundleProductInAdminGrid"
-       description: "Clears the Grid Filters on the Catalog Grid page and applies Filter by Name and Sku. Then checks to see if the Product exists in the 1st row. Then clears the Grid Filters again for future Tests."
- 
-- filename: "AdminOrderBundleProductActionGroup.xml"
-  repo: "https://github.com/magento/magento2/blob/2.3/app/code/Magento/Bundle/Test/Mftf/ActionGroup/AdminOrderBundleProductActionGroup.xml"
-  module: "Bundle"
-  actiongroups:
-     - name: "AdminOrderConfigureBundleProduct"
-       description: ""
- 
-- filename: "StorefrontProductCartActionGroup.xml"
-  repo: "https://github.com/magento/magento2/blob/2.3/app/code/Magento/Bundle/Test/Mftf/ActionGroup/StorefrontProductCartActionGroup.xml"
-  module: "Bundle"
-  actiongroups:
-     - name: "StorefrontAddCategoryBundleProductToCartActionGroup"
-       description: "Adds a Bundled Product to the Cart from the Category page."
-
-     - name: "StorefrontAddBundleProductFromCategoryToCartActionGroup"
-       description: "Adds a Bundled Product to the Cart from the Product page. PLEASE NOTE: The Quantity selection is not available in the Action Group."
-
-     - name: "StorefrontAddBundleProductFromProductToCartActionGroup"
-       description: "Adds a Bundled Product to the Cart from the Product page. PLEASE NOTE: The Quantity selection is not available in the Action Group."
-
-     - name: "StorefrontAddBundleProductFromProductToCartWithMultiOption"
-       description: "Selects a Bundled Product option on the Bundled Product page. PLEASE NOTE: The Quantity selection is not available in the Action Group."
- 
-- filename: "EnableDisableProductActionGroup.xml"
-  repo: "https://github.com/magento/magento2/blob/2.3/app/code/Magento/Bundle/Test/Mftf/ActionGroup/EnableDisableProductActionGroup.xml"
-  module: "Bundle"
-  actiongroups:
-     - name: "AncillaryPrepBundleProduct"
-       description: "Requires Navigation to the Product Creation page. Fills out Name, Sku, and SEO information using the BundleProduct Data Entity. PLEASE NOTE: The Action Group values are Hardcoded."
-
-     - name: "FindProductToEdit"
-       description: "Clears the Backend Admin Grid Filters on the Backend Admin Product Grid page. Searches for the BundleProduct Data Entity. Then clicks on the first item in the Admin Grid. PLEASE NOTE: The Action Group values are Hardcoded."
- 
-- filename: "AdminCreateApiBundleProductActionGroup.xml"
-  repo: "https://github.com/magento/magento2/blob/2.3/app/code/Magento/Bundle/Test/Mftf/ActionGroup/AdminCreateApiBundleProductActionGroup.xml"
-  module: "Bundle"
-  actiongroups:
-     - name: "AdminCreateApiDynamicBundleProductActionGroup"
-       description: "Creates 4 products with varying prices. Creates the bundle product with specified name. Adds the multiple select and checkbox options and 4 links to the created products. Uses the 'ApiBundleProduct' entity."
-
-     - name: "AdminCreateApiFixedBundleProductActionGroup"
-       description: "Creates 4 products with varying prices. Creates the bundle product with specified name. Adds the multiple select and checkbox options and 4 links to the created products. Uses the 'ApiFixedBundleProduct' entity."
-
-     - name: "AdminCreateApiDynamicBundleProductAllOptionTypesActionGroup"
-       description: "Creates 3 products with varying prices. Creates the dynamic bundle product with specified name. Adds the multiple select, checkbox options and links to the created products. Uses the 'ApiBundleProduct' entity."
- 
-- filename: "SetBundleProductAttributesActionGroup.xml"
-  repo: "https://github.com/magento/magento2/blob/2.3/app/code/Magento/Bundle/Test/Mftf/ActionGroup/SetBundleProductAttributesActionGroup.xml"
-  module: "Bundle"
-  actiongroups:
-     - name: "SetBundleProductAttributes"
-       description: "Requires navigation to the Product Creation page. Fills in the arguments listed below on the product page. Saves the changes."
- 
-- filename: "AdminClearFiltersActionGroup.xml"
-  repo: "https://github.com/magento/magento2/blob/2.3/app/code/Magento/Bundle/Test/Mftf/ActionGroup/AdminClearFiltersActionGroup.xml"
-  module: "Bundle"
-  actiongroups:
-     - name: "AdminClearFiltersActionGroup"
-       description: "Goes to the Catalog Backend Admin Grid page. Then clears the Grid Filters."
- 
-- filename: "VerifyProductTypeOrderActionGroup.xml"
-  repo: "https://github.com/magento/magento2/blob/2.3/app/code/Magento/Bundle/Test/Mftf/ActionGroup/VerifyProductTypeOrderActionGroup.xml"
-  module: "Bundle"
-  actiongroups:
-     - name: "VerifyProductTypeOrder"
-       description: "Checks that Bundle is in the correct order in comparison to other product types on the add product dropdown."
- 
-- filename: "CreateBundleProductActionGroup.xml"
-  repo: "https://github.com/magento/magento2/blob/2.3/app/code/Magento/Bundle/Test/Mftf/ActionGroup/CreateBundleProductActionGroup.xml"
-  module: "Bundle"
-  actiongroups:
-     - name: "CreateBasicBundleProduct"
-       description: "Requires Navigation to the Product Creation page. Fills out Name, Sku, and SEO information using the BundleProduct Data Entity. PLEASE NOTE: The Action Group values are Hardcoded."
-
-     - name: "addBundleOptionWithTwoProducts"
-       description: "Requires Navigation to the Product Creation page. Adds Bundle Option with Two Products using the provided arguments. 'x' refers to Bundle option number. 'n' refers to the first number after x."
-
-     - name: "addBundleOptionWithOneProduct"
-       description: "Requires Navigation to the Product Creation page. Adds Bundle Option with One Product as specified in arguments. 'x' refers to Bundle option number. 'n' refers to the first number after x."
-
-     - name: "addBundleOptionWithTreeProducts"
-       description: "Requires Navigation to the Product Creation page. Adds Bundle Option with Three Products using the provided arguments. 'x' refers to Bundle option number. 'n' refers to the first number after x."
-
-     - name: "addBundleOptionWithSixProducts"
-       description: "Requires Navigation to Product Creation page. Adds Bundle Option with Six Products as specified in arguments. 'x' refers to Bundle option number. 'n' refers to the first number after x."
-
-     - name: "deleteBundleOptionByIndex"
-       description: "Requires Navigation to Product Creation page. Removes any Bundle Option by index specified in arguments. 'deleteIndex' refers to Bundle option number."
- 
-- filename: "StorefrontSelectBundleProductDropDownOptionActionGroup.xml"
-  repo: "https://github.com/magento/magento2/blob/2.3/app/code/Magento/Bundle/Test/Mftf/ActionGroup/StorefrontSelectBundleProductDropDownOptionActionGroup.xml"
-  module: "Bundle"
-  actiongroups:
-     - name: "StorefrontSelectBundleProductDropDownOptionActionGroup"
-       description: "Selects the provided Product Name on a Storefront Bundled Product page."
- 
-- filename: "AssertAdminUserIsInGridActionGroup.xml"
-  repo: "https://github.com/magento/magento2/blob/2.3/app/code/Magento/User/Test/Mftf/ActionGroup/AssertAdminUserIsInGridActionGroup.xml"
-  module: "User"
-  actiongroups:
-     - name: "AssertAdminUserIsInGridActionGroup"
-       description: ""
- 
-- filename: "AdminUpdateUserRoleActionGroup.xml"
-  repo: "https://github.com/magento/magento2/blob/2.3/app/code/Magento/User/Test/Mftf/ActionGroup/AdminUpdateUserRoleActionGroup.xml"
-  module: "User"
-  actiongroups:
-     - name: "AdminUpdateUserRoleActionGroup"
-       description: ""
- 
-- filename: "AdminUserActionGroup.xml"
-  repo: "https://github.com/magento/magento2/blob/2.3/app/code/Magento/User/Test/Mftf/ActionGroup/AdminUserActionGroup.xml"
-  module: "User"
-  actiongroups:
-     - name: "LoginNewUser"
-       description: "Goes to the Backend Admin Login page. Fill Username and Password. Click on Sign In."
- 
-- filename: "AdminDeleteUserRoleActionGroup.xml"
-  repo: "https://github.com/magento/magento2/blob/2.3/app/code/Magento/User/Test/Mftf/ActionGroup/AdminDeleteUserRoleActionGroup.xml"
-  module: "User"
-  actiongroups:
-     - name: "AdminDeleteUserRoleActionGroup"
-       description: ""
- 
-- filename: "AdminClickSaveButtonOnUserFormActionGroup.xml"
-  repo: "https://github.com/magento/magento2/blob/2.3/app/code/Magento/User/Test/Mftf/ActionGroup/AdminClickSaveButtonOnUserFormActionGroup.xml"
-  module: "User"
-  actiongroups:
-     - name: "AdminClickSaveButtonOnUserFormActionGroup"
-       description: "Clicks on the Save button on the Admin User creation/edit page."
- 
-- filename: "AdminCreateUserActionGroup.xml"
-  repo: "https://github.com/magento/magento2/blob/2.3/app/code/Magento/User/Test/Mftf/ActionGroup/AdminCreateUserActionGroup.xml"
-  module: "User"
-  actiongroups:
-     - name: "AdminCreateUserActionGroup"
-       description: "Goes to the Admin Users grid page. Clicks on Create User. Fills in the provided Role and User."
-
-     - name: "AdminCreateUserWithRoleActionGroup"
-       description: "Goes to the Admin Users grid page. Clicks on Create User. Fills in the provided Role and User."
-
-     - name: "AdminCreateUserWithApiRoleActionGroup"
-       description: ""
- 
-- filename: "AdminAddNewUserRoleActionGroup.xml"
-  repo: "https://github.com/magento/magento2/blob/2.3/app/code/Magento/User/Test/Mftf/ActionGroup/AdminAddNewUserRoleActionGroup.xml"
-  module: "User"
-  actiongroups:
-     - name: "AdminAddNewUserRoleActionGroup"
+     - name: "CreateCustomTemplate"
        description: ""
 
-     - name: "AdminAddNewUserRoleWithCustomRoleScopes"
-       description: ""
- 
-- filename: "AdminDeleteUserActionGroup.xml"
-  repo: "https://github.com/magento/magento2/blob/2.3/app/code/Magento/User/Test/Mftf/ActionGroup/AdminDeleteUserActionGroup.xml"
-  module: "User"
-  actiongroups:
-     - name: "AdminDeleteUserActionGroup"
-       description: "Goes to the Admin Users grid page. Deletes the provided User. Validates that the Success Message is present and correct."
-
-     - name: "AdminDeleteCustomUserActionGroup"
-       description: "Goes to the Admin Users grid page. Deletes the provided User. Validates that the Success Message is present and correct."
- 
-- filename: "AdminDeleteUserViaCurlActionGroup.xml"
-  repo: "https://github.com/magento/magento2/blob/2.3/app/code/Magento/User/Test/Mftf/ActionGroup/AdminDeleteUserViaCurlActionGroup.xml"
-  module: "User"
-  actiongroups:
-     - name: "AdminDeleteUserViaCurlActionGroup"
-       description: ""
- 
-- filename: "AdminCreateRoleActionGroup.xml"
-  repo: "https://github.com/magento/magento2/blob/2.3/app/code/Magento/User/Test/Mftf/ActionGroup/AdminCreateRoleActionGroup.xml"
-  module: "User"
-  actiongroups:
-     - name: "AdminCreateRoleActionGroup"
-       description: "Goes to the Admin Edit Role page. Fills in the provided User details. Add the provided Role. Clicks on Save."
-
-     - name: "AdminFillUserRoleRequiredData"
+     - name: "PrepareDraftCustomTemplate"
        description: ""
 
-     - name: "AdminAddRestrictedRole"
+     - name: "FindAndOpenEmailTemplate"
        description: ""
 
-     - name: "AdminCreateRole"
-       description: "Clicks on 'Add New Role'. Fills in the provided details (Role, Resource, Scope and Websites). Clicks on Save. Validates that the Success Message is present and correct."
- 
-- filename: "AdminFillUserRoleFormActionGroup.xml"
-  repo: "https://github.com/magento/magento2/blob/2.3/app/code/Magento/User/Test/Mftf/ActionGroup/AdminFillUserRoleFormActionGroup.xml"
-  module: "User"
-  actiongroups:
-     - name: "AdminFillUserRoleFormActionGroup"
-       description: "Fills in the provided Role and Current Admin Password on the Admin Roles creation/edit page."
- 
-- filename: "AdminOpenNewUserPageActionGroup.xml"
-  repo: "https://github.com/magento/magento2/blob/2.3/app/code/Magento/User/Test/Mftf/ActionGroup/AdminOpenNewUserPageActionGroup.xml"
-  module: "User"
-  actiongroups:
-     - name: "AdminOpenNewUserPageActionGroup"
-       description: "Goes to the Admin New User page."
- 
-- filename: "AssertAdminUserSaveMessageActionGroup.xml"
-  repo: "https://github.com/magento/magento2/blob/2.3/app/code/Magento/User/Test/Mftf/ActionGroup/AssertAdminUserSaveMessageActionGroup.xml"
-  module: "User"
-  actiongroups:
-     - name: "AssertAdminUserSaveMessageActionGroup"
-       description: "Validates that the provided Save Message is present and correct."
- 
-- filename: "AdminFillNewUserFormRequiredFieldsActionGroup.xml"
-  repo: "https://github.com/magento/magento2/blob/2.3/app/code/Magento/User/Test/Mftf/ActionGroup/AdminFillNewUserFormRequiredFieldsActionGroup.xml"
-  module: "User"
-  actiongroups:
-     - name: "AdminFillNewUserFormRequiredFieldsActionGroup"
-       description: "Fills in the provided User details on the New User creation page."
- 
-- filename: "AdminClickSaveButtonOnUserRoleFormActionGroup.xml"
-  repo: "https://github.com/magento/magento2/blob/2.3/app/code/Magento/User/Test/Mftf/ActionGroup/AdminClickSaveButtonOnUserRoleFormActionGroup.xml"
-  module: "User"
-  actiongroups:
-     - name: "AdminClickSaveButtonOnUserRoleFormActionGroup"
-       description: "Clicks on Save on the Admin Roles creation/edit page."
- 
-- filename: "AdminDeleteCreatedUserActionGroup.xml"
-  repo: "https://github.com/magento/magento2/blob/2.3/app/code/Magento/User/Test/Mftf/ActionGroup/AdminDeleteCreatedUserActionGroup.xml"
-  module: "User"
-  actiongroups:
-     - name: "AdminDeleteCreatedUserActionGroup"
-       description: "Goes to the Admin Users grid page. Edits the provided User. Deletes the User. Validates that the Success Message is present and correct."
+     - name: "DeleteEmailTemplate"
+       description: "Clicks on Delete Template. Accepts the Popup. Validates that the Email Template is NOT present in the Email Templates Grid."
 
-     - name: "AdminDeleteNewUserActionGroup"
-       description: "Deletes a User that contains the name 'John'. PLEASE NOTE: The Action Group values are Hardcoded."
- 
-- filename: "AdminOpenUserEditPageActionGroup.xml"
-  repo: "https://github.com/magento/magento2/blob/2.3/app/code/Magento/User/Test/Mftf/ActionGroup/AdminOpenUserEditPageActionGroup.xml"
-  module: "User"
-  actiongroups:
-     - name: "AdminOpenUserEditPageActionGroup"
-       description: ""
- 
-- filename: "AdminOpenAdminUsersPageActionGroup.xml"
-  repo: "https://github.com/magento/magento2/blob/2.3/app/code/Magento/User/Test/Mftf/ActionGroup/AdminOpenAdminUsersPageActionGroup.xml"
-  module: "User"
-  actiongroups:
-     - name: "AdminOpenAdminUsersPageActionGroup"
-       description: ""
- 
-- filename: "AdminOpenForgotPasswordPageActionGroup.xml"
-  repo: "https://github.com/magento/magento2/blob/2.3/app/code/Magento/User/Test/Mftf/ActionGroup/AdminOpenForgotPasswordPageActionGroup.xml"
-  module: "User"
-  actiongroups:
-     - name: "AdminOpenForgotPasswordPageActionGroup"
-       description: "Goes to the Admin Login page. Clicks on the 'Forgot Password' link."
- 
-- filename: "AssertUserRoleRestrictedAccessActionGroup.xml"
-  repo: "https://github.com/magento/magento2/blob/2.3/app/code/Magento/User/Test/Mftf/ActionGroup/AssertUserRoleRestrictedAccessActionGroup.xml"
-  module: "User"
-  actiongroups:
-     - name: "AssertUserRoleRestrictedAccessActionGroup"
-       description: ""
- 
-- filename: "AdminSubmitForgotPasswordFormActionGroup.xml"
-  repo: "https://github.com/magento/magento2/blob/2.3/app/code/Magento/User/Test/Mftf/ActionGroup/AdminSubmitForgotPasswordFormActionGroup.xml"
-  module: "User"
-  actiongroups:
-     - name: "AdminSubmitForgotPasswordFormActionGroup"
-       description: "Clicks on the Retrieve Password button."
- 
-- filename: "AdminDeleteCreatedRoleActionGroup.xml"
-  repo: "https://github.com/magento/magento2/blob/2.3/app/code/Magento/User/Test/Mftf/ActionGroup/AdminDeleteCreatedRoleActionGroup.xml"
-  module: "User"
-  actiongroups:
-     - name: "AdminDeleteCreatedRoleActionGroup"
+     - name: "PreviewEmailTemplate"
        description: ""
 
-     - name: "AdminDeleteRoleByRoleNameActionGroup"
+     - name: "AssertEmailTemplateContent"
        description: ""
- 
-- filename: "AdminFillForgotPasswordFormActionGroup.xml"
-  repo: "https://github.com/magento/magento2/blob/2.3/app/code/Magento/User/Test/Mftf/ActionGroup/AdminFillForgotPasswordFormActionGroup.xml"
-  module: "User"
+- filename: "AdminMarketingSiteMapNavigateNewActionGroup.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/Sitemap/Test/Mftf/ActionGroup/AdminMarketingSiteMapNavigateNewActionGroup.xml"
+  module: "Sitemap"
   actiongroups:
-     - name: "AdminFillForgotPasswordFormActionGroup"
-       description: "Fills in the provided Email Address on the Admin Forgot Password page."
- 
-- filename: "AdminOpenCreateRolePageActionGroup.xml"
-  repo: "https://github.com/magento/magento2/blob/2.3/app/code/Magento/User/Test/Mftf/ActionGroup/AdminOpenCreateRolePageActionGroup.xml"
-  module: "User"
+     - name: "AdminMarketingSiteMapNavigateNewActionGroup"
+       description: "Navigate to New Site Map"
+- filename: "AdminMarketingSiteMapFillFormActionGroup.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/Sitemap/Test/Mftf/ActionGroup/AdminMarketingSiteMapFillFormActionGroup.xml"
+  module: "Sitemap"
   actiongroups:
-     - name: "AdminOpenCreateRolePageActionGroup"
-       description: "Goes to the Admin Roles edit page."
- 
-- filename: "AssertAdminUserIsInGridActionGroup.xml"
-  repo: "https://github.com/magento/magento2/blob/2.3/app/code/Magento/Backend/Test/Mftf/ActionGroup/AssertAdminUserIsInGridActionGroup.xml"
-  module: "Backend"
+     - name: "AdminMarketingSiteMapFillFormActionGroup"
+       description: "Fill data to Site map form"
+- filename: "AdminMarketingSiteDeleteByNameActionGroup.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/Sitemap/Test/Mftf/ActionGroup/AdminMarketingSiteDeleteByNameActionGroup.xml"
+  module: "Sitemap"
   actiongroups:
-     - name: "AssertAdminUserIsInGridActionGroup"
+     - name: "AdminMarketingSiteDeleteByNameActionGroup"
+       description: "Go to the Site map page. Delete a site map based on the provided Name."
+- filename: "AssertSiteMapCreateSuccessActionGroup.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/Sitemap/Test/Mftf/ActionGroup/AssertSiteMapCreateSuccessActionGroup.xml"
+  module: "Sitemap"
+  actiongroups:
+     - name: "AssertSiteMapCreateSuccessActionGroup"
+       description: "Validate the success message after creating site map."
+- filename: "AssertSiteMapDeleteSuccessActionGroup.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/Sitemap/Test/Mftf/ActionGroup/AssertSiteMapDeleteSuccessActionGroup.xml"
+  module: "Sitemap"
+  actiongroups:
+     - name: "AssertSiteMapDeleteSuccessActionGroup"
+       description: "Validate the success message after delete site map."
+- filename: "AdminOpenInstantPurchaseConfigPageActionGroup.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/InstantPurchase/Test/Mftf/ActionGroup/AdminOpenInstantPurchaseConfigPageActionGroup.xml"
+  module: "InstantPurchase"
+  actiongroups:
+     - name: "AdminOpenInstantPurchaseConfigPageActionGroup"
        description: ""
- 
-- filename: "AdminClickFormActionButtonActionGroup.xml"
-  repo: "https://github.com/magento/magento2/blob/2.3/app/code/Magento/Backend/Test/Mftf/ActionGroup/AdminClickFormActionButtonActionGroup.xml"
-  module: "Backend"
+- filename: "AdminChangeInstantPurchaseButtonTextActionGroup.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/InstantPurchase/Test/Mftf/ActionGroup/AdminChangeInstantPurchaseButtonTextActionGroup.xml"
+  module: "InstantPurchase"
   actiongroups:
-     - name: "AdminClickFormActionButtonActionGroup"
+     - name: "AdminChangeInstantPurchaseButtonTextActionGroup"
        description: ""
- 
-- filename: "AssertMessageInAdminPanelActionGroup.xml"
-  repo: "https://github.com/magento/magento2/blob/2.3/app/code/Magento/Backend/Test/Mftf/ActionGroup/AssertMessageInAdminPanelActionGroup.xml"
-  module: "Backend"
+- filename: "AdminChangeInstantPurchaseStatusActionGroup.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/InstantPurchase/Test/Mftf/ActionGroup/AdminChangeInstantPurchaseStatusActionGroup.xml"
+  module: "InstantPurchase"
   actiongroups:
-     - name: "AssertMessageInAdminPanelActionGroup"
-       description: "Validates that the provided Message appears in the provided Message Type on an Admin page."
- 
-- filename: "LogoutActionGroup.xml"
-  repo: "https://github.com/magento/magento2/blob/2.3/app/code/Magento/Backend/Test/Mftf/ActionGroup/LogoutActionGroup.xml"
-  module: "Backend"
-  actiongroups:
-     - name: "logout"
-       description: "Logout of the Backend Admin. PLEASE NOTE: This Action Group does NOT validate that you are Logged Out."
- 
-- filename: "LoginAsAdminActionGroup.xml"
-  repo: "https://github.com/magento/magento2/blob/2.3/app/code/Magento/Backend/Test/Mftf/ActionGroup/LoginAsAdminActionGroup.xml"
-  module: "Backend"
-  actiongroups:
-     - name: "LoginAsAdmin"
-       description: "Login to Backend Admin using provided User Data. PLEASE NOTE: This Action Group does NOT validate that you are Logged In."
- 
-- filename: "LoginAdminWithCredentialsActionGroup.xml"
-  repo: "https://github.com/magento/magento2/blob/2.3/app/code/Magento/Backend/Test/Mftf/ActionGroup/LoginAdminWithCredentialsActionGroup.xml"
-  module: "Backend"
-  actiongroups:
-     - name: "LoginAdminWithCredentialsActionGroup"
-       description: "Login to Backend Admin using provided Admin credentials. PLEASE NOTE: This Action Group does NOT validate that you are Logged In."
- 
-- filename: "ClickSaveActionGroup.xml"
-  repo: "https://github.com/magento/magento2/blob/2.3/app/code/Magento/Backend/Test/Mftf/ActionGroup/ClickSaveActionGroup.xml"
-  module: "Backend"
-  actiongroups:
-     - name: "ClickSaveButtonActionGroup"
+     - name: "AdminChangeInstantPurchaseStatusActionGroup"
        description: ""
- 
-- filename: "AssertAdminSuccessLoginActionGroup.xml"
-  repo: "https://github.com/magento/magento2/blob/2.3/app/code/Magento/Backend/Test/Mftf/ActionGroup/AssertAdminSuccessLoginActionGroup.xml"
-  module: "Backend"
-  actiongroups:
-     - name: "AssertAdminSuccessLoginActionGroup"
-       description: "Wait for the current Admin Name to appear in the Backend Admin."
- 
-- filename: "SecondaryGridActionGroup.xml"
-  repo: "https://github.com/magento/magento2/blob/2.3/app/code/Magento/Backend/Test/Mftf/ActionGroup/SecondaryGridActionGroup.xml"
-  module: "Backend"
-  actiongroups:
-     - name: "deleteEntitySecondaryGrid"
-       description: "This Action Group deletes an item from a grid based on provided Name. After Searching, the First Row is clicked."
- 
-- filename: "LoginActionGroup.xml"
-  repo: "https://github.com/magento/magento2/blob/2.3/app/code/Magento/Backend/Test/Mftf/ActionGroup/LoginActionGroup.xml"
-  module: "Backend"
-  actiongroups:
-     - name: "LoginActionGroup"
-       description: "Login to Backend Admin using ENV Admin credentials. PLEASE NOTE: This Action Group does NOT validate that you are Logged In."
- 
-- filename: "AdminNavigateMenuActionGroup.xml"
-  repo: "https://github.com/magento/magento2/blob/2.3/app/code/Magento/Backend/Test/Mftf/ActionGroup/AdminNavigateMenuActionGroup.xml"
-  module: "Backend"
-  actiongroups:
-     - name: "AdminNavigateMenuActionGroup"
-       description: "Open Backend Admin side Navigation Menu. Click on Sub-Navigation Menu item."
- 
-- filename: "AssertMessageOnAdminLoginActionGroup.xml"
-  repo: "https://github.com/magento/magento2/blob/2.3/app/code/Magento/Backend/Test/Mftf/ActionGroup/AssertMessageOnAdminLoginActionGroup.xml"
-  module: "Backend"
-  actiongroups:
-     - name: "AssertMessageOnAdminLoginActionGroup"
-       description: "Validate Backend Admin Login status message is present and correct."
- 
-- filename: "AdminAssertPageTitleActionGroup.xml"
-  repo: "https://github.com/magento/magento2/blob/2.3/app/code/Magento/Backend/Test/Mftf/ActionGroup/AdminAssertPageTitleActionGroup.xml"
-  module: "Backend"
-  actiongroups:
-     - name: "AdminAssertPageTitleActionGroup"
-       description: "Validate Backend Admin Grid Page Title is present and correct."
- 
-- filename: "AdminFilterLegacyGridActionGroup.xml"
-  repo: "https://github.com/magento/magento2/blob/2.3/app/code/Magento/Backend/Test/Mftf/ActionGroup/AdminFilterLegacyGridActionGroup.xml"
-  module: "Backend"
-  actiongroups:
-     - name: "AdminFilterLegacyGridActionGroup"
-       description: ""
- 
-- filename: "AssertAdminDashboardPageIsVisibleActionGroup.xml"
-  repo: "https://github.com/magento/magento2/blob/2.3/app/code/Magento/Backend/Test/Mftf/ActionGroup/AssertAdminDashboardPageIsVisibleActionGroup.xml"
-  module: "Backend"
-  actiongroups:
-     - name: "AssertAdminDashboardPageIsVisibleActionGroup"
-       description: "Validate the Backend Admin Dashboard URI is correct. Validate the Backend Admin Dashboard Title is present and correct."
- 
-- filename: "AssertAdminPageIsNot404ActionGroup.xml"
-  repo: "https://github.com/magento/magento2/blob/2.3/app/code/Magento/Backend/Test/Mftf/ActionGroup/AssertAdminPageIsNot404ActionGroup.xml"
-  module: "Backend"
-  actiongroups:
-     - name: "AssertAdminPageIsNot404ActionGroup"
-       description: "Validates that the '404 Error' message is present and correct in the Admin Page Header."
- 
-- filename: "AdminResetLegacyGridFilterActionGroup.xml"
-  repo: "https://github.com/magento/magento2/blob/2.3/app/code/Magento/Backend/Test/Mftf/ActionGroup/AdminResetLegacyGridFilterActionGroup.xml"
-  module: "Backend"
-  actiongroups:
-     - name: "AdminResetLegacyGridFilterActionGroup"
-       description: ""
- 
-- filename: "AssertUserRoleRestrictedAccessActionGroup.xml"
-  repo: "https://github.com/magento/magento2/blob/2.3/app/code/Magento/Backend/Test/Mftf/ActionGroup/AssertUserRoleRestrictedAccessActionGroup.xml"
-  module: "Backend"
-  actiongroups:
-     - name: "AssertUserRoleRestrictedAccessActionGroup"
-       description: ""
- 
-- filename: "SetWebsiteCountryOptionsToDefaultActionGroup.xml"
-  repo: "https://github.com/magento/magento2/blob/2.3/app/code/Magento/Backend/Test/Mftf/ActionGroup/SetWebsiteCountryOptionsToDefaultActionGroup.xml"
-  module: "Backend"
-  actiongroups:
-     - name: "SetWebsiteCountryOptionsToDefaultActionGroup"
-       description: "Sets the Website Country configuration setting to the Default values."
- 
-- filename: "AssertOrderGraphImageOnDashboardActionGroup.xml"
-  repo: "https://github.com/magento/magento2/blob/2.3/app/code/Magento/Backend/Test/Mftf/ActionGroup/AssertOrderGraphImageOnDashboardActionGroup.xml"
-  module: "Backend"
-  actiongroups:
-     - name: "AssertOrderGraphImageOnDashboardActionGroup"
-       description: ""
- 
-- filename: "SetAdminAccountActionGroup.xml"
-  repo: "https://github.com/magento/magento2/blob/2.3/app/code/Magento/Backend/Test/Mftf/ActionGroup/SetAdminAccountActionGroup.xml"
-  module: "Backend"
-  actiongroups:
-     - name: "SetAdminAccountActionGroup"
-       description: "Update the Interface Language configuration setting using provided Interface Language."
- 
-- filename: "SortByIdDescendingActionGroup.xml"
-  repo: "https://github.com/magento/magento2/blob/2.3/app/code/Magento/Backend/Test/Mftf/ActionGroup/SortByIdDescendingActionGroup.xml"
-  module: "Backend"
-  actiongroups:
-     - name: "SortByIdDescendingActionGroup"
-       description: "Sorts a Backend Admin Grid by descending order for the ID column."
- 
-- filename: "AdminImportProductsActionGroup.xml"
-  repo: "https://github.com/magento/magento2/blob/2.3/app/code/Magento/ImportExport/Test/Mftf/ActionGroup/AdminImportProductsActionGroup.xml"
-  module: "ImportExport"
-  actiongroups:
-     - name: "AdminImportProductsActionGroup"
-       description: "Goes to the Admin Import page. Imports the provided File. Validates that the Success Message is present and correct."
-
-     - name: "AdminImportProductsWithCheckValidationResultActionGroup"
-       description: ""
-
-     - name: "AdminCheckDataForImportProductActionGroup"
-       description: ""
- 
-- filename: "AdminAssertVisiblePagerActionGroup.xml"
-  repo: "https://github.com/magento/magento2/blob/2.3/app/code/Magento/ImportExport/Test/Mftf/ActionGroup/AdminAssertVisiblePagerActionGroup.xml"
-  module: "ImportExport"
-  actiongroups:
-     - name: "AdminAssertVisiblePagerActionGroup"
-       description: ""
- 
-- filename: "AdminNavigateToExportPageActionGroup.xml"
-  repo: "https://github.com/magento/magento2/blob/2.3/app/code/Magento/ImportExport/Test/Mftf/ActionGroup/AdminNavigateToExportPageActionGroup.xml"
-  module: "ImportExport"
-  actiongroups:
-     - name: "AdminNavigateToExportPageActionGroup"
-       description: ""
- 
-- filename: "AssertStoreFrontNoQuotesMessageActionGroup.xml"
-  repo: "https://github.com/magento/magento2/blob/2.3/app/code/Magento/Shipping/Test/Mftf/ActionGroup/AssertStoreFrontNoQuotesMessageActionGroup.xml"
-  module: "Shipping"
-  actiongroups:
-     - name: "AssertStoreFrontNoQuotesMessageActionGroup"
-       description: ""
- 
-- filename: "AdminChangeTableRatesShippingMethodStatusActionGroup.xml"
-  repo: "https://github.com/magento/magento2/blob/2.3/app/code/Magento/Shipping/Test/Mftf/ActionGroup/AdminChangeTableRatesShippingMethodStatusActionGroup.xml"
-  module: "Shipping"
-  actiongroups:
-     - name: "AdminChangeTableRatesShippingMethodStatusActionGroup"
-       description: ""
-
-     - name: "AdminImportFileTableRatesShippingMethodActionGroup"
-       description: "Import a file in Table Rates tab in Shipping Method config page."
- 
-- filename: "AssertStoreFrontShippingMethodAvailableActionGroup.xml"
-  repo: "https://github.com/magento/magento2/blob/2.3/app/code/Magento/Shipping/Test/Mftf/ActionGroup/AssertStoreFrontShippingMethodAvailableActionGroup.xml"
-  module: "Shipping"
-  actiongroups:
-     - name: "AssertStoreFrontShippingMethodAvailableActionGroup"
-       description: ""
- 
-- filename: "AdminOpenShippingMethodsConfigPageActionGroup.xml"
-  repo: "https://github.com/magento/magento2/blob/2.3/app/code/Magento/Shipping/Test/Mftf/ActionGroup/AdminOpenShippingMethodsConfigPageActionGroup.xml"
-  module: "Shipping"
-  actiongroups:
-     - name: "AdminOpenShippingMethodsConfigPageActionGroup"
-       description: ""
- 
-- filename: "AdminAssertTrackingValidationErrorActionGroup.xml"
-  repo: "https://github.com/magento/magento2/blob/2.3/app/code/Magento/Shipping/Test/Mftf/ActionGroup/AdminAssertTrackingValidationErrorActionGroup.xml"
-  module: "Shipping"
-  actiongroups:
-     - name: "AdminAssertTrackingValidationErrorActionGroup"
-       description: ""
- 
-- filename: "AdminSelectFirstGridRowActionGroup.xml"
-  repo: "https://github.com/magento/magento2/blob/2.3/app/code/Magento/Shipping/Test/Mftf/ActionGroup/AdminSelectFirstGridRowActionGroup.xml"
-  module: "Shipping"
-  actiongroups:
-     - name: "AdminSelectFirstGridRowActionGroup"
-       description: ""
- 
-- filename: "StorefrontSetShippingMethodActionGroup.xml"
-  repo: "https://github.com/magento/magento2/blob/2.3/app/code/Magento/Shipping/Test/Mftf/ActionGroup/StorefrontSetShippingMethodActionGroup.xml"
-  module: "Shipping"
-  actiongroups:
-     - name: "StorefrontSetShippingMethodActionGroup"
-       description: "Selects the provided Shipping Method on checkout shipping and wait loading mask."
- 
-- filename: "AdminDeleteTrackingNumberActionGroup.xml"
-  repo: "https://github.com/magento/magento2/blob/2.3/app/code/Magento/Shipping/Test/Mftf/ActionGroup/AdminDeleteTrackingNumberActionGroup.xml"
-  module: "Shipping"
-  actiongroups:
-     - name: "AdminDeleteTrackingNumberActionGroup"
-       description: ""
- 
-- filename: "AdminAssertShipmentInShipmentsGridActionGroup.xml"
-  repo: "https://github.com/magento/magento2/blob/2.3/app/code/Magento/Shipping/Test/Mftf/ActionGroup/AdminAssertShipmentInShipmentsGridActionGroup.xml"
-  module: "Shipping"
-  actiongroups:
-     - name: "AdminAssertShipmentInShipmentsGrid"
-       description: ""
- 
-- filename: "AdminShipmentActionGroup.xml"
-  repo: "https://github.com/magento/magento2/blob/2.3/app/code/Magento/Shipping/Test/Mftf/ActionGroup/AdminShipmentActionGroup.xml"
-  module: "Shipping"
-  actiongroups:
-     - name: "verifyBasicShipmentInformation"
-       description: "Validates that the provided Customer, Shipping Address, Billing Address and Customer Group are present and correct on the view Admin Order page."
-
-     - name: "seeProductInShipmentItems"
-       description: "Validates that the provided Product is present and correct on the view Admin Order Shipment page under the 'Items Shipped' section."
-
-     - name: "goToShipmentIntoOrder"
-       description: "Clicks on the 'Ship' button on the view Admin Order page. Validates that the URL and Page Title are present and correct."
-
-     - name: "submitShipmentIntoOrder"
-       description: "Clicks on the 'Submit Shipment' button on the view Admin Order Shipment page. Validates that the URL and Page Title are present and correct."
-
-     - name: "AdminShipmentCreateShippingLabelActionGroup"
-       description: ""
-
-     - name: "AdminGoToShipmentTabActionGroup"
-       description: ""
- 
-- filename: "AdminCreateShipmentFromOrderPageActionGroup.xml"
-  repo: "https://github.com/magento/magento2/blob/2.3/app/code/Magento/Shipping/Test/Mftf/ActionGroup/AdminCreateShipmentFromOrderPageActionGroup.xml"
-  module: "Shipping"
-  actiongroups:
-     - name: "AdminCreateShipmentFromOrderPage"
-       description: ""
- 
-- filename: "AdminAssertCreatedShipmentInShipmentsTabActionGroup.xml"
-  repo: "https://github.com/magento/magento2/blob/2.3/app/code/Magento/Shipping/Test/Mftf/ActionGroup/AdminAssertCreatedShipmentInShipmentsTabActionGroup.xml"
-  module: "Shipping"
-  actiongroups:
-     - name: "AdminAssertCreatedShipmentsInShipmentsTabActionGroup"
-       description: ""
- 
-- filename: "AdminAssertExistingTrackingNumberActionGroup.xml"
-  repo: "https://github.com/magento/magento2/blob/2.3/app/code/Magento/Shipping/Test/Mftf/ActionGroup/AdminAssertExistingTrackingNumberActionGroup.xml"
-  module: "Shipping"
-  actiongroups:
-     - name: "AdminAssertExistingTrackingNumberActionGroup"
-       description: ""
- 
-- filename: "AdminAssertShipmentItemsActionGroup.xml"
-  repo: "https://github.com/magento/magento2/blob/2.3/app/code/Magento/Shipping/Test/Mftf/ActionGroup/AdminAssertShipmentItemsActionGroup.xml"
-  module: "Shipping"
-  actiongroups:
-     - name: "AdminAssertShipmentItemsActionGroup"
-       description: ""
- 
-- filename: "AssertThereIsNoShipButtonActionGroup.xml"
-  repo: "https://github.com/magento/magento2/blob/2.3/app/code/Magento/Shipping/Test/Mftf/ActionGroup/AssertThereIsNoShipButtonActionGroup.xml"
-  module: "Shipping"
-  actiongroups:
-     - name: "AssertThereIsNoShipButtonActionGroup"
-       description: ""
- 
-- filename: "AdminChangeFlatRateShippingMethodStatusActionGroup.xml"
-  repo: "https://github.com/magento/magento2/blob/2.3/app/code/Magento/Shipping/Test/Mftf/ActionGroup/AdminChangeFlatRateShippingMethodStatusActionGroup.xml"
-  module: "Shipping"
-  actiongroups:
-     - name: "AdminChangeFlatRateShippingMethodStatusActionGroup"
-       description: ""
- 
-- filename: "AssertStoreFrontShippingMethodUnavailableActionGroup.xml"
-  repo: "https://github.com/magento/magento2/blob/2.3/app/code/Magento/Shipping/Test/Mftf/ActionGroup/AssertStoreFrontShippingMethodUnavailableActionGroup.xml"
-  module: "Shipping"
-  actiongroups:
-     - name: "AssertStoreFrontShippingMethodUnavailableActionGroup"
-       description: ""
- 
-- filename: "AdminAddTrackingNumberToShipmentActionGroup.xml"
-  repo: "https://github.com/magento/magento2/blob/2.3/app/code/Magento/Shipping/Test/Mftf/ActionGroup/AdminAddTrackingNumberToShipmentActionGroup.xml"
-  module: "Shipping"
-  actiongroups:
-     - name: "AdminAddTrackingNumberToShipmentActionGroup"
-       description: ""
- 
-- filename: "StorefrontOpenDownloadableLinkActionGroup.xml"
-  repo: "https://github.com/magento/magento2/blob/2.3/app/code/Magento/Downloadable/Test/Mftf/ActionGroup/StorefrontOpenDownloadableLinkActionGroup.xml"
+- filename: "StorefrontAssertDownloadableProductIsPresentInCustomerAccountActionGroup.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/Downloadable/Test/Mftf/ActionGroup/StorefrontAssertDownloadableProductIsPresentInCustomerAccountActionGroup.xml"
   module: "Downloadable"
   actiongroups:
-     - name: "StorefrontOpenDownloadableLinkActionGroup"
-       description: ""
- 
-- filename: "AdminAddDownloadableLinkInformationActionGroup.xml"
-  repo: "https://github.com/magento/magento2/blob/2.3/app/code/Magento/Downloadable/Test/Mftf/ActionGroup/AdminAddDownloadableLinkInformationActionGroup.xml"
-  module: "Downloadable"
-  actiongroups:
-     - name: "AdminAddDownloadableLinkInformationActionGroup"
-       description: "Checks 'Is this downloadable Product?'. Fills in the provided Downloadable details under the 'Downloadable Information'."
- 
+     - name: "StorefrontAssertDownloadableProductIsPresentInCustomerAccount"
+       description: "Goes to the Storefront Customer Dashboard page. Clicks on 'My Downloadable Products'. Validates that the provided Product is present."
 - filename: "AdminDownloadableProductActionGroup.xml"
-  repo: "https://github.com/magento/magento2/blob/2.3/app/code/Magento/Downloadable/Test/Mftf/ActionGroup/AdminDownloadableProductActionGroup.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/Downloadable/Test/Mftf/ActionGroup/AdminDownloadableProductActionGroup.xml"
   module: "Downloadable"
   actiongroups:
      - name: "fillMainDownloadableProductForm"
@@ -3213,30 +3519,131 @@
 
      - name: "addDownloadableSampleUrl"
        description: "Clicks on 'Add Link' under the 'Samples' section. Fills in the provided Downloadable Sample URL details."
- 
-- filename: "StorefrontAssertDownloadableProductIsPresentInCustomerAccountActionGroup.xml"
-  repo: "https://github.com/magento/magento2/blob/2.3/app/code/Magento/Downloadable/Test/Mftf/ActionGroup/StorefrontAssertDownloadableProductIsPresentInCustomerAccountActionGroup.xml"
-  module: "Downloadable"
-  actiongroups:
-     - name: "StorefrontAssertDownloadableProductIsPresentInCustomerAccount"
-       description: "Goes to the Storefront Customer Dashboard page. Clicks on 'My Downloadable Products'. Validates that the provided Product is present."
- 
-- filename: "StorefrontOpenDownloadableSampleActionGroup.xml"
-  repo: "https://github.com/magento/magento2/blob/2.3/app/code/Magento/Downloadable/Test/Mftf/ActionGroup/StorefrontOpenDownloadableSampleActionGroup.xml"
-  module: "Downloadable"
-  actiongroups:
-     - name: "StorefrontOpenDownloadableSampleActionGroup"
-       description: ""
- 
 - filename: "VerifyProductTypeOrderActionGroup.xml"
-  repo: "https://github.com/magento/magento2/blob/2.3/app/code/Magento/Downloadable/Test/Mftf/ActionGroup/VerifyProductTypeOrderActionGroup.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/Downloadable/Test/Mftf/ActionGroup/VerifyProductTypeOrderActionGroup.xml"
   module: "Downloadable"
   actiongroups:
      - name: "VerifyProductTypeOrder"
        description: "Validates that the 'Downloadable Product' option is present in the 'Add Product' dropdown menu on the Products grid page."
- 
+- filename: "AddDownloadableProductLinkActionGroup.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/Downloadable/Test/Mftf/ActionGroup/AddDownloadableProductLinkActionGroup.xml"
+  module: "Downloadable"
+  actiongroups:
+     - name: "AddDownloadableProductLinkActionGroup"
+       description: "Clicks on 'Add Link', under the 'Links' section. Fills in the provided Link details including Unlimited Downloads."
+- filename: "AddDownloadableProductLinkWithMaxDownloadsActionGroup.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/Downloadable/Test/Mftf/ActionGroup/AddDownloadableProductLinkWithMaxDownloadsActionGroup.xml"
+  module: "Downloadable"
+  actiongroups:
+     - name: "AddDownloadableProductLinkWithMaxDownloadsActionGroup"
+       description: "Clicks on 'Add Link'. Fills in the provided Link details including a Max Downloads limit."
+- filename: "StorefrontOpenDownloadableSampleActionGroup.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/Downloadable/Test/Mftf/ActionGroup/StorefrontOpenDownloadableSampleActionGroup.xml"
+  module: "Downloadable"
+  actiongroups:
+     - name: "StorefrontOpenDownloadableSampleActionGroup"
+       description: ""
+- filename: "StorefrontOpenDownloadableLinkActionGroup.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/Downloadable/Test/Mftf/ActionGroup/StorefrontOpenDownloadableLinkActionGroup.xml"
+  module: "Downloadable"
+  actiongroups:
+     - name: "StorefrontOpenDownloadableLinkActionGroup"
+       description: ""
+- filename: "AdminAddDownloadableLinkInformationActionGroup.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/Downloadable/Test/Mftf/ActionGroup/AdminAddDownloadableLinkInformationActionGroup.xml"
+  module: "Downloadable"
+  actiongroups:
+     - name: "AdminAddDownloadableLinkInformationActionGroup"
+       description: "Checks 'Is this downloadable Product?'. Fills in the provided Downloadable details under the 'Downloadable Information'."
+- filename: "AdminClickSearchInGridActionGroup.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/Ui/Test/Mftf/ActionGroup/AdminClickSearchInGridActionGroup.xml"
+  module: "Ui"
+  actiongroups:
+     - name: "AdminClickSearchInGridActionGroup"
+       description: ""
+- filename: "AdminGridFilterApplyActionGroup.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/Ui/Test/Mftf/ActionGroup/AdminGridFilterApplyActionGroup.xml"
+  module: "Ui"
+  actiongroups:
+     - name: "AdminGridFilterApplyActionGroup"
+       description: "Clicks on 'Apply Filters' in the 'Filters' section of an Admin Grid page."
+- filename: "AdminDataGridSelectPerPageActionGroup.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/Ui/Test/Mftf/ActionGroup/AdminDataGridSelectPerPageActionGroup.xml"
+  module: "Ui"
+  actiongroups:
+     - name: "AdminDataGridSelectPerPageActionGroup"
+       description: "Sets the provided preset 'per page' display setting on an Admin Grid page."
+- filename: "AdminGridFilterSearchResultsActionGroup.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/Ui/Test/Mftf/ActionGroup/AdminGridFilterSearchResultsActionGroup.xml"
+  module: "Ui"
+  actiongroups:
+     - name: "AdminGridFilterSearchResultsByInput"
+       description: "Filters an Admin Grid page using the provided Filter Selector and Search Value."
+- filename: "ClearFiltersAdminDataGridActionGroup.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/Ui/Test/Mftf/ActionGroup/ClearFiltersAdminDataGridActionGroup.xml"
+  module: "Ui"
+  actiongroups:
+     - name: "ClearFiltersAdminDataGridActionGroup"
+       description: "Clicks on 'Clear Filters' on an Admin Grid page."
+- filename: "AdminSaveAndCloseActionGroup.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/Ui/Test/Mftf/ActionGroup/AdminSaveAndCloseActionGroup.xml"
+  module: "Ui"
+  actiongroups:
+     - name: "AdminFormSaveAndClose"
+       description: "Clicks on 'Save and Close'. Validates that the Success Message is present."
+
+     - name: "AdminFormSaveAndDuplicate"
+       description: "Clicks on 'Save and Duplicate'. Validates that the Success Message is present and correct."
+- filename: "AdminDataGridFilterActionGroup.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/Ui/Test/Mftf/ActionGroup/AdminDataGridFilterActionGroup.xml"
+  module: "Ui"
+  actiongroups:
+     - name: "searchAdminDataGridByKeyword"
+       description: "Fills 'Search by keyword' on an Admin Grid page. Clicks on Submit Search."
+
+     - name: "resetAdminDataGridToDefaultView"
+       description: "Resets an Admin Grid page to the 'Default View'."
+
+     - name: "clearFiltersAdminDataGrid"
+       description: "Clicks on 'Clear Filters' on an Admin Grid page."
+- filename: "AdminGridFilterFillInputFieldActionGroup.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/Ui/Test/Mftf/ActionGroup/AdminGridFilterFillInputFieldActionGroup.xml"
+  module: "Ui"
+  actiongroups:
+     - name: "AdminGridFilterFillInputFieldActionGroup"
+       description: "Expands the 'Filters' section of an Admin Grid page. Fills in the provided Filter Value for the provided Filter Name."
+- filename: "AdminGridFilterResetActionGroup.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/Ui/Test/Mftf/ActionGroup/AdminGridFilterResetActionGroup.xml"
+  module: "Ui"
+  actiongroups:
+     - name: "AdminGridFilterResetActionGroup"
+       description: "Scrolls to the top of the page. Clicks on the 'Clear Filters' link, if present, in the Admin Grid 'Filters' section."
+- filename: "AdminFillInputFilterFieldActionGroup.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/Ui/Test/Mftf/ActionGroup/AdminFillInputFilterFieldActionGroup.xml"
+  module: "Ui"
+  actiongroups:
+     - name: "AdminFillInputFilterFieldActionGroup"
+       description: ""
+- filename: "AdminDataGridPaginationActionGroup.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/Ui/Test/Mftf/ActionGroup/AdminDataGridPaginationActionGroup.xml"
+  module: "Ui"
+  actiongroups:
+     - name: "adminDataGridSelectPerPage"
+       description: "Sets the provided preset 'per page' display setting on an Admin Grid page."
+
+     - name: "adminDataGridSelectCustomPerPage"
+       description: "Sets the provided custom 'per page' display setting on an Admin Grid page."
+
+     - name: "adminDataGridDeleteCustomPerPage"
+       description: "Sets the provided custom 'per page' display setting on an Admin Grid page. Deletes the Items listed in a grid. Validates that the 'per page' count in NOT present."
+- filename: "SearchAdminDataGridByKeywordActionGroup.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/Ui/Test/Mftf/ActionGroup/SearchAdminDataGridByKeywordActionGroup.xml"
+  module: "Ui"
+  actiongroups:
+     - name: "SearchAdminDataGridByKeywordActionGroup"
+       description: "Fills 'Search by keyword' on an Admin Grid page. Clicks on Submit Search."
 - filename: "AdminExportActionGroup.xml"
-  repo: "https://github.com/magento/magento2/blob/2.3/app/code/Magento/CatalogImportExport/Test/Mftf/ActionGroup/AdminExportActionGroup.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/CatalogImportExport/Test/Mftf/ActionGroup/AdminExportActionGroup.xml"
   module: "CatalogImportExport"
   actiongroups:
      - name: "exportProductsFilterByAttribute"
@@ -3253,1294 +3660,8 @@
 
      - name: "deleteAllExportedFiles"
        description: ""
- 
-- filename: "OpenStoreFrontCheckoutShippingPageActionGroup.xml"
-  repo: "https://github.com/magento/magento2/blob/2.3/app/code/Magento/Checkout/Test/Mftf/ActionGroup/OpenStoreFrontCheckoutShippingPageActionGroup.xml"
-  module: "Checkout"
-  actiongroups:
-     - name: "OpenStoreFrontCheckoutShippingPageActionGroup"
-       description: ""
- 
-- filename: "StorefrontAssertCheckoutEstimateShippingInformationActionGroup.xml"
-  repo: "https://github.com/magento/magento2/blob/2.3/app/code/Magento/Checkout/Test/Mftf/ActionGroup/StorefrontAssertCheckoutEstimateShippingInformationActionGroup.xml"
-  module: "Checkout"
-  actiongroups:
-     - name: "StorefrontAssertCheckoutEstimateShippingInformationActionGroup"
-       description: "Validates that the provided Customer details (Country, State and Zip Code) are present and correct on the Storefront Checkout page."
- 
-- filename: "StorefrontAddSimpleProductToShopingCartActionGroup.xml"
-  repo: "https://github.com/magento/magento2/blob/2.3/app/code/Magento/Checkout/Test/Mftf/ActionGroup/StorefrontAddSimpleProductToShopingCartActionGroup.xml"
-  module: "Checkout"
-  actiongroups:
-     - name: "StorefrontAddSimpleProductToShoppingCartActionGroup"
-       description: ""
- 
-- filename: "StorefrontCheckoutAndAssertOrderSummaryDisplayActionGroup.xml"
-  repo: "https://github.com/magento/magento2/blob/2.3/app/code/Magento/Checkout/Test/Mftf/ActionGroup/StorefrontCheckoutAndAssertOrderSummaryDisplayActionGroup.xml"
-  module: "Checkout"
-  actiongroups:
-     - name: "StorefrontCheckoutAndAssertOrderSummaryDisplayActionGroup"
-       description: "Clicks on 'Go To Checkout' in the Storefront Mini Shopping Cart modal. Validates that the provided Items in Cart Text is present and correct on the Storefront Checkout page under the 'Summary' section."
- 
-- filename: "FillGuestCheckoutShippingAddressFormActionGroup.xml"
-  repo: "https://github.com/magento/magento2/blob/2.3/app/code/Magento/Checkout/Test/Mftf/ActionGroup/FillGuestCheckoutShippingAddressFormActionGroup.xml"
-  module: "Checkout"
-  actiongroups:
-     - name: "FillGuestCheckoutShippingAddressFormActionGroup"
-       description: ""
-
-     - name: "FillGuestCheckoutShippingAddressWithCountryActionGroup"
-       description: ""
- 
-- filename: "FillShippingZipFormActionGroup.xml"
-  repo: "https://github.com/magento/magento2/blob/2.3/app/code/Magento/Checkout/Test/Mftf/ActionGroup/FillShippingZipFormActionGroup.xml"
-  module: "Checkout"
-  actiongroups:
-     - name: "FillShippingZipForm"
-       description: "Fills in the provided Address details (Country, State and Zip Code) in the 'Estimate Shipping and Tax' section of the Storefront Shopping Cart page."
- 
-- filename: "AssertStorefronElementVisibleActionGroup.xml"
-  repo: "https://github.com/magento/magento2/blob/2.3/app/code/Magento/Checkout/Test/Mftf/ActionGroup/AssertStorefronElementVisibleActionGroup.xml"
-  module: "Checkout"
-  actiongroups:
-     - name: "AssertStorefrontElementVisibleActionGroup"
-       description: "Validates that the provided Selector contains the provided Value on a Storefront page."
- 
-- filename: "DeleteProductFromShoppingCartActionGroup.xml"
-  repo: "https://github.com/magento/magento2/blob/2.3/app/code/Magento/Checkout/Test/Mftf/ActionGroup/DeleteProductFromShoppingCartActionGroup.xml"
-  module: "Checkout"
-  actiongroups:
-     - name: "DeleteProductFromShoppingCartActionGroup"
-       description: "Removes the provided Product Name from the Storefront Mini Shopping Cart. Validates that the Success Message is present and correct."
- 
-- filename: "StorefrontCustomerSignInPopUpActionGroup.xml"
-  repo: "https://github.com/magento/magento2/blob/2.3/app/code/Magento/Checkout/Test/Mftf/ActionGroup/StorefrontCustomerSignInPopUpActionGroup.xml"
-  module: "Checkout"
-  actiongroups:
-     - name: "StorefrontCustomerSignInPopUpActionGroup"
-       description: ""
- 
-- filename: "AssertStorefrontNotCalculatedValueInShippingTotalInOrderSummaryActionGroup.xml"
-  repo: "https://github.com/magento/magento2/blob/2.3/app/code/Magento/Checkout/Test/Mftf/ActionGroup/AssertStorefrontNotCalculatedValueInShippingTotalInOrderSummaryActionGroup.xml"
-  module: "Checkout"
-  actiongroups:
-     - name: "AssertStorefrontNotCalculatedValueInShippingTotalInOrderSummaryActionGroup"
-       description: "Validates value of the Shipping total is not calculated."
- 
-- filename: "StorefrontAssertGuestShippingInfoActionGroup.xml"
-  repo: "https://github.com/magento/magento2/blob/2.3/app/code/Magento/Checkout/Test/Mftf/ActionGroup/StorefrontAssertGuestShippingInfoActionGroup.xml"
-  module: "Checkout"
-  actiongroups:
-     - name: "StorefrontAssertGuestShippingInfoActionGroup"
-       description: "Validates that the provided Customer details are present and correct in the 'Shipping Address' section on the Storefront Check page."
- 
-- filename: "StorefrontOpenCheckoutPageActionGroup.xml"
-  repo: "https://github.com/magento/magento2/blob/2.3/app/code/Magento/Checkout/Test/Mftf/ActionGroup/StorefrontOpenCheckoutPageActionGroup.xml"
-  module: "Checkout"
-  actiongroups:
-     - name: "StorefrontOpenCheckoutPageActionGroup"
-       description: "Goes to the Storefront Checkout page."
- 
-- filename: "CustomerCheckoutFillNewShippingAddressActionGroup.xml"
-  repo: "https://github.com/magento/magento2/blob/2.3/app/code/Magento/Checkout/Test/Mftf/ActionGroup/CustomerCheckoutFillNewShippingAddressActionGroup.xml"
-  module: "Checkout"
-  actiongroups:
-     - name: "CustomerCheckoutFillNewShippingAddressActionGroup"
-       description: "Fills in the provided Address details in the 'Shipping Address' section on the Storefront Checkout page."
- 
-- filename: "StorefrontCheckCartDiscountAndSummaryActionGroup.xml"
-  repo: "https://github.com/magento/magento2/blob/2.3/app/code/Magento/Checkout/Test/Mftf/ActionGroup/StorefrontCheckCartDiscountAndSummaryActionGroup.xml"
-  module: "Checkout"
-  actiongroups:
-     - name: "StorefrontCheckCartDiscountAndSummaryActionGroup"
-       description: "Validates that the provided Order Total and Discount Totals are present and correct under the 'Summary' section of the Storefront Shopping Cart page."
- 
-- filename: "AssertAdminEmailValidationMessageOnCheckoutActionGroup.xml"
-  repo: "https://github.com/magento/magento2/blob/2.3/app/code/Magento/Checkout/Test/Mftf/ActionGroup/AssertAdminEmailValidationMessageOnCheckoutActionGroup.xml"
-  module: "Checkout"
-  actiongroups:
-     - name: "AssertAdminEmailValidationMessageOnCheckoutActionGroup"
-       description: ""
- 
-- filename: "LoginAsCustomerOnCheckoutPageActionGroup.xml"
-  repo: "https://github.com/magento/magento2/blob/2.3/app/code/Magento/Checkout/Test/Mftf/ActionGroup/LoginAsCustomerOnCheckoutPageActionGroup.xml"
-  module: "Checkout"
-  actiongroups:
-     - name: "LoginAsCustomerOnCheckoutPageActionGroup"
-       description: "Fills in the provided Customer (Email and Password) details in the 'Sign In' modal on the Storefront Checkout page."
- 
-- filename: "StorefrontSelectOptionDateTimeActionGroup.xml"
-  repo: "https://github.com/magento/magento2/blob/2.3/app/code/Magento/Checkout/Test/Mftf/ActionGroup/StorefrontSelectOptionDateTimeActionGroup.xml"
-  module: "Checkout"
-  actiongroups:
-     - name: "StorefrontSelectOptionDateTimeActionGroup"
-       description: "Selects the provided Month, Day, Year, Hour, Minute and Part of Day for the provided Product Option on a Storefront product page."
- 
-- filename: "StorefrontUpdateProductQtyMiniShoppingCartActionGroup.xml"
-  repo: "https://github.com/magento/magento2/blob/2.3/app/code/Magento/Checkout/Test/Mftf/ActionGroup/StorefrontUpdateProductQtyMiniShoppingCartActionGroup.xml"
-  module: "Checkout"
-  actiongroups:
-     - name: "StorefrontUpdateProductQtyMiniShoppingCartActionGroup"
-       description: "Clicks on the Storefront Mini Shopping Cart icon in the Header. Fills in the provided Quantity for the provided Product in the Mini Shopping Cart. Clicks on Update."
- 
-- filename: "AssertToolbarTextIsVisibleInCartActionGroup.xml"
-  repo: "https://github.com/magento/magento2/blob/2.3/app/code/Magento/Checkout/Test/Mftf/ActionGroup/AssertToolbarTextIsVisibleInCartActionGroup.xml"
-  module: "Checkout"
-  actiongroups:
-     - name: "AssertToolbarTextIsVisibleInCartActionGroup"
-       description: ""
- 
-- filename: "FillNewShippingAddressModalActionGroup.xml"
-  repo: "https://github.com/magento/magento2/blob/2.3/app/code/Magento/Checkout/Test/Mftf/ActionGroup/FillNewShippingAddressModalActionGroup.xml"
-  module: "Checkout"
-  actiongroups:
-     - name: "FillNewShippingAddressModalActionGroup"
-       description: "EXTENDS: FillShippingAddressOneStreetActionGroup. Selects the provided State in the 'Shipping Address' section of the Storefront Checkout page."
- 
-- filename: "StorefrontAssertShippingAddressPageDisplayActionGroup.xml"
-  repo: "https://github.com/magento/magento2/blob/2.3/app/code/Magento/Checkout/Test/Mftf/ActionGroup/StorefrontAssertShippingAddressPageDisplayActionGroup.xml"
-  module: "Checkout"
-  actiongroups:
-     - name: "StorefrontAssertShippingAddressPageDisplayActionGroup"
-       description: "Goes to the Storefront Checkout page. Validates that the 'Shipping Address' Title and Main Area are present."
- 
-- filename: "AssertShoppingCartIsEmptyActionGroup.xml"
-  repo: "https://github.com/magento/magento2/blob/2.3/app/code/Magento/Checkout/Test/Mftf/ActionGroup/AssertShoppingCartIsEmptyActionGroup.xml"
-  module: "Checkout"
-  actiongroups:
-     - name: "AssertShoppingCartIsEmptyActionGroup"
-       description: "Goes to the Storefront Shopping Cart page. Validates that the Empty Shopping Cart message is present and correct. PLEASE NOTE: The message is Hardcoded."
- 
-- filename: "StorefrontCartEstimateShippingAndTaxActionGroup.xml"
-  repo: "https://github.com/magento/magento2/blob/2.3/app/code/Magento/Checkout/Test/Mftf/ActionGroup/StorefrontCartEstimateShippingAndTaxActionGroup.xml"
-  module: "Checkout"
-  actiongroups:
-     - name: "StorefrontCartEstimateShippingAndTaxActionGroup"
-       description: "Fills in the provided Address details (Country, State and Zip Code) under the 'Summary' section on the Storefront Shopping Cart page."
- 
-- filename: "StorefrontAddToTheCartActionGroup.xml"
-  repo: "https://github.com/magento/magento2/blob/2.3/app/code/Magento/Checkout/Test/Mftf/ActionGroup/StorefrontAddToTheCartActionGroup.xml"
-  module: "Checkout"
-  actiongroups:
-     - name: "StorefrontAddToTheCartActionGroup"
-       description: "Scrolls to the Add To Cart button. Clicks on Add To Cart."
- 
-- filename: "AssertStorefrontEmailTooltipContentOnCheckoutActionGroup.xml"
-  repo: "https://github.com/magento/magento2/blob/2.3/app/code/Magento/Checkout/Test/Mftf/ActionGroup/AssertStorefrontEmailTooltipContentOnCheckoutActionGroup.xml"
-  module: "Checkout"
-  actiongroups:
-     - name: "AssertStorefrontEmailTooltipContentOnCheckoutActionGroup"
-       description: "Clicks on the Email Address tooltip. Validates that the provided Message appears in the Email Address Tooltip."
- 
-- filename: "StorefrontAddProductWithSelectedConfigurableAndCustomOptionsToCartActionGroup.xml"
-  repo: "https://github.com/magento/magento2/blob/2.3/app/code/Magento/Checkout/Test/Mftf/ActionGroup/StorefrontAddProductWithSelectedConfigurableAndCustomOptionsToCartActionGroup.xml"
-  module: "Checkout"
-  actiongroups:
-     - name: "StorefrontAddProductWithSelectedConfigurableAndCustomOptionsToCartActionGroup"
-       description: "Selects the provided Customizable Option in the Product Options drop down on a Storefront Configurable product page. Clicks on Add to Cart. Validates that the Success Message is present and correct."
- 
-- filename: "FillShippingAddressOneStreetActionGroup.xml"
-  repo: "https://github.com/magento/magento2/blob/2.3/app/code/Magento/Checkout/Test/Mftf/ActionGroup/FillShippingAddressOneStreetActionGroup.xml"
-  module: "Checkout"
-  actiongroups:
-     - name: "FillShippingAddressOneStreetActionGroup"
-       description: "Fills in the provided Address details in the 'Shipping Address' (Fills in Street Address 1 only) section of the Storefront Checkout page."
- 
-- filename: "StorefrontSelectOptionDateActionGroup.xml"
-  repo: "https://github.com/magento/magento2/blob/2.3/app/code/Magento/Checkout/Test/Mftf/ActionGroup/StorefrontSelectOptionDateActionGroup.xml"
-  module: "Checkout"
-  actiongroups:
-     - name: "StorefrontSelectOptionDateActionGroup"
-       description: "Selects the provided Month, Day and Year for the provided Product Option on a Storefront Product page."
- 
-- filename: "StorefrontCheckoutCheckProductActionGroup.xml"
-  repo: "https://github.com/magento/magento2/blob/2.3/app/code/Magento/Checkout/Test/Mftf/ActionGroup/StorefrontCheckoutCheckProductActionGroup.xml"
-  module: "Checkout"
-  actiongroups:
-     - name: "StorefrontCheckoutCheckProductActionGroup"
-       description: "Validates that the provided Product and Cart Item are present and correct on the Storefront Shopping Cart page."
- 
-- filename: "GuestCheckoutFillNewShippingAddressActionGroup.xml"
-  repo: "https://github.com/magento/magento2/blob/2.3/app/code/Magento/Checkout/Test/Mftf/ActionGroup/GuestCheckoutFillNewShippingAddressActionGroup.xml"
-  module: "Checkout"
-  actiongroups:
-     - name: "GuestCheckoutFillNewShippingAddressActionGroup"
-       description: "Fills in the provided Customer/Address details in the 'Shipping Address' section on the Storefront Checkout page."
- 
-- filename: "AssertIsNotVisibleCartPagerTextActionGroup.xml"
-  repo: "https://github.com/magento/magento2/blob/2.3/app/code/Magento/Checkout/Test/Mftf/ActionGroup/AssertIsNotVisibleCartPagerTextActionGroup.xml"
-  module: "Checkout"
-  actiongroups:
-     - name: "AssertPagerTextIsNotVisibleActionGroup"
-       description: ""
- 
-- filename: "StorefrontAddProductToCartFromCategoryActionGroup.xml"
-  repo: "https://github.com/magento/magento2/blob/2.3/app/code/Magento/Checkout/Test/Mftf/ActionGroup/StorefrontAddProductToCartFromCategoryActionGroup.xml"
-  module: "Checkout"
-  actiongroups:
-     - name: "StorefrontAddProductToCartFromCategoryActionGroup"
-       description: ""
- 
-- filename: "AssertStorefrontCheckoutSuccessActionGroup.xml"
-  repo: "https://github.com/magento/magento2/blob/2.3/app/code/Magento/Checkout/Test/Mftf/ActionGroup/AssertStorefrontCheckoutSuccessActionGroup.xml"
-  module: "Checkout"
-  actiongroups:
-     - name: "AssertStorefrontCheckoutSuccessActionGroup"
-       description: "Verifies if the order is placed successfully on the 'one page checkout' page."
- 
-- filename: "StorefrontAssertProductDetailsInOrderSummaryActionGroup.xml"
-  repo: "https://github.com/magento/magento2/blob/2.3/app/code/Magento/Checkout/Test/Mftf/ActionGroup/StorefrontAssertProductDetailsInOrderSummaryActionGroup.xml"
-  module: "Checkout"
-  actiongroups:
-     - name: "StorefrontAssertProductDetailsInOrderSummaryActionGroup"
-       description: "Validates that the provided Product Name, Quantity and Price are present in the 'Order Summary' section on the Storefront Checkout page."
- 
-- filename: "StorefrontAssertCheckoutShippingMethodSelectedActionGroup.xml"
-  repo: "https://github.com/magento/magento2/blob/2.3/app/code/Magento/Checkout/Test/Mftf/ActionGroup/StorefrontAssertCheckoutShippingMethodSelectedActionGroup.xml"
-  module: "Checkout"
-  actiongroups:
-     - name: "StorefrontAssertCheckoutShippingMethodSelectedActionGroup"
-       description: "Validates that the provided Shipping Method is checked on the Storefront Checkout page."
- 
-- filename: "StorefrontMiniCartActionGroup.xml"
-  repo: "https://github.com/magento/magento2/blob/2.3/app/code/Magento/Checkout/Test/Mftf/ActionGroup/StorefrontMiniCartActionGroup.xml"
-  module: "Checkout"
-  actiongroups:
-     - name: "clickViewAndEditCartFromMiniCart"
-       description: "Clicks on the Storefront Mini Shopping Cart icon. Clicks on the 'View and Edit Cart' link. Validates that the URL is present and correct. PLEASE NOTE: The URL is Hardcoded."
-
-     - name: "assertOneProductNameInMiniCart"
-       description: "Validates that the provided Product Name is present in the Storefront Mini Shopping Cart."
-
-     - name: "removeProductFromMiniCart"
-       description: "Removed the provided Product from the Storefront Mini Shopping Cart."
-
-     - name: "assertMiniCartEmpty"
-       description: "Validates that the provided Product Count appears in the Storefront Header next to the Shopping Cart icon. Clicks on the Mini Shopping Cart icon. Validates that the 'No Items' message is present and correct in the Storefront Mini Shopping Cart."
- 
-- filename: "StorefrontFillGuestShippingInfoActionGroup.xml"
-  repo: "https://github.com/magento/magento2/blob/2.3/app/code/Magento/Checkout/Test/Mftf/ActionGroup/StorefrontFillGuestShippingInfoActionGroup.xml"
-  module: "Checkout"
-  actiongroups:
-     - name: "StorefrontFillGuestShippingInfoActionGroup"
-       description: "Fills in the provided Customer details on the Storefront Checkout page under the 'Shipping Address' section."
- 
-- filename: "AssertStorefrontSeeElementActionGroup.xml"
-  repo: "https://github.com/magento/magento2/blob/2.3/app/code/Magento/Checkout/Test/Mftf/ActionGroup/AssertStorefrontSeeElementActionGroup.xml"
-  module: "Checkout"
-  actiongroups:
-     - name: "AssertStorefrontSeeElementActionGroup"
-       description: "Scrolls to the provided Selector. Validates that the provided Selector is present."
- 
-- filename: "StorefrontSelectOptionCheckBoxActionGroup.xml"
-  repo: "https://github.com/magento/magento2/blob/2.3/app/code/Magento/Checkout/Test/Mftf/ActionGroup/StorefrontSelectOptionCheckBoxActionGroup.xml"
-  module: "Checkout"
-  actiongroups:
-     - name: "StorefrontSelectOptionCheckBoxActionGroup"
-       description: "Checks the provided Product Option Title on a Storefront Product page."
- 
-- filename: "StorefrontSelectOptionDropDownActionGroup.xml"
-  repo: "https://github.com/magento/magento2/blob/2.3/app/code/Magento/Checkout/Test/Mftf/ActionGroup/StorefrontSelectOptionDropDownActionGroup.xml"
-  module: "Checkout"
-  actiongroups:
-     - name: "StorefrontSelectOptionDropDownActionGroup"
-       description: "Selects the provided Product Option Value under the provided Product Option Title on a Storefront Product page."
- 
-- filename: "AssertStorefrontElementInvisibleActionGroup.xml"
-  repo: "https://github.com/magento/magento2/blob/2.3/app/code/Magento/Checkout/Test/Mftf/ActionGroup/AssertStorefrontElementInvisibleActionGroup.xml"
-  module: "Checkout"
-  actiongroups:
-     - name: "AssertStorefrontElementInvisibleActionGroup"
-       description: ""
- 
-- filename: "StorefrontRegisterCustomerAfterCheckoutActionGroup.xml"
-  repo: "https://github.com/magento/magento2/blob/2.3/app/code/Magento/Checkout/Test/Mftf/ActionGroup/StorefrontRegisterCustomerAfterCheckoutActionGroup.xml"
-  module: "Checkout"
-  actiongroups:
-     - name: "StorefrontRegisterCustomerAfterCheckoutActionGroup"
-       description: ""
- 
-- filename: "StorefrontFillOptionFieldInputActionGroup.xml"
-  repo: "https://github.com/magento/magento2/blob/2.3/app/code/Magento/Checkout/Test/Mftf/ActionGroup/StorefrontFillOptionFieldInputActionGroup.xml"
-  module: "Checkout"
-  actiongroups:
-     - name: "StorefrontFillOptionFieldInputActionGroup"
-       description: "Fills in the provided Option Title with the provided Value on a Storefront product page."
- 
-- filename: "CheckoutActionGroup.xml"
-  repo: "https://github.com/magento/magento2/blob/2.3/app/code/Magento/Checkout/Test/Mftf/ActionGroup/CheckoutActionGroup.xml"
-  module: "Checkout"
-  actiongroups:
-     - name: "CheckoutSelectFlatRateShippingMethodActionGroup"
-       description: "Clicks on the 'Flat Rate' Shipping Method on the Storefront Checkout page."
-
-     - name: "GoToCheckoutFromMinicartActionGroup"
-       description: "Clicks on the Storefront Mini Shopping Cart icon. Clicks on 'Proceed to Checkout'."
-
-     - name: "GoToCheckoutFromCartActionGroup"
-       description: "Clicks on the 'View and Edit Cart' link in the Storefront Mini Shopping Cart. Validates that the Storefront Shopping Cart URL is present and correct. Clicks on 'Proceed to Checkout'."
-
-     - name: "GuestCheckoutFillingShippingSectionActionGroup"
-       description: "Fills in the provided Customer/Address (Including Region) details on the Storefront Checkout page under the 'Shipping Address' section. Selects the provided Shipping Method. Clicks on Next. Validates that the URL is present and correct."
-
-     - name: "GuestCheckoutFillShippingNoWaitForPaymentActionGroup"
-       description: "EXTENDS: GuestCheckoutFillingShippingSectionActionGroup. Removed 'waitForPaymentSectionLoaded' and 'assertCheckoutPaymentUrl'."
-
-     - name: "GuestCheckoutFillingShippingSectionWithoutRegionActionGroup"
-       description: "Fills in the provided Customer/Address (Excluding Region) details on the Storefront Checkout page under the 'Shipping Address' section. Selects the provided Shipping Method. Clicks on Next. Validates that the URL is present and correct."
-
-     - name: "GuestCheckoutFillingShippingSectionUnavailablePaymentActionGroup"
-       description: "Fills in the provided Customer/Address (Including Region) details on the Storefront Checkout page under the 'Shipping Address' section. Selects the 1st Shipping Method. Clicks on Next. Validates that the Payment Error Message and URL are present and correct."
-
-     - name: "GuestCheckoutWithSpecificCountryOptionForPaymentMethodActionGroup"
-       description: "EXTENDS: GuestCheckoutFillingShippingSectionUnavailablePaymentActionGroup. Removes 'checkMessage'. Validates that the provided Payment Method Name is NOT present on the Storefront Checkout page."
-
-     - name: "LoggedInUserCheckoutFillingShippingSectionActionGroup"
-       description: "Fills in the provided Customer/Address (Including Region) details on the Storefront Checkout page under the 'Shipping Address' section. Selects the 1st Shipping Method. Clicks on Next. Validates that the Payment Error Message and URL are present and correct."
-
-     - name: "StorefrontCheckoutForwardFromShippingStep"
-       description: "Clicks next on Checkout Shipping step"
-
-     - name: "LoggedInUserCheckoutAddNewShippingSectionWithoutRegionActionGroup"
-       description: "Fills in the provided Customer/Address (Excluding Region) details on the Storefront Checkout page under the 'Shipping Address' section. Selects the 1st Shipping Method. Clicks on Next. Validates that the Payment Error Message and URL are present and correct."
-
-     - name: "PlaceOrderWithLoggedUserActionGroup"
-       description: "Clicks on 'Proceed to Checkout' on the Storefront Shopping Cart page. Selects the provided Shipping Method. Clicks on Next. Clicks on Place Order. Validates that the Success Message is present and correct."
-
-     - name: "CheckProductInCheckoutCartItemsActionGroup"
-       description: "Validates the provided Product appears in the Storefront Checkout 'Order Summary' section."
-
-     - name: "CheckOrderSummaryInCheckoutActionGroup"
-       description: "Validates that the provided Subtotal, Shipping Total, Shipping Method and Total are present and correct on the Storefront Checkout page under the 'Order Summary' section."
-
-     - name: "CheckTotalsSortOrderInSummarySection"
-       description: "Validates that the provided Element Name appears at the provided Position in the Storefront Checkout 'Order Summary' section."
-
-     - name: "CheckShipToInformationInCheckoutActionGroup"
-       description: "Validates that the provided Customer and Address details are present and correct on the Storefront Checkout page under the 'Ship To' section."
-
-     - name: "CheckShippingMethodInCheckoutActionGroup"
-       description: "Validates that the provided Shipping Method Name is present on the Storefront Checkout page under the 'Shipping Method' section."
-
-     - name: "CheckoutSelectCheckMoneyOrderPaymentActionGroup"
-       description: "Selects the 'Check / Money Order' Payment Method on the Storefront Checkout page."
-
-     - name: "CheckSelectedShippingAddressInCheckoutActionGroup"
-       description: "Validates that the provided Customer and Address details are listed on the Storefront Checkout page under the 'Shipping Address' section when multiple Addresses are present for a Customer."
-
-     - name: "CheckBillingAddressInCheckoutActionGroup"
-       description: "Validates that the provided Customer and Address details are present on the Storefront Checkout page under the 'Payment Method' section."
-
-     - name: "CheckBillingAddressInCheckoutWithBillingAddressOnPaymentPageActionGroup"
-       description: "Validates that the provided Customer and Address details appear on the Storefront Checkout page under the 'Billing Address' section."
-
-     - name: "CheckoutPlaceOrderActionGroup"
-       description: "Clicks on 'Place Order'. Validates that the provided Order ID and Email You messages are present and correct."
-
-     - name: "VerifyTopDestinationsCountry"
-       description: "Validates that the provided Country is listed at the provided Index in 'Country' drop down menu on the Storefront Shopping Cart page under the 'Summary' section."
-
-     - name: "StorefrontSignOutActionGroup"
-       description: "Clicks on the Customer Account link. Clicks on 'Sign Out'. Validates that the Signed Out message is present and correct."
-
-     - name: "ClickPlaceOrderActionGroup"
-       description: "Clicks on the 'Place Order' button. Validates that the Success Message is present and correct."
- 
-- filename: "StorefrontProductCartActionGroup.xml"
-  repo: "https://github.com/magento/magento2/blob/2.3/app/code/Magento/Checkout/Test/Mftf/ActionGroup/StorefrontProductCartActionGroup.xml"
-  module: "Checkout"
-  actiongroups:
-     - name: "StorefrontAddCategoryProductToCartActionGroup"
-       description: "Adds the provided Product to the Cart from a Storefront Category page. Validates that the Success Message is present and correct. Validates that the Mini Shopping Cart contains the provided Product Count."
-
-     - name: "StorefrontAddCategoryProductToCartWithQuantityActionGroup"
-       description: "Adds the provided Product to the Cart from a Storefront Category page. Validates that the Success Message is present and correct. Updates the Product Quantity using the provided Product Quantity. Validates that the provided Quantity is present and correct in the Mini Shopping Cart."
-
-     - name: "StorefrontAddProductToCartActionGroup"
-       description: "Clicks on Add to Cart on a Storefront Product page. Validates that the Success Message is present and correct. Validates that the provided Product Count is present and correct in the Mini Shopping Cart."
-
-     - name: "StorefrontOpenMinicartAndCheckSimpleProductActionGroup"
-       description: "Clicks on the Storefront Mini Shopping Cart icon. Validates that the provided Product is present and correct in the Mini Shopping Cart."
-
-     - name: "StorefrontCheckCartSimpleProductActionGroup"
-       description: "Validates that the provided Product details (Name and Price) are present and correct in the Mini Shopping Cart. Validates that the provided Product Quantity is present and correct in the Mini Shopping Cart."
-
-     - name: "StorefrontCheckCartActionGroup"
-       description: "Goes to the Storefront Shopping Cart page. Validates that the provided Subtotal, Shipping, Shipping Method and Total are present and correct."
-
-     - name: "StorefrontOpenCartFromMinicartActionGroup"
-       description: "Clicks on the Storefront Mini Shopping Cart icon. Click on 'View and Edit Cart'."
-
-     - name: "changeSummaryQuoteAddress"
-       description: "Fills in the provided Address details (Country, State and Zip Code) under the 'Summary' section on the Storefront Shopping Cart page."
-
-     - name: "StorefrontCheckCartTotalWithDiscountCategoryActionGroup"
-       description: "EXTENDS: StorefrontCheckCartActionGroup. Validates that the provided Discount is present in the Storefront Shopping Cart."
- 
-- filename: "ClearShippingAddressActionGroup.xml"
-  repo: "https://github.com/magento/magento2/blob/2.3/app/code/Magento/Checkout/Test/Mftf/ActionGroup/ClearShippingAddressActionGroup.xml"
-  module: "Checkout"
-  actiongroups:
-     - name: "ClearShippingAddressActionGroup"
-       description: "Clears all of the fields for the Shipping Address section on the Storefront Checkout page."
- 
-- filename: "AssertStorefrontShoppingCartSummaryItemsActionGroup.xml"
-  repo: "https://github.com/magento/magento2/blob/2.3/app/code/Magento/Checkout/Test/Mftf/ActionGroup/AssertStorefrontShoppingCartSummaryItemsActionGroup.xml"
-  module: "Checkout"
-  actiongroups:
-     - name: "AssertStorefrontShoppingCartSummaryItemsActionGroup"
-       description: "Goes to the Storefront Shopping Cart page. Validates that the provided Subtotal/Total are present and correct."
- 
-- filename: "AssertMiniShoppingCartSubTotalActionGroup.xml"
-  repo: "https://github.com/magento/magento2/blob/2.3/app/code/Magento/Checkout/Test/Mftf/ActionGroup/AssertMiniShoppingCartSubTotalActionGroup.xml"
-  module: "Checkout"
-  actiongroups:
-     - name: "AssertMiniShoppingCartSubTotalActionGroup"
-       description: "Validates that the provided Subtotal (Price and Store Currency) is present and correct."
- 
-- filename: "AssertStorefrontOrderCannotBePlacedActionGroup.xml"
-  repo: "https://github.com/magento/magento2/blob/2.3/app/code/Magento/Checkout/Test/Mftf/ActionGroup/AssertStorefrontOrderCannotBePlacedActionGroup.xml"
-  module: "Checkout"
-  actiongroups:
-     - name: "AssertStorefrontOrderCannotBePlacedActionGroup"
-       description: "Validates order cannot be placed and checks error message."
- 
-- filename: "AssertStorefrontMiniCartSubtotalActionGroup.xml"
-  repo: "https://github.com/magento/magento2/blob/2.3/app/code/Magento/Checkout/Test/Mftf/ActionGroup/AssertStorefrontMiniCartSubtotalActionGroup.xml"
-  module: "Checkout"
-  actiongroups:
-     - name: "AssertStorefrontMiniCartSubtotalActionGroup"
-       description: ""
- 
-- filename: "StorefrontShippmentFromActionGroup.xml"
-  repo: "https://github.com/magento/magento2/blob/2.3/app/code/Magento/Checkout/Test/Mftf/ActionGroup/StorefrontShippmentFromActionGroup.xml"
-  module: "Checkout"
-  actiongroups:
-     - name: "ShipmentFormFreeShippingActionGroup"
-       description: "Fills in the Customer details for the 'Shipping Address' section of the Storefront Checkout page. Selects 'Free Shipping'. Clicks on Next. Validates that the URL is present and correct."
- 
-- filename: "StorefrontCheckThatCartIsEmptyActionGroup.xml"
-  repo: "https://github.com/magento/magento2/blob/2.3/app/code/Magento/Checkout/Test/Mftf/ActionGroup/StorefrontCheckThatCartIsEmptyActionGroup.xml"
-  module: "Checkout"
-  actiongroups:
-     - name: "StorefrontCheckThatCartIsEmptyActionGroup"
-       description: "Clicks on the Mini Shopping Cart icon in the Storefront Header. Validates that the 'Empty Cart' message is present and correct."
- 
-- filename: "StorefrontSelectOptionTimeActionGroup.xml"
-  repo: "https://github.com/magento/magento2/blob/2.3/app/code/Magento/Checkout/Test/Mftf/ActionGroup/StorefrontSelectOptionTimeActionGroup.xml"
-  module: "Checkout"
-  actiongroups:
-     - name: "StorefrontSelectOptionTimeActionGroup"
-       description: "Selects the provided Hour, Minute and Part of Day under the provided Product Option Title on a Storefront Product page."
- 
-- filename: "StorefrontAddBundleProductToTheCartActionGroup.xml"
-  repo: "https://github.com/magento/magento2/blob/2.3/app/code/Magento/Checkout/Test/Mftf/ActionGroup/StorefrontAddBundleProductToTheCartActionGroup.xml"
-  module: "Checkout"
-  actiongroups:
-     - name: "StorefrontAddBundleProductToTheCartActionGroup"
-       description: "Clicks on 'Customize and Add to Cart' button on a Storefront Bundled product page. Adds the provided Product Name/Quantity. Clicks on Add to Cart."
- 
-- filename: "StorefrontOpenCartPageActionGroup.xml"
-  repo: "https://github.com/magento/magento2/blob/2.3/app/code/Magento/Checkout/Test/Mftf/ActionGroup/StorefrontOpenCartPageActionGroup.xml"
-  module: "Checkout"
-  actiongroups:
-     - name: "StorefrontOpenCartPageActionGroup"
-       description: ""
- 
-- filename: "StorefrontFillOptionTextAreaActionGroup.xml"
-  repo: "https://github.com/magento/magento2/blob/2.3/app/code/Magento/Checkout/Test/Mftf/ActionGroup/StorefrontFillOptionTextAreaActionGroup.xml"
-  module: "Checkout"
-  actiongroups:
-     - name: "StorefrontFillOptionTextAreaActionGroup"
-       description: "Fills in the provided Option Title with the provided Value on a Storefront product page."
- 
-- filename: "AssertStorefrontCheckoutCartItemsActionGroup.xml"
-  repo: "https://github.com/magento/magento2/blob/2.3/app/code/Magento/Checkout/Test/Mftf/ActionGroup/AssertStorefrontCheckoutCartItemsActionGroup.xml"
-  module: "Checkout"
-  actiongroups:
-     - name: "AssertStorefrontCheckoutCartItemsActionGroup"
-       description: "Validates that the provided Product details (Name, SKU, Price, Subtotal and Quantity) are present and correct on the Storefront Shopping Cart page."
- 
-- filename: "AdminCheckoutActionGroup.xml"
-  repo: "https://github.com/magento/magento2/blob/2.3/app/code/Magento/Checkout/Test/Mftf/ActionGroup/AdminCheckoutActionGroup.xml"
-  module: "Checkout"
-  actiongroups:
-     - name: "AdminCheckoutSelectCheckMoneyOrderBillingMethodActionGroup"
-       description: "Selects the Billing Method \"Check / Money order\" on the Admin 'Create New Order for' page."
- 
-- filename: "VerifyCheckoutPaymentOrderSummaryActionGroup.xml"
-  repo: "https://github.com/magento/magento2/blob/2.3/app/code/Magento/Checkout/Test/Mftf/ActionGroup/VerifyCheckoutPaymentOrderSummaryActionGroup.xml"
-  module: "Checkout"
-  actiongroups:
-     - name: "VerifyCheckoutPaymentOrderSummaryActionGroup"
-       description: "Validates that the provided Subtotal, Shipping Total and Summary Total prices are present and correct on the Storefront Checkout page."
-
-     - name: "AssertStorefrontCheckoutPaymentSummarySubtotalActionGroup"
-       description: ""
-
-     - name: "AssertStorefrontCheckoutPaymentSummaryTotalActionGroup"
-       description: ""
-
-     - name: "AssertStorefrontCheckoutPaymentSummaryTotalMissingActionGroup"
-       description: ""
- 
-- filename: "StorefrontSelectOptionRadioButtonActionGroup.xml"
-  repo: "https://github.com/magento/magento2/blob/2.3/app/code/Magento/Checkout/Test/Mftf/ActionGroup/StorefrontSelectOptionRadioButtonActionGroup.xml"
-  module: "Checkout"
-  actiongroups:
-     - name: "StorefrontSelectOptionRadioButtonActionGroup"
-       description: "Checks the provided Product Option radio button for the provided Product Option Price on a Storefront Product page."
- 
-- filename: "StorefrontAssertCartEstimateShippingAndTaxActionGroup.xml"
-  repo: "https://github.com/magento/magento2/blob/2.3/app/code/Magento/Checkout/Test/Mftf/ActionGroup/StorefrontAssertCartEstimateShippingAndTaxActionGroup.xml"
-  module: "Checkout"
-  actiongroups:
-     - name: "StorefrontAssertCartEstimateShippingAndTaxActionGroup"
-       description: "Validates that the provided Customer details (Country, State and Zip Code) are present and correct in the 'Estimate Shipping and Tax' section on the Storefront Shopping Cart page."
- 
-- filename: "StorefrontSelectOptionMultiSelectActionGroup.xml"
-  repo: "https://github.com/magento/magento2/blob/2.3/app/code/Magento/Checkout/Test/Mftf/ActionGroup/StorefrontSelectOptionMultiSelectActionGroup.xml"
-  module: "Checkout"
-  actiongroups:
-     - name: "StorefrontSelectOptionMultiSelectActionGroup"
-       description: "Selects the provided Product Option under the provided Product Option Title on a Storefront Product page."
- 
-- filename: "StorefrontAssertMiniCartItemCountActionGroup.xml"
-  repo: "https://github.com/magento/magento2/blob/2.3/app/code/Magento/Checkout/Test/Mftf/ActionGroup/StorefrontAssertMiniCartItemCountActionGroup.xml"
-  module: "Checkout"
-  actiongroups:
-     - name: "StorefrontAssertMiniCartItemCountActionGroup"
-       description: "Validates that the provided Product Count appears in the Storefront Header next to the Shopping Cart icon. Validates that the provided Product Count Text appears in the Storefront Mini Shopping Cart."
- 
-- filename: "StorefrontFillEmailFieldOnCheckoutActionGroup.xml"
-  repo: "https://github.com/magento/magento2/blob/2.3/app/code/Magento/Checkout/Test/Mftf/ActionGroup/StorefrontFillEmailFieldOnCheckoutActionGroup.xml"
-  module: "Checkout"
-  actiongroups:
-     - name: "StorefrontFillEmailFieldOnCheckoutActionGroup"
-       description: "Fills in the provided Email Address on the Storefront Checkout page. Double clicks on the Email tooltip."
- 
-- filename: "StorefrontAssertShippingMethodOptionPresentInCartActionGroup.xml"
-  repo: "https://github.com/magento/magento2/blob/2.3/app/code/Magento/Checkout/Test/Mftf/ActionGroup/StorefrontAssertShippingMethodOptionPresentInCartActionGroup.xml"
-  module: "Checkout"
-  actiongroups:
-     - name: "StorefrontAssertShippingMethodOptionPresentInCartActionGroup"
-       description: ""
- 
-- filename: "StorefrontClickOnMiniCartActionGroup.xml"
-  repo: "https://github.com/magento/magento2/blob/2.3/app/code/Magento/Checkout/Test/Mftf/ActionGroup/StorefrontClickOnMiniCartActionGroup.xml"
-  module: "Checkout"
-  actiongroups:
-     - name: "StorefrontClickOnMiniCartActionGroup"
-       description: "Scrolls to the Top of the Page. Clicks on the Mini Shopping Cart icon in the Storefront Header."
- 
-- filename: "StorefrontAssertNoValidationErrorForCheckoutAddressFieldsActionGroup.xml"
-  repo: "https://github.com/magento/magento2/blob/2.3/app/code/Magento/Checkout/Test/Mftf/ActionGroup/StorefrontAssertNoValidationErrorForCheckoutAddressFieldsActionGroup.xml"
-  module: "Checkout"
-  actiongroups:
-     - name: "StorefrontAssertNoValidationErrorForCheckoutAddressFieldsActionGroup"
-       description: ""
- 
-- filename: "StorefrontAddSimpleProductToCartActionGroup.xml"
-  repo: "https://github.com/magento/magento2/blob/2.3/app/code/Magento/Checkout/Test/Mftf/ActionGroup/StorefrontAddSimpleProductToCartActionGroup.xml"
-  module: "Checkout"
-  actiongroups:
-     - name: "StorefrontAddSimpleProductToCartActionGroup"
-       description: "Adds the provided Product to the Storefront Shopping Cart from a Storefront Category page. Validates that the provided Success Message is present and correct."
- 
-- filename: "AssertStorefrontMiniCartItemsActionGroup.xml"
-  repo: "https://github.com/magento/magento2/blob/2.3/app/code/Magento/Checkout/Test/Mftf/ActionGroup/AssertStorefrontMiniCartItemsActionGroup.xml"
-  module: "Checkout"
-  actiongroups:
-     - name: "AssertStorefrontMiniCartItemsActionGroup"
-       description: "Validates that the provided Product details (Name, Price, Subtotal and Quantity) are present and correct in the Storefront Mini Shopping Cart."
-
-     - name: "AssertStorefrontMiniCartProductDetailsAbsentActionGroup"
-       description: "Validates that the provided Product details (Name, Price) are
-                not present in the Storefront Mini Shopping Cart."
- 
-- filename: "StorefrontAttachOptionFileActionGroup.xml"
-  repo: "https://github.com/magento/magento2/blob/2.3/app/code/Magento/Checkout/Test/Mftf/ActionGroup/StorefrontAttachOptionFileActionGroup.xml"
-  module: "Checkout"
-  actiongroups:
-     - name: "StorefrontAttachOptionFileActionGroup"
-       description: "Attaches the provided File to the provided Product Option on a Storefront Product page."
- 
-- filename: "StorefrontOpenMiniCartActionGroup.xml"
-  repo: "https://github.com/magento/magento2/blob/2.3/app/code/Magento/Checkout/Test/Mftf/ActionGroup/StorefrontOpenMiniCartActionGroup.xml"
-  module: "Checkout"
-  actiongroups:
-     - name: "StorefrontOpenMiniCartActionGroup"
-       description: "Clicks on the Mini Shopping Cart icon in the Storefront Header."
- 
-- filename: "LoginAsCustomerUsingSignInLinkActionGroup.xml"
-  repo: "https://github.com/magento/magento2/blob/2.3/app/code/Magento/Checkout/Test/Mftf/ActionGroup/LoginAsCustomerUsingSignInLinkActionGroup.xml"
-  module: "Checkout"
-  actiongroups:
-     - name: "LoginAsCustomerUsingSignInLinkActionGroup"
-       description: "Clicks on 'Sign In' on the Storefront Checkout page. Fills in the provided Customer details (Email and Password). Clicks on Sign In."
- 
-- filename: "AssertStorefrontShoppingCartSummaryWithShippingActionGroup.xml"
-  repo: "https://github.com/magento/magento2/blob/2.3/app/code/Magento/Checkout/Test/Mftf/ActionGroup/AssertStorefrontShoppingCartSummaryWithShippingActionGroup.xml"
-  module: "Checkout"
-  actiongroups:
-     - name: "AssertStorefrontShoppingCartSummaryWithShippingActionGroup"
-       description: "EXTENDS: AssertStorefrontShoppingCartSummaryItemsActionGroup. Waits for the Storefront Checkout 'Shipping Methods' section to appear."
- 
-- filename: "StorefrontAssertShippingMethodPresentInCartActionGroup.xml"
-  repo: "https://github.com/magento/magento2/blob/2.3/app/code/Magento/Checkout/Test/Mftf/ActionGroup/StorefrontAssertShippingMethodPresentInCartActionGroup.xml"
-  module: "Checkout"
-  actiongroups:
-     - name: "StorefrontAssertShippingMethodPresentInCartActionGroup"
-       description: "Validates that the provided Shipping Method Name is present in the 'Summary' section of the Storefront Shopping Cart page."
- 
-- filename: "StorefrontAddProductWithSelectedOptionToCartActionGroup.xml"
-  repo: "https://github.com/magento/magento2/blob/2.3/app/code/Magento/Checkout/Test/Mftf/ActionGroup/StorefrontAddProductWithSelectedOptionToCartActionGroup.xml"
-  module: "Checkout"
-  actiongroups:
-     - name: "StorefrontAddProductWithSelectedConfigurableOptionToCartActionGroup"
-       description: "Selects the provided Product Option in the drop down on a Storefront Configurable product page. Clicks on Add to Cart. Validates that the Success Message is present and correct."
- 
-- filename: "GuestCheckoutFillNewBillingAddressActionGroup.xml"
-  repo: "https://github.com/magento/magento2/blob/2.3/app/code/Magento/Checkout/Test/Mftf/ActionGroup/GuestCheckoutFillNewBillingAddressActionGroup.xml"
-  module: "Checkout"
-  actiongroups:
-     - name: "GuestCheckoutFillNewBillingAddressActionGroup"
-       description: "Fills in the provided Customer and Address details on the Storefront Checkout page."
-
-     - name: "StorefrontCheckoutFillNewBillingAddressActionGroup"
-       description: ""
-
-     - name: "LoggedInCheckoutFillNewBillingAddressActionGroup"
-       description: "Fills in the provided Address details on the Storefront Checkout Address sections based on the provided Class Prefix (i.e. '._show', '[aria-hidden=false]')."
-
-     - name: "LoggedInCheckoutWithOneAddressFieldWithoutStateField"
-       description: "EXTENDS: LoggedInCheckoutFillNewBillingAddressActionGroup. Removes 'fillStreetAddress2' and 'selectState'."
-
-     - name: "clearCheckoutAddressPopupFieldsActionGroup"
-       description: "Clears the fields for the Customer/Address fields on the Storefront Checkout Address sections based on the provided Class Prefix (i.e. '._show', '[aria-hidden=false]')."
-
-     - name: "GuestCheckoutSelectPaymentAndFillNewBillingAddressActionGroup"
-       description: "EXTENDS: GuestCheckoutFillNewBillingAddressActionGroup. Clicks on the provided Payment Method on the Storefront Checkout page."
- 
-- filename: "StorefrontEnterProductQuantityAndAddToTheCartActionGroup.xml"
-  repo: "https://github.com/magento/magento2/blob/2.3/app/code/Magento/Checkout/Test/Mftf/ActionGroup/StorefrontEnterProductQuantityAndAddToTheCartActionGroup.xml"
-  module: "Checkout"
-  actiongroups:
-     - name: "StorefrontEnterProductQuantityAndAddToTheCartActionGroup"
-       description: "Fills in the provided Product Quantity on a Storefront Bundled product page. Clicks on Add to Cart."
- 
-- filename: "StorefrontCheckoutCheckOutOfStockProductActionGroup.xml"
-  repo: "https://github.com/magento/magento2/blob/2.3/app/code/Magento/Checkout/Test/Mftf/ActionGroup/StorefrontCheckoutCheckOutOfStockProductActionGroup.xml"
-  module: "Checkout"
-  actiongroups:
-     - name: "StorefrontCheckoutCheckOutOfStockProductActionGroup"
-       description: "Validates that the 'Out of Stock' Error Message is present and correct on the Storefront Checkout page for the provided Product."
- 
-- filename: "AssertStorefrontShippingLabelDescriptionInOrderSummaryActionGroup.xml"
-  repo: "https://github.com/magento/magento2/blob/2.3/app/code/Magento/Checkout/Test/Mftf/ActionGroup/AssertStorefrontShippingLabelDescriptionInOrderSummaryActionGroup.xml"
-  module: "Checkout"
-  actiongroups:
-     - name: "AssertStorefrontShippingLabelDescriptionInOrderSummaryActionGroup"
-       description: "Validates that the Shipping label description is present and correct."
- 
-- filename: "AssertStorefrontEmailNoteMessageOnCheckoutActionGroup.xml"
-  repo: "https://github.com/magento/magento2/blob/2.3/app/code/Magento/Checkout/Test/Mftf/ActionGroup/AssertStorefrontEmailNoteMessageOnCheckoutActionGroup.xml"
-  module: "Checkout"
-  actiongroups:
-     - name: "AssertStorefrontEmailNoteMessageOnCheckoutActionGroup"
-       description: "Validates that the provided 'Email Address' message is present on the Storefront Checkout page under the 'Email Address' field."
- 
-- filename: "AssertStorefrontEmailValidationMessageOnCheckoutActionGroup.xml"
-  repo: "https://github.com/magento/magento2/blob/2.3/app/code/Magento/Checkout/Test/Mftf/ActionGroup/AssertStorefrontEmailValidationMessageOnCheckoutActionGroup.xml"
-  module: "Checkout"
-  actiongroups:
-     - name: "AssertStorefrontEmailValidationMessageOnCheckoutActionGroup"
-       description: "Validates that the provided Error Message appears on the Storefront Checkout page after an invalid Email Addressed is inputted."
- 
-- filename: "StorefrontAssertCartShippingMethodSelectedActionGroup.xml"
-  repo: "https://github.com/magento/magento2/blob/2.3/app/code/Magento/Checkout/Test/Mftf/ActionGroup/StorefrontAssertCartShippingMethodSelectedActionGroup.xml"
-  module: "Checkout"
-  actiongroups:
-     - name: "StorefrontAssertCartShippingMethodSelectedActionGroup"
-       description: "Validates that the provided Shipping Method Carrier/Method Code is checked on the Storefront Shopping Cart page."
- 
-- filename: "CheckoutFillEstimateShippingAndTaxActionGroup.xml"
-  repo: "https://github.com/magento/magento2/blob/2.3/app/code/Magento/Checkout/Test/Mftf/ActionGroup/CheckoutFillEstimateShippingAndTaxActionGroup.xml"
-  module: "Checkout"
-  actiongroups:
-     - name: "CheckoutFillEstimateShippingAndTaxActionGroup"
-       description: ""
- 
-- filename: "StorefrontRemoveCartItemActionGroup.xml"
-  repo: "https://github.com/magento/magento2/blob/2.3/app/code/Magento/Checkout/Test/Mftf/ActionGroup/StorefrontRemoveCartItemActionGroup.xml"
-  module: "Checkout"
-  actiongroups:
-     - name: "StorefrontRemoveCartItemActionGroup"
-       description: ""
- 
-- filename: "IdentityOfDefaultBillingAndShippingAddressActionGroup.xml"
-  repo: "https://github.com/magento/magento2/blob/2.3/app/code/Magento/Checkout/Test/Mftf/ActionGroup/IdentityOfDefaultBillingAndShippingAddressActionGroup.xml"
-  module: "Checkout"
-  actiongroups:
-     - name: "AssertThatShippingAndBillingAddressTheSame"
-       description: "Validates that the Shipping and Billing Addresses are the same."
- 
-- filename: "CaptchaFormsDisplayingActionGroup.xml"
-  repo: "https://github.com/magento/magento2/blob/2.3/app/code/Magento/Captcha/Test/Mftf/ActionGroup/CaptchaFormsDisplayingActionGroup.xml"
-  module: "Captcha"
-  actiongroups:
-     - name: "CaptchaFormsDisplayingActionGroup"
-       description: "Navigates to store configuration page through UI and expands the CAPTCHA section under Customers &gt; Customer Configuration."
- 
-- filename: "StorefrontCustomerChangeEmailWithCaptchaActionGroup.xml"
-  repo: "https://github.com/magento/magento2/blob/2.3/app/code/Magento/Captcha/Test/Mftf/ActionGroup/StorefrontCustomerChangeEmailWithCaptchaActionGroup.xml"
-  module: "Captcha"
-  actiongroups:
-     - name: "StorefrontCustomerChangeEmailWithCaptchaActionGroup"
-       description: "EXTENDS: StorefrontCustomerChangeEmailActionGroup. Fills in the Captcha field on the Storefront Customer Information page."
- 
-- filename: "AssertCaptchaVisibleOnCustomerAccountCreatePageActionGroup.xml"
-  repo: "https://github.com/magento/magento2/blob/2.3/app/code/Magento/Captcha/Test/Mftf/ActionGroup/AssertCaptchaVisibleOnCustomerAccountCreatePageActionGroup.xml"
-  module: "Captcha"
-  actiongroups:
-     - name: "AssertCaptchaVisibleOnCustomerAccountCreatePageActionGroup"
-       description: "Validate that the Captcha IS present on the Storefront Create Customer page."
- 
-- filename: "AssertCaptchaVisibleOnCustomerAccountInfoActionGroup.xml"
-  repo: "https://github.com/magento/magento2/blob/2.3/app/code/Magento/Captcha/Test/Mftf/ActionGroup/AssertCaptchaVisibleOnCustomerAccountInfoActionGroup.xml"
-  module: "Captcha"
-  actiongroups:
-     - name: "AssertCaptchaVisibleOnCustomerAccountInfoActionGroup"
-       description: "Validate that the Captcha IS present on the Storefront Customer Account Information page."
- 
-- filename: "StorefrontFillContactUsFormWithCaptchaActionGroup.xml"
-  repo: "https://github.com/magento/magento2/blob/2.3/app/code/Magento/Captcha/Test/Mftf/ActionGroup/StorefrontFillContactUsFormWithCaptchaActionGroup.xml"
-  module: "Captcha"
-  actiongroups:
-     - name: "StorefrontFillContactUsFormWithCaptchaActionGroup"
-       description: "EXTENDS: StorefrontFillContactUsFormActionGroup. Fills in the Captcha field on the Storefront Contact Us page."
- 
-- filename: "StorefrontFillCustomerLoginFormWithCaptchaActionGroup.xml"
-  repo: "https://github.com/magento/magento2/blob/2.3/app/code/Magento/Captcha/Test/Mftf/ActionGroup/StorefrontFillCustomerLoginFormWithCaptchaActionGroup.xml"
-  module: "Captcha"
-  actiongroups:
-     - name: "StorefrontFillCustomerLoginFormWithCaptchaActionGroup"
-       description: "EXTENDS: StorefrontFillCustomerLoginFormActionGroup. Fills in the Captcha field on the Storefront Customer Login page."
- 
-- filename: "AssertCaptchaVisibleOnContactUsFormActionGroup.xml"
-  repo: "https://github.com/magento/magento2/blob/2.3/app/code/Magento/Captcha/Test/Mftf/ActionGroup/AssertCaptchaVisibleOnContactUsFormActionGroup.xml"
-  module: "Captcha"
-  actiongroups:
-     - name: "AssertCaptchaVisibleOnContactUsFormActionGroup"
-       description: "Validate that the Captcha IS present on the Storefront Contact Us page."
- 
-- filename: "AssertCaptchaVisibleOnAdminLoginFormActionGroup.xml"
-  repo: "https://github.com/magento/magento2/blob/2.3/app/code/Magento/Captcha/Test/Mftf/ActionGroup/AssertCaptchaVisibleOnAdminLoginFormActionGroup.xml"
-  module: "Captcha"
-  actiongroups:
-     - name: "AssertCaptchaVisibleOnAdminLoginFormActionGroup"
-       description: "Validate that the Captcha IS present on the Backend Admin Login page."
- 
-- filename: "AdminLoginWithCaptchaActionGroup.xml"
-  repo: "https://github.com/magento/magento2/blob/2.3/app/code/Magento/Captcha/Test/Mftf/ActionGroup/AdminLoginWithCaptchaActionGroup.xml"
-  module: "Captcha"
-  actiongroups:
-     - name: "AdminLoginWithCaptchaActionGroup"
-       description: "EXTENDS: LoginAsAdmin. Fills in the Captcha field on the Backend Admin Login page."
- 
-- filename: "AssertCaptchaNotVisibleOnCustomerLoginFormActionGroup.xml"
-  repo: "https://github.com/magento/magento2/blob/2.3/app/code/Magento/Captcha/Test/Mftf/ActionGroup/AssertCaptchaNotVisibleOnCustomerLoginFormActionGroup.xml"
-  module: "Captcha"
-  actiongroups:
-     - name: "AssertCaptchaNotVisibleOnCustomerLoginFormActionGroup"
-       description: "Validate that the Captcha is NOT present on the Backend Admin Login page."
- 
-- filename: "StorefrontFillCustomerAccountCreationFormWithCaptchaActionGroup.xml"
-  repo: "https://github.com/magento/magento2/blob/2.3/app/code/Magento/Captcha/Test/Mftf/ActionGroup/StorefrontFillCustomerAccountCreationFormWithCaptchaActionGroup.xml"
-  module: "Captcha"
-  actiongroups:
-     - name: "StorefrontFillCustomerAccountCreationFormWithCaptchaActionGroup"
-       description: "EXTENDS: StorefrontFillCustomerAccountCreationFormActionGroup. Fills in the Captcha field on the Storefront Create Customer page."
- 
-- filename: "AssertCaptchaVisibleOnCustomerLoginFormActionGroup.xml"
-  repo: "https://github.com/magento/magento2/blob/2.3/app/code/Magento/Captcha/Test/Mftf/ActionGroup/AssertCaptchaVisibleOnCustomerLoginFormActionGroup.xml"
-  module: "Captcha"
-  actiongroups:
-     - name: "AssertCaptchaVisibleOnCustomerLoginFormActionGroup"
-       description: "Validate that the Captcha IS present on the Storefront Customer Login page."
- 
-- filename: "StoreFrontSelectDropDownSearchSuggestionActionGroup.xml"
-  repo: "https://github.com/magento/magento2/blob/2.3/app/code/Magento/Search/Test/Mftf/ActionGroup/StoreFrontSelectDropDownSearchSuggestionActionGroup.xml"
-  module: "Search"
-  actiongroups:
-     - name: "StoreFrontSelectDropDownSearchSuggestionActionGroup"
-       description: "Fills the Storefront Quick Search field. Validates that the provided Search Suggestion is present and correct."
- 
-- filename: "AdminSearchTermActionGroup.xml"
-  repo: "https://github.com/magento/magento2/blob/2.3/app/code/Magento/Search/Test/Mftf/ActionGroup/AdminSearchTermActionGroup.xml"
-  module: "Search"
-  actiongroups:
-     - name: "searchTermFilterBySearchQuery"
-       description: "Fills in the provided Search Query on the Admin Search Term grid page."
-
-     - name: "deleteSearchTerm"
-       description: "Deletes the Search Terms in the Admin Search Term grid."
-
-     - name: "DeleteAllSearchTerms"
-       description: ""
- 
-- filename: "AdminEditSearchTermActionGroup.xml"
-  repo: "https://github.com/magento/magento2/blob/2.3/app/code/Magento/Search/Test/Mftf/ActionGroup/AdminEditSearchTermActionGroup.xml"
-  module: "Search"
-  actiongroups:
-     - name: "AdminFillAllSearchTermFieldsActionGroup"
-       description: "Fills in the provided Search Term on the Admin Search Terms grid page."
- 
-- filename: "AdminGroupedProductActionGroup.xml"
-  repo: "https://github.com/magento/magento2/blob/2.3/app/code/Magento/GroupedProduct/Test/Mftf/ActionGroup/AdminGroupedProductActionGroup.xml"
-  module: "GroupedProduct"
-  actiongroups:
-     - name: "checkRequiredFieldsInGroupedProductForm"
-       description: "Clears the Product Name and SKU fields when adding a Grouped Product and then verifies that they are required after attempting to Save."
-
-     - name: "fillGroupedProductForm"
-       description: "Fills in the provided Product Name and SKU on the Grouped Product creation/edit page."
-
-     - name: "viewGroupedProductInAdminGrid"
-       description: "Goes to the Admin Products grid page. Filters the grid for the provided Product. Validates that the provided Product appears in the grid."
-
-     - name: "fillDefaultQuantityForLinkedToGroupProductInGrid"
-       description: "Fills the provided Qty for a Product linked to a Grouped Product."
-
-     - name: "AdminAssignProductToGroup"
-       description: "Adds the provided Product to a Grouped Product on an Admin Grouped Product creation/edit page."
- 
-- filename: "StorefrontAddGroupedProductWithTwoLinksToCartActionGroup.xml"
-  repo: "https://github.com/magento/magento2/blob/2.3/app/code/Magento/GroupedProduct/Test/Mftf/ActionGroup/StorefrontAddGroupedProductWithTwoLinksToCartActionGroup.xml"
-  module: "GroupedProduct"
-  actiongroups:
-     - name: "StorefrontAddGroupedProductWithTwoLinksToCartActionGroup"
-       description: "Adding to the Shopping Cart single Grouped product, with 2 associated from the Product page"
- 
-- filename: "StorefrontAddThreeGroupedProductToTheCartActionGroup.xml"
-  repo: "https://github.com/magento/magento2/blob/2.3/app/code/Magento/GroupedProduct/Test/Mftf/ActionGroup/StorefrontAddThreeGroupedProductToTheCartActionGroup.xml"
-  module: "GroupedProduct"
-  actiongroups:
-     - name: "StorefrontAddThreeGroupedProductToTheCartActionGroup"
-       description: "Goes to the provided URL for a Grouped Product. Validates that the provided Products and Quantities are present and correct."
- 
-- filename: "AssertLinkPresenceOnGroupedProductPageActionGroup.xml"
-  repo: "https://github.com/magento/magento2/blob/2.3/app/code/Magento/GroupedProduct/Test/Mftf/ActionGroup/AssertLinkPresenceOnGroupedProductPageActionGroup.xml"
-  module: "GroupedProduct"
-  actiongroups:
-     - name: "AssertLinkPresenceOnGroupedProductPage"
-       description: "Validates that the provided Product Name is present and correct on a Storefront Grouped Product page."
- 
-- filename: "AdminOrderGroupedProductActionGroup.xml"
-  repo: "https://github.com/magento/magento2/blob/2.3/app/code/Magento/GroupedProduct/Test/Mftf/ActionGroup/AdminOrderGroupedProductActionGroup.xml"
-  module: "GroupedProduct"
-  actiongroups:
-     - name: "AdminOrderConfigureGroupedProduct"
-       description: ""
- 
-- filename: "VerifyProductTypeOrderActionGroup.xml"
-  repo: "https://github.com/magento/magento2/blob/2.3/app/code/Magento/GroupedProduct/Test/Mftf/ActionGroup/VerifyProductTypeOrderActionGroup.xml"
-  module: "GroupedProduct"
-  actiongroups:
-     - name: "VerifyProductTypeOrder"
-       description: "Checks that Grouped is in the correct order in comparison to other product types on the add product dropdown."
- 
-- filename: "SelectBillingInfoActionGroup.xml"
-  repo: "https://github.com/magento/magento2/blob/2.3/app/code/Magento/Multishipping/Test/Mftf/ActionGroup/SelectBillingInfoActionGroup.xml"
-  module: "Multishipping"
-  actiongroups:
-     - name: "SelectBillingInfoActionGroup"
-       description: ""
- 
-- filename: "CheckingWithMultipleAddressesActionGroup.xml"
-  repo: "https://github.com/magento/magento2/blob/2.3/app/code/Magento/Multishipping/Test/Mftf/ActionGroup/CheckingWithMultipleAddressesActionGroup.xml"
-  module: "Multishipping"
-  actiongroups:
-     - name: "CheckingWithSingleAddressActionGroup"
-       description: ""
-
-     - name: "CheckingWithMultipleAddressesActionGroup"
-       description: ""
-
-     - name: "StorefrontCheckoutWithMultipleAddressesActionGroup"
-       description: ""
-
-     - name: "StorefrontSelectAddressActionGroup"
-       description: ""
-
-     - name: "StorefrontSaveAddressActionGroup"
-       description: ""
- 
-- filename: "StorefrontMultishippingCheckoutActionGroup.xml"
-  repo: "https://github.com/magento/magento2/blob/2.3/app/code/Magento/Multishipping/Test/Mftf/ActionGroup/StorefrontMultishippingCheckoutActionGroup.xml"
-  module: "Multishipping"
-  actiongroups:
-     - name: "StorefrontCheckoutShippingSelectMultipleAddressesActionGroup"
-       description: ""
-
-     - name: "StorefrontGoCheckoutWithMultipleAddresses"
-       description: ""
-
-     - name: "StorefrontGoToBillingInformationActionGroup"
-       description: ""
- 
-- filename: "CheckingWithMinicartActionGroup.xml"
-  repo: "https://github.com/magento/magento2/blob/2.3/app/code/Magento/Multishipping/Test/Mftf/ActionGroup/CheckingWithMinicartActionGroup.xml"
-  module: "Multishipping"
-  actiongroups:
-     - name: "CheckingWithMinicartActionGroup"
-       description: ""
- 
-- filename: "ReviewOrderActionGroup.xml"
-  repo: "https://github.com/magento/magento2/blob/2.3/app/code/Magento/Multishipping/Test/Mftf/ActionGroup/ReviewOrderActionGroup.xml"
-  module: "Multishipping"
-  actiongroups:
-     - name: "ReviewOrderForSingleShipmentActionGroup"
-       description: ""
-
-     - name: "ReviewOrderForMultiShipmentActionGroup"
-       description: ""
- 
-- filename: "SelectShippingInfoActionGroup.xml"
-  repo: "https://github.com/magento/magento2/blob/2.3/app/code/Magento/Multishipping/Test/Mftf/ActionGroup/SelectShippingInfoActionGroup.xml"
-  module: "Multishipping"
-  actiongroups:
-     - name: "SelectSingleShippingInfoActionGroup"
-       description: ""
-
-     - name: "SelectMultiShippingInfoActionGroup"
-       description: ""
-
-     - name: "StorefrontLeaveDefaultShippingMethodsAndGoToBillingInfoActionGroup"
-       description: ""
- 
-- filename: "AdminSalesOrderActionGroup.xml"
-  repo: "https://github.com/magento/magento2/blob/2.3/app/code/Magento/Multishipping/Test/Mftf/ActionGroup/AdminSalesOrderActionGroup.xml"
-  module: "Multishipping"
-  actiongroups:
-     - name: "AdminSalesOrderActionGroup"
-       description: ""
- 
-- filename: "AssertStorefrontSalesOrderMatchesGrandTotalActionGroup.xml"
-  repo: "https://github.com/magento/magento2/blob/2.3/app/code/Magento/Multishipping/Test/Mftf/ActionGroup/AssertStorefrontSalesOrderMatchesGrandTotalActionGroup.xml"
-  module: "Multishipping"
-  actiongroups:
-     - name: "AssertStorefrontSalesOrderMatchesGrandTotalActionGroup"
-       description: ""
- 
-- filename: "PlaceOrderActionGroup.xml"
-  repo: "https://github.com/magento/magento2/blob/2.3/app/code/Magento/Multishipping/Test/Mftf/ActionGroup/PlaceOrderActionGroup.xml"
-  module: "Multishipping"
-  actiongroups:
-     - name: "PlaceOrderActionGroup"
-       description: ""
-
-     - name: "StorefrontPlaceOrderForMultipleAddressesActionGroup"
-       description: ""
- 
-- filename: "AdminOpenCMSPagesGridActionGroup.xml"
-  repo: "https://github.com/magento/magento2/blob/2.3/app/code/Magento/Cms/Test/Mftf/ActionGroup/AdminOpenCMSPagesGridActionGroup.xml"
-  module: "Cms"
-  actiongroups:
-     - name: "AdminOpenCMSPagesGridActionGroup"
-       description: "Goes to the Admin Pages grid page."
- 
-- filename: "AssertCMSBlockContentActionGroup.xml"
-  repo: "https://github.com/magento/magento2/blob/2.3/app/code/Magento/Cms/Test/Mftf/ActionGroup/AssertCMSBlockContentActionGroup.xml"
-  module: "Cms"
-  actiongroups:
-     - name: "AssertBlockContent"
-       description: "Validates that the Block details are present and correct. PLEASE NOTE: The Block data is Hardcoded, using '_defaultBlock'."
- 
-- filename: "AdminOpenCmsBlockActionGroup.xml"
-  repo: "https://github.com/magento/magento2/blob/2.3/app/code/Magento/Cms/Test/Mftf/ActionGroup/AdminOpenCmsBlockActionGroup.xml"
-  module: "Cms"
-  actiongroups:
-     - name: "AdminOpenCmsBlockActionGroup"
-       description: ""
- 
-- filename: "StorefrontGoToCMSPageActionGroup.xml"
-  repo: "https://github.com/magento/magento2/blob/2.3/app/code/Magento/Cms/Test/Mftf/ActionGroup/StorefrontGoToCMSPageActionGroup.xml"
-  module: "Cms"
-  actiongroups:
-     - name: "StorefrontGoToCMSPageActionGroup"
-       description: "Goes to the provided Storefront CMS Page."
- 
-- filename: "ClearWidgetsFromCMSContentActionGroup.xml"
-  repo: "https://github.com/magento/magento2/blob/2.3/app/code/Magento/Cms/Test/Mftf/ActionGroup/ClearWidgetsFromCMSContentActionGroup.xml"
-  module: "Cms"
-  actiongroups:
-     - name: "ClearWidgetsFromCMSContent"
-       description: "Goes to the Admin CMS Page Edit page for the Page ID number 2. Clears the Widget and replaces it with Text. PLEASE NOTE: The Page ID/Text are Hardcoded."
-
-     - name: "ClearWidgetsForCMSHomePageContentWYSIWYGDisabled"
-       description: ""
- 
-- filename: "AssertCMSPageNotFoundOnStorefrontActionGroup.xml"
-  repo: "https://github.com/magento/magento2/blob/2.3/app/code/Magento/Cms/Test/Mftf/ActionGroup/AssertCMSPageNotFoundOnStorefrontActionGroup.xml"
-  module: "Cms"
-  actiongroups:
-     - name: "AssertCMSPageNotFoundOnStorefrontActionGroup"
-       description: "Validates that the 'Whoops, our bad' error message is present and correct for a Storefront CMS Page that doesn't exist."
- 
-- filename: "AdminOpenCmsPageActionGroup.xml"
-  repo: "https://github.com/magento/magento2/blob/2.3/app/code/Magento/Cms/Test/Mftf/ActionGroup/AdminOpenCmsPageActionGroup.xml"
-  module: "Cms"
-  actiongroups:
-     - name: "AdminOpenCmsPageActionGroup"
-       description: ""
- 
-- filename: "AdminCMSPageMassActionSelectActionGroup.xml"
-  repo: "https://github.com/magento/magento2/blob/2.3/app/code/Magento/Cms/Test/Mftf/ActionGroup/AdminCMSPageMassActionSelectActionGroup.xml"
-  module: "Cms"
-  actiongroups:
-     - name: "AdminCMSPageMassActionSelectActionGroup"
-       description: "Selects the provided Action in the 'Mass Action' drop down menu on the Admin Pages grid."
- 
-- filename: "FillOutCMSPageContentActionGroup.xml"
-  repo: "https://github.com/magento/magento2/blob/2.3/app/code/Magento/Cms/Test/Mftf/ActionGroup/FillOutCMSPageContentActionGroup.xml"
-  module: "Cms"
-  actiongroups:
-     - name: "FillOutCMSPageContent"
-       description: "Fills out the Page details (Page Title, Content and URL Key) on the Admin Page creation/edit page. PLEASE NOTE: The values are Hardcoded using '_duplicatedCMSPage'."
- 
-- filename: "CMSActionGroup.xml"
-  repo: "https://github.com/magento/magento2/blob/2.3/app/code/Magento/Cms/Test/Mftf/ActionGroup/CMSActionGroup.xml"
-  module: "Cms"
-  actiongroups:
-     - name: "navigateToCreatedCMSPage"
-       description: "Goes to the Admin CMS Pages page. "
-
-     - name: "navigateToCreatedCMSBlockPage"
-       description: "Goes to the Admin Blocks page. Clicks on 'Edit' for the provided Block."
-
-     - name: "DeleteCMSBlockActionGroup"
-       description: "Goes to the Admin CMS Blocks page. Deletes the '_defaultBlock' Block. Validates that the Success Message is present and correct. PLEASE NOTE: The Block that is deleted it Hardcoded."
-
-     - name: "AddStoreViewToCmsPage"
-       description: "EXTENDS: navigateToCreatedCMSPage. Adds the provided Store View to a Page."
-
-     - name: "saveAndCloseCMSBlockWithSplitButton"
-       description: "Clicks on the Save and Close button."
-
-     - name: "navigateToStorefrontForCreatedPage"
-       description: "Goes to the provided Page on the Storefront."
-
-     - name: "saveCMSBlock"
-       description: "Clicks on the Save button. Validates that the Save message is present and correct. PLEASE NOTE: The message is Hardcoded."
-
-     - name: "saveAndContinueEditCmsPage"
-       description: "Clicks on the Save and Continue button."
-
-     - name: "saveCmsPage"
-       description: "Clicks on the Save button. Validates that the Success Message is present."
-
-     - name: "setLayout"
-       description: "Sets the provided option for 'Layout', under 'Design' on the Page creation/edit page. "
- 
-- filename: "AssignBlockToCMSPageActionGroup.xml"
-  repo: "https://github.com/magento/magento2/blob/2.3/app/code/Magento/Cms/Test/Mftf/ActionGroup/AssignBlockToCMSPageActionGroup.xml"
-  module: "Cms"
-  actiongroups:
-     - name: "AssignBlockToCMSPage"
-       description: "Goes to the Admin Pages grid page. Adds a Block to a CMS Page. Clicks on Save."
- 
-- filename: "FillOutBlockContentActionGroup.xml"
-  repo: "https://github.com/magento/magento2/blob/2.3/app/code/Magento/Cms/Test/Mftf/ActionGroup/FillOutBlockContentActionGroup.xml"
-  module: "Cms"
-  actiongroups:
-     - name: "FillOutBlockContent"
-       description: "Fills in the Block Title, Identifier, Store View and Content. PLEASE NOTE: The values are Hardcoded using '_defaultBlock'."
- 
-- filename: "AdminOpentCmsBlockActionGroup.xml"
-  repo: "https://github.com/magento/magento2/blob/2.3/app/code/Magento/Cms/Test/Mftf/ActionGroup/AdminOpentCmsBlockActionGroup.xml"
-  module: "Cms"
-  actiongroups:
-     - name: "AdminOpenCmsBlockActionGroup"
-       description: ""
- 
-- filename: "RestoreLayoutSettingActionGroup.xml"
-  repo: "https://github.com/magento/magento2/blob/2.3/app/code/Magento/Cms/Test/Mftf/ActionGroup/RestoreLayoutSettingActionGroup.xml"
-  module: "Cms"
-  actiongroups:
-     - name: "RestoreLayoutSetting"
-       description: "Sets the 'Default Page Layout' to '1 column'. PLEASE NOTE: The value is Hardcoded."
- 
-- filename: "VerifyTinyMCEActionGroup.xml"
-  repo: "https://github.com/magento/magento2/blob/2.3/app/code/Magento/Cms/Test/Mftf/ActionGroup/VerifyTinyMCEActionGroup.xml"
-  module: "Cms"
-  actiongroups:
-     - name: "VerifyTinyMCEActionGroup"
-       description: "Goes to Admin CMS Page creation page. Validates that all of the Tiny MCE buttons are present."
-
-     - name: "VerifyMagentoEntityActionGroup"
-       description: "Validates that the Insert Widget and Insert Variables buttons are present."
- 
-- filename: "SearchBlockOnGridPageActionGroup.xml"
-  repo: "https://github.com/magento/magento2/blob/2.3/app/code/Magento/Cms/Test/Mftf/ActionGroup/SearchBlockOnGridPageActionGroup.xml"
-  module: "Cms"
-  actiongroups:
-     - name: "searchBlockOnGridPage"
-       description: "Searches the Admin CMS Blocks grid based on the provided Block."
-
-     - name: "deleteBlock"
-       description: "Goes to the Admin CMS Blocks page. Filters the grid based on the provided Block. Deletes the Block via the grid."
- 
-- filename: "AssertCMSPageContentActionGroup.xml"
-  repo: "https://github.com/magento/magento2/blob/2.3/app/code/Magento/Cms/Test/Mftf/ActionGroup/AssertCMSPageContentActionGroup.xml"
-  module: "Cms"
-  actiongroups:
-     - name: "AssertCMSPageContent"
-       description: "Validates that the CMS Page details are present and correct. PLEASE NOTE: The CMS Page data is Hardcoded, using '_duplicatedCMSPage'."
-
-     - name: "AssertStoreFrontCMSPage"
-       description: "Validates that the provided CMS Page Title, Content and Heading are present and correct on a Storefront CMS Page."
- 
-- filename: "AssertCMSPageInGridActionGroup.xml"
-  repo: "https://github.com/magento/magento2/blob/2.3/app/code/Magento/Cms/Test/Mftf/ActionGroup/AssertCMSPageInGridActionGroup.xml"
-  module: "Cms"
-  actiongroups:
-     - name: "AssertCMSPageInGridActionGroup"
-       description: "Validates that the provided CMS Page is present in the Admin Pages grid."
- 
-- filename: "NavigateToMediaFolderActionGroup.xml"
-  repo: "https://github.com/magento/magento2/blob/2.3/app/code/Magento/Cms/Test/Mftf/ActionGroup/NavigateToMediaFolderActionGroup.xml"
-  module: "Cms"
-  actiongroups:
-     - name: "NavigateToMediaFolderActionGroup"
-       description: "Clicks on the provided Folder Name in the Storage folder tree."
- 
-- filename: "AdminSelectCMSPageInGridActionGroup.xml"
-  repo: "https://github.com/magento/magento2/blob/2.3/app/code/Magento/Cms/Test/Mftf/ActionGroup/AdminSelectCMSPageInGridActionGroup.xml"
-  module: "Cms"
-  actiongroups:
-     - name: "AdminSelectCMSPageInGridActionGroup"
-       description: "Checks the Row for the provided Identifier on the Admin Pages grid page."
- 
-- filename: "SelectImageFromMediaStorageActionGroup.xml"
-  repo: "https://github.com/magento/magento2/blob/2.3/app/code/Magento/Cms/Test/Mftf/ActionGroup/SelectImageFromMediaStorageActionGroup.xml"
-  module: "Cms"
-  actiongroups:
-     - name: "clickBrowseBtnOnUploadPopup"
-       description: "Clicks on the Browse button in the 'Insert/edit image' model."
-
-     - name: "VerifyMediaGalleryStorageActions"
-       description: "Validates that the Media Gallery 'Cancel'/'Create Folder' buttons are present."
-
-     - name: "CreateImageFolder"
-       description: "Creates a folder in the Media Gallery based on the provided Folder."
-
-     - name: "attachImage"
-       description: "Uploads the provided Image to Media Gallery.
-                If you use this action group, you MUST add steps to delete the image in the \"after\" steps."
-
-     - name: "deleteImage"
-       description: "Deletes the selected Image from the Media Gallery."
-
-     - name: "saveImage"
-       description: "Clicks on Insert File in the Media Gallery."
-
-     - name: "fillOutUploadImagePopup"
-       description: "Fills in the Image Description and Height fields. PLEASE NOTE: The values are Hardcoded using 'ImageUpload'."
-
-     - name: "verifyOversizeValidationMsg"
-       description: "Validates that the Oversize validation message is present and correct."
-
-     - name: "verifyWrongExtensionValidationMsg"
-       description: "Validates that the Wrong Extensions validation message is present and correct."
- 
-- filename: "DeletePageByUrlKeyActionGroup.xml"
-  repo: "https://github.com/magento/magento2/blob/2.3/app/code/Magento/Cms/Test/Mftf/ActionGroup/DeletePageByUrlKeyActionGroup.xml"
-  module: "Cms"
-  actiongroups:
-     - name: "DeletePageByUrlKeyActionGroup"
-       description: "Goes to the Admin CMS Pages page. Deletes a Page based on the provided URL Key. Validates that the Success Message is present and correct."
- 
-- filename: "CreateNewPageWithAllValuesActionGroup.xml"
-  repo: "https://github.com/magento/magento2/blob/2.3/app/code/Magento/Cms/Test/Mftf/ActionGroup/CreateNewPageWithAllValuesActionGroup.xml"
-  module: "Cms"
-  actiongroups:
-     - name: "CreateNewPageWithAllValues"
-       description: "Goes to the Admin CMS creation page. Fills in the provided Page details (Title, Heading, URL, Store View and Hierarchy)."
-
-     - name: "CreateNewPageWithAllValuesAndContent"
-       description: ""
- 
-- filename: "AdminCMSBlockContentActionGroup.xml"
-  repo: "https://github.com/magento/magento2/blob/2.3/app/code/Magento/Cms/Test/Mftf/ActionGroup/AdminCMSBlockContentActionGroup.xml"
-  module: "Cms"
-  actiongroups:
-     - name: "AdminAddImageToCMSBlockContent"
-       description: ""
- 
-- filename: "CreateNewPageWithWidgetActionGroup.xml"
-  repo: "https://github.com/magento/magento2/blob/2.3/app/code/Magento/Cms/Test/Mftf/ActionGroup/CreateNewPageWithWidgetActionGroup.xml"
-  module: "Cms"
-  actiongroups:
-     - name: "CreateNewPageWithWidget"
-       description: "Goes to Admin CMS Page creation page. Adds the provided Title, Category, Conditions and Widget. Clicks on Save. Validates that the Success Message is present and correct."
- 
-- filename: "DeleteImageFromStorageActionGroup.xml"
-  repo: "https://github.com/magento/magento2/blob/2.3/app/code/Magento/Cms/Test/Mftf/ActionGroup/DeleteImageFromStorageActionGroup.xml"
-  module: "Cms"
-  actiongroups:
-     - name: "DeleteImageFromStorageActionGroup"
-       description: "Deletes the provided Image from Storage."
- 
-- filename: "StorefrontClickOnHeaderLogoActionGroup.xml"
-  repo: "https://github.com/magento/magento2/blob/2.3/app/code/Magento/Theme/Test/Mftf/ActionGroup/StorefrontClickOnHeaderLogoActionGroup.xml"
-  module: "Theme"
-  actiongroups:
-     - name: "StorefrontClickOnHeaderLogoActionGroup"
-       description: "Goes to the Storefront. Clicks on the Logo."
- 
-- filename: "AdminChangeStorefrontThemeActionGroup.xml"
-  repo: "https://github.com/magento/magento2/blob/2.3/app/code/Magento/Theme/Test/Mftf/ActionGroup/AdminChangeStorefrontThemeActionGroup.xml"
-  module: "Theme"
-  actiongroups:
-     - name: "AdminChangeStorefrontThemeActionGroup"
-       description: ""
- 
-- filename: "StorefrontCheckElementColorActionGroup.xml"
-  repo: "https://github.com/magento/magento2/blob/2.3/app/code/Magento/Theme/Test/Mftf/ActionGroup/StorefrontCheckElementColorActionGroup.xml"
-  module: "Theme"
-  actiongroups:
-     - name: "StorefrontCheckElementColorActionGroup"
-       description: "Checks element color on storefront."
- 
-- filename: "NavigateToFaviconMediaFolderActionGroup.xml"
-  repo: "https://github.com/magento/magento2/blob/2.3/app/code/Magento/Theme/Test/Mftf/ActionGroup/NavigateToFaviconMediaFolderActionGroup.xml"
-  module: "Theme"
-  actiongroups:
-     - name: "NavigateToFaviconMediaFolderActionGroup"
-       description: "Navigates to the Favicon Media folder in the 'Media Gallery'. Clicks on the provided Store Folder."
- 
-- filename: "AdminUrlRewriteActionGroup.xml"
-  repo: "https://github.com/magento/magento2/blob/2.3/app/code/Magento/UrlRewrite/Test/Mftf/ActionGroup/AdminUrlRewriteActionGroup.xml"
-  module: "UrlRewrite"
-  actiongroups:
-     - name: "AdminAddUrlRewrite"
-       description: "Goes to the Admin Add URL Rewrite edit page. Fills in the provided URL details. Clicks on Save. Validates that the Success Message is present."
-
-     - name: "AdminAddUrlRewriteForProduct"
-       description: "Adds the provided URL Rewrite details for a Product."
-
-     - name: "AdminAddCustomUrlRewrite"
-       description: "Goes to the Admin URL Rewrite edit page. Adds the provided Custom URL Rewrite details. Clicks on Save. Validates that the Success Message is present."
-
-     - name: "AdminUpdateUrlRewrite"
-       description: "Updates the URL Rewrite fields with the provided details."
-
-     - name: "AdminUpdateCustomUrlRewrite"
-       description: "Updates the Custom URL Rewrite fields with the provided details."
- 
 - filename: "StorefrontUrlRewriteRedirectActionGroup.xml"
-  repo: "https://github.com/magento/magento2/blob/2.3/app/code/Magento/UrlRewrite/Test/Mftf/ActionGroup/StorefrontUrlRewriteRedirectActionGroup.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/UrlRewrite/Test/Mftf/ActionGroup/StorefrontUrlRewriteRedirectActionGroup.xml"
   module: "UrlRewrite"
   actiongroups:
      - name: "AssertStorefrontUrlRewriteRedirect"
@@ -4548,23 +3669,14 @@
 
      - name: "AssertStorefrontProductRedirect"
        description: "Goes to the provided New Product URL. Validates that the redirect works and the provided Product is present and correct."
- 
 - filename: "AdminProductFormUpdateUrlKeyActionGroup.xml"
-  repo: "https://github.com/magento/magento2/blob/2.3/app/code/Magento/UrlRewrite/Test/Mftf/ActionGroup/AdminProductFormUpdateUrlKeyActionGroup.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/UrlRewrite/Test/Mftf/ActionGroup/AdminProductFormUpdateUrlKeyActionGroup.xml"
   module: "UrlRewrite"
   actiongroups:
      - name: "AdminProductFormUpdateUrlKeyActionGroup"
        description: "Update UrlKey for Product on Custom Store View."
- 
-- filename: "StorefrontCheckProductUrlActionGroup.xml"
-  repo: "https://github.com/magento/magento2/blob/2.3/app/code/Magento/UrlRewrite/Test/Mftf/ActionGroup/StorefrontCheckProductUrlActionGroup.xml"
-  module: "UrlRewrite"
-  actiongroups:
-     - name: "StorefrontCheckProductUrlActionGroup"
-       description: "Validates that the provided Simple Product Url is correct."
- 
 - filename: "AdminUrlRewriteGridActionGroup.xml"
-  repo: "https://github.com/magento/magento2/blob/2.3/app/code/Magento/UrlRewrite/Test/Mftf/ActionGroup/AdminUrlRewriteGridActionGroup.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/UrlRewrite/Test/Mftf/ActionGroup/AdminUrlRewriteGridActionGroup.xml"
   module: "UrlRewrite"
   actiongroups:
      - name: "AdminSearchByRequestPath"
@@ -4584,406 +3696,104 @@
 
      - name: "AdminSearchAndSelectUrlRewriteInGrid"
        description: "Goes to the Admin URL Rewrite grid page. Searches the grid for the provided Request Path. Clicks on Edit."
- 
-- filename: "StorefrontPayPalPaymentActionGroup.xml"
-  repo: "https://github.com/magento/magento2/blob/2.3/app/code/Magento/Paypal/Test/Mftf/ActionGroup/StorefrontPayPalPaymentActionGroup.xml"
-  module: "Paypal"
+- filename: "AdminUrlRewriteActionGroup.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/UrlRewrite/Test/Mftf/ActionGroup/AdminUrlRewriteActionGroup.xml"
+  module: "UrlRewrite"
   actiongroups:
-     - name: "LoginToPayPalPaymentAccount"
-       description: ""
- 
-- filename: "OpenPayPalButtonCheckoutPageActionGroup.xml"
-  repo: "https://github.com/magento/magento2/blob/2.3/app/code/Magento/Paypal/Test/Mftf/ActionGroup/OpenPayPalButtonCheckoutPageActionGroup.xml"
-  module: "Paypal"
-  actiongroups:
-     - name: "OpenPayPalButtonCheckoutPage"
-       description: "Clicks on 'Configure' for 'PayPal Express Checkout' on the Admin Configuration page. Expands the 'Advanced Settings' tab. Expands the 'Frontend Experience Settings' tab. Expands the 'Checkout Page' tab."
- 
-- filename: "StorefrontPayOrderOnPayPalCheckoutActionGroup.xml"
-  repo: "https://github.com/magento/magento2/blob/2.3/app/code/Magento/Paypal/Test/Mftf/ActionGroup/StorefrontPayOrderOnPayPalCheckoutActionGroup.xml"
-  module: "Paypal"
-  actiongroups:
-     - name: "StorefrontPayOrderOnPayPalCheckoutActionGroup"
-       description: "Verifies product name on Paypal cart and clicks 'Pay Now' on PayPal payment checkout page."
- 
-- filename: "PayPalExpressCheckoutConfigurationActionGroup.xml"
-  repo: "https://github.com/magento/magento2/blob/2.3/app/code/Magento/Paypal/Test/Mftf/ActionGroup/PayPalExpressCheckoutConfigurationActionGroup.xml"
-  module: "Paypal"
-  actiongroups:
-     - name: "ConfigPayPalExpressCheckout"
-       description: "Goes to the 'Configuration' page for 'Payment Methods'. Fills in the provided PayPal credentials and other details. Clicks on Save."
+     - name: "AdminAddUrlRewrite"
+       description: "Goes to the Admin Add URL Rewrite edit page. Fills in the provided URL details. Clicks on Save. Validates that the Success Message is present."
 
-     - name: "SampleConfigPayPalExpressCheckout"
-       description: "Goes to the 'Configuration' page for 'Payment Methods'. Fills in the provided Sample PayPal credentials and other details. Clicks on Save."
+     - name: "AdminAddUrlRewriteForProduct"
+       description: "Adds the provided URL Rewrite details for a Product."
 
-     - name: "CreatePayPalOrderWithSelectedPaymentMethodActionGroup"
-       description: "EXTENDS: CreateOrderToPrintPageActionGroup. Clicks on PayPal. Fills the PayPay details in the modal. PLEASE NOTE: The PayPal Payment credentials are Hardcoded using 'Payer'."
+     - name: "AdminAddCustomUrlRewrite"
+       description: "Goes to the Admin URL Rewrite edit page. Adds the provided Custom URL Rewrite details. Clicks on Save. Validates that the Success Message is present."
 
-     - name: "addProductToCheckoutPage"
-       description: "Goes to the provided Category page on the Storefront. Adds the 1st Product to the Cart. Goes to Checkout. Select the Shipping Method. Selects PayPal as the Payment Method."
- 
-- filename: "OtherPayPalConfigurationActionGroup.xml"
-  repo: "https://github.com/magento/magento2/blob/2.3/app/code/Magento/Paypal/Test/Mftf/ActionGroup/OtherPayPalConfigurationActionGroup.xml"
-  module: "Paypal"
-  actiongroups:
-     - name: "EnablePayPalConfiguration"
-       description: "Expands the 'OTHER PAYPAL PAYMENT SOLUTIONS' tab on the Admin Configuration page. Enables the provided PayPal Config type for the provided Country Code."
+     - name: "AdminUpdateUrlRewrite"
+       description: "Updates the URL Rewrite fields with the provided details."
 
-     - name: "EnablePayPalSolutionWithoutSave"
-       description: "Expands the 'OTHER PAYPAL PAYMENT SOLUTIONS' tab on the Admin Configuration page. Enables the provided PayPal Config type for the provided Country Code without saving."
-
-     - name: "CheckEnableOptionPayPalConfiguration"
-       description: "Expands the 'OTHER PAYPAL PAYMENT SOLUTIONS' tab on the Admin Configuration page. Enables the provided PayPal Config type for the provided Country Code."
- 
-- filename: "AdminSaveReviewActionGroup.xml"
-  repo: "https://github.com/magento/magento2/blob/2.3/app/code/Magento/Review/Test/Mftf/ActionGroup/AdminSaveReviewActionGroup.xml"
-  module: "Review"
+     - name: "AdminUpdateCustomUrlRewrite"
+       description: "Updates the Custom URL Rewrite fields with the provided details."
+- filename: "StorefrontCheckProductUrlActionGroup.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/UrlRewrite/Test/Mftf/ActionGroup/StorefrontCheckProductUrlActionGroup.xml"
+  module: "UrlRewrite"
   actiongroups:
-     - name: "AdminSaveReviewActionGroup"
-       description: ""
- 
-- filename: "AdminOpenReviewByUserNicknameActionGroup.xml"
-  repo: "https://github.com/magento/magento2/blob/2.3/app/code/Magento/Review/Test/Mftf/ActionGroup/AdminOpenReviewByUserNicknameActionGroup.xml"
-  module: "Review"
+     - name: "StorefrontCheckProductUrlActionGroup"
+       description: "Validates that the provided Simple Product Url is correct."
+- filename: "AssertSearchResultActionGroup.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/Elasticsearch/Test/Mftf/ActionGroup/AssertSearchResultActionGroup.xml"
+  module: "Elasticsearch"
   actiongroups:
-     - name: "AdminOpenReviewByUserNicknameActionGroup"
-       description: ""
- 
-- filename: "StorefrontAssertReviewAtProductPageActionGroup.xml"
-  repo: "https://github.com/magento/magento2/blob/2.3/app/code/Magento/Review/Test/Mftf/ActionGroup/StorefrontAssertReviewAtProductPageActionGroup.xml"
-  module: "Review"
+     - name: "AssertSearchResultActionGroup"
+       description: "Check search result on Storefront"
+- filename: "ModifyCustomAttributeValueActionGroup.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/Elasticsearch/Test/Mftf/ActionGroup/ModifyCustomAttributeValueActionGroup.xml"
+  module: "Elasticsearch"
   actiongroups:
-     - name: "StorefrontAssertReviewAtProductPageActionGroup"
-       description: ""
- 
-- filename: "AdminOpenReviewsPageActionGroup.xml"
-  repo: "https://github.com/magento/magento2/blob/2.3/app/code/Magento/Review/Test/Mftf/ActionGroup/AdminOpenReviewsPageActionGroup.xml"
-  module: "Review"
-  actiongroups:
-     - name: "AdminOpenReviewsPageActionGroup"
-       description: ""
- 
-- filename: "AdminAssertStoreViewRatingTitleWhenSingleStoreModeIsNoActionGroup.xml"
-  repo: "https://github.com/magento/magento2/blob/2.3/app/code/Magento/Review/Test/Mftf/ActionGroup/AdminAssertStoreViewRatingTitleWhenSingleStoreModeIsNoActionGroup.xml"
-  module: "Review"
-  actiongroups:
-     - name: "AdminAssertStoreViewRatingTitleWhenSingleStoreModeIsNoActionGroup"
-       description: "If Single Store Mode is disabled, default store view title label should be displayed."
- 
-- filename: "AdminNavigateToNewRatingFormActionGroup.xml"
-  repo: "https://github.com/magento/magento2/blob/2.3/app/code/Magento/Review/Test/Mftf/ActionGroup/AdminNavigateToNewRatingFormActionGroup.xml"
-  module: "Review"
-  actiongroups:
-     - name: "AdminNavigateToNewRatingFormActionGroup"
-       description: "Open New Rating Form"
- 
-- filename: "AdminOpenPendingReviewsPageActionGroup.xml"
-  repo: "https://github.com/magento/magento2/blob/2.3/app/code/Magento/Review/Test/Mftf/ActionGroup/AdminOpenPendingReviewsPageActionGroup.xml"
-  module: "Review"
-  actiongroups:
-     - name: "AdminOpenPendingReviewsPageActionGroup"
-       description: ""
- 
-- filename: "AdminDeleteReviewsByUserNicknameActionGroup.xml"
-  repo: "https://github.com/magento/magento2/blob/2.3/app/code/Magento/Review/Test/Mftf/ActionGroup/AdminDeleteReviewsByUserNicknameActionGroup.xml"
-  module: "Review"
-  actiongroups:
-     - name: "AdminDeleteReviewsByUserNicknameActionGroup"
-       description: ""
- 
-- filename: "AdminAssertStoreViewRatingTitleWhenSingleStoreModeIsYesActionGroup.xml"
-  repo: "https://github.com/magento/magento2/blob/2.3/app/code/Magento/Review/Test/Mftf/ActionGroup/AdminAssertStoreViewRatingTitleWhenSingleStoreModeIsYesActionGroup.xml"
-  module: "Review"
-  actiongroups:
-     - name: "AdminAssertStoreViewRatingTitleWhenSingleStoreModeIsYesActionGroup"
-       description: "If Single Store Mode is enabled, default store view title label should not be displayed."
- 
-- filename: "AdminChangeReviewStatusActionGroup.xml"
-  repo: "https://github.com/magento/magento2/blob/2.3/app/code/Magento/Review/Test/Mftf/ActionGroup/AdminChangeReviewStatusActionGroup.xml"
-  module: "Review"
-  actiongroups:
-     - name: "AdminChangeReviewStatusActionGroup"
-       description: ""
- 
-- filename: "StorefrontProductActionGroup.xml"
-  repo: "https://github.com/magento/magento2/blob/2.3/app/code/Magento/Swatches/Test/Mftf/ActionGroup/StorefrontProductActionGroup.xml"
-  module: "Swatches"
-  actiongroups:
-     - name: "StorefrontSelectSwatchOptionOnProductPage"
-       description: ""
-
-     - name: "StorefrontAssertSwatchOptionPrice"
-       description: ""
-
-     - name: "StorefrontSelectSwatchOptionOnProductPageAndCheckImage"
-       description: ""
- 
-- filename: "AdminEditPropertiesTabForSwatchProductAtributeActionGroup.xml"
-  repo: "https://github.com/magento/magento2/blob/2.3/app/code/Magento/Swatches/Test/Mftf/ActionGroup/AdminEditPropertiesTabForSwatchProductAtributeActionGroup.xml"
-  module: "Swatches"
-  actiongroups:
-     - name: "AdminAddSwatchOptionAndFillFieldsActionGroup"
-       description: ""
-
-     - name: "AdminUpdateProductPreviewImageActionGroup"
-       description: ""
- 
-- filename: "ColorPickerActionGroup.xml"
-  repo: "https://github.com/magento/magento2/blob/2.3/app/code/Magento/Swatches/Test/Mftf/ActionGroup/ColorPickerActionGroup.xml"
-  module: "Swatches"
-  actiongroups:
-     - name: "setColorPickerByHex"
-       description: "Sets the provided HEX value in the provided Color Picker."
-
-     - name: "assertSwatchColor"
-       description: "Validates that the provided Color Picker contains the provided Style."
-
-     - name: "assertStorefrontSwatchColor"
-       description: "Validates that the Storefront Product has the provided Swatch with the provided Color."
-
-     - name: "openSwatchMenuByIndex"
-       description: "Options the Swatch Menu based on the provided Index."
- 
-- filename: "AddSwatchToProductActionGroup.xml"
-  repo: "https://github.com/magento/magento2/blob/2.3/app/code/Magento/Swatches/Test/Mftf/ActionGroup/AddSwatchToProductActionGroup.xml"
-  module: "Swatches"
-  actiongroups:
-     - name: "AddVisualSwatchToProductActionGroup"
-       description: "Adds the provided Visual Swatch Attribute and Options (2) to a Product on the Admin Product creation/edit page. Clicks on Save. Validates that the Success Message is present."
-
-     - name: "AddVisualSwatchToProductWithStorefrontConfigActionGroup"
-       description: "EXTENDS: AddVisualSwatchToProductActionGroup. Add the provided Visual Swatch Attribute and Options (2) to a Product with Storefront Configurations."
-
-     - name: "AddVisualSwatchWithProductWithStorefrontPreviewImageConfigActionGroup"
-       description: ""
-
-     - name: "AddTextSwatchToProductActionGroup"
-       description: "Add text swatch property attribute."
- 
-- filename: "StorefrontAddProductWithSwatchAttributeToTheCartActionGroup.xml"
-  repo: "https://github.com/magento/magento2/blob/2.3/app/code/Magento/Swatches/Test/Mftf/ActionGroup/StorefrontAddProductWithSwatchAttributeToTheCartActionGroup.xml"
-  module: "Swatches"
-  actiongroups:
-     - name: "StorefrontAddProductWithSwatchesToTheCartActionGroup"
-       description: ""
-
-     - name: "StorefrontUpdateCartConfigurableProductWithSwatches"
-       description: ""
- 
-- filename: "DisplayOutOfStockProductActionGroup.xml"
-  repo: "https://github.com/magento/magento2/blob/2.3/app/code/Magento/CatalogInventory/Test/Mftf/ActionGroup/DisplayOutOfStockProductActionGroup.xml"
-  module: "CatalogInventory"
-  actiongroups:
-     - name: "displayOutOfStockProduct"
-       description: "Goes to the 'Configuration' page for 'Inventory'. Enables 'Display Out of Stock Products'. Clicks on the Save button."
-
-     - name: "noDisplayOutOfStockProduct"
-       description: "Goes to the 'Configuration' page for 'Inventory'. Disables 'Display Out of Stock Products'. Clicks on the Save button."
- 
-- filename: "AdminProductActionGroup.xml"
-  repo: "https://github.com/magento/magento2/blob/2.3/app/code/Magento/CatalogInventory/Test/Mftf/ActionGroup/AdminProductActionGroup.xml"
-  module: "CatalogInventory"
-  actiongroups:
-     - name: "AdminProductSetMaxQtyAllowedInShoppingCart"
-       description: ""
-
-     - name: "AdminProductMaxQtyAllowedInShoppingCartValidationActionGroup"
-       description: ""
- 
-- filename: "StorefrontAssertProductStockStatusActionGroup.xml"
-  repo: "https://github.com/magento/magento2/blob/2.3/app/code/Magento/CatalogInventory/Test/Mftf/ActionGroup/StorefrontAssertProductStockStatusActionGroup.xml"
-  module: "CatalogInventory"
-  actiongroups:
-     - name: "StorefrontCheckProductStockStatus"
-       description: ""
- 
-- filename: "AdminCatalogInventoryConfigurationActionGroup.xml"
-  repo: "https://github.com/magento/magento2/blob/2.3/app/code/Magento/CatalogInventory/Test/Mftf/ActionGroup/AdminCatalogInventoryConfigurationActionGroup.xml"
-  module: "CatalogInventory"
-  actiongroups:
-     - name: "AdminCatalogInventoryConfigurationMaxQtyAllowedInShoppingCartValidationActionGroup"
-       description: ""
- 
+     - name: "ModifyCustomAttributeValueActionGroup"
+       description: "Update value for custom attribute"
 - filename: "CheckingGiftOptionsActionGroup.xml"
-  repo: "https://github.com/magento/magento2/blob/2.3/app/code/Magento/GiftMessage/Test/Mftf/ActionGroup/CheckingGiftOptionsActionGroup.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/GiftMessage/Test/Mftf/ActionGroup/CheckingGiftOptionsActionGroup.xml"
   module: "GiftMessage"
   actiongroups:
      - name: "CheckingGiftOptionsActionGroup"
        description: "Clicks on Checkout with Multiple Addresses. Clicks on Add Gift option. Validates that the Success Message is present and correct. PLEASE NOTE: The message is Hardcoded."
- 
-- filename: "AdminDeleteCatalogRuleActionGroup.xml"
-  repo: "https://github.com/magento/magento2/blob/2.3/app/code/Magento/CatalogRule/Test/Mftf/ActionGroup/AdminDeleteCatalogRuleActionGroup.xml"
-  module: "CatalogRule"
+- filename: "DeleteBackupActionGroup.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/Backup/Test/Mftf/ActionGroup/DeleteBackupActionGroup.xml"
+  module: "Backup"
   actiongroups:
-     - name: "AdminDeleteCatalogRuleActionGroup"
-       description: "Clicks on the Delete button on a Admin Catalog Price Rule edit page. Clicks on Ok. Validates that the provided Success Message is present and correct."
- 
-- filename: "AssertCustomerGroupNotOnCatalogPriceRuleFormActionGroup.xml"
-  repo: "https://github.com/magento/magento2/blob/2.3/app/code/Magento/CatalogRule/Test/Mftf/ActionGroup/AssertCustomerGroupNotOnCatalogPriceRuleFormActionGroup.xml"
-  module: "CatalogRule"
+     - name: "deleteBackup"
+       description: "Deletes a Backup using provided Backup Entity."
+- filename: "CreateBackupActionGroup.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/Backup/Test/Mftf/ActionGroup/CreateBackupActionGroup.xml"
+  module: "Backup"
   actiongroups:
-     - name: "AssertCustomerGroupNotOnCatalogPriceRuleFormActionGroup"
-       description: "Validate that the provided Customer Group is not present on the Catalog Price Rules creation/edit page."
- 
-- filename: "AdminAssertCustomerGroupOnCatalogPriceRuleFormActionGroup.xml"
-  repo: "https://github.com/magento/magento2/blob/2.3/app/code/Magento/CatalogRule/Test/Mftf/ActionGroup/AdminAssertCustomerGroupOnCatalogPriceRuleFormActionGroup.xml"
-  module: "CatalogRule"
-  actiongroups:
-     - name: "AdminAssertCustomerGroupOnCatalogPriceRuleForm"
-       description: ""
- 
-- filename: "SaveAndApplyCatalogPriceRuleActionGroup.xml"
-  repo: "https://github.com/magento/magento2/blob/2.3/app/code/Magento/CatalogRule/Test/Mftf/ActionGroup/SaveAndApplyCatalogPriceRuleActionGroup.xml"
-  module: "CatalogRule"
-  actiongroups:
-     - name: "SaveAndApplyCatalogPriceRuleActionGroup"
-       description: "Clicks on Save and Apply. Validates that the Success Message is present and correct on the Admin Catalog Price Rule creation/edit page."
- 
-- filename: "AssertCatalogPriceRuleFormActionGroup.xml"
-  repo: "https://github.com/magento/magento2/blob/2.3/app/code/Magento/CatalogRule/Test/Mftf/ActionGroup/AssertCatalogPriceRuleFormActionGroup.xml"
-  module: "CatalogRule"
-  actiongroups:
-     - name: "AssertCatalogPriceRuleFormActionGroup"
-       description: "Validates that the provided Catalog Rule, Status, Websites and Customer Group details are present and correct on a Admin Catalog Price Rule creation/edit page."
- 
-- filename: "AdminCreateNewCatalogPriceRuleActionGroup.xml"
-  repo: "https://github.com/magento/magento2/blob/2.3/app/code/Magento/CatalogRule/Test/Mftf/ActionGroup/AdminCreateNewCatalogPriceRuleActionGroup.xml"
-  module: "CatalogRule"
-  actiongroups:
-     - name: "AdminCreateNewCatalogPriceRuleActionGroup"
-       description: "Goes to the Admin Catalog Price Rule creation page. Fills in the provided Catalog Rule details. Selects the provided Customer Group."
- 
-- filename: "AssertCatalogRuleInGridActionGroup.xml"
-  repo: "https://github.com/magento/magento2/blob/2.3/app/code/Magento/CatalogRule/Test/Mftf/ActionGroup/AssertCatalogRuleInGridActionGroup.xml"
-  module: "CatalogRule"
-  actiongroups:
-     - name: "AssertCatalogRuleInGridActionGroup"
-       description: "Validates that the provided Catalog Rule Name, Status, Websites and Catalog Rule ID are present in the 1st row of the Admin Catalog Price Rule grid."
- 
-- filename: "AdminOpenCatalogPriceRulePageActionGroup.xml"
-  repo: "https://github.com/magento/magento2/blob/2.3/app/code/Magento/CatalogRule/Test/Mftf/ActionGroup/AdminOpenCatalogPriceRulePageActionGroup.xml"
-  module: "CatalogRule"
-  actiongroups:
-     - name: "AdminOpenCatalogPriceRulePageActionGroup"
-       description: ""
- 
-- filename: "CreateCatalogPriceRuleConditionWithAttributeAndOptionActionGroup.xml"
-  repo: "https://github.com/magento/magento2/blob/2.3/app/code/Magento/CatalogRule/Test/Mftf/ActionGroup/CreateCatalogPriceRuleConditionWithAttributeAndOptionActionGroup.xml"
-  module: "CatalogRule"
-  actiongroups:
-     - name: "CreateCatalogPriceRuleConditionWithAttributeAndOptionActionGroup"
-       description: "Adds the provided Attribute Name, Select Value, Index A and Index B details to the 'Conditions' section on the Admin Catalog Price Rule creation/edit page."
- 
-- filename: "CatalogSelectCustomerGroupActionGroup.xml"
-  repo: "https://github.com/magento/magento2/blob/2.3/app/code/Magento/CatalogRule/Test/Mftf/ActionGroup/CatalogSelectCustomerGroupActionGroup.xml"
-  module: "CatalogRule"
-  actiongroups:
-     - name: "CatalogSelectCustomerGroupActionGroup"
-       description: "Selects the provided Customer Group Name on the Admin Catalog Price Rule creation/edit page."
- 
-- filename: "CatalogPriceRuleActionGroup.xml"
-  repo: "https://github.com/magento/magento2/blob/2.3/app/code/Magento/CatalogRule/Test/Mftf/ActionGroup/CatalogPriceRuleActionGroup.xml"
-  module: "CatalogRule"
-  actiongroups:
-     - name: "newCatalogPriceRuleByUI"
-       description: "Goes to the Catalog Price Rule grid. Clicks on Add. Fills in the provided Catalog Rule details."
+     - name: "createSystemBackup"
+       description: "Creates a System Backup using provided Backup Entity."
 
-     - name: "createCatalogPriceRule"
-       description: "Clicks on the Add button. Fills Rule Name, Description, Website and Discount Value."
+     - name: "createMediaBackup"
+       description: "Creates a Media Backup using provided Backup Entity."
 
-     - name: "AdminCreateCatalogPriceRuleWithConditionActionGroup"
-       description: ""
-
-     - name: "AdminCreateMultipleWebsiteCatalogPriceRule"
-       description: ""
-
-     - name: "CreateCatalogPriceRuleViaTheUi"
-       description: ""
-
-     - name: "CreateCatalogPriceRuleConditionWithAttribute"
-       description: "Add Conditional Requirements to a Catalog Price Rule from the creation/edit page."
-
-     - name: "applyCatalogPriceRules"
-       description: "Goes to the Catalog Price Rule grid page. Clicks on Apply Rules. Validates that the Success Message is present and correct."
-
-     - name: "newCatalogPriceRuleByUIWithConditionIsSKU"
-       description: "EXTENDS: newCatalogPriceRuleByUI. Add a Catalog Price Rule Condition based on the provided SKU."
-
-     - name: "newCatalogPriceRuleByUIWithConditionIsCategory"
-       description: "EXTENDS: newCatalogPriceRuleByUI. Add a Catalog Price Rule Condition based on the provided Category ID."
-
-     - name: "selectGeneralCustomerGroupActionGroup"
-       description: "Selects the 'General' Customer Group for a Catalog Price Rule on the creation/edit page."
-
-     - name: "selectNotLoggedInCustomerGroupActionGroup"
-       description: "Selects the 'NOT LOGGED IN' Customer Group for a Catalog Price Rule on the creation/edit page."
-
-     - name: "OpenCatalogPriceRule"
-       description: ""
-
-     - name: "RemoveCatalogPriceRule"
-       description: ""
-
-     - name: "AdminFillCatalogRuleConditionActionGroup"
-       description: "Clicks on the Conditions tab. Fills in the provided condition for Catalog Price Rule."
- 
-- filename: "AdminSearchCatalogRuleInGridActionGroup.xml"
-  repo: "https://github.com/magento/magento2/blob/2.3/app/code/Magento/CatalogRule/Test/Mftf/ActionGroup/AdminSearchCatalogRuleInGridActionGroup.xml"
-  module: "CatalogRule"
+     - name: "createDatabaseBackup"
+       description: "Creates a Database Backup using provided Backup Entity."
+- filename: "StorefrontOpenContactUsPageActionGroup.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/Contact/Test/Mftf/ActionGroup/StorefrontOpenContactUsPageActionGroup.xml"
+  module: "Contact"
   actiongroups:
-     - name: "AdminSearchCatalogRuleInGridActionGroup"
-       description: "Goes to the Admin Catalog Price Rules grid page. Searches the grid for the provided Catalog Price Rule name."
- 
-- filename: "AdminSaveAndApplyRulesActionGroup.xml"
-  repo: "https://github.com/magento/magento2/blob/2.3/app/code/Magento/CatalogRule/Test/Mftf/ActionGroup/AdminSaveAndApplyRulesActionGroup.xml"
-  module: "CatalogRule"
+     - name: "StorefrontOpenContactUsPageActionGroup"
+       description: "Goes to the Storefront 'Contact Us' page."
+- filename: "StorefrontFillContactUsFormActionGroup.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/Contact/Test/Mftf/ActionGroup/StorefrontFillContactUsFormActionGroup.xml"
+  module: "Contact"
   actiongroups:
-     - name: "AdminSaveAndApplyRulesActionGroup"
-       description: "Clicks Save on a Admin Catalog Price Rule creation/edit page. Validates that the Success Message is present. Clicks Apply Rules. Validates that the Success Message is present."
- 
-- filename: "AdminOpenNewCatalogPriceRuleFormPageActionGroup.xml"
-  repo: "https://github.com/magento/magento2/blob/2.3/app/code/Magento/CatalogRule/Test/Mftf/ActionGroup/AdminOpenNewCatalogPriceRuleFormPageActionGroup.xml"
-  module: "CatalogRule"
+     - name: "StorefrontFillContactUsFormActionGroup"
+       description: "Fills Name, Email and Comment on the Storefront 'Contact Us' page."
+- filename: "StorefrontSubmitContactUsFormActionGroup.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/Contact/Test/Mftf/ActionGroup/StorefrontSubmitContactUsFormActionGroup.xml"
+  module: "Contact"
   actiongroups:
-     - name: "AdminOpenNewCatalogPriceRuleFormPageActionGroup"
-       description: "Goes to the create Catalog Price Rule page."
- 
-- filename: "AdminSelectCatalogRuleFromGridActionGroup.xml"
-  repo: "https://github.com/magento/magento2/blob/2.3/app/code/Magento/CatalogRule/Test/Mftf/ActionGroup/AdminSelectCatalogRuleFromGridActionGroup.xml"
-  module: "CatalogRule"
+     - name: "StorefrontSubmitContactUsFormActionGroup"
+       description: "Clicks on the 'Submit' button on the Storefront 'Contact Us' page."
+- filename: "AssertMessageContactUsFormActionGroup.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/Contact/Test/Mftf/ActionGroup/AssertMessageContactUsFormActionGroup.xml"
+  module: "Contact"
   actiongroups:
-     - name: "AdminSelectCatalogRuleFromGridActionGroup"
-       description: "Clicks on the Admin Catalog Price Rule row that contains the provided Catalog Price Rule name."
- 
-- filename: "VerifySubscribedNewsletterDisplayedActionGroup.xml"
-  repo: "https://github.com/magento/magento2/blob/2.3/app/code/Magento/Newsletter/Test/Mftf/ActionGroup/VerifySubscribedNewsletterDisplayedActionGroup.xml"
-  module: "Newsletter"
-  actiongroups:
-     - name: "StorefrontCreateNewAccountNewsletterChecked"
-       description: "EXTENDS: SignUpNewUserFromStorefrontActionGroup. Clicks on 'Sign Up for Newsletter'. Validates that the Subscription Confirmation message is present and correct."
-
-     - name: "StorefrontCreateNewAccountNewsletterUnchecked"
-       description: "EXTENDS: SignUpNewUserFromStorefrontActionGroup. Validates that the you are NOT subscribed message is present and correct."
-
-     - name: "CheckSubscribedNewsletterActionGroup"
-       description: "Goes to the Storefront Newsletter Management page. Validates that the 'Subscription' checkbox is checked."
- 
-- filename: "AdminNewsletterTemplateActionGroup.xml"
-  repo: "https://github.com/magento/magento2/blob/2.3/app/code/Magento/Newsletter/Test/Mftf/ActionGroup/AdminNewsletterTemplateActionGroup.xml"
-  module: "Newsletter"
-  actiongroups:
-     - name: "SwitchToPreviewIframeActionGroup"
-       description: ""
- 
-- filename: "StorefrontCheckCategoryConfigurableProductWithUpdatedPriceActionGroup.xml"
-  repo: "https://github.com/magento/magento2/blob/2.3/app/code/Magento/ConfigurableProduct/Test/Mftf/ActionGroup/StorefrontCheckCategoryConfigurableProductWithUpdatedPriceActionGroup.xml"
+     - name: "AssertMessageContactUsFormActionGroup"
+       description: "Validates that the provided Message appears in the correct Message Type on the Storefront 'Contact Us' page."
+- filename: "AdminSelectAttributeInConfigurableAttributesGridActionGroup.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/ConfigurableProduct/Test/Mftf/ActionGroup/AdminSelectAttributeInConfigurableAttributesGridActionGroup.xml"
   module: "ConfigurableProduct"
   actiongroups:
-     - name: "StorefrontCheckCategoryConfigurableProductWithUpdatedPriceActionGroup"
-       description: "Validates that the provided Product Name and Price for a Configurable Product are present on a Storefront Category page."
- 
+     - name: "AdminSelectAttributeInConfigurableAttributesGrid"
+       description: "EXTENDS: AdminFilterAttributeInConfigurableAttributesGrid. Select first filtered attribute."
+- filename: "SaveConfigurableProductActionGroup.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/ConfigurableProduct/Test/Mftf/ActionGroup/SaveConfigurableProductActionGroup.xml"
+  module: "ConfigurableProduct"
+  actiongroups:
+     - name: "SaveConfigurableProductActionGroup"
+       description: "Save configurable product"
 - filename: "ConfigurableProductAttributeNameDesignActionGroup.xml"
-  repo: "https://github.com/magento/magento2/blob/2.3/app/code/Magento/ConfigurableProduct/Test/Mftf/ActionGroup/ConfigurableProductAttributeNameDesignActionGroup.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/ConfigurableProduct/Test/Mftf/ActionGroup/ConfigurableProductAttributeNameDesignActionGroup.xml"
   module: "ConfigurableProduct"
   actiongroups:
      - name: "GotoCatalogProductsPage"
@@ -5000,43 +3810,20 @@
 
      - name: "DeleteCreatedAttribute"
        description: "Deletes the Configurable Product Attribute."
- 
-- filename: "StorefrontCategoryActionGroup.xml"
-  repo: "https://github.com/magento/magento2/blob/2.3/app/code/Magento/ConfigurableProduct/Test/Mftf/ActionGroup/StorefrontCategoryActionGroup.xml"
+- filename: "AdminChangeConfigurableProductVariationQtyActionGroup.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/ConfigurableProduct/Test/Mftf/ActionGroup/AdminChangeConfigurableProductVariationQtyActionGroup.xml"
   module: "ConfigurableProduct"
   actiongroups:
-     - name: "StorefrontCheckCategoryConfigurableProduct"
-       description: "Validates that the provided Configurable Product is present and correct on a Category page."
-
-     - name: "StorefrontCheckCategoryOutOfStockConfigurableProduct"
-       description: "Validates that the provided Configurable Product is present and correct on a Category page."
- 
-- filename: "AdminCreateApiConfigurableProductActionGroup.xml"
-  repo: "https://github.com/magento/magento2/blob/2.3/app/code/Magento/ConfigurableProduct/Test/Mftf/ActionGroup/AdminCreateApiConfigurableProductActionGroup.xml"
+     - name: "AdminChangeConfigurableProductVariationQty"
+       description: "Change quantity value for configurable product generated variation"
+- filename: "AdminFilterAttributeInConfigurableAttributesGridActionGroup.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/ConfigurableProduct/Test/Mftf/ActionGroup/AdminFilterAttributeInConfigurableAttributesGridActionGroup.xml"
   module: "ConfigurableProduct"
   actiongroups:
-     - name: "AdminCreateApiConfigurableProductActionGroup"
-       description: "Creates a Configurable Product with 2 Product Options via the API."
-
-     - name: "AdminCreateApiConfigurableProductWithHiddenChildActionGroup"
-       description: "EXTENDS: AdminCreateApiConfigurableProductActionGroup. Adds 2 Hidden Product Options."
- 
-- filename: "ConfigurableProductCheckoutActionGroup.xml"
-  repo: "https://github.com/magento/magento2/blob/2.3/app/code/Magento/ConfigurableProduct/Test/Mftf/ActionGroup/ConfigurableProductCheckoutActionGroup.xml"
-  module: "ConfigurableProduct"
-  actiongroups:
-     - name: "CheckConfigurableProductInCheckoutCartItemsActionGroup"
-       description: "Validates that the Configurable Product is present and correct in the Cart area on the Checkout page."
- 
-- filename: "StorefrontAddConfigurableProductToTheCartActionGroup.xml"
-  repo: "https://github.com/magento/magento2/blob/2.3/app/code/Magento/ConfigurableProduct/Test/Mftf/ActionGroup/StorefrontAddConfigurableProductToTheCartActionGroup.xml"
-  module: "ConfigurableProduct"
-  actiongroups:
-     - name: "StorefrontAddConfigurableProductToTheCartActionGroup"
-       description: "Goes to the provided Storefront URL. Selects the provided Product Option under the Product Attribute. Fills in the provided Quantity. Clicks Add to Cart. Validates that the Success Message is present."
- 
+     - name: "AdminFilterAttributeInConfigurableAttributesGrid"
+       description: "Filter attribute in configurable attributes grid by attribute code value"
 - filename: "StorefrontProductActionGroup.xml"
-  repo: "https://github.com/magento/magento2/blob/2.3/app/code/Magento/ConfigurableProduct/Test/Mftf/ActionGroup/StorefrontProductActionGroup.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/ConfigurableProduct/Test/Mftf/ActionGroup/StorefrontProductActionGroup.xml"
   module: "ConfigurableProduct"
   actiongroups:
      - name: "StorefrontCheckConfigurableProduct"
@@ -5059,9 +3846,20 @@
 
      - name: "assertConfigurableProductWithSpecialPriceOnStorefrontProductPage"
        description: "Validates that Special Price for a Configurable Product is present and correct when the provided Product Option is selected."
- 
+- filename: "VerifyProductTypeOrderActionGroup.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/ConfigurableProduct/Test/Mftf/ActionGroup/VerifyProductTypeOrderActionGroup.xml"
+  module: "ConfigurableProduct"
+  actiongroups:
+     - name: "VerifyProductTypeOrder"
+       description: "Validates that the 'Configurable Product' option is present in the 'Add Product' dropdown menu on the Products grid page."
+- filename: "ConfigurableProductCheckoutActionGroup.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/ConfigurableProduct/Test/Mftf/ActionGroup/ConfigurableProductCheckoutActionGroup.xml"
+  module: "ConfigurableProduct"
+  actiongroups:
+     - name: "CheckConfigurableProductInCheckoutCartItemsActionGroup"
+       description: "Validates that the Configurable Product is present and correct in the Cart area on the Checkout page."
 - filename: "StorefrontProductCartActionGroup.xml"
-  repo: "https://github.com/magento/magento2/blob/2.3/app/code/Magento/ConfigurableProduct/Test/Mftf/ActionGroup/StorefrontProductCartActionGroup.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/ConfigurableProduct/Test/Mftf/ActionGroup/StorefrontProductCartActionGroup.xml"
   module: "ConfigurableProduct"
   actiongroups:
      - name: "StorefrontCheckCartConfigurableProductActionGroup"
@@ -5069,37 +3867,14 @@
 
      - name: "StorefrontOpenMinicartAndCheckConfigurableProductActionGroup"
        description: "Validates that the provided Option Price is present and correct in the Mini Shopping Cart on the Storefront."
- 
-- filename: "AdminAddOptionsToAttributeActionGroup.xml"
-  repo: "https://github.com/magento/magento2/blob/2.3/app/code/Magento/ConfigurableProduct/Test/Mftf/ActionGroup/AdminAddOptionsToAttributeActionGroup.xml"
-  module: "ConfigurableProduct"
-  actiongroups:
-     - name: "addOptionsToAttributeActionGroup"
-       description: "Adds 5 provided Options to a new Attribute on the Configurable Product creation/edit page."
- 
-- filename: "StorefrontProductAttributeActionGroup.xml"
-  repo: "https://github.com/magento/magento2/blob/2.3/app/code/Magento/ConfigurableProduct/Test/Mftf/ActionGroup/StorefrontProductAttributeActionGroup.xml"
-  module: "ConfigurableProduct"
-  actiongroups:
-     - name: "SelectStorefrontSideBarAttributeOption"
-       description: "Goes to the provided Storefront Category page. Validates that the provided Attribute Label is present and correct."
- 
 - filename: "StorefrontCompareActionGroup.xml"
-  repo: "https://github.com/magento/magento2/blob/2.3/app/code/Magento/ConfigurableProduct/Test/Mftf/ActionGroup/StorefrontCompareActionGroup.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/ConfigurableProduct/Test/Mftf/ActionGroup/StorefrontCompareActionGroup.xml"
   module: "ConfigurableProduct"
   actiongroups:
      - name: "StorefrontCheckCompareConfigurableProductActionGroup"
        description: "Validates that the Configurable Product is present and correct in the Compare Product area."
- 
-- filename: "VerifyProductTypeOrderActionGroup.xml"
-  repo: "https://github.com/magento/magento2/blob/2.3/app/code/Magento/ConfigurableProduct/Test/Mftf/ActionGroup/VerifyProductTypeOrderActionGroup.xml"
-  module: "ConfigurableProduct"
-  actiongroups:
-     - name: "VerifyProductTypeOrder"
-       description: "Validates that the 'Configurable Product' option is present in the 'Add Product' dropdown menu on the Products grid page."
- 
 - filename: "AdminConfigurableProductActionGroup.xml"
-  repo: "https://github.com/magento/magento2/blob/2.3/app/code/Magento/ConfigurableProduct/Test/Mftf/ActionGroup/AdminConfigurableProductActionGroup.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/ConfigurableProduct/Test/Mftf/ActionGroup/AdminConfigurableProductActionGroup.xml"
   module: "ConfigurableProduct"
   actiongroups:
      - name: "CreateConfigurableProductWithAttributeSet"
@@ -5188,868 +3963,1819 @@
 
      - name: "StartCreateConfigurationsForAttribute"
        description: ""
- 
 - filename: "AdminOrderConfigurableProductActionGroup.xml"
-  repo: "https://github.com/magento/magento2/blob/2.3/app/code/Magento/ConfigurableProduct/Test/Mftf/ActionGroup/AdminOrderConfigurableProductActionGroup.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/ConfigurableProduct/Test/Mftf/ActionGroup/AdminOrderConfigurableProductActionGroup.xml"
   module: "ConfigurableProduct"
   actiongroups:
      - name: "AdminOrderConfigureConfigurableProduct"
        description: ""
- 
-- filename: "CreateBackupActionGroup.xml"
-  repo: "https://github.com/magento/magento2/blob/2.3/app/code/Magento/Backup/Test/Mftf/ActionGroup/CreateBackupActionGroup.xml"
-  module: "Backup"
+- filename: "SaveConfigurableProductAddToCurrentAttributeSetActionGroup.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/ConfigurableProduct/Test/Mftf/ActionGroup/SaveConfigurableProductAddToCurrentAttributeSetActionGroup.xml"
+  module: "ConfigurableProduct"
   actiongroups:
-     - name: "createSystemBackup"
-       description: "Creates a System Backup using provided Backup Entity."
-
-     - name: "createMediaBackup"
-       description: "Creates a Media Backup using provided Backup Entity."
-
-     - name: "createDatabaseBackup"
-       description: "Creates a Database Backup using provided Backup Entity."
- 
-- filename: "DeleteBackupActionGroup.xml"
-  repo: "https://github.com/magento/magento2/blob/2.3/app/code/Magento/Backup/Test/Mftf/ActionGroup/DeleteBackupActionGroup.xml"
-  module: "Backup"
+     - name: "SaveConfigurableProductAddToCurrentAttributeSetActionGroup"
+       description: "Clicks on 'Save'. Clicks on 'Confirm' in the 'Choose Affected Attribute Set' model on the Configurable Product creation/edit page."
+- filename: "StorefrontAddConfigurableProductToTheCartActionGroup.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/ConfigurableProduct/Test/Mftf/ActionGroup/StorefrontAddConfigurableProductToTheCartActionGroup.xml"
+  module: "ConfigurableProduct"
   actiongroups:
-     - name: "deleteBackup"
-       description: "Deletes a Backup using provided Backup Entity."
- 
+     - name: "StorefrontAddConfigurableProductToTheCartActionGroup"
+       description: "Goes to the provided Storefront URL. Selects the provided Product Option under the Product Attribute. Fills in the provided Quantity. Clicks Add to Cart. Validates that the Success Message is present."
+- filename: "AdminAddOptionsToAttributeActionGroup.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/ConfigurableProduct/Test/Mftf/ActionGroup/AdminAddOptionsToAttributeActionGroup.xml"
+  module: "ConfigurableProduct"
+  actiongroups:
+     - name: "addOptionsToAttributeActionGroup"
+       description: "Adds 5 provided Options to a new Attribute on the Configurable Product creation/edit page."
+- filename: "StorefrontCategoryActionGroup.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/ConfigurableProduct/Test/Mftf/ActionGroup/StorefrontCategoryActionGroup.xml"
+  module: "ConfigurableProduct"
+  actiongroups:
+     - name: "StorefrontCheckCategoryConfigurableProduct"
+       description: "Validates that the provided Configurable Product is present and correct on a Category page."
+
+     - name: "StorefrontCheckCategoryOutOfStockConfigurableProduct"
+       description: "Validates that the provided Configurable Product is present and correct on a Category page."
+- filename: "CreateApiConfigurableProductWithProductAttributeAdvanceSearchActionGroup.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/ConfigurableProduct/Test/Mftf/ActionGroup/CreateApiConfigurableProductWithProductAttributeAdvanceSearchActionGroup.xml"
+  module: "ConfigurableProduct"
+  actiongroups:
+     - name: "CreateApiConfigurableProductWithDescriptionActionGroup"
+       description: "Creates a Configurable Product with Description and 2 Product Options via API."
+- filename: "SaveConfiguredProductActionGroup.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/ConfigurableProduct/Test/Mftf/ActionGroup/SaveConfiguredProductActionGroup.xml"
+  module: "ConfigurableProduct"
+  actiongroups:
+     - name: "SaveConfiguredProductActionGroup"
+       description: "Save the Configurable Product on the Configurable Product creation/edit page. Validates that the Success Message is present."
+- filename: "StorefrontCheckCategoryConfigurableProductWithUpdatedPriceActionGroup.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/ConfigurableProduct/Test/Mftf/ActionGroup/StorefrontCheckCategoryConfigurableProductWithUpdatedPriceActionGroup.xml"
+  module: "ConfigurableProduct"
+  actiongroups:
+     - name: "StorefrontCheckCategoryConfigurableProductWithUpdatedPriceActionGroup"
+       description: "Validates that the provided Product Name and Price for a Configurable Product are present on a Storefront Category page."
+- filename: "SaveConfigurableProductWithNewAttributeSetActionGroup.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/ConfigurableProduct/Test/Mftf/ActionGroup/SaveConfigurableProductWithNewAttributeSetActionGroup.xml"
+  module: "ConfigurableProduct"
+  actiongroups:
+     - name: "SaveConfigurableProductWithNewAttributeSetActionGroup"
+       description: "Clicks on 'Save'. Clicks radio for '...new Attribute Set...' in the 'Choose Affected Attribute Set' modal. Clicks on 'Confirm' in the model on the Configurable Product creation/edit page."
+- filename: "AdminCreateApiConfigurableProductActionGroup.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/ConfigurableProduct/Test/Mftf/ActionGroup/AdminCreateApiConfigurableProductActionGroup.xml"
+  module: "ConfigurableProduct"
+  actiongroups:
+     - name: "AdminCreateApiConfigurableProductActionGroup"
+       description: "Creates a Configurable Product with 2 Product Options via the API."
+
+     - name: "AdminCreateApiConfigurableProductWithHiddenChildActionGroup"
+       description: "EXTENDS: AdminCreateApiConfigurableProductActionGroup. Adds 2 Hidden Product Options."
+- filename: "StorefrontProductAttributeActionGroup.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/ConfigurableProduct/Test/Mftf/ActionGroup/StorefrontProductAttributeActionGroup.xml"
+  module: "ConfigurableProduct"
+  actiongroups:
+     - name: "SelectStorefrontSideBarAttributeOption"
+       description: "Goes to the provided Storefront Category page. Validates that the provided Attribute Label is present and correct."
+- filename: "GenerateConfigurationsByAttributeCodeActionGroup.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/ConfigurableProduct/Test/Mftf/ActionGroup/GenerateConfigurationsByAttributeCodeActionGroup.xml"
+  module: "ConfigurableProduct"
+  actiongroups:
+     - name: "GenerateConfigurationsByAttributeCodeActionGroup"
+       description: "Generates the Product Configurations for the provided Attribute Code on the Configurable Product creation/edit page."
+- filename: "AdminOrderBundleProductActionGroup.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/Bundle/Test/Mftf/ActionGroup/AdminOrderBundleProductActionGroup.xml"
+  module: "Bundle"
+  actiongroups:
+     - name: "AdminOrderConfigureBundleProduct"
+       description: ""
+- filename: "CreateBundleProductActionGroup.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/Bundle/Test/Mftf/ActionGroup/CreateBundleProductActionGroup.xml"
+  module: "Bundle"
+  actiongroups:
+     - name: "CreateBasicBundleProduct"
+       description: "Requires Navigation to the Product Creation page. Fills out Name, Sku, and SEO information using the BundleProduct Data Entity. PLEASE NOTE: The Action Group values are Hardcoded."
+
+     - name: "addBundleOptionWithTwoProducts"
+       description: "Requires Navigation to the Product Creation page. Adds Bundle Option with Two Products using the provided arguments. 'x' refers to Bundle option number. 'n' refers to the first number after x."
+
+     - name: "addBundleOptionWithOneProduct"
+       description: "Requires Navigation to the Product Creation page. Adds Bundle Option with One Product as specified in arguments. 'x' refers to Bundle option number. 'n' refers to the first number after x."
+
+     - name: "addBundleOptionWithTreeProducts"
+       description: "Requires Navigation to the Product Creation page. Adds Bundle Option with Three Products using the provided arguments. 'x' refers to Bundle option number. 'n' refers to the first number after x."
+
+     - name: "addBundleOptionWithSixProducts"
+       description: "Requires Navigation to Product Creation page. Adds Bundle Option with Six Products as specified in arguments. 'x' refers to Bundle option number. 'n' refers to the first number after x."
+
+     - name: "deleteBundleOptionByIndex"
+       description: "Requires Navigation to Product Creation page. Removes any Bundle Option by index specified in arguments. 'deleteIndex' refers to Bundle option number."
+- filename: "VerifyProductTypeOrderActionGroup.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/Bundle/Test/Mftf/ActionGroup/VerifyProductTypeOrderActionGroup.xml"
+  module: "Bundle"
+  actiongroups:
+     - name: "VerifyProductTypeOrder"
+       description: "Checks that Bundle is in the correct order in comparison to other product types on the add product dropdown."
+- filename: "StoreFrontAddProductToCartFromBundleActionGroup.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/Bundle/Test/Mftf/ActionGroup/StoreFrontAddProductToCartFromBundleActionGroup.xml"
+  module: "Bundle"
+  actiongroups:
+     - name: "StoreFrontAddProductToCartFromBundleWithCurrencyActionGroup"
+       description: "Adds a Bundled Product to the Cart with a specified Currency Value."
+- filename: "StorefrontProductCartActionGroup.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/Bundle/Test/Mftf/ActionGroup/StorefrontProductCartActionGroup.xml"
+  module: "Bundle"
+  actiongroups:
+     - name: "StorefrontAddCategoryBundleProductToCartActionGroup"
+       description: "Adds a Bundled Product to the Cart from the Category page."
+
+     - name: "StorefrontAddBundleProductFromCategoryToCartActionGroup"
+       description: "Adds a Bundled Product to the Cart from the Product page. PLEASE NOTE: The Quantity selection is not available in the Action Group."
+
+     - name: "StorefrontAddBundleProductFromProductToCartActionGroup"
+       description: "Adds a Bundled Product to the Cart from the Product page. PLEASE NOTE: The Quantity selection is not available in the Action Group."
+
+     - name: "StorefrontAddBundleProductFromProductToCartWithMultiOption"
+       description: "Selects a Bundled Product option on the Bundled Product page. PLEASE NOTE: The Quantity selection is not available in the Action Group."
+- filename: "EnableDisableProductActionGroup.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/Bundle/Test/Mftf/ActionGroup/EnableDisableProductActionGroup.xml"
+  module: "Bundle"
+  actiongroups:
+     - name: "AncillaryPrepBundleProduct"
+       description: "Requires Navigation to the Product Creation page. Fills out Name, Sku, and SEO information using the BundleProduct Data Entity. PLEASE NOTE: The Action Group values are Hardcoded."
+
+     - name: "FindProductToEdit"
+       description: "Clears the Backend Admin Grid Filters on the Backend Admin Product Grid page. Searches for the BundleProduct Data Entity. Then clicks on the first item in the Admin Grid. PLEASE NOTE: The Action Group values are Hardcoded."
+- filename: "AdminClearFiltersActionGroup.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/Bundle/Test/Mftf/ActionGroup/AdminClearFiltersActionGroup.xml"
+  module: "Bundle"
+  actiongroups:
+     - name: "AdminClearFiltersActionGroup"
+       description: "Goes to the Catalog Backend Admin Grid page. Then clears the Grid Filters."
+- filename: "StorefrontSelectCustomizeAndAddToTheCartButtonActionGroup.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/Bundle/Test/Mftf/ActionGroup/StorefrontSelectCustomizeAndAddToTheCartButtonActionGroup.xml"
+  module: "Bundle"
+  actiongroups:
+     - name: "StorefrontSelectCustomizeAndAddToTheCartButtonActionGroup"
+       description: "Clicks 'Customize and Add to Cart' on a Storefront Bundled Product page."
+- filename: "StorefrontSelectBundleProductDropDownOptionActionGroup.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/Bundle/Test/Mftf/ActionGroup/StorefrontSelectBundleProductDropDownOptionActionGroup.xml"
+  module: "Bundle"
+  actiongroups:
+     - name: "StorefrontSelectBundleProductDropDownOptionActionGroup"
+       description: "Selects the provided Product Name on a Storefront Bundled Product page."
+- filename: "AdminBundleProductActionGroup.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/Bundle/Test/Mftf/ActionGroup/AdminBundleProductActionGroup.xml"
+  module: "Bundle"
+  actiongroups:
+     - name: "fillMainBundleProductForm"
+       description: "Fills the Name, SKU and Stock Status fields."
+
+     - name: "checkRequiredFieldsInBundleProductForm"
+       description: "Clears the Name and SKU fields when adding a Product and then verifies that they are required after attempting to Save."
+
+     - name: "viewBundleProductInAdminGrid"
+       description: "Clears the Grid Filters on the Catalog Grid page and applies Filter by Name and Sku. Then checks to see if the Product exists in the 1st row. Then clears the Grid Filters again for future Tests."
+- filename: "AdminCreateApiBundleProductActionGroup.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/Bundle/Test/Mftf/ActionGroup/AdminCreateApiBundleProductActionGroup.xml"
+  module: "Bundle"
+  actiongroups:
+     - name: "AdminCreateApiDynamicBundleProductActionGroup"
+       description: "Creates 4 products with varying prices. Creates the bundle product with specified name. Adds the multiple select and checkbox options and 4 links to the created products. Uses the 'ApiBundleProduct' entity."
+
+     - name: "AdminCreateApiFixedBundleProductActionGroup"
+       description: "Creates 4 products with varying prices. Creates the bundle product with specified name. Adds the multiple select and checkbox options and 4 links to the created products. Uses the 'ApiFixedBundleProduct' entity."
+
+     - name: "AdminCreateApiDynamicBundleProductAllOptionTypesActionGroup"
+       description: "Creates 3 products with varying prices. Creates the dynamic bundle product with specified name. Adds the multiple select, checkbox options and links to the created products. Uses the 'ApiBundleProduct' entity."
+- filename: "SetBundleProductAttributesActionGroup.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/Bundle/Test/Mftf/ActionGroup/SetBundleProductAttributesActionGroup.xml"
+  module: "Bundle"
+  actiongroups:
+     - name: "SetBundleProductAttributes"
+       description: "Requires navigation to the Product Creation page. Fills in the arguments listed below on the product page. Saves the changes."
+- filename: "BundleProductFilterActionGroup.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/Bundle/Test/Mftf/ActionGroup/BundleProductFilterActionGroup.xml"
+  module: "Bundle"
+  actiongroups:
+     - name: "BundleProductFilter"
+       description: "Applies a Backend Admin Grid filter for Bundle Products."
+- filename: "AdminSetShippingOriginConfigurationActionGroup.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/Shipping/Test/Mftf/ActionGroup/AdminSetShippingOriginConfigurationActionGroup.xml"
+  module: "Shipping"
+  actiongroups:
+     - name: "AdminSetShippingOriginConfigurationActionGroup"
+       description: "Set Shipping Origin configurations"
+- filename: "AdminOpenShippingMethodsConfigPageActionGroup.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/Shipping/Test/Mftf/ActionGroup/AdminOpenShippingMethodsConfigPageActionGroup.xml"
+  module: "Shipping"
+  actiongroups:
+     - name: "AdminOpenShippingMethodsConfigPageActionGroup"
+       description: ""
+- filename: "AdminAssertShipmentItemsActionGroup.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/Shipping/Test/Mftf/ActionGroup/AdminAssertShipmentItemsActionGroup.xml"
+  module: "Shipping"
+  actiongroups:
+     - name: "AdminAssertShipmentItemsActionGroup"
+       description: ""
+- filename: "AdminAssertExistingTrackingNumberActionGroup.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/Shipping/Test/Mftf/ActionGroup/AdminAssertExistingTrackingNumberActionGroup.xml"
+  module: "Shipping"
+  actiongroups:
+     - name: "AdminAssertExistingTrackingNumberActionGroup"
+       description: ""
+- filename: "AdminChangeTableRatesShippingMethodStatusActionGroup.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/Shipping/Test/Mftf/ActionGroup/AdminChangeTableRatesShippingMethodStatusActionGroup.xml"
+  module: "Shipping"
+  actiongroups:
+     - name: "AdminChangeTableRatesShippingMethodStatusActionGroup"
+       description: ""
+
+     - name: "AdminImportFileTableRatesShippingMethodActionGroup"
+       description: "Import a file in Table Rates tab in Shipping Method config page."
+- filename: "AdminShipmentActionGroup.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/Shipping/Test/Mftf/ActionGroup/AdminShipmentActionGroup.xml"
+  module: "Shipping"
+  actiongroups:
+     - name: "verifyBasicShipmentInformation"
+       description: "Validates that the provided Customer, Shipping Address, Billing Address and Customer Group are present and correct on the view Admin Order page."
+
+     - name: "seeProductInShipmentItems"
+       description: "Validates that the provided Product is present and correct on the view Admin Order Shipment page under the 'Items Shipped' section."
+
+     - name: "goToShipmentIntoOrder"
+       description: "Clicks on the 'Ship' button on the view Admin Order page. Validates that the URL and Page Title are present and correct."
+
+     - name: "submitShipmentIntoOrder"
+       description: "Clicks on the 'Submit Shipment' button on the view Admin Order Shipment page. Validates that the URL and Page Title are present and correct."
+
+     - name: "AdminShipmentCreateShippingLabelActionGroup"
+       description: ""
+
+     - name: "AdminGoToShipmentTabActionGroup"
+       description: ""
+- filename: "AssertStoreFrontShippingMethodUnavailableActionGroup.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/Shipping/Test/Mftf/ActionGroup/AssertStoreFrontShippingMethodUnavailableActionGroup.xml"
+  module: "Shipping"
+  actiongroups:
+     - name: "AssertStoreFrontShippingMethodUnavailableActionGroup"
+       description: ""
+- filename: "AdminAssertShipmentInShipmentsGridActionGroup.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/Shipping/Test/Mftf/ActionGroup/AdminAssertShipmentInShipmentsGridActionGroup.xml"
+  module: "Shipping"
+  actiongroups:
+     - name: "AdminAssertShipmentInShipmentsGrid"
+       description: ""
+- filename: "AssertStoreFrontNoQuotesMessageActionGroup.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/Shipping/Test/Mftf/ActionGroup/AssertStoreFrontNoQuotesMessageActionGroup.xml"
+  module: "Shipping"
+  actiongroups:
+     - name: "AssertStoreFrontNoQuotesMessageActionGroup"
+       description: ""
+- filename: "AdminResetShippingOriginConfigurationActionGroup.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/Shipping/Test/Mftf/ActionGroup/AdminResetShippingOriginConfigurationActionGroup.xml"
+  module: "Shipping"
+  actiongroups:
+     - name: "AdminResetShippingOriginConfigurationActionGroup"
+       description: "Reset Shipping Origin configurations to default"
+- filename: "AdminAssertTrackingValidationErrorActionGroup.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/Shipping/Test/Mftf/ActionGroup/AdminAssertTrackingValidationErrorActionGroup.xml"
+  module: "Shipping"
+  actiongroups:
+     - name: "AdminAssertTrackingValidationErrorActionGroup"
+       description: ""
+- filename: "AdminAddTrackingNumberToShipmentActionGroup.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/Shipping/Test/Mftf/ActionGroup/AdminAddTrackingNumberToShipmentActionGroup.xml"
+  module: "Shipping"
+  actiongroups:
+     - name: "AdminAddTrackingNumberToShipmentActionGroup"
+       description: ""
+- filename: "AdminDeleteTrackingNumberActionGroup.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/Shipping/Test/Mftf/ActionGroup/AdminDeleteTrackingNumberActionGroup.xml"
+  module: "Shipping"
+  actiongroups:
+     - name: "AdminDeleteTrackingNumberActionGroup"
+       description: ""
+- filename: "StorefrontSetShippingMethodActionGroup.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/Shipping/Test/Mftf/ActionGroup/StorefrontSetShippingMethodActionGroup.xml"
+  module: "Shipping"
+  actiongroups:
+     - name: "StorefrontSetShippingMethodActionGroup"
+       description: "Selects the provided Shipping Method on checkout shipping and wait loading mask."
+- filename: "AssertStoreFrontShippingMethodAvailableActionGroup.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/Shipping/Test/Mftf/ActionGroup/AssertStoreFrontShippingMethodAvailableActionGroup.xml"
+  module: "Shipping"
+  actiongroups:
+     - name: "AssertStoreFrontShippingMethodAvailableActionGroup"
+       description: ""
+- filename: "AssertThereIsNoShipButtonActionGroup.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/Shipping/Test/Mftf/ActionGroup/AssertThereIsNoShipButtonActionGroup.xml"
+  module: "Shipping"
+  actiongroups:
+     - name: "AssertThereIsNoShipButtonActionGroup"
+       description: ""
+- filename: "AdminSelectFirstGridRowActionGroup.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/Shipping/Test/Mftf/ActionGroup/AdminSelectFirstGridRowActionGroup.xml"
+  module: "Shipping"
+  actiongroups:
+     - name: "AdminSelectFirstGridRowActionGroup"
+       description: ""
+- filename: "AdminCreateShipmentFromOrderPageActionGroup.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/Shipping/Test/Mftf/ActionGroup/AdminCreateShipmentFromOrderPageActionGroup.xml"
+  module: "Shipping"
+  actiongroups:
+     - name: "AdminCreateShipmentFromOrderPage"
+       description: ""
+- filename: "AdminAssertCreatedShipmentInShipmentsTabActionGroup.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/Shipping/Test/Mftf/ActionGroup/AdminAssertCreatedShipmentInShipmentsTabActionGroup.xml"
+  module: "Shipping"
+  actiongroups:
+     - name: "AdminAssertCreatedShipmentsInShipmentsTabActionGroup"
+       description: ""
+- filename: "AdminChangeFlatRateShippingMethodStatusActionGroup.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/Shipping/Test/Mftf/ActionGroup/AdminChangeFlatRateShippingMethodStatusActionGroup.xml"
+  module: "Shipping"
+  actiongroups:
+     - name: "AdminChangeFlatRateShippingMethodStatusActionGroup"
+       description: ""
+- filename: "AdminFillCatalogProductsListWidgetCategoryActionGroup.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/CatalogWidget/Test/Mftf/ActionGroup/AdminFillCatalogProductsListWidgetCategoryActionGroup.xml"
+  module: "CatalogWidget"
+  actiongroups:
+     - name: "AdminFillCatalogProductsListWidgetCategoryActionGroup"
+       description: "Fill catalog products list widget category."
 - filename: "AdminCreateBlockWithWidgetActionGroup.xml"
-  repo: "https://github.com/magento/magento2/blob/2.3/app/code/Magento/CatalogWidget/Test/Mftf/ActionGroup/AdminCreateBlockWithWidgetActionGroup.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/CatalogWidget/Test/Mftf/ActionGroup/AdminCreateBlockWithWidgetActionGroup.xml"
   module: "CatalogWidget"
   actiongroups:
      - name: "AdminCreateBlockWithWidget"
        description: "Inserts a Widget into a Block on the Block creation/edit page."
- 
-- filename: "AdminSwitchIndexerToActionModeActionGroup.xml"
-  repo: "https://github.com/magento/magento2/blob/2.3/app/code/Magento/Indexer/Test/Mftf/ActionGroup/AdminSwitchIndexerToActionModeActionGroup.xml"
-  module: "Indexer"
+- filename: "AdminUserActionGroup.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/Braintree/Test/Mftf/ActionGroup/AdminUserActionGroup.xml"
+  module: "Braintree"
   actiongroups:
-     - name: "AdminSwitchIndexerToActionModeActionGroup"
-       description: ""
- 
-- filename: "AdminReindexAndFlushCacheActionGroup.xml"
-  repo: "https://github.com/magento/magento2/blob/2.3/app/code/Magento/Indexer/Test/Mftf/ActionGroup/AdminReindexAndFlushCacheActionGroup.xml"
-  module: "Indexer"
-  actiongroups:
-     - name: "AdminReindexAndFlushCache"
-       description: "Run reindex and flush cache."
- 
-- filename: "IndexerActionGroup.xml"
-  repo: "https://github.com/magento/magento2/blob/2.3/app/code/Magento/Indexer/Test/Mftf/ActionGroup/IndexerActionGroup.xml"
-  module: "Indexer"
-  actiongroups:
-     - name: "updateIndexerBySchedule"
-       description: "Goes to the Index Management page. Checks the provided Indexer Name. Selects 'Update by Schedule'. Clicks on Submit."
+     - name: "GoToAllUsers"
+       description: "Navigate to the Users page via Backend Admin Side Menu. PLEASE NOTE: Use the amOnPage action instead."
 
-     - name: "updateIndexerOnSave"
-       description: "Goes to the Index Management page. Checks the provided Indexer Name. Selects 'Update on Save'. Clicks on Submit."
- 
-- filename: "AdminSwitchAllIndexerToActionModeActionGroup.xml"
-  repo: "https://github.com/magento/magento2/blob/2.3/app/code/Magento/Indexer/Test/Mftf/ActionGroup/AdminSwitchAllIndexerToActionModeActionGroup.xml"
-  module: "Indexer"
+     - name: "AdminCreateUserAction"
+       description: "Creates a User using the NewAdmin User Entity and User Role Entity. PLEASE NOTE: The Action Group values are Hardcoded."
+- filename: "StorefrontFillCartDataActionGroup.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/Braintree/Test/Mftf/ActionGroup/StorefrontFillCartDataActionGroup.xml"
+  module: "Braintree"
   actiongroups:
-     - name: "AdminSwitchAllIndexerToActionModeActionGroup"
-       description: ""
- 
-- filename: "LoginAsAdminActionGroup.xml"
-  repo: "https://github.com/magento/magento2/blob/2.3/app/code/Magento/AdminAnalytics/Test/Mftf/ActionGroup/LoginAsAdminActionGroup.xml"
-  module: "AdminAnalytics"
+     - name: "StorefrontFillCartDataActionGroup"
+       description: "Fills Cart Data with Braintree using the provided Data Entity."
+- filename: "AdminOrderBraintreeFillActionGroup.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/Braintree/Test/Mftf/ActionGroup/AdminOrderBraintreeFillActionGroup.xml"
+  module: "Braintree"
   actiongroups:
-     - name: "LoginAsAdmin"
-       description: ""
- 
-- filename: "LoginAdminWithCredentialsActionGroup.xml"
-  repo: "https://github.com/magento/magento2/blob/2.3/app/code/Magento/AdminAnalytics/Test/Mftf/ActionGroup/LoginAdminWithCredentialsActionGroup.xml"
-  module: "AdminAnalytics"
+     - name: "AdminOrderBraintreeFillActionGroup"
+       description: "Fills in the Payment Method using Braintree details. PLEASE NOTE: The Braintree details are Hardcoded using 'PaymentAndShippingInfo'."
+- filename: "AdminRoleActionGroup.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/Braintree/Test/Mftf/ActionGroup/AdminRoleActionGroup.xml"
+  module: "Braintree"
   actiongroups:
-     - name: "LoginAdminWithCredentialsActionGroup"
-       description: ""
- 
-- filename: "SelectAdminUsageSettingActionGroup.xml"
-  repo: "https://github.com/magento/magento2/blob/2.3/app/code/Magento/AdminAnalytics/Test/Mftf/ActionGroup/SelectAdminUsageSettingActionGroup.xml"
-  module: "AdminAnalytics"
-  actiongroups:
-     - name: "SelectAdminUsageSetting"
-       description: ""
- 
-- filename: "CloseAllDialogBoxesActionGroup.xml"
-  repo: "https://github.com/magento/magento2/blob/2.3/app/code/Magento/AdminAnalytics/Test/Mftf/ActionGroup/CloseAllDialogBoxesActionGroup.xml"
-  module: "AdminAnalytics"
-  actiongroups:
-     - name: "CloseAllDialogBoxes"
-       description: ""
- 
-- filename: "EmailTemplateActionGroup.xml"
-  repo: "https://github.com/magento/magento2/blob/2.3/app/code/Magento/Email/Test/Mftf/ActionGroup/EmailTemplateActionGroup.xml"
-  module: "Email"
-  actiongroups:
-     - name: "CreateNewTemplate"
-       description: "Clicks on Add New Template. Fills the Template details. Clicks on Save. PLEASE NOTE: The values are Hardcoded."
+     - name: "GoToUserRoles"
+       description: "Navigate to the User Roles page via Backend Admin Side Menu. PLEASE NOTE: Use the amOnPage action instead."
 
-     - name: "CreateCustomTemplate"
+     - name: "AdminCreateNewRole"
+       description: "Creates a User Role using the provided Data."
+
+     - name: "AdminDeleteRoleActionGroup"
+       description: "Deletes a User Role."
+- filename: "ConfigureBraintreeActionGroup.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/Braintree/Test/Mftf/ActionGroup/ConfigureBraintreeActionGroup.xml"
+  module: "Braintree"
+  actiongroups:
+     - name: "ConfigureBraintree"
+       description: "Sets up the Braintree configuration setting using the BraintreeConfigurationSection Data Entity. PLEASE NOTE: The Action Group values are Hardcoded."
+
+     - name: "DisableBrainTree"
+       description: "Disables the Braintree and BraintreePaypal configuration settings via the CLI."
+- filename: "CheckingWithMultipleAddressesActionGroup.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/Multishipping/Test/Mftf/ActionGroup/CheckingWithMultipleAddressesActionGroup.xml"
+  module: "Multishipping"
+  actiongroups:
+     - name: "CheckingWithSingleAddressActionGroup"
        description: ""
 
-     - name: "PrepareDraftCustomTemplate"
+     - name: "CheckingWithMultipleAddressesActionGroup"
        description: ""
 
-     - name: "FindAndOpenEmailTemplate"
+     - name: "StorefrontCheckoutWithMultipleAddressesActionGroup"
        description: ""
 
-     - name: "DeleteEmailTemplate"
-       description: "Clicks on Delete Template. Accepts the Popup. Validates that the Email Template is NOT present in the Email Templates Grid."
-
-     - name: "PreviewEmailTemplate"
+     - name: "StorefrontSelectAddressActionGroup"
        description: ""
 
-     - name: "AssertEmailTemplateContent"
+     - name: "StorefrontSaveAddressActionGroup"
        description: ""
- 
-- filename: "AdminSystemMessagesActionGroup.xml"
-  repo: "https://github.com/magento/magento2/blob/2.3/app/code/Magento/AdminNotification/Test/Mftf/ActionGroup/AdminSystemMessagesActionGroup.xml"
-  module: "AdminNotification"
+- filename: "StorefrontMultishippingCheckoutActionGroup.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/Multishipping/Test/Mftf/ActionGroup/StorefrontMultishippingCheckoutActionGroup.xml"
+  module: "Multishipping"
   actiongroups:
-     - name: "AdminSystemMessagesWarningActionGroup"
-       description: "Check warning system message exists."
- 
-- filename: "AdminCreateCustomerGroupActionGroup.xml"
-  repo: "https://github.com/magento/magento2/blob/2.3/app/code/Magento/Customer/Test/Mftf/ActionGroup/AdminCreateCustomerGroupActionGroup.xml"
-  module: "Customer"
-  actiongroups:
-     - name: "AdminCreateCustomerGroupActionGroup"
-       description: "Goes to the Customer Groups creation page. Fills Name. Selects Tax Class. Clicks on Save. Validate that the Success Message is present and correct."
- 
-- filename: "StorefrontCustomerAddressBookNumberOfAddressesActionGroup.xml"
-  repo: "https://github.com/magento/magento2/blob/2.3/app/code/Magento/Customer/Test/Mftf/ActionGroup/StorefrontCustomerAddressBookNumberOfAddressesActionGroup.xml"
-  module: "Customer"
-  actiongroups:
-     - name: "StorefrontCustomerAddressBookNumberOfAddresses"
-       description: "Validate that the Customer Address count is present and correct on the Storefront Customer Dashboard page."
- 
-- filename: "CreateCustomerActionGroup.xml"
-  repo: "https://github.com/magento/magento2/blob/2.3/app/code/Magento/Customer/Test/Mftf/ActionGroup/CreateCustomerActionGroup.xml"
-  module: "Customer"
-  actiongroups:
-     - name: "CreateCustomerActionGroup"
-       description: "Goes to the Add Customers page via the Admin Nav Menu. Fills in the Customer details. Clicks on Save. PLEASE NOTE: The Customer data is Hardcoded using 'NewCustomerData'."
- 
-- filename: "AssertStorefrontPasswordAutocompleteOffActionGroup.xml"
-  repo: "https://github.com/magento/magento2/blob/2.3/app/code/Magento/Customer/Test/Mftf/ActionGroup/AssertStorefrontPasswordAutocompleteOffActionGroup.xml"
-  module: "Customer"
-  actiongroups:
-     - name: "AssertStorefrontPasswordAutoCompleteOffActionGroup"
-       description: "Goes to the Storefront Customer Sign-In page. Validates that the Password field does NOT contain the 'autocomplete' attribute."
- 
-- filename: "AssertMessageCustomerCreateAccountActionGroup.xml"
-  repo: "https://github.com/magento/magento2/blob/2.3/app/code/Magento/Customer/Test/Mftf/ActionGroup/AssertMessageCustomerCreateAccountActionGroup.xml"
-  module: "Customer"
-  actiongroups:
-     - name: "AssertMessageCustomerCreateAccountActionGroup"
-       description: "Validates that the provided Message/Message Type are present and correct."
- 
-- filename: "AdminNavigateNewCustomerActionGroup.xml"
-  repo: "https://github.com/magento/magento2/blob/2.3/app/code/Magento/Customer/Test/Mftf/ActionGroup/AdminNavigateNewCustomerActionGroup.xml"
-  module: "Customer"
-  actiongroups:
-     - name: "AdminNavigateNewCustomerActionGroup"
-       description: "Goes to the New Customer page."
- 
-- filename: "AdminAssertCustomerNoDefaultShippingAddressActionGroup.xml"
-  repo: "https://github.com/magento/magento2/blob/2.3/app/code/Magento/Customer/Test/Mftf/ActionGroup/AdminAssertCustomerNoDefaultShippingAddressActionGroup.xml"
-  module: "Customer"
-  actiongroups:
-     - name: "AdminAssertCustomerNoDefaultShippingAddress"
-       description: "Validates that a Customer does NOT have a Default Shipping Address assigned. PLEASE NOTE: The error message is hardcoded."
- 
-- filename: "AdminAssertCustomerNoDefaultBillingAddressActionGroup.xml"
-  repo: "https://github.com/magento/magento2/blob/2.3/app/code/Magento/Customer/Test/Mftf/ActionGroup/AdminAssertCustomerNoDefaultBillingAddressActionGroup.xml"
-  module: "Customer"
-  actiongroups:
-     - name: "AdminAssertCustomerNoDefaultBillingAddress"
-       description: "Validates that a Customer does NOT have a Default Billing Address assigned. PLEASE NOTE: The error message is hardcoded."
- 
-- filename: "AdminCustomerShopingCartActionGroup.xml"
-  repo: "https://github.com/magento/magento2/blob/2.3/app/code/Magento/Customer/Test/Mftf/ActionGroup/AdminCustomerShopingCartActionGroup.xml"
-  module: "Customer"
-  actiongroups:
-     - name: "AdminAddProductToShoppingCartActionGroup"
-       description: "Adds the provided Product Name to the Cart on the Admin Customer creation/edit page."
- 
-- filename: "AdminAssertCustomerDefaultBillingAddressActionGroup.xml"
-  repo: "https://github.com/magento/magento2/blob/2.3/app/code/Magento/Customer/Test/Mftf/ActionGroup/AdminAssertCustomerDefaultBillingAddressActionGroup.xml"
-  module: "Customer"
-  actiongroups:
-     - name: "AdminAssertCustomerDefaultBillingAddress"
-       description: "Validates that the provided Default Customer Billing Address details are present and correct on the Customer creation/edit page. Under the section 'Addresses'."
- 
-- filename: "AssertCustomerGroupNotInGridActionGroup.xml"
-  repo: "https://github.com/magento/magento2/blob/2.3/app/code/Magento/Customer/Test/Mftf/ActionGroup/AssertCustomerGroupNotInGridActionGroup.xml"
-  module: "Customer"
-  actiongroups:
-     - name: "AssertCustomerGroupNotInGridActionGroup"
-       description: "Filters the Admin Customers grid for the Customer Group (Code). Validates that the grid is empty."
- 
-- filename: "StorefrontClickCreateAnAccountCustomerAccountCreationFormActionGroup.xml"
-  repo: "https://github.com/magento/magento2/blob/2.3/app/code/Magento/Customer/Test/Mftf/ActionGroup/StorefrontClickCreateAnAccountCustomerAccountCreationFormActionGroup.xml"
-  module: "Customer"
-  actiongroups:
-     - name: "StorefrontClickCreateAnAccountCustomerAccountCreationFormActionGroup"
-       description: "Clicks on the Storefront Header 'Create Account' link."
- 
-- filename: "AdminCustomerGridActionGroup.xml"
-  repo: "https://github.com/magento/magento2/blob/2.3/app/code/Magento/Customer/Test/Mftf/ActionGroup/AdminCustomerGridActionGroup.xml"
-  module: "Customer"
-  actiongroups:
-     - name: "AdminFilterCustomerByEmail"
-       description: "Goes to the Customer grid page. Filter results based on provided Customer Email Address."
- 
-- filename: "StorefrontClickSignInButtonActionGroup.xml"
-  repo: "https://github.com/magento/magento2/blob/2.3/app/code/Magento/Customer/Test/Mftf/ActionGroup/StorefrontClickSignInButtonActionGroup.xml"
-  module: "Customer"
-  actiongroups:
-     - name: "StorefrontClickSignInButtonActionGroup"
-       description: "Click on the Storefront Header 'Sign-In' link."
- 
-- filename: "AdminAssertCustomerAccountInformationActionGroup.xml"
-  repo: "https://github.com/magento/magento2/blob/2.3/app/code/Magento/Customer/Test/Mftf/ActionGroup/AdminAssertCustomerAccountInformationActionGroup.xml"
-  module: "Customer"
-  actiongroups:
-     - name: "AdminAssertCustomerAccountInformation"
-       description: "Validates that the provided Customer details are present and correct on the Customer creation/edit page. Under the 'Account Information' section."
- 
-- filename: "AdminAssertCustomerGroupOnProductFormActionGroup.xml"
-  repo: "https://github.com/magento/magento2/blob/2.3/app/code/Magento/Customer/Test/Mftf/ActionGroup/AdminAssertCustomerGroupOnProductFormActionGroup.xml"
-  module: "Customer"
-  actiongroups:
-     - name: "AdminAssertCustomerGroupOnProductForm"
-       description: ""
- 
-- filename: "StorefrontOpenCustomerLoginPageActionGroup.xml"
-  repo: "https://github.com/magento/magento2/blob/2.3/app/code/Magento/Customer/Test/Mftf/ActionGroup/StorefrontOpenCustomerLoginPageActionGroup.xml"
-  module: "Customer"
-  actiongroups:
-     - name: "StorefrontOpenCustomerLoginPageActionGroup"
-       description: "Goes to the Storefront Customer Sign-In page."
- 
-- filename: "SetGroupCustomerActionGroup.xml"
-  repo: "https://github.com/magento/magento2/blob/2.3/app/code/Magento/Customer/Test/Mftf/ActionGroup/SetGroupCustomerActionGroup.xml"
-  module: "Customer"
-  actiongroups:
-     - name: "SetCustomerGroupForSelectedCustomersViaGrid"
-       description: "Clicks on the 'Actions' dropdown menu. Clicks on 'Assign a Customer Group'. Clicks on 'Ok'."
- 
-- filename: "AdminFilterCustomerGroupByNameActionGroup.xml"
-  repo: "https://github.com/magento/magento2/blob/2.3/app/code/Magento/Customer/Test/Mftf/ActionGroup/AdminFilterCustomerGroupByNameActionGroup.xml"
-  module: "Customer"
-  actiongroups:
-     - name: "AdminFilterCustomerGroupByNameActionGroup"
-       description: "Filters the Admin Customers grid by the provided Customer Group Name."
- 
-- filename: "AssertMessageCustomerLoginActionGroup.xml"
-  repo: "https://github.com/magento/magento2/blob/2.3/app/code/Magento/Customer/Test/Mftf/ActionGroup/AssertMessageCustomerLoginActionGroup.xml"
-  module: "Customer"
-  actiongroups:
-     - name: "AssertMessageCustomerLoginActionGroup"
-       description: "Validates that the provided Message/Message Type are present and correct."
- 
-- filename: "StoreFrontClickEditDefaultShippingAddressActionGroup.xml"
-  repo: "https://github.com/magento/magento2/blob/2.3/app/code/Magento/Customer/Test/Mftf/ActionGroup/StoreFrontClickEditDefaultShippingAddressActionGroup.xml"
-  module: "Customer"
-  actiongroups:
-     - name: "StoreFrontClickEditDefaultShippingAddressActionGroup"
-       description: "Click on the edit default shipping address link."
- 
-- filename: "AdminEditCustomerAddressSetDefaultShippingAndBillingActionGroup.xml"
-  repo: "https://github.com/magento/magento2/blob/2.3/app/code/Magento/Customer/Test/Mftf/ActionGroup/AdminEditCustomerAddressSetDefaultShippingAndBillingActionGroup.xml"
-  module: "Customer"
-  actiongroups:
-     - name: "AdminEditCustomerAddressSetDefaultShippingAndBilling"
-       description: "EXTENDS: AdminEditCustomerAddressesFrom. Removes 'selectState' and 'fillZipCode'."
- 
-- filename: "StorefrontNavigateToCustomerOrdersHistoryPageActionGroup.xml"
-  repo: "https://github.com/magento/magento2/blob/2.3/app/code/Magento/Customer/Test/Mftf/ActionGroup/StorefrontNavigateToCustomerOrdersHistoryPageActionGroup.xml"
-  module: "Customer"
-  actiongroups:
-     - name: "StorefrontNavigateToCustomerOrdersHistoryPageActionGroup"
-       description: ""
- 
-- filename: "StorefrontAssertSuccessLoginToStorefrontActionGroup.xml"
-  repo: "https://github.com/magento/magento2/blob/2.3/app/code/Magento/Customer/Test/Mftf/ActionGroup/StorefrontAssertSuccessLoginToStorefrontActionGroup.xml"
-  module: "Customer"
-  actiongroups:
-     - name: "StorefrontAssertSuccessLoginToStorefront"
-       description: "EXTENDS: LoginToStorefrontActionGroup. Validates that the provided Customer name is present and correct."
- 
-- filename: "SignUpNewUserFromStorefrontActionGroup.xml"
-  repo: "https://github.com/magento/magento2/blob/2.3/app/code/Magento/Customer/Test/Mftf/ActionGroup/SignUpNewUserFromStorefrontActionGroup.xml"
-  module: "Customer"
-  actiongroups:
-     - name: "SignUpNewUserFromStorefrontActionGroup"
-       description: "Goes to the Storefront. Clicks on 'Create Account'. Fills in the provided Customer details, excluding Newsletter Sign-Up. Clicks on 'Create Account' button. Validate that the Customer details are present and correct."
-
-     - name: "StorefrontCreateCustomerSignedUpNewsletterActionGroup"
-       description: "Goes to the Storefront. Clicks on 'Create Account'. Fills in the provided Customer details, including Newsletter Sign-Up. Clicks on 'Create Account' button."
-
-     - name: "StorefrontFillRegistrationFormActionGroup"
+     - name: "StorefrontCheckoutShippingSelectMultipleAddressesActionGroup"
        description: ""
 
-     - name: "SaveRegistrationFormActionGroup"
+     - name: "StorefrontGoCheckoutWithMultipleAddresses"
        description: ""
 
-     - name: "AssertSignedUpNewsletterActionGroup"
-       description: "Validates that the provided Customer details are present and correct on the Storefront Customer Dashboard page."
-
-     - name: "EnterCustomerAddressInfo"
-       description: "Fills in the provided Customer details (First/Last Name, Company, Phone # and Address) on the Admin Customer creation/edit page. Clicks on the Save button."
-
-     - name: "EnterCustomerAddressInfoFillState"
-       description: "EXTENDS: EnterCustomerAddressInfo. Fills the State field."
-
-     - name: "VerifyCustomerBillingAddress"
-       description: "Goes to the Storefront Customer Dashboard Address area. Validates that the provided Customer Billing Address is present and correct on the Storefront Customer Dashboard Address section."
-
-     - name: "VerifyCustomerShippingAddress"
-       description: "Goes to the Storefront Customer Dashboard Address area. Validates that the provided Customer Shipping Address is present and correct."
-
-     - name: "VerifyCustomerBillingAddressWithState"
-       description: "Goes to the Storefront Customer Dashboard Address area. Validates that the provided Customer Billing Address, including the State, is present and correct."
-
-     - name: "VerifyCustomerShippingAddressWithState"
-       description: "Goes to the Storefront Customer Dashboard Address area. Validates that the provided Customer Shipping Address, including the State, is present and correct."
-
-     - name: "VerifyCustomerNameOnFrontend"
-       description: "Goes to the Storefront Customer Dashboard page. Validates that the Customer First/Last Name is present and correct."
-
-     - name: "SignUpNewCustomerStorefrontActionGroup"
-       description: "EXTENDS: SignUpNewUserFromStorefrontActionGroup. Adds a waitForPageLoad action to the Action Group. Removes the action for 'seeThankYouMessage'."
- 
-- filename: "AssertCustomerGroupNotOnProductFormActionGroup.xml"
-  repo: "https://github.com/magento/magento2/blob/2.3/app/code/Magento/Customer/Test/Mftf/ActionGroup/AssertCustomerGroupNotOnProductFormActionGroup.xml"
-  module: "Customer"
-  actiongroups:
-     - name: "AssertCustomerGroupNotOnProductFormActionGroup"
-       description: "Clicks on 'Advanced Pricing' on the Admin Customers creation/edit page. Validates that the provided Customer Group does NOT appear in the dropdown menu."
- 
-- filename: "VerifyGroupCustomerActionGroup.xml"
-  repo: "https://github.com/magento/magento2/blob/2.3/app/code/Magento/Customer/Test/Mftf/ActionGroup/VerifyGroupCustomerActionGroup.xml"
-  module: "Customer"
-  actiongroups:
-     - name: "VerifyCustomerGroupForCustomer"
-       description: "Clicks on the Edit link for the provided Customer Email Address."
- 
-- filename: "AdminDeleteAddressInCustomersAddressGridActionGroup.xml"
-  repo: "https://github.com/magento/magento2/blob/2.3/app/code/Magento/Customer/Test/Mftf/ActionGroup/AdminDeleteAddressInCustomersAddressGridActionGroup.xml"
-  module: "Customer"
-  actiongroups:
-     - name: "AdminDeleteAddressInCustomersAddressGrid"
-       description: "Deletes a Customer Address from the Customer creation/edit page under the 'Addresses' section."
- 
-- filename: "AssertStorefrontCustomerSavedCardActionGroup.xml"
-  repo: "https://github.com/magento/magento2/blob/2.3/app/code/Magento/Customer/Test/Mftf/ActionGroup/AssertStorefrontCustomerSavedCardActionGroup.xml"
-  module: "Customer"
-  actiongroups:
-     - name: "AssertStorefrontCustomerSavedCardActionGroup"
+     - name: "StorefrontGoToBillingInformationActionGroup"
        description: ""
- 
-- filename: "NavigateCustomerGroupActionGroup.xml"
-  repo: "https://github.com/magento/magento2/blob/2.3/app/code/Magento/Customer/Test/Mftf/ActionGroup/NavigateCustomerGroupActionGroup.xml"
-  module: "Customer"
+- filename: "AssertStorefrontSalesOrderMatchesGrandTotalActionGroup.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/Multishipping/Test/Mftf/ActionGroup/AssertStorefrontSalesOrderMatchesGrandTotalActionGroup.xml"
+  module: "Multishipping"
   actiongroups:
-     - name: "NavigateToCustomerGroupPage"
-       description: "Goes to the Admin Customer Groups page."
- 
-- filename: "StorefrontFillBillingAddressActionGroup.xml"
-  repo: "https://github.com/magento/magento2/blob/2.3/app/code/Magento/Customer/Test/Mftf/ActionGroup/StorefrontFillBillingAddressActionGroup.xml"
-  module: "Customer"
-  actiongroups:
-     - name: "StorefrontFillBillingAddressActionGroup"
+     - name: "AssertStorefrontSalesOrderMatchesGrandTotalActionGroup"
        description: ""
- 
-- filename: "StorefrontRegisterCustomerFromOrderSuccessPageActionGroup.xml"
-  repo: "https://github.com/magento/magento2/blob/2.3/app/code/Magento/Customer/Test/Mftf/ActionGroup/StorefrontRegisterCustomerFromOrderSuccessPageActionGroup.xml"
-  module: "Customer"
+- filename: "AdminSalesOrderActionGroup.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/Multishipping/Test/Mftf/ActionGroup/AdminSalesOrderActionGroup.xml"
+  module: "Multishipping"
   actiongroups:
-     - name: "StorefrontRegisterCustomerFromOrderSuccessPage"
-       description: "Clicks on 'Create Account' on the Storefront Checkout Success page. Fills in the provided Customer details. Clicks on 'Create Account'. Validates that the Success Message is present and correct."
- 
-- filename: "AssertMessageCustomerChangeAccountInfoActionGroup.xml"
-  repo: "https://github.com/magento/magento2/blob/2.3/app/code/Magento/Customer/Test/Mftf/ActionGroup/AssertMessageCustomerChangeAccountInfoActionGroup.xml"
-  module: "Customer"
-  actiongroups:
-     - name: "AssertMessageCustomerChangeAccountInfoActionGroup"
-       description: "Validates that the provided Message/Message Type are present and correct."
- 
-- filename: "StorefrontOpenCustomerAccountInfoEditPageActionGroup.xml"
-  repo: "https://github.com/magento/magento2/blob/2.3/app/code/Magento/Customer/Test/Mftf/ActionGroup/StorefrontOpenCustomerAccountInfoEditPageActionGroup.xml"
-  module: "Customer"
-  actiongroups:
-     - name: "StorefrontOpenCustomerAccountInfoEditPageActionGroup"
-       description: "Goes to the Storefront Customer Edit page."
- 
-- filename: "AdminFilterCustomerByNameActionGroup.xml"
-  repo: "https://github.com/magento/magento2/blob/2.3/app/code/Magento/Customer/Test/Mftf/ActionGroup/AdminFilterCustomerByNameActionGroup.xml"
-  module: "Customer"
-  actiongroups:
-     - name: "AdminFilterCustomerByName"
-       description: "Filters the Admin Customers grid by the provided Name."
- 
-- filename: "AssertCustomerAccountPageTitleActionGroup.xml"
-  repo: "https://github.com/magento/magento2/blob/2.3/app/code/Magento/Customer/Test/Mftf/ActionGroup/AssertCustomerAccountPageTitleActionGroup.xml"
-  module: "Customer"
-  actiongroups:
-     - name: "AssertCustomerAccountPageTitleActionGroup"
-       description: "Validates that the provided Page Title is present and correct on the Storefront Customer Dashboard."
- 
-- filename: "AdminAssertNumberOfRecordsInCustomersAddressGridActionGroup.xml"
-  repo: "https://github.com/magento/magento2/blob/2.3/app/code/Magento/Customer/Test/Mftf/ActionGroup/AdminAssertNumberOfRecordsInCustomersAddressGridActionGroup.xml"
-  module: "Customer"
-  actiongroups:
-     - name: "AdminAssertNumberOfRecordsInCustomersAddressGrid"
-       description: "Validates that the Number of Records listed on the Customer grid page is present and correct."
- 
-- filename: "AdminCreateCustomerWithDefaultAddressWithoutPhoneActionGroup.xml"
-  repo: "https://github.com/magento/magento2/blob/2.3/app/code/Magento/Customer/Test/Mftf/ActionGroup/AdminCreateCustomerWithDefaultAddressWithoutPhoneActionGroup.xml"
-  module: "Customer"
-  actiongroups:
-     - name: "AdminCreateCustomerWithDefaultAddressWithoutPhoneActionGroup"
+     - name: "AdminSalesOrderActionGroup"
        description: ""
- 
-- filename: "AssertCustomerResetPasswordActionGroup.xml"
-  repo: "https://github.com/magento/magento2/blob/2.3/app/code/Magento/Customer/Test/Mftf/ActionGroup/AssertCustomerResetPasswordActionGroup.xml"
-  module: "Customer"
+- filename: "SelectShippingInfoActionGroup.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/Multishipping/Test/Mftf/ActionGroup/SelectShippingInfoActionGroup.xml"
+  module: "Multishipping"
   actiongroups:
-     - name: "AssertCustomerResetPasswordActionGroup"
-       description: "Validates that the provided URL is present and correct. Validates that the provided Message/Message Type is present and correct."
- 
-- filename: "AdminUpdateCustomerGroupActionGroup.xml"
-  repo: "https://github.com/magento/magento2/blob/2.3/app/code/Magento/Customer/Test/Mftf/ActionGroup/AdminUpdateCustomerGroupActionGroup.xml"
-  module: "Customer"
-  actiongroups:
-     - name: "AdminUpdateCustomerGroupByEmailActionGroup"
-       description: "Goes to the Admin Customers grid page. Filters the grid for the provided Email Address. Edits the Customer. Updates the Customer Group with the provided Customer Group. Clicks on Save."
- 
-- filename: "AdminConfigCustomerActionGroup.xml"
-  repo: "https://github.com/magento/magento2/blob/2.3/app/code/Magento/Customer/Test/Mftf/ActionGroup/AdminConfigCustomerActionGroup.xml"
-  module: "Customer"
-  actiongroups:
-     - name: "SetCustomerDataLifetimeActionGroup"
-       description: "Goes to the Customer Configuration page. Fills Customer Data Lifetime. Clicks on Save. Validates that the Success message is present."
- 
-- filename: "DeleteCustomerActionGroup.xml"
-  repo: "https://github.com/magento/magento2/blob/2.3/app/code/Magento/Customer/Test/Mftf/ActionGroup/DeleteCustomerActionGroup.xml"
-  module: "Customer"
-  actiongroups:
-     - name: "DeleteCustomerActionGroup"
-       description: "Goes to the Admin Customers grid page. Deletes a Customer based on the provided Last Name."
-
-     - name: "DeleteCustomerByEmailActionGroup"
-       description: "Goes to the Admin Customers grid page. Deletes a Customer based on the provided Email Address."
- 
-- filename: "AdminResetFilterInCustomerAddressGridActionGroup.xml"
-  repo: "https://github.com/magento/magento2/blob/2.3/app/code/Magento/Customer/Test/Mftf/ActionGroup/AdminResetFilterInCustomerAddressGridActionGroup.xml"
-  module: "Customer"
-  actiongroups:
-     - name: "AdminResetFilterInCustomerAddressGrid"
-       description: "Clears the Admin Customer Address grid Filters. Sets the grid view to 'Default View'."
- 
-- filename: "StorefrontCustomerLogoutActionGroup.xml"
-  repo: "https://github.com/magento/magento2/blob/2.3/app/code/Magento/Customer/Test/Mftf/ActionGroup/StorefrontCustomerLogoutActionGroup.xml"
-  module: "Customer"
-  actiongroups:
-     - name: "StorefrontCustomerLogoutActionGroup"
-       description: "Goes to the Storefront Customer Logout page."
-
-     - name: "StorefrontSignOutActionGroup"
-       description: "Clicks on Customer Account. Clicks on 'Sign-Out'. Validates that the success message is present and correct. PLEASE NOTE: The Success Message is hardcoded."
- 
-- filename: "StorefrontCustomerElementNotVisibleActionGroup.xml"
-  repo: "https://github.com/magento/magento2/blob/2.3/app/code/Magento/Customer/Test/Mftf/ActionGroup/StorefrontCustomerElementNotVisibleActionGroup.xml"
-  module: "Customer"
-  actiongroups:
-     - name: "StorefrontCustomerReorderButtonNotVisibleActionGroup"
+     - name: "SelectSingleShippingInfoActionGroup"
        description: ""
- 
-- filename: "FillNewCustomerAddressRequiredFieldsActionGroup.xml"
-  repo: "https://github.com/magento/magento2/blob/2.3/app/code/Magento/Customer/Test/Mftf/ActionGroup/FillNewCustomerAddressRequiredFieldsActionGroup.xml"
-  module: "Customer"
-  actiongroups:
-     - name: "FillNewCustomerAddressRequiredFieldsActionGroup"
+
+     - name: "SelectMultiShippingInfoActionGroup"
        description: ""
- 
-- filename: "AdminAssertErrorMessageCustomerGroupAlreadyExistsActionGroup.xml"
-  repo: "https://github.com/magento/magento2/blob/2.3/app/code/Magento/Customer/Test/Mftf/ActionGroup/AdminAssertErrorMessageCustomerGroupAlreadyExistsActionGroup.xml"
-  module: "Customer"
-  actiongroups:
-     - name: "AdminAssertErrorMessageCustomerGroupAlreadyExists"
+
+     - name: "StorefrontLeaveDefaultShippingMethodsAndGoToBillingInfoActionGroup"
        description: ""
- 
-- filename: "AdminSaveCustomerAndAssertSuccessMessageActionGroup.xml"
-  repo: "https://github.com/magento/magento2/blob/2.3/app/code/Magento/Customer/Test/Mftf/ActionGroup/AdminSaveCustomerAndAssertSuccessMessageActionGroup.xml"
-  module: "Customer"
+- filename: "ReviewOrderActionGroup.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/Multishipping/Test/Mftf/ActionGroup/ReviewOrderActionGroup.xml"
+  module: "Multishipping"
   actiongroups:
-     - name: "AdminSaveCustomerAndAssertSuccessMessage"
-       description: "Clicks on the Save button. Validates that the Success Message is present and correct. PLEASE NOTE: The message is Hardcoded."
- 
-- filename: "AdminAssertCustomerGroupOnCustomerFormActionGroup.xml"
-  repo: "https://github.com/magento/magento2/blob/2.3/app/code/Magento/Customer/Test/Mftf/ActionGroup/AdminAssertCustomerGroupOnCustomerFormActionGroup.xml"
-  module: "Customer"
-  actiongroups:
-     - name: "AdminAssertCustomerGroupOnCustomerForm"
+     - name: "ReviewOrderForSingleShipmentActionGroup"
        description: ""
- 
-- filename: "AssertCustomerGroupOnCustomerFormActionGroup.xml"
-  repo: "https://github.com/magento/magento2/blob/2.3/app/code/Magento/Customer/Test/Mftf/ActionGroup/AssertCustomerGroupOnCustomerFormActionGroup.xml"
-  module: "Customer"
-  actiongroups:
-     - name: "AssertCustomerGroupOnCustomerFormActionGroup"
-       description: "Validates that the provided Customer Group is selected on the Admin Customer edit page."
- 
-- filename: "StorefrontAddCustomerAddressActionGroup.xml"
-  repo: "https://github.com/magento/magento2/blob/2.3/app/code/Magento/Customer/Test/Mftf/ActionGroup/StorefrontAddCustomerAddressActionGroup.xml"
-  module: "Customer"
-  actiongroups:
-     - name: "StorefrontAddNewCustomerAddressActionGroup"
-       description: "Goes to the Storefront Customer Add New Address page. Fills in the provided Address details. Clicks on Save."
 
-     - name: "StorefrontAddCustomerDefaultAddressActionGroup"
-       description: "Goes to the Storefront Customer Add New Default Address page. Fills in the provided Address details. Clicks on Save."
- 
-- filename: "AdminFilterCustomerGridByEmailActionGroup.xml"
-  repo: "https://github.com/magento/magento2/blob/2.3/app/code/Magento/Customer/Test/Mftf/ActionGroup/AdminFilterCustomerGridByEmailActionGroup.xml"
-  module: "Customer"
-  actiongroups:
-     - name: "AdminFilterCustomerGridByEmail"
-       description: "Filters the Admin Customers grid by the provided Email Address."
- 
-- filename: "AdminAssertDefaultValueDisableAutoGroupInCustomerFormActionGroup.xml"
-  repo: "https://github.com/magento/magento2/blob/2.3/app/code/Magento/Customer/Test/Mftf/ActionGroup/AdminAssertDefaultValueDisableAutoGroupInCustomerFormActionGroup.xml"
-  module: "Customer"
-  actiongroups:
-     - name: "AdminAssertDefaultValueDisableAutoGroupInCustomerFormActionGroup"
-       description: "Check Default Value for Disable Automatic Group Changes Based on VAT ID in Create Customer form."
- 
-- filename: "AdminSaveCustomerAddressActionGroup.xml"
-  repo: "https://github.com/magento/magento2/blob/2.3/app/code/Magento/Customer/Test/Mftf/ActionGroup/AdminSaveCustomerAddressActionGroup.xml"
-  module: "Customer"
-  actiongroups:
-     - name: "AdminSaveCustomerAddressActionGroup"
+     - name: "ReviewOrderForMultiShipmentActionGroup"
        description: ""
- 
-- filename: "AdminDeleteCustomerActionGroup.xml"
-  repo: "https://github.com/magento/magento2/blob/2.3/app/code/Magento/Customer/Test/Mftf/ActionGroup/AdminDeleteCustomerActionGroup.xml"
-  module: "Customer"
+- filename: "SelectBillingInfoActionGroup.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/Multishipping/Test/Mftf/ActionGroup/SelectBillingInfoActionGroup.xml"
+  module: "Multishipping"
   actiongroups:
-     - name: "AdminDeleteCustomerActionGroup"
-       description: "Goes to the Customers grid page. Check the row for the provided Customer Email Address. Delete the Customer."
- 
-- filename: "AssertAuthorizationPopUpPasswordAutoCompleteOffActionGroup.xml"
-  repo: "https://github.com/magento/magento2/blob/2.3/app/code/Magento/Customer/Test/Mftf/ActionGroup/AssertAuthorizationPopUpPasswordAutoCompleteOffActionGroup.xml"
-  module: "Customer"
-  actiongroups:
-     - name: "AssertAuthorizationPopUpPasswordAutoCompleteOffActionGroup"
-       description: "Validates that the Storefront Customer Sign-In popup form does NOT contain the 'autocomplete=off' attribute."
- 
-- filename: "AdminEditCustomerAddressesFromActionGroup.xml"
-  repo: "https://github.com/magento/magento2/blob/2.3/app/code/Magento/Customer/Test/Mftf/ActionGroup/AdminEditCustomerAddressesFromActionGroup.xml"
-  module: "Customer"
-  actiongroups:
-     - name: "AdminEditCustomerAddressesFrom"
-       description: "Adds the provided Address to a Customer from the Admin Customers creation/edit page."
-
-     - name: "AdminEditCustomerAddressSetDefaultShippingAndBilling"
-       description: "EXTENDS: AdminEditCustomerAddressesFrom. Clicks on 'Set Default' for Billing/Shipping."
-
-     - name: "AdminEditCustomerAddressNoZipNoState"
-       description: "EXTENDS: AdminEditCustomerAddressesFrom. Removes 'selectState' and 'fillZipCode'. Clicks on 'Set Default' for Billing/Shipping."
-
-     - name: "SelectDropdownCustomerAddressAttributeValueActionGroup"
-       description: "Selects the provided Option in the provided Customer Address Attribute drop down menu. Clicks on Save."
- 
-- filename: "AssertCustomerLoggedInActionGroup.xml"
-  repo: "https://github.com/magento/magento2/blob/2.3/app/code/Magento/Customer/Test/Mftf/ActionGroup/AssertCustomerLoggedInActionGroup.xml"
-  module: "Customer"
-  actiongroups:
-     - name: "AssertCustomerWelcomeMessageActionGroup"
-       description: "Validates that the Welcome message is present and correct, including the provided Customers Full Name."
- 
-- filename: "SwitchAccountActionGroup.xml"
-  repo: "https://github.com/magento/magento2/blob/2.3/app/code/Magento/Customer/Test/Mftf/ActionGroup/SwitchAccountActionGroup.xml"
-  module: "Customer"
-  actiongroups:
-     - name: "SignOut"
-       description: "Click on the Backend Admin current Admin User menu. Click on 'Logout'. Validate that you are logged out."
- 
-- filename: "StorefrontAssertRegistrationPageFieldsActionGroup.xml"
-  repo: "https://github.com/magento/magento2/blob/2.3/app/code/Magento/Customer/Test/Mftf/ActionGroup/StorefrontAssertRegistrationPageFieldsActionGroup.xml"
-  module: "Customer"
-  actiongroups:
-     - name: "StorefrontAssertRegistrationPageFields"
+     - name: "SelectBillingInfoActionGroup"
        description: ""
- 
-- filename: "AdminAssertCustomerGroupPresentInGridActionGroup.xml"
-  repo: "https://github.com/magento/magento2/blob/2.3/app/code/Magento/Customer/Test/Mftf/ActionGroup/AdminAssertCustomerGroupPresentInGridActionGroup.xml"
-  module: "Customer"
+- filename: "CheckingWithMinicartActionGroup.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/Multishipping/Test/Mftf/ActionGroup/CheckingWithMinicartActionGroup.xml"
+  module: "Multishipping"
   actiongroups:
-     - name: "AdminAssertCustomerGroupPresentInGrid"
+     - name: "CheckingWithMinicartActionGroup"
        description: ""
- 
-- filename: "OpenStorefrontStoredPaymentMethodsPageActionGroup.xml"
-  repo: "https://github.com/magento/magento2/blob/2.3/app/code/Magento/Customer/Test/Mftf/ActionGroup/OpenStorefrontStoredPaymentMethodsPageActionGroup.xml"
-  module: "Customer"
+- filename: "PlaceOrderActionGroup.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/Multishipping/Test/Mftf/ActionGroup/PlaceOrderActionGroup.xml"
+  module: "Multishipping"
   actiongroups:
-     - name: "OpenStorefrontCustomerStoredPaymentMethodsPageActionGroup"
+     - name: "PlaceOrderActionGroup"
        description: ""
- 
-- filename: "StorefrontFillCustomerLoginFormWithWrongPasswordActionGroup.xml"
-  repo: "https://github.com/magento/magento2/blob/2.3/app/code/Magento/Customer/Test/Mftf/ActionGroup/StorefrontFillCustomerLoginFormWithWrongPasswordActionGroup.xml"
-  module: "Customer"
-  actiongroups:
-     - name: "StorefrontFillCustomerLoginFormWithWrongPasswordActionGroup"
-       description: "EXTENDS: StorefrontFillCustomerLoginFormActionGroup. Removes 'fillPassword'. Fills in an invalid Password."
- 
-- filename: "StorefrontClickSignOnCustomerLoginFormActionGroup.xml"
-  repo: "https://github.com/magento/magento2/blob/2.3/app/code/Magento/Customer/Test/Mftf/ActionGroup/StorefrontClickSignOnCustomerLoginFormActionGroup.xml"
-  module: "Customer"
-  actiongroups:
-     - name: "StorefrontClickSignOnCustomerLoginFormActionGroup"
-       description: "Click on the Customer Sign In button on the Storefront Customer Sign-In page."
- 
-- filename: "StorefrontCustomerAddressBookNotContainsActionGroup.xml"
-  repo: "https://github.com/magento/magento2/blob/2.3/app/code/Magento/Customer/Test/Mftf/ActionGroup/StorefrontCustomerAddressBookNotContainsActionGroup.xml"
-  module: "Customer"
-  actiongroups:
-     - name: "StorefrontCustomerAddressBookNotContains"
-       description: "Validate that the provided Address does NOT appear in the Storefront Customer Address list."
- 
-- filename: "StorefrontOpenMyAccountPageActionGroup.xml"
-  repo: "https://github.com/magento/magento2/blob/2.3/app/code/Magento/Customer/Test/Mftf/ActionGroup/StorefrontOpenMyAccountPageActionGroup.xml"
-  module: "Customer"
-  actiongroups:
-     - name: "StorefrontOpenMyAccountPageActionGroup"
+
+     - name: "StorefrontPlaceOrderForMultipleAddressesActionGroup"
        description: ""
- 
-- filename: "AdminDeleteCustomerGroupActionGroup.xml"
-  repo: "https://github.com/magento/magento2/blob/2.3/app/code/Magento/Customer/Test/Mftf/ActionGroup/AdminDeleteCustomerGroupActionGroup.xml"
-  module: "Customer"
+- filename: "AdminOpenNewIntegrationPageActionGroup.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/Integration/Test/Mftf/ActionGroup/AdminOpenNewIntegrationPageActionGroup.xml"
+  module: "Integration"
   actiongroups:
-     - name: "AdminDeleteCustomerGroupActionGroup"
-       description: "Goes to the Customer Groups grid page. Filter results based on provided Customer Group Name. Delete Customer from grid page."
- 
-- filename: "FillCustomerSignInPopupFormActionGroup.xml"
-  repo: "https://github.com/magento/magento2/blob/2.3/app/code/Magento/Customer/Test/Mftf/ActionGroup/FillCustomerSignInPopupFormActionGroup.xml"
-  module: "Customer"
+     - name: "AdminOpenNewIntegrationPageActionGroup"
+       description: ""
+- filename: "AdminSearchIntegrationInGridActionGroup.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/Integration/Test/Mftf/ActionGroup/AdminSearchIntegrationInGridActionGroup.xml"
+  module: "Integration"
   actiongroups:
-     - name: "FillCustomerSignInPopupFormActionGroup"
-       description: "Fills in the provided Customer details (Email and Password) in the Customer Sign In modal on the Storefront Checkout page. Clicks on Sign In."
- 
-- filename: "LoginToStorefrontActionGroup.xml"
-  repo: "https://github.com/magento/magento2/blob/2.3/app/code/Magento/Customer/Test/Mftf/ActionGroup/LoginToStorefrontActionGroup.xml"
-  module: "Customer"
+     - name: "AdminSearchIntegrationInGridActionGroup"
+       description: ""
+- filename: "AdminDeleteIntegrationEntityActionGroup.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/Integration/Test/Mftf/ActionGroup/AdminDeleteIntegrationEntityActionGroup.xml"
+  module: "Integration"
   actiongroups:
-     - name: "LoginToStorefrontActionGroup"
-       description: "Goes to the Storefront Customer Sign In page. Logs in using the provided Customer."
- 
-- filename: "StorefrontFillCustomerAccountCreationFormActionGroup.xml"
-  repo: "https://github.com/magento/magento2/blob/2.3/app/code/Magento/Customer/Test/Mftf/ActionGroup/StorefrontFillCustomerAccountCreationFormActionGroup.xml"
-  module: "Customer"
+     - name: "AdminDeleteIntegrationEntityActionGroup"
+       description: ""
+- filename: "AdminCreatesNewIntegrationActionGroup.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/Integration/Test/Mftf/ActionGroup/AdminCreatesNewIntegrationActionGroup.xml"
+  module: "Integration"
   actiongroups:
-     - name: "StorefrontFillCustomerAccountCreationFormActionGroup"
-       description: "Fills in the provided Customer details on the Storefront Customer creation page."
- 
-- filename: "OpenEditCustomerFromAdminActionGroup.xml"
-  repo: "https://github.com/magento/magento2/blob/2.3/app/code/Magento/Customer/Test/Mftf/ActionGroup/OpenEditCustomerFromAdminActionGroup.xml"
-  module: "Customer"
+     - name: "AdminCreatesNewIntegrationActionGroup"
+       description: ""
+- filename: "AdminNavigateToCreateIntegrationPageActionGroup.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/Integration/Test/Mftf/ActionGroup/AdminNavigateToCreateIntegrationPageActionGroup.xml"
+  module: "Integration"
   actiongroups:
-     - name: "OpenEditCustomerFromAdminActionGroup"
-       description: "Goes to the Admin Customers grid page. Filters the grid based on the provided Customer. Clicks on Edit."
+     - name: "AdminNavigateToCreateIntegrationPageActionGroup"
+       description: ""
+- filename: "AdminSubmitNewIntegrationFormActionGroup.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/Integration/Test/Mftf/ActionGroup/AdminSubmitNewIntegrationFormActionGroup.xml"
+  module: "Integration"
+  actiongroups:
+     - name: "AdminSubmitNewIntegrationFormActionGroup"
+       description: ""
+- filename: "AdminSaveIntegrationActionGroup.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/Integration/Test/Mftf/ActionGroup/AdminSaveIntegrationActionGroup.xml"
+  module: "Integration"
+  actiongroups:
+     - name: "AdminClickSaveButtonIntegrationFormActionGroup"
+       description: ""
+- filename: "AssertDeletedIntegrationIsNotInGridActionGroup.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/Integration/Test/Mftf/ActionGroup/AssertDeletedIntegrationIsNotInGridActionGroup.xml"
+  module: "Integration"
+  actiongroups:
+     - name: "AssertDeletedIntegrationIsNotInGridActionGroup"
+       description: ""
+- filename: "AdminFillIntegrationFormActionGroup.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/Integration/Test/Mftf/ActionGroup/AdminFillIntegrationFormActionGroup.xml"
+  module: "Integration"
+  actiongroups:
+     - name: "AdminFillIntegrationFormActionGroup"
+       description: ""
+- filename: "AssertAdminMessageCreateIntegrationEntityActionGroup.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/Integration/Test/Mftf/ActionGroup/AssertAdminMessageCreateIntegrationEntityActionGroup.xml"
+  module: "Integration"
+  actiongroups:
+     - name: "AssertAdminMessageCreateIntegrationEntityActionGroup"
+       description: ""
+- filename: "AssignBlockToCMSPageActionGroup.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/Cms/Test/Mftf/ActionGroup/AssignBlockToCMSPageActionGroup.xml"
+  module: "Cms"
+  actiongroups:
+     - name: "AssignBlockToCMSPage"
+       description: "Goes to the Admin Pages grid page. Adds a Block to a CMS Page. Clicks on Save."
+- filename: "AddStoreViewToCmsPageActionGroup.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/Cms/Test/Mftf/ActionGroup/AddStoreViewToCmsPageActionGroup.xml"
+  module: "Cms"
+  actiongroups:
+     - name: "AddStoreViewToCmsPageActionGroup"
+       description: "EXTENDS: navigateToCreatedCMSPage. Adds the provided Store View to a Page."
+- filename: "SaveAndCloseCMSBlockWithSplitButtonActionGroup.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/Cms/Test/Mftf/ActionGroup/SaveAndCloseCMSBlockWithSplitButtonActionGroup.xml"
+  module: "Cms"
+  actiongroups:
+     - name: "SaveAndCloseCMSBlockWithSplitButtonActionGroup"
+       description: "Clicks on the Save and Close button."
+- filename: "AdminCreateStoreViewActionGroup.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/Cms/Test/Mftf/ActionGroup/AdminCreateStoreViewActionGroup.xml"
+  module: "Cms"
+  actiongroups:
+     - name: "AdminCreateStoreViewActionGroup"
+       description: "Goes to the Admin Store View creation page. Fills in the provided Store View and Store details. Clicks on Save. Validates that the Success Message is present and correct."
+- filename: "FillOutUploadImagePopupActionGroup.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/Cms/Test/Mftf/ActionGroup/FillOutUploadImagePopupActionGroup.xml"
+  module: "Cms"
+  actiongroups:
+     - name: "FillOutUploadImagePopupActionGroup"
+       description: "Fills in the Image Description and Height fields. PLEASE NOTE: The values are Hardcoded using 'ImageUpload'."
+- filename: "AdminCMSPageMassActionSelectActionGroup.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/Cms/Test/Mftf/ActionGroup/AdminCMSPageMassActionSelectActionGroup.xml"
+  module: "Cms"
+  actiongroups:
+     - name: "AdminCMSPageMassActionSelectActionGroup"
+       description: "Selects the provided Action in the 'Mass Action' drop down menu on the Admin Pages grid."
+- filename: "AttachImageActionGroup.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/Cms/Test/Mftf/ActionGroup/AttachImageActionGroup.xml"
+  module: "Cms"
+  actiongroups:
+     - name: "AttachImageActionGroup"
+       description: "Uploads the provided Image to Media Gallery.
+                If you use this action group, you MUST add steps to delete the image in the 'after' steps."
+- filename: "SaveCMSBlockActionGroup.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/Cms/Test/Mftf/ActionGroup/SaveCMSBlockActionGroup.xml"
+  module: "Cms"
+  actiongroups:
+     - name: "SaveCMSBlockActionGroup"
+       description: "Clicks on the Save button. Validates that the Save message is present and correct. PLEASE NOTE: The message is Hardcoded."
+- filename: "AssertCMSPageNotFoundOnStorefrontActionGroup.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/Cms/Test/Mftf/ActionGroup/AssertCMSPageNotFoundOnStorefrontActionGroup.xml"
+  module: "Cms"
+  actiongroups:
+     - name: "AssertCMSPageNotFoundOnStorefrontActionGroup"
+       description: "Validates that the 'Whoops, our bad' error message is present and correct for a Storefront CMS Page that doesn't exist."
+- filename: "FillOutCMSPageContentActionGroup.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/Cms/Test/Mftf/ActionGroup/FillOutCMSPageContentActionGroup.xml"
+  module: "Cms"
+  actiongroups:
+     - name: "FillOutCMSPageContent"
+       description: "Fills out the Page details (Page Title, Content and URL Key) on the Admin Page creation/edit page. PLEASE NOTE: The values are Hardcoded using '_duplicatedCMSPage'."
+- filename: "AdminOpenCmsBlockActionGroup.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/Cms/Test/Mftf/ActionGroup/AdminOpenCmsBlockActionGroup.xml"
+  module: "Cms"
+  actiongroups:
+     - name: "AdminOpenCmsBlockActionGroup"
+       description: ""
+- filename: "AssertCMSPageContentActionGroup.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/Cms/Test/Mftf/ActionGroup/AssertCMSPageContentActionGroup.xml"
+  module: "Cms"
+  actiongroups:
+     - name: "AssertCMSPageContent"
+       description: "Validates that the CMS Page details are present and correct. PLEASE NOTE: The CMS Page data is Hardcoded, using '_duplicatedCMSPage'."
 
-     - name: "OpenEditCustomerAddressFromAdminActionGroup"
-       description: "Filters the Admin Customers Addresses based on the provided Address. Clicks on Edit."
+     - name: "AssertStoreFrontCMSPage"
+       description: "Validates that the provided CMS Page Title, Content and Heading are present and correct on a Storefront CMS Page."
+- filename: "CreateNewPageWithWidgetActionGroup.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/Cms/Test/Mftf/ActionGroup/CreateNewPageWithWidgetActionGroup.xml"
+  module: "Cms"
+  actiongroups:
+     - name: "CreateNewPageWithWidget"
+       description: "Goes to Admin CMS Page creation page. Adds the provided Title, Category, Conditions and Widget. Clicks on Save. Validates that the Success Message is present and correct."
+- filename: "NavigateToStorefrontForCreatedPageActionGroup.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/Cms/Test/Mftf/ActionGroup/NavigateToStorefrontForCreatedPageActionGroup.xml"
+  module: "Cms"
+  actiongroups:
+     - name: "NavigateToStorefrontForCreatedPageActionGroup"
+       description: "Goes to the provided Page on the Storefront."
+- filename: "AdminOpentCmsBlockActionGroup.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/Cms/Test/Mftf/ActionGroup/AdminOpentCmsBlockActionGroup.xml"
+  module: "Cms"
+  actiongroups:
+     - name: "AdminOpenCmsBlockActionGroup"
+       description: ""
+- filename: "AssertCMSPageInGridActionGroup.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/Cms/Test/Mftf/ActionGroup/AssertCMSPageInGridActionGroup.xml"
+  module: "Cms"
+  actiongroups:
+     - name: "AssertCMSPageInGridActionGroup"
+       description: "Validates that the provided CMS Page is present in the Admin Pages grid."
+- filename: "AdminSelectCMSPageInGridActionGroup.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/Cms/Test/Mftf/ActionGroup/AdminSelectCMSPageInGridActionGroup.xml"
+  module: "Cms"
+  actiongroups:
+     - name: "AdminSelectCMSPageInGridActionGroup"
+       description: "Checks the Row for the provided Identifier on the Admin Pages grid page."
+- filename: "AdminEditCMSPageContentActionGroup.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/Cms/Test/Mftf/ActionGroup/AdminEditCMSPageContentActionGroup.xml"
+  module: "Cms"
+  actiongroups:
+     - name: "AdminEditCMSPageContentActionGroup"
+       description: ""
+- filename: "FillOutBlockContentActionGroup.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/Cms/Test/Mftf/ActionGroup/FillOutBlockContentActionGroup.xml"
+  module: "Cms"
+  actiongroups:
+     - name: "FillOutBlockContent"
+       description: "Fills in the Block Title, Identifier, Store View and Content. PLEASE NOTE: The values are Hardcoded using '_defaultBlock'."
+- filename: "SetLayoutActionGroup.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/Cms/Test/Mftf/ActionGroup/SetLayoutActionGroup.xml"
+  module: "Cms"
+  actiongroups:
+     - name: "SetLayoutActionGroup"
+       description: "Sets the provided option for 'Layout', under 'Design' on the Page creation/edit page. "
+- filename: "NavigateToCreatedCMSPageActionGroup.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/Cms/Test/Mftf/ActionGroup/NavigateToCreatedCMSPageActionGroup.xml"
+  module: "Cms"
+  actiongroups:
+     - name: "NavigateToCreatedCMSPageActionGroup"
+       description: "Goes to the Admin CMS Pages page. "
+- filename: "SaveImageActionGroup.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/Cms/Test/Mftf/ActionGroup/SaveImageActionGroup.xml"
+  module: "Cms"
+  actiongroups:
+     - name: "SaveImageActionGroup"
+       description: "Clicks on Insert File in the Media Gallery."
+- filename: "DeletePageByUrlKeyActionGroup.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/Cms/Test/Mftf/ActionGroup/DeletePageByUrlKeyActionGroup.xml"
+  module: "Cms"
+  actiongroups:
+     - name: "DeletePageByUrlKeyActionGroup"
+       description: "Goes to the Admin CMS Pages page. Deletes a Page based on the provided URL Key. Validates that the Success Message is present and correct."
+- filename: "VerifyMediaGalleryStorageActionsActionGroup.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/Cms/Test/Mftf/ActionGroup/VerifyMediaGalleryStorageActionsActionGroup.xml"
+  module: "Cms"
+  actiongroups:
+     - name: "VerifyMediaGalleryStorageActionsActionGroup"
+       description: "Validates that the Media Gallery 'Cancel'/'Create Folder' buttons are present."
+- filename: "VerifyTinyMCEActionGroup.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/Cms/Test/Mftf/ActionGroup/VerifyTinyMCEActionGroup.xml"
+  module: "Cms"
+  actiongroups:
+     - name: "VerifyTinyMCEActionGroup"
+       description: "Goes to Admin CMS Page creation page. Validates that all of the Tiny MCE buttons are present."
 
-     - name: "DeleteCustomerFromAdminActionGroup"
-       description: "Goes to the Admin Customers grid page. Deletes the provided Customer from the grid. Validates that the Success message is present and correct."
+     - name: "VerifyMagentoEntityActionGroup"
+       description: "Validates that the Insert Widget and Insert Variables buttons are present."
+- filename: "SelectImageFromMediaStorageActionGroup.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/Cms/Test/Mftf/ActionGroup/SelectImageFromMediaStorageActionGroup.xml"
+  module: "Cms"
+  actiongroups:
+     - name: "clickBrowseBtnOnUploadPopup"
+       description: "Clicks on the Browse button in the 'Insert/edit image' model."
 
-     - name: "AdminClearCustomersFiltersActionGroup"
-       description: "Goes to the Admin Customers grid page. Clicks on 'Clear Filters'."
- 
-- filename: "AdminEditCustomerAddressNoZipNoStateActionGroup.xml"
-  repo: "https://github.com/magento/magento2/blob/2.3/app/code/Magento/Customer/Test/Mftf/ActionGroup/AdminEditCustomerAddressNoZipNoStateActionGroup.xml"
-  module: "Customer"
-  actiongroups:
-     - name: "AdminEditCustomerAddressNoZipNoState"
-       description: "EXTENDS: AdminEditCustomerAddressesFrom. Removes 'selectState' and 'fillZipCode'. Clicks on 'Set Default' for Billing/Shipping."
- 
-- filename: "OpenMyAccountPageActionGroup.xml"
-  repo: "https://github.com/magento/magento2/blob/2.3/app/code/Magento/Customer/Test/Mftf/ActionGroup/OpenMyAccountPageActionGroup.xml"
-  module: "Customer"
-  actiongroups:
-     - name: "OpenMyAccountPageActionGroup"
-       description: "Clicks on the Storefront Customer menu in the Header. Clicks on 'My Account'."
- 
-- filename: "StorefrontCustomerActionGroup.xml"
-  repo: "https://github.com/magento/magento2/blob/2.3/app/code/Magento/Customer/Test/Mftf/ActionGroup/StorefrontCustomerActionGroup.xml"
-  module: "Customer"
-  actiongroups:
-     - name: "CustomerLogoutStorefrontByMenuItemsActionGroup"
-       description: "Click on the Storefront Current Customer menu. Click on Logout."
- 
-- filename: "StorefrontCustomerChangeEmailActionGroup.xml"
-  repo: "https://github.com/magento/magento2/blob/2.3/app/code/Magento/Customer/Test/Mftf/ActionGroup/StorefrontCustomerChangeEmailActionGroup.xml"
-  module: "Customer"
-  actiongroups:
-     - name: "StorefrontCustomerChangeEmailActionGroup"
-       description: "Change the Customer Email Address for a Customer Account via the Storefront Customer Dashboard page."
- 
-- filename: "LoginToStorefrontWithEmailAndPasswordActionGroup.xml"
-  repo: "https://github.com/magento/magento2/blob/2.3/app/code/Magento/Customer/Test/Mftf/ActionGroup/LoginToStorefrontWithEmailAndPasswordActionGroup.xml"
-  module: "Customer"
-  actiongroups:
-     - name: "LoginToStorefrontWithEmailAndPassword"
-       description: "Goes to the Storefront Customer Sign In page. Logs in using the provided Email and Password."
- 
-- filename: "NavigateThroughCustomerTabsActionGroup.xml"
-  repo: "https://github.com/magento/magento2/blob/2.3/app/code/Magento/Customer/Test/Mftf/ActionGroup/NavigateThroughCustomerTabsActionGroup.xml"
-  module: "Customer"
-  actiongroups:
-     - name: "NavigateThroughCustomerTabsActionGroup"
-       description: "Clicks on the provided Storefront Customer Dashboard Side Bar tab names."
- 
-- filename: "StorefrontOpenCustomerAccountCreatePageActionGroup.xml"
-  repo: "https://github.com/magento/magento2/blob/2.3/app/code/Magento/Customer/Test/Mftf/ActionGroup/StorefrontOpenCustomerAccountCreatePageActionGroup.xml"
-  module: "Customer"
-  actiongroups:
-     - name: "StorefrontOpenCustomerAccountCreatePageActionGroup"
-       description: "Goes to the Storefront Customer Create page."
+     - name: "VerifyMediaGalleryStorageActions"
+       description: "Validates that the Media Gallery 'Cancel'/'Create Folder' buttons are present."
 
-     - name: "StorefrontOpenCustomerAccountCreatePageUsingStoreCodeInUrlActionGroup"
-       description: "Goes to the Storefront Customer Create page using Store code in URL option."
- 
-- filename: "AdminResetFilterInCustomerGridActionGroup.xml"
-  repo: "https://github.com/magento/magento2/blob/2.3/app/code/Magento/Customer/Test/Mftf/ActionGroup/AdminResetFilterInCustomerGridActionGroup.xml"
-  module: "Customer"
-  actiongroups:
-     - name: "AdminResetFilterInCustomerGrid"
-       description: "Clears the Admin Customer grid Filters. Sets the grid view to 'Default View'."
- 
-- filename: "AdminAssertCustomerDefaultShippingAddressActionGroup.xml"
-  repo: "https://github.com/magento/magento2/blob/2.3/app/code/Magento/Customer/Test/Mftf/ActionGroup/AdminAssertCustomerDefaultShippingAddressActionGroup.xml"
-  module: "Customer"
-  actiongroups:
-     - name: "AdminAssertCustomerDefaultShippingAddress"
-       description: "Validates that the provided Default Customer Shipping Address details are present and correct on the Customer creation/edit page. Under the section 'Addresses'."
- 
-- filename: "AdminAssertAddressInCustomersAddressGridActionGroup.xml"
-  repo: "https://github.com/magento/magento2/blob/2.3/app/code/Magento/Customer/Test/Mftf/ActionGroup/AdminAssertAddressInCustomersAddressGridActionGroup.xml"
-  module: "Customer"
-  actiongroups:
-     - name: "AdminAssertAddressInCustomersAddressGrid"
-       description: "Validates that the provided Customer Address is present in the Customer Address grid on the Customer creation/edit page. Under the 'Addresses' section."
- 
-- filename: "StorefrontCustomerAddressBookContainsActionGroup.xml"
-  repo: "https://github.com/magento/magento2/blob/2.3/app/code/Magento/Customer/Test/Mftf/ActionGroup/StorefrontCustomerAddressBookContainsActionGroup.xml"
-  module: "Customer"
-  actiongroups:
-     - name: "StorefrontCustomerAddressBookContains"
-       description: "Validate that the provided Address appears in the Storefront Customer Address list."
- 
-- filename: "AdminOpenCustomerEditPageActionGroup.xml"
-  repo: "https://github.com/magento/magento2/blob/2.3/app/code/Magento/Customer/Test/Mftf/ActionGroup/AdminOpenCustomerEditPageActionGroup.xml"
-  module: "Customer"
-  actiongroups:
-     - name: "AdminOpenCustomerEditPageActionGroup"
-       description: "Goes to the Admin Customer Edit page for the provided Customer ID #."
- 
-- filename: "EditCustomerAddressesFromAdminActionGroup.xml"
-  repo: "https://github.com/magento/magento2/blob/2.3/app/code/Magento/Customer/Test/Mftf/ActionGroup/EditCustomerAddressesFromAdminActionGroup.xml"
-  module: "Customer"
-  actiongroups:
-     - name: "EditCustomerAddressesFromAdminActionGroup"
-       description: "Adds the provided Address to a Customer from the Admin Customers creation/edit page."
- 
-- filename: "AdminFilterCustomerAddressGridByPhoneNumberActionGroup.xml"
-  repo: "https://github.com/magento/magento2/blob/2.3/app/code/Magento/Customer/Test/Mftf/ActionGroup/AdminFilterCustomerAddressGridByPhoneNumberActionGroup.xml"
-  module: "Customer"
-  actiongroups:
-     - name: "AdminFilterCustomerAddressGridByPhoneNumber"
-       description: "Filters the Admin Customers grid by the provided Phone Number."
- 
-- filename: "NavigateCustomerActionGroup.xml"
-  repo: "https://github.com/magento/magento2/blob/2.3/app/code/Magento/Customer/Test/Mftf/ActionGroup/NavigateCustomerActionGroup.xml"
-  module: "Customer"
-  actiongroups:
-     - name: "NavigateToAllCustomerPage"
-       description: "Goes to the Admin Customers grid page."
- 
-- filename: "AdminCustomerSaveAndContinueActionGroup.xml"
-  repo: "https://github.com/magento/magento2/blob/2.3/app/code/Magento/Customer/Test/Mftf/ActionGroup/AdminCustomerSaveAndContinueActionGroup.xml"
-  module: "Customer"
-  actiongroups:
-     - name: "AdminCustomerSaveAndContinue"
-       description: "Clicks on 'Save and Continue' on the Customer creation/edit page."
- 
-- filename: "AdminEditCustomerInformationFromActionGroup.xml"
-  repo: "https://github.com/magento/magento2/blob/2.3/app/code/Magento/Customer/Test/Mftf/ActionGroup/AdminEditCustomerInformationFromActionGroup.xml"
-  module: "Customer"
-  actiongroups:
-     - name: "AdminEditCustomerAccountInformationActionGroup"
-       description: "Fills in the Customer First Name, Last Name and Email. Clicks on Save and Continue."
- 
-- filename: "StorefrontCustomerGoToSidebarMenuActionGroup.xml"
-  repo: "https://github.com/magento/magento2/blob/2.3/app/code/Magento/Customer/Test/Mftf/ActionGroup/StorefrontCustomerGoToSidebarMenuActionGroup.xml"
-  module: "Customer"
-  actiongroups:
-     - name: "StorefrontCustomerGoToSidebarMenu"
-       description: "Click on the Storefront Customer Account Dashboard sub-menu based on the provided Menu Name."
- 
-- filename: "AdminCreateCustomerWithWebsiteAndStoreViewActionGroup.xml"
-  repo: "https://github.com/magento/magento2/blob/2.3/app/code/Magento/Customer/Test/Mftf/ActionGroup/AdminCreateCustomerWithWebsiteAndStoreViewActionGroup.xml"
-  module: "Customer"
-  actiongroups:
-     - name: "AdminCreateCustomerWithWebsiteAndStoreViewActionGroup"
-       description: "Goes to the Customer grid page. Click on 'Add New Customer'. Fills provided Customer Data. Fill provided Customer Address data. Assigns Product to Website and Store View. Click on Save Address."
+     - name: "CreateImageFolder"
+       description: "Creates a folder in the Media Gallery based on the provided Folder."
 
-     - name: "AdminCreateCustomerWithWebSiteAndGroup"
-       description: "Goes to the Customer grid page. Click on 'Add New Customer'. Fills provided Customer Data. Fill provided Customer Address data. Assigns Product to Website and Store View. Clicks on Save."
- 
-- filename: "StorefrontFillCustomerLoginFormActionGroup.xml"
-  repo: "https://github.com/magento/magento2/blob/2.3/app/code/Magento/Customer/Test/Mftf/ActionGroup/StorefrontFillCustomerLoginFormActionGroup.xml"
-  module: "Customer"
+     - name: "attachImage"
+       description: "Uploads the provided Image to Media Gallery.
+                If you use this action group, you MUST add steps to delete the image in the 'after' steps."
+
+     - name: "deleteImage"
+       description: "Deletes the selected Image from the Media Gallery."
+
+     - name: "saveImage"
+       description: "Clicks on Insert File in the Media Gallery."
+
+     - name: "fillOutUploadImagePopup"
+       description: "Fills in the Image Description and Height fields. PLEASE NOTE: The values are Hardcoded using 'ImageUpload'."
+
+     - name: "verifyOversizeValidationMsg"
+       description: "Validates that the Oversize validation message is present and correct."
+
+     - name: "verifyWrongExtensionValidationMsg"
+       description: "Validates that the Wrong Extensions validation message is present and correct."
+- filename: "AdminOpenCmsPageActionGroup.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/Cms/Test/Mftf/ActionGroup/AdminOpenCmsPageActionGroup.xml"
+  module: "Cms"
   actiongroups:
-     - name: "StorefrontFillCustomerLoginFormActionGroup"
-       description: "Fills Storefront Customer Login Email Address. Fills Storefront Customer Login Password."
- 
-- filename: "AdminSelectCustomerByEmailActionGroup.xml"
-  repo: "https://github.com/magento/magento2/blob/2.3/app/code/Magento/Customer/Test/Mftf/ActionGroup/AdminSelectCustomerByEmailActionGroup.xml"
-  module: "Customer"
+     - name: "AdminOpenCmsPageActionGroup"
+       description: ""
+- filename: "ClickBrowseBtnOnUploadPopupActionGroup.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/Cms/Test/Mftf/ActionGroup/ClickBrowseBtnOnUploadPopupActionGroup.xml"
+  module: "Cms"
   actiongroups:
-     - name: "AdminSelectCustomerByEmail"
-       description: "Checks the Customer for the provided Customer Email Address in the Admin Customers grid."
- 
-- filename: "AdminSelectAllCustomersActionGroup.xml"
-  repo: "https://github.com/magento/magento2/blob/2.3/app/code/Magento/Customer/Test/Mftf/ActionGroup/AdminSelectAllCustomersActionGroup.xml"
-  module: "Customer"
+     - name: "ClickBrowseBtnOnUploadPopupActionGroup"
+       description: "Clicks on the Browse button in the 'Insert/edit image' model."
+- filename: "NavigateToMediaFolderActionGroup.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/Cms/Test/Mftf/ActionGroup/NavigateToMediaFolderActionGroup.xml"
+  module: "Cms"
   actiongroups:
-     - name: "AdminSelectAllCustomers"
-       description: "Selects All of the Customers in the Admin Customers grid."
- 
-- filename: "StorefrontCustomerResetPasswordActionGroup.xml"
-  repo: "https://github.com/magento/magento2/blob/2.3/app/code/Magento/Customer/Test/Mftf/ActionGroup/StorefrontCustomerResetPasswordActionGroup.xml"
-  module: "Customer"
+     - name: "NavigateToMediaFolderActionGroup"
+       description: "Clicks on the provided Folder Name in the Storage folder tree."
+- filename: "AdminOpenCMSPagesGridActionGroup.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/Cms/Test/Mftf/ActionGroup/AdminOpenCMSPagesGridActionGroup.xml"
+  module: "Cms"
   actiongroups:
-     - name: "StorefrontCustomerResetPasswordActionGroup"
-       description: "Goes to the Storefront Customer Sign-In page. Clicks on 'Forgot Password'. Fills Email Address. Clicks on Reset Password."
- 
-- filename: "AdminAssertCustomerInCustomersGridActionGroup.xml"
-  repo: "https://github.com/magento/magento2/blob/2.3/app/code/Magento/Customer/Test/Mftf/ActionGroup/AdminAssertCustomerInCustomersGridActionGroup.xml"
-  module: "Customer"
+     - name: "AdminOpenCMSPagesGridActionGroup"
+       description: "Goes to the Admin Pages grid page."
+- filename: "ClearWidgetsFromCMSContentActionGroup.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/Cms/Test/Mftf/ActionGroup/ClearWidgetsFromCMSContentActionGroup.xml"
+  module: "Cms"
   actiongroups:
-     - name: "AdminAssertCustomerInCustomersGrid"
-       description: "Validates that the provided Customer is present and correct in the Backend Customer grid page."
- 
+     - name: "ClearWidgetsFromCMSContent"
+       description: "Goes to the Admin CMS Page Edit page for the Page ID number 2. Clears the Widget and replaces it with Text. PLEASE NOTE: The Page ID/Text are Hardcoded."
+
+     - name: "ClearWidgetsForCMSHomePageContentWYSIWYGDisabled"
+       description: ""
+- filename: "SearchBlockOnGridPageActionGroup.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/Cms/Test/Mftf/ActionGroup/SearchBlockOnGridPageActionGroup.xml"
+  module: "Cms"
+  actiongroups:
+     - name: "searchBlockOnGridPage"
+       description: "Searches the Admin CMS Blocks grid based on the provided Block."
+
+     - name: "deleteBlock"
+       description: "Goes to the Admin CMS Blocks page. Filters the grid based on the provided Block. Deletes the Block via the grid."
+- filename: "CreateImageFolderActionGroup.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/Cms/Test/Mftf/ActionGroup/CreateImageFolderActionGroup.xml"
+  module: "Cms"
+  actiongroups:
+     - name: "CreateImageFolderActionGroup"
+       description: "Creates a folder in the Media Gallery based on the provided Folder."
+- filename: "AdminInsertWidgetToCmsPageContentActionGroup.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/Cms/Test/Mftf/ActionGroup/AdminInsertWidgetToCmsPageContentActionGroup.xml"
+  module: "Cms"
+  actiongroups:
+     - name: "AdminInsertWidgetToCmsPageContentActionGroup"
+       description: "Insert widget to CMS Page content field. You are on CMS edit page, content tab is expanded."
+- filename: "DeleteImageFromStorageActionGroup.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/Cms/Test/Mftf/ActionGroup/DeleteImageFromStorageActionGroup.xml"
+  module: "Cms"
+  actiongroups:
+     - name: "DeleteImageFromStorageActionGroup"
+       description: "Deletes the provided Image from Storage."
+- filename: "AdminClickInsertWidgetActionGroup.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/Cms/Test/Mftf/ActionGroup/AdminClickInsertWidgetActionGroup.xml"
+  module: "Cms"
+  actiongroups:
+     - name: "AdminClickInsertWidgetActionGroup"
+       description: "Click 'Insert Widget' button in the opened widget popup"
+- filename: "SaveCmsPageActionGroup.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/Cms/Test/Mftf/ActionGroup/SaveCmsPageActionGroup.xml"
+  module: "Cms"
+  actiongroups:
+     - name: "SaveCmsPageActionGroup"
+       description: "Clicks on the Save button. Validates that the Success Message is present."
+- filename: "CMSActionGroup.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/Cms/Test/Mftf/ActionGroup/CMSActionGroup.xml"
+  module: "Cms"
+  actiongroups:
+     - name: "navigateToCreatedCMSPage"
+       description: "Goes to the Admin CMS Pages page. "
+
+     - name: "navigateToCreatedCMSBlockPage"
+       description: "Goes to the Admin Blocks page. Clicks on 'Edit' for the provided Block."
+
+     - name: "DeleteCMSBlockActionGroup"
+       description: "Goes to the Admin CMS Blocks page. Deletes the '_defaultBlock' Block. Validates that the Success Message is present and correct. PLEASE NOTE: The Block that is deleted it Hardcoded."
+
+     - name: "AddStoreViewToCmsPage"
+       description: "EXTENDS: navigateToCreatedCMSPage. Adds the provided Store View to a Page."
+
+     - name: "saveAndCloseCMSBlockWithSplitButton"
+       description: "Clicks on the Save and Close button."
+
+     - name: "navigateToStorefrontForCreatedPage"
+       description: "Goes to the provided Page on the Storefront."
+
+     - name: "saveCMSBlock"
+       description: "Clicks on the Save button. Validates that the Save message is present and correct. PLEASE NOTE: The message is Hardcoded."
+
+     - name: "saveAndContinueEditCmsPage"
+       description: "Clicks on the Save and Continue button."
+
+     - name: "saveCmsPage"
+       description: "Clicks on the Save button. Validates that the Success Message is present."
+
+     - name: "setLayout"
+       description: "Sets the provided option for 'Layout', under 'Design' on the Page creation/edit page. "
+- filename: "AdminCMSBlockContentActionGroup.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/Cms/Test/Mftf/ActionGroup/AdminCMSBlockContentActionGroup.xml"
+  module: "Cms"
+  actiongroups:
+     - name: "AdminAddImageToCMSBlockContent"
+       description: ""
+- filename: "SaveAndContinueEditCmsPageActionGroup.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/Cms/Test/Mftf/ActionGroup/SaveAndContinueEditCmsPageActionGroup.xml"
+  module: "Cms"
+  actiongroups:
+     - name: "SaveAndContinueEditCmsPageActionGroup"
+       description: "Clicks on the Save and Continue button."
+- filename: "StorefrontGoToCMSPageActionGroup.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/Cms/Test/Mftf/ActionGroup/StorefrontGoToCMSPageActionGroup.xml"
+  module: "Cms"
+  actiongroups:
+     - name: "StorefrontGoToCMSPageActionGroup"
+       description: "Goes to the provided Storefront CMS Page."
+- filename: "AdminInsertRecentlyViewedWidgetActionGroup.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/Cms/Test/Mftf/ActionGroup/AdminInsertRecentlyViewedWidgetActionGroup.xml"
+  module: "Cms"
+  actiongroups:
+     - name: "AdminInsertRecentlyViewedWidgetActionGroup"
+       description: ""
+- filename: "CreateNewPageWithAllValuesActionGroup.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/Cms/Test/Mftf/ActionGroup/CreateNewPageWithAllValuesActionGroup.xml"
+  module: "Cms"
+  actiongroups:
+     - name: "CreateNewPageWithAllValues"
+       description: "Goes to the Admin CMS creation page. Fills in the provided Page details (Title, Heading, URL, Store View and Hierarchy)."
+
+     - name: "CreateNewPageWithAllValuesAndContent"
+       description: ""
+- filename: "RestoreLayoutSettingActionGroup.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/Cms/Test/Mftf/ActionGroup/RestoreLayoutSettingActionGroup.xml"
+  module: "Cms"
+  actiongroups:
+     - name: "RestoreLayoutSetting"
+       description: "Sets the 'Default Page Layout' to '1 column'. PLEASE NOTE: The value is Hardcoded."
+- filename: "NavigateToCreatedCMSBlockPageActionGroup.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/Cms/Test/Mftf/ActionGroup/NavigateToCreatedCMSBlockPageActionGroup.xml"
+  module: "Cms"
+  actiongroups:
+     - name: "NavigateToCreatedCMSBlockPageActionGroup"
+       description: "Goes to the Admin Blocks page. Clicks on 'Edit' for the provided Block."
+- filename: "AssertCMSBlockContentActionGroup.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/Cms/Test/Mftf/ActionGroup/AssertCMSBlockContentActionGroup.xml"
+  module: "Cms"
+  actiongroups:
+     - name: "AssertBlockContent"
+       description: "Validates that the Block details are present and correct. PLEASE NOTE: The Block data is Hardcoded, using '_defaultBlock'."
+- filename: "NavigateToAdminContentManagementPageActionGroup.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/Cms/Test/Mftf/ActionGroup/NavigateToAdminContentManagementPageActionGroup.xml"
+  module: "Cms"
+  actiongroups:
+     - name: "NavigateToAdminContentManagementPageActionGroup"
+       description: "Goes to the 'Configuration' page for 'Content Management'."
+- filename: "AdminEditPropertiesTabForSwatchProductAtributeActionGroup.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/Swatches/Test/Mftf/ActionGroup/AdminEditPropertiesTabForSwatchProductAtributeActionGroup.xml"
+  module: "Swatches"
+  actiongroups:
+     - name: "AdminAddSwatchOptionAndFillFieldsActionGroup"
+       description: ""
+
+     - name: "AdminUpdateProductPreviewImageActionGroup"
+       description: ""
+- filename: "AddSwatchToProductActionGroup.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/Swatches/Test/Mftf/ActionGroup/AddSwatchToProductActionGroup.xml"
+  module: "Swatches"
+  actiongroups:
+     - name: "AddVisualSwatchToProductActionGroup"
+       description: "Adds the provided Visual Swatch Attribute and Options (2) to a Product on the Admin Product creation/edit page. Clicks on Save. Validates that the Success Message is present."
+
+     - name: "AddVisualSwatchToProductWithStorefrontConfigActionGroup"
+       description: "EXTENDS: AddVisualSwatchToProductActionGroup. Add the provided Visual Swatch Attribute and Options (2) to a Product with Storefront Configurations."
+
+     - name: "AddVisualSwatchWithProductWithStorefrontPreviewImageConfigActionGroup"
+       description: ""
+
+     - name: "AddTextSwatchToProductActionGroup"
+       description: "Add text swatch property attribute."
+- filename: "StorefrontProductActionGroup.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/Swatches/Test/Mftf/ActionGroup/StorefrontProductActionGroup.xml"
+  module: "Swatches"
+  actiongroups:
+     - name: "StorefrontSelectSwatchOptionOnProductPage"
+       description: ""
+
+     - name: "StorefrontAssertSwatchOptionPrice"
+       description: ""
+
+     - name: "StorefrontSelectSwatchOptionOnProductPageAndCheckImage"
+       description: ""
+- filename: "StorefrontAddProductWithSwatchAttributeToTheCartActionGroup.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/Swatches/Test/Mftf/ActionGroup/StorefrontAddProductWithSwatchAttributeToTheCartActionGroup.xml"
+  module: "Swatches"
+  actiongroups:
+     - name: "StorefrontAddProductWithSwatchesToTheCartActionGroup"
+       description: ""
+
+     - name: "StorefrontUpdateCartConfigurableProductWithSwatches"
+       description: ""
+- filename: "ColorPickerActionGroup.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/Swatches/Test/Mftf/ActionGroup/ColorPickerActionGroup.xml"
+  module: "Swatches"
+  actiongroups:
+     - name: "setColorPickerByHex"
+       description: "Sets the provided HEX value in the provided Color Picker."
+
+     - name: "assertSwatchColor"
+       description: "Validates that the provided Color Picker contains the provided Style."
+
+     - name: "assertStorefrontSwatchColor"
+       description: "Validates that the Storefront Product has the provided Swatch with the provided Color."
+
+     - name: "openSwatchMenuByIndex"
+       description: "Options the Swatch Menu based on the provided Index."
+- filename: "DisplayOutOfStockProductActionGroup.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/CatalogInventory/Test/Mftf/ActionGroup/DisplayOutOfStockProductActionGroup.xml"
+  module: "CatalogInventory"
+  actiongroups:
+     - name: "displayOutOfStockProduct"
+       description: "Goes to the 'Configuration' page for 'Inventory'. Enables 'Display Out of Stock Products'. Clicks on the Save button."
+
+     - name: "noDisplayOutOfStockProduct"
+       description: "Goes to the 'Configuration' page for 'Inventory'. Disables 'Display Out of Stock Products'. Clicks on the Save button."
+- filename: "AdminCatalogInventoryChangeManageStockActionGroup.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/CatalogInventory/Test/Mftf/ActionGroup/AdminCatalogInventoryChangeManageStockActionGroup.xml"
+  module: "CatalogInventory"
+  actiongroups:
+     - name: "AdminCatalogInventoryChangeManageStockActionGroup"
+       description: "Opens advanced inventory modal if it has not opened yet. Sets Manage stock value."
+- filename: "StorefrontAssertProductStockStatusActionGroup.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/CatalogInventory/Test/Mftf/ActionGroup/StorefrontAssertProductStockStatusActionGroup.xml"
+  module: "CatalogInventory"
+  actiongroups:
+     - name: "StorefrontCheckProductStockStatus"
+       description: ""
+- filename: "AdminCatalogInventoryConfigurationActionGroup.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/CatalogInventory/Test/Mftf/ActionGroup/AdminCatalogInventoryConfigurationActionGroup.xml"
+  module: "CatalogInventory"
+  actiongroups:
+     - name: "AdminCatalogInventoryConfigurationMaxQtyAllowedInShoppingCartValidationActionGroup"
+       description: ""
+- filename: "AdminProductActionGroup.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/CatalogInventory/Test/Mftf/ActionGroup/AdminProductActionGroup.xml"
+  module: "CatalogInventory"
+  actiongroups:
+     - name: "AdminProductSetMaxQtyAllowedInShoppingCart"
+       description: ""
+
+     - name: "AdminProductMaxQtyAllowedInShoppingCartValidationActionGroup"
+       description: ""
+- filename: "AdminOrderActionOnGridActionGroup.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/Sales/Test/Mftf/ActionGroup/AdminOrderActionOnGridActionGroup.xml"
+  module: "Sales"
+  actiongroups:
+     - name: "AdminOrderActionOnGridActionGroup"
+       description: ""
+
+     - name: "AdminTwoOrderActionOnGridActionGroup"
+       description: ""
+- filename: "StorefrontFillOrdersAndReturnsFormActionGroup.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/Sales/Test/Mftf/ActionGroup/StorefrontFillOrdersAndReturnsFormActionGroup.xml"
+  module: "Sales"
+  actiongroups:
+     - name: "StorefrontFillOrdersAndReturnsFormActionGroup"
+       description: ""
+- filename: "SelectCheckMoneyPaymentMethodActionGroup.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/Sales/Test/Mftf/ActionGroup/SelectCheckMoneyPaymentMethodActionGroup.xml"
+  module: "Sales"
+  actiongroups:
+     - name: "SelectCheckMoneyPaymentMethodActionGroup"
+       description: "Selects the 'Check / Money Order' Payment Method on the Admin Create New Order page."
+- filename: "AdminAddToOrderCouponCodeActionGroup.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/Sales/Test/Mftf/ActionGroup/AdminAddToOrderCouponCodeActionGroup.xml"
+  module: "Sales"
+  actiongroups:
+     - name: "AdminAddToOrderCouponCodeActionGroup"
+       description: ""
+- filename: "AdminAssertProductQtyInGridActionGroup.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/Sales/Test/Mftf/ActionGroup/AdminAssertProductQtyInGridActionGroup.xml"
+  module: "Sales"
+  actiongroups:
+     - name: "AdminAssertProductQtyInGridActionGroup"
+       description: "Goes tot he Admin Catalog Product grid page. Filters the grid based on the provided Product SKU. Validates that the provided Product Qty is present."
+- filename: "AdminApplyCouponToOrderActionGroup.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/Sales/Test/Mftf/ActionGroup/AdminApplyCouponToOrderActionGroup.xml"
+  module: "Sales"
+  actiongroups:
+     - name: "AdminApplyCouponToOrderActionGroup"
+       description: ""
+- filename: "AssertAdminItemOrderedErrorActionGroup.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/Sales/Test/Mftf/ActionGroup/AssertAdminItemOrderedErrorActionGroup.xml"
+  module: "Sales"
+  actiongroups:
+     - name: "AssertAdminItemOrderedErrorActionGroup"
+       description: "Assert that item in 'Item Ordered' grid has an error/notice"
+- filename: "AdminSubmitOrderActionGroup.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/Sales/Test/Mftf/ActionGroup/AdminSubmitOrderActionGroup.xml"
+  module: "Sales"
+  actiongroups:
+     - name: "AdminSubmitOrderActionGroup"
+       description: ""
+- filename: "AdminAddToOrderBundleProductActionGroup.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/Sales/Test/Mftf/ActionGroup/AdminAddToOrderBundleProductActionGroup.xml"
+  module: "Sales"
+  actiongroups:
+     - name: "AdminAddToOrderBundleProductActionGroup"
+       description: ""
+- filename: "AdminOpenShipmentFromOrderPageActionGroup.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/Sales/Test/Mftf/ActionGroup/AdminOpenShipmentFromOrderPageActionGroup.xml"
+  module: "Sales"
+  actiongroups:
+     - name: "AdminOpenShipmentFromOrderPageActionGroup"
+       description: "Admin open shipment from order"
+- filename: "AdminStartToCreateCreditMemoFromOrderPageActionGroup.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/Sales/Test/Mftf/ActionGroup/AdminStartToCreateCreditMemoFromOrderPageActionGroup.xml"
+  module: "Sales"
+  actiongroups:
+     - name: "AdminStartToCreateCreditMemoFromOrderPageActionGroup"
+       description: "Admin start to create credit memo from order"
+- filename: "AdminOrderStatusFormFillAndSaveActionGroup.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/Sales/Test/Mftf/ActionGroup/AdminOrderStatusFormFillAndSaveActionGroup.xml"
+  module: "Sales"
+  actiongroups:
+     - name: "AdminOrderStatusFormFillAndSave"
+       description: "Fills in the provided Status and Label on the Admin Order Status section."
+- filename: "VerifyBasicOrderInformationActionGroup.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/Sales/Test/Mftf/ActionGroup/VerifyBasicOrderInformationActionGroup.xml"
+  module: "Sales"
+  actiongroups:
+     - name: "VerifyBasicOrderInformationActionGroup"
+       description: "Validates that the provided Customer, Shipping/Billing Address and Customer Group are present and correct on the Admin Orders view page."
+- filename: "AdminSelectFlatRateShippingMethodActionGroup.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/Sales/Test/Mftf/ActionGroup/AdminSelectFlatRateShippingMethodActionGroup.xml"
+  module: "Sales"
+  actiongroups:
+     - name: "AdminSelectFlatRateShippingMethodActionGroup"
+       description: ""
+- filename: "GoToInvoiceIntoOrderActionGroup.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/Sales/Test/Mftf/ActionGroup/GoToInvoiceIntoOrderActionGroup.xml"
+  module: "Sales"
+  actiongroups:
+     - name: "GoToInvoiceIntoOrderActionGroup"
+       description: "Clicks on 'Invoice' on the Admin Orders view page. Validates that the URL and Page Title are correct."
+- filename: "AdminStartCreateCreditMemoFromOrderPageActionGroup.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/Sales/Test/Mftf/ActionGroup/AdminStartCreateCreditMemoFromOrderPageActionGroup.xml"
+  module: "Sales"
+  actiongroups:
+     - name: "AdminStartCreateCreditMemoFromOrderPageActionGroup"
+       description: "Start to create Credit Memo from order page"
+- filename: "AdminShipThePendingOrderActionGroup.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/Sales/Test/Mftf/ActionGroup/AdminShipThePendingOrderActionGroup.xml"
+  module: "Sales"
+  actiongroups:
+     - name: "AdminShipThePendingOrderActionGroup"
+       description: ""
+- filename: "FilterOrderGridByIdActionGroup.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/Sales/Test/Mftf/ActionGroup/FilterOrderGridByIdActionGroup.xml"
+  module: "Sales"
+  actiongroups:
+     - name: "FilterOrderGridByIdActionGroup"
+       description: "Goes to the Admin Orders page. Filters the grid based on the provided Order ID."
+- filename: "AdminFilterProductInCreateOrderActionGroup.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/Sales/Test/Mftf/ActionGroup/AdminFilterProductInCreateOrderActionGroup.xml"
+  module: "Sales"
+  actiongroups:
+     - name: "AdminFilterProductInCreateOrderActionGroup"
+       description: ""
+- filename: "AssertAdminItemOrderedErrorNotVisibleActionGroup.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/Sales/Test/Mftf/ActionGroup/AssertAdminItemOrderedErrorNotVisibleActionGroup.xml"
+  module: "Sales"
+  actiongroups:
+     - name: "AssertAdminItemOrderedErrorNotVisibleActionGroup"
+       description: "Assert that item in 'Item Ordered' grid does not have an error/notice"
+- filename: "AssertStorefrontShippingDescriptionInOrderViewActionGroup.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/Sales/Test/Mftf/ActionGroup/AssertStorefrontShippingDescriptionInOrderViewActionGroup.xml"
+  module: "Sales"
+  actiongroups:
+     - name: "AssertStorefrontShippingDescriptionInOrderViewActionGroup"
+       description: "Validates that the Shipping Description will shown in Shipping total description."
+- filename: "StorefrontAssertSalesPrintOrderBillingAddressActionGroup.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/Sales/Test/Mftf/ActionGroup/StorefrontAssertSalesPrintOrderBillingAddressActionGroup.xml"
+  module: "Sales"
+  actiongroups:
+     - name: "AssertSalesPrintOrderBillingAddress"
+       description: ""
+- filename: "AdminOpenInvoiceFromOrderPageActionGroup.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/Sales/Test/Mftf/ActionGroup/AdminOpenInvoiceFromOrderPageActionGroup.xml"
+  module: "Sales"
+  actiongroups:
+     - name: "AdminOpenInvoiceFromOrderPageActionGroup"
+       description: "Admin open invoice from order"
+- filename: "AdminAddToOrderDownloadableProductActionGroup.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/Sales/Test/Mftf/ActionGroup/AdminAddToOrderDownloadableProductActionGroup.xml"
+  module: "Sales"
+  actiongroups:
+     - name: "AdminAddToOrderDownloadableProductActionGroup"
+       description: ""
+- filename: "AdminOrderGridActionGroup.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/Sales/Test/Mftf/ActionGroup/AdminOrderGridActionGroup.xml"
+  module: "Sales"
+  actiongroups:
+     - name: "filterOrderGridById"
+       description: "Goes to the Admin Orders page. Filters the grid based on the provided Order ID."
+
+     - name: "filterOrderGridByBillingName"
+       description: "Goes to the Admin Orders page. Filters the grid based on the provided Customer."
+
+     - name: "filterOrderGridByBaseTotalRange"
+       description: "Goes to the Admin Orders page. Filters the grid based on the provided Grand Total From/To values."
+
+     - name: "filterOrderGridByPurchaseDate"
+       description: "Goes to the Admin Orders page. Filters the grid based on the provided Purchased Date From/To values."
+
+     - name: "filterOrderGridByStatus"
+       description: "Filters the Admin Orders grid based on the provided Order Status."
+
+     - name: "AdminOrdersGridClearFiltersActionGroup"
+       description: "Goes to the Admin Orders grid page. Clicks on 'Clear Filters', if present."
+
+     - name: "OpenOrderById"
+       description: "EXTENDS: filterOrderGridById. Clicks on the 1st row of the Admin Orders grid."
+- filename: "AdminAssertOrderAvailableButtonsActionGroup.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/Sales/Test/Mftf/ActionGroup/AdminAssertOrderAvailableButtonsActionGroup.xml"
+  module: "Sales"
+  actiongroups:
+     - name: "AdminAssertOrderAvailableButtonsActionGroup"
+       description: ""
+- filename: "StorefrontCustomerReorderActionGroup.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/Sales/Test/Mftf/ActionGroup/StorefrontCustomerReorderActionGroup.xml"
+  module: "Sales"
+  actiongroups:
+     - name: "StorefrontCustomerReorderActionGroup"
+       description: "Navigate to customer dashboard -&gt; orders. Press 'reorder' button for specified order id. Notice: customer should be logged in."
+- filename: "NavigateToNewOrderPageExistingCustomerActionGroup.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/Sales/Test/Mftf/ActionGroup/NavigateToNewOrderPageExistingCustomerActionGroup.xml"
+  module: "Sales"
+  actiongroups:
+     - name: "NavigateToNewOrderPageExistingCustomerActionGroup"
+       description: ""
+- filename: "CreateNewOrderActionGroup.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/Sales/Test/Mftf/ActionGroup/CreateNewOrderActionGroup.xml"
+  module: "Sales"
+  actiongroups:
+     - name: "useBraintreeForMasterCard"
+       description: "Selects 'Braintree' as the Payment Method on the Admin New Order creation page. Enters Credit Card details. PLEASE NOTE: The Credit Card details used are Hardcoded using 'PaymentAndShippingInfo'."
+- filename: "AdminAddToOrderConfigurableProductActionGroup.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/Sales/Test/Mftf/ActionGroup/AdminAddToOrderConfigurableProductActionGroup.xml"
+  module: "Sales"
+  actiongroups:
+     - name: "AdminAddToOrderConfigurableProductActionGroup"
+       description: ""
+- filename: "FilterShipmentGridByOrderIdActionGroup.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/Sales/Test/Mftf/ActionGroup/FilterShipmentGridByOrderIdActionGroup.xml"
+  module: "Sales"
+  actiongroups:
+     - name: "FilterShipmentGridByOrderIdActionGroup"
+       description: ""
+- filename: "AdminOpenCreditMemoFromOrderPageActionGroup.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/Sales/Test/Mftf/ActionGroup/AdminOpenCreditMemoFromOrderPageActionGroup.xml"
+  module: "Sales"
+  actiongroups:
+     - name: "AdminOpenCreditMemoFromOrderPageActionGroup"
+       description: "Admin open creditmemo from order"
+- filename: "SelectActionForOrdersActionGroup.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/Sales/Test/Mftf/ActionGroup/SelectActionForOrdersActionGroup.xml"
+  module: "Sales"
+  actiongroups:
+     - name: "SelectActionForOrdersActionGroup"
+       description: ""
+- filename: "StartCreateInvoiceFromOrderPageActionGroup.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/Sales/Test/Mftf/ActionGroup/StartCreateInvoiceFromOrderPageActionGroup.xml"
+  module: "Sales"
+  actiongroups:
+     - name: "StartCreateInvoiceFromOrderPageActionGroup"
+       description: "Clicks on 'Invoice' on the Admin Orders view page. Validates that the URL and Page Title are correct."
+- filename: "CancelPendingOrderActionGroup.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/Sales/Test/Mftf/ActionGroup/CancelPendingOrderActionGroup.xml"
+  module: "Sales"
+  actiongroups:
+     - name: "CancelPendingOrderActionGroup"
+       description: "Cancels the Pending Order on the Admin Orders view page. Validates that the provided Order Status is present and correct."
+- filename: "AdminAssertRefundOrderStatusInCommentsHistoryActionGroup.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/Sales/Test/Mftf/ActionGroup/AdminAssertRefundOrderStatusInCommentsHistoryActionGroup.xml"
+  module: "Sales"
+  actiongroups:
+     - name: "AdminAssertRefundOrderStatusCommentsHistoryActionGroup"
+       description: "Clicks on the 'Comments History' on Admin View Order page. Validates that the provided Order Status and Refund message are present and correct."
+- filename: "AdminAssertRefundInRefundsGridActionGroup.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/Sales/Test/Mftf/ActionGroup/AdminAssertRefundInRefundsGridActionGroup.xml"
+  module: "Sales"
+  actiongroups:
+     - name: "AdminAssertRefundInRefundsGridActionGroup"
+       description: "Goes to the Admin Credit Memo grid page. Filters the grid for the provided Order ID, Memo ID, Refund Status and Refunded Total. Validates that the provided details are present and correct."
+- filename: "AssertOrderStatusFormSaveSuccessActionGroup.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/Sales/Test/Mftf/ActionGroup/AssertOrderStatusFormSaveSuccessActionGroup.xml"
+  module: "Sales"
+  actiongroups:
+     - name: "AssertOrderStatusFormSaveSuccess"
+       description: "Validates that the Success Message is present and correct."
+- filename: "StorefrontOrderActionGroupActionGroup.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/Sales/Test/Mftf/ActionGroup/StorefrontOrderActionGroupActionGroup.xml"
+  module: "Sales"
+  actiongroups:
+     - name: "StorefrontSearchGuestOrderActionGroup"
+       description: "Goes to the Storefront Customer Orders and Returns page. Fills in the provided Order ID, Billing Last Name and Email. Clicks on Continue. Validates that the URL is correct."
+- filename: "AdminCreateInvoiceActionGroup.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/Sales/Test/Mftf/ActionGroup/AdminCreateInvoiceActionGroup.xml"
+  module: "Sales"
+  actiongroups:
+     - name: "AdminCreateInvoiceActionGroup"
+       description: ""
+
+     - name: "AdminCreateInvoiceAndShipmentActionGroup"
+       description: ""
+
+     - name: "AdminCreateInvoiceAndCreditMemoActionGroup"
+       description: ""
+- filename: "AdminCreditMemoActionGroup.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/Sales/Test/Mftf/ActionGroup/AdminCreditMemoActionGroup.xml"
+  module: "Sales"
+  actiongroups:
+     - name: "verifyBasicCreditMemoInformation"
+       description: "Validates that the provided Customer, Shipping/Billing Address and Customer Group are present and correct on the Admin Credit Memo view page."
+
+     - name: "seeProductInItemsRefunded"
+       description: "Validates that the provided Product appears in the 'Product' column on the Admin Credit Memo view page."
+
+     - name: "StartToCreateCreditMemoActionGroup"
+       description: ""
+
+     - name: "SubmitCreditMemoActionGroup"
+       description: ""
+
+     - name: "UpdateCreditMemoTotalsActionGroup"
+       description: ""
+- filename: "AssertAdminShippingDescriptionInOrderViewActionGroup.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/Sales/Test/Mftf/ActionGroup/AssertAdminShippingDescriptionInOrderViewActionGroup.xml"
+  module: "Sales"
+  actiongroups:
+     - name: "AssertAdminShippingDescriptionInOrderViewActionGroup"
+       description: "Validates that the Shipping Description will shown in Shipping total description."
+- filename: "FillOrderCustomerInformationActionGroup.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/Sales/Test/Mftf/ActionGroup/FillOrderCustomerInformationActionGroup.xml"
+  module: "Sales"
+  actiongroups:
+     - name: "FillOrderCustomerInformationActionGroup"
+       description: "Fills in the provided Customer and Address details on the Admin 'Create New Order for' page."
+- filename: "CreateOrderToPrintPageActionGroup.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/Sales/Test/Mftf/ActionGroup/CreateOrderToPrintPageActionGroup.xml"
+  module: "Sales"
+  actiongroups:
+     - name: "CreateOrderToPrintPageActionGroup"
+       description: "Goes to the provided Storefront Category page. Adds the Product to the Cart. Places the Order. Clicks on Print Order."
+
+     - name: "CreateOrderToPrintPageWithSelectedPaymentMethodActionGroup"
+       description: "EXTENDS: CreateOrderToPrintPageActionGroup. Clicks on 'Check / Money Order'."
+- filename: "FilterOrderStatusByLabelAndCodeActionGroup.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/Sales/Test/Mftf/ActionGroup/FilterOrderStatusByLabelAndCodeActionGroup.xml"
+  module: "Sales"
+  actiongroups:
+     - name: "FilterOrderStatusByLabelAndCodeActionGroup"
+       description: ""
+- filename: "SubmitInvoiceActionGroup.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/Sales/Test/Mftf/ActionGroup/SubmitInvoiceActionGroup.xml"
+  module: "Sales"
+  actiongroups:
+     - name: "SubmitInvoiceActionGroup"
+       description: "Clicks on 'Submit Invoice' on the Admin 'New Invoice' page. Validates that the Success Message is present and correct. Validates that the Order ID appears in the URL."
+- filename: "AdminMoveProductToItemsOrderedFromShoppingCartActionGroup.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/Sales/Test/Mftf/ActionGroup/AdminMoveProductToItemsOrderedFromShoppingCartActionGroup.xml"
+  module: "Sales"
+  actiongroups:
+     - name: "AdminMoveProductToItemsOrderedFromShoppingCartActionGroup"
+       description: "Move product to the 'Items Ordered' section from shopping cart."
+- filename: "AdminOpenAndFillCreditMemoRefundActionGroup.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/Sales/Test/Mftf/ActionGroup/AdminOpenAndFillCreditMemoRefundActionGroup.xml"
+  module: "Sales"
+  actiongroups:
+     - name: "AdminOpenAndFillCreditMemoRefundActionGroup"
+       description: "Clicks on the 'Credit Memos' section on the Admin Orders edit page. Fills in the provided Refund details (Qty to Refund, Shipping Refund, Adjustment Refund, Adjustment Fee and Row number)."
+
+     - name: "AdminOpenAndFillCreditMemoRefundAndBackToStockActionGroup"
+       description: "EXTENDS: AdminOpenAndFillCreditMemoRefundActionGroup. Checks 'Return to Stock'."
+- filename: "AdminInvoiceActionGroup.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/Sales/Test/Mftf/ActionGroup/AdminInvoiceActionGroup.xml"
+  module: "Sales"
+  actiongroups:
+     - name: "verifyBasicInvoiceInformation"
+       description: "Validates that the provided Customer, Address and Customer Group details are present and correct on the Admin View Invoice page."
+
+     - name: "seeProductInInvoiceItems"
+       description: "Validates that the provided Product appears under the 'SKU' column in the Admin Invoices edit page."
+
+     - name: "adminFastCreateInvoice"
+       description: "Clicks on 'Invoice' on the Admin Orders view page. Clicks on 'Submit Invoice'. Clicks on 'View Invoice'."
+
+     - name: "clearInvoicesGridFilters"
+       description: "Goes to the Admin Invoices grid page. Clicks on 'Clear Filters', if present."
+
+     - name: "goToInvoiceIntoOrder"
+       description: "Clicks on 'Invoice' on the Admin Orders view page. Validates that the URL and Page Title are correct."
+
+     - name: "StartCreateInvoiceFromOrderPage"
+       description: "Clicks on 'Invoice' on the Admin Orders view page. Validates that the URL and Page Title are correct."
+
+     - name: "SubmitInvoice"
+       description: "Clicks on 'Submit Invoice' on the Admin 'New Invoice' page. Validates that the Success Message is present and correct. Validates that the Order ID appears in the URL."
+
+     - name: "filterInvoiceGridByOrderId"
+       description: "Goes to the Admin Invoices grid page. Filters the grid for the provided Order ID."
+
+     - name: "FilterInvoiceGridByOrderIdWithCleanFiltersActionGroup"
+       description: ""
+- filename: "AdminAssertProductInShoppingCartSectionActionGroup.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/Sales/Test/Mftf/ActionGroup/AdminAssertProductInShoppingCartSectionActionGroup.xml"
+  module: "Sales"
+  actiongroups:
+     - name: "AdminAssertProductInShoppingCartSectionActionGroup"
+       description: "Assert product in Shopping cart section in Customer's Activities block on Create Order Page."
+- filename: "OpenOrderByIdActionGroup.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/Sales/Test/Mftf/ActionGroup/OpenOrderByIdActionGroup.xml"
+  module: "Sales"
+  actiongroups:
+     - name: "OpenOrderByIdActionGroup"
+       description: "EXTENDS: FilterOrderGridByIdActionGroup. Clicks on the 1st row of the Admin Orders grid."
+- filename: "OrderSelectFlatRateShippingActionGroup.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/Sales/Test/Mftf/ActionGroup/OrderSelectFlatRateShippingActionGroup.xml"
+  module: "Sales"
+  actiongroups:
+     - name: "OrderSelectFlatRateShippingActionGroup"
+       description: "Selects the 'Flat Rate' Shipping Method on the Admin 'Create New Order for' page."
+- filename: "AssertOrderStatusFormSaveDuplicateErrorActionGroup.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/Sales/Test/Mftf/ActionGroup/AssertOrderStatusFormSaveDuplicateErrorActionGroup.xml"
+  module: "Sales"
+  actiongroups:
+     - name: "AssertOrderStatusFormSaveDuplicateError"
+       description: "Validates that the 'Duplicate Order' Error Message is present and correct."
+- filename: "VerifyCreatedOrderInformationActionGroup.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/Sales/Test/Mftf/ActionGroup/VerifyCreatedOrderInformationActionGroup.xml"
+  module: "Sales"
+  actiongroups:
+     - name: "VerifyCreatedOrderInformationActionGroup"
+       description: "Validates that the Success Message, Order Status (Pending) and Order ID are present and correct."
+- filename: "AdminOrderSelectShippingMethodActionGroup.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/Sales/Test/Mftf/ActionGroup/AdminOrderSelectShippingMethodActionGroup.xml"
+  module: "Sales"
+  actiongroups:
+     - name: "AdminOrderSelectShippingMethodActionGroup"
+       description: "Select Shipping method from admin order page."
+- filename: "AssertOrderButtonsAvailableActionGroup.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/Sales/Test/Mftf/ActionGroup/AssertOrderButtonsAvailableActionGroup.xml"
+  module: "Sales"
+  actiongroups:
+     - name: "AssertOrderButtonsAvailableActionGroup"
+       description: "Validates that the primary buttons appear on the Admin Order edit page."
+- filename: "AssertAdminCreditMemoGrandTotalActionGroup.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/Sales/Test/Mftf/ActionGroup/AssertAdminCreditMemoGrandTotalActionGroup.xml"
+  module: "Sales"
+  actiongroups:
+     - name: "AssertAdminCreditMemoGrandTotalActionGroup"
+       description: "Admin assert creditmemo grant total sum"
+- filename: "AdminOrderActionGroup.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/Sales/Test/Mftf/ActionGroup/AdminOrderActionGroup.xml"
+  module: "Sales"
+  actiongroups:
+     - name: "navigateToNewOrderPageNewCustomer"
+       description: "Goes to the Admin Orders grid page. Clicks on 'Create New Order'. Clicks on 'Create New Customer'. Select the provided Store View, if present. Validates that Page Title is present and correct."
+
+     - name: "navigateToNewOrderPageNewCustomerSingleStore"
+       description: "Goes to the Admin Orders grid page. Clicks on 'Create New Order'. Clicks on 'Create New Customer'. Validates that Page Title is present and correct."
+
+     - name: "navigateToNewOrderPageExistingCustomer"
+       description: "Goes tot he Admin Orders grid page. Clicks on 'Create New Order'. Filters the grid for the provided Customer. Clicks on the Customer. Selects the provided Store View, if present. Validates that the Page Title is present and correct."
+
+     - name: "NavigateToNewOrderPageExistingCustomerAndStoreActionGroup"
+       description: "EXTENDS: navigateToNewOrderPageExistingCustomer. Clicks on the provided Store View."
+
+     - name: "checkRequiredFieldsNewOrderForm"
+       description: "Clears the Email, First Name, Last Name, Street Line 1, City, Postal Code and Phone fields when adding an Order and then verifies that they are required after attempting to Save."
+
+     - name: "addSimpleProductToOrder"
+       description: "Adds the provided Simple Product to an Order. Fills in the provided Product Qty. Clicks on 'Add Selected Product(s) to Order'."
+
+     - name: "AddSimpleProductWithQtyToOrderActionGroup"
+       description: ""
+
+     - name: "addConfigurableProductToOrder"
+       description: "Adds the provided Configurable Product with the provided Option to an Order. Fills in the provided Product Qty. Clicks on 'Add Selected Product(s) to Order'."
+
+     - name: "newAddConfigurableProductToOrder"
+       description: ""
+
+     - name: "addConfigurableProductToOrderFromAdmin"
+       description: "EXTENDS: addConfigurableProductToOrder. Selects the provided Option to the Configurable Product."
+
+     - name: "configureOrderedConfigurableProduct"
+       description: "Clicks on 'Configure' for a Product in the 'Please select products' under the 'Create New Order for' page. Selects the provided Option and Attribute. Fills in the provided Qty. Clicks on Ok."
+
+     - name: "addBundleProductToOrder"
+       description: "Adds the provided Bundled Product with the provided Option to an Order. Fills in the provided Product Qty. Clicks on 'Add Selected Product(s) to Order'."
+
+     - name: "addBundleProductToOrderAndCheckPriceInGrid"
+       description: "EXTENDS: addBundleProductToOrder. Validates that the provided Product Price is present and correct in the 'Items Ordered' section."
+
+     - name: "addDownloadableProductToOrder"
+       description: "Adds a Downloadable Product to an Order. Clicks on 'Add Selected Product(s) to Order'."
+
+     - name: "addGroupedProductOptionToOrder"
+       description: "Adds the provided Grouped Product with the provided Option to an Order. Fills in the provided Product Qty. Clicks on 'Add Selected Product(s) to Order'."
+
+     - name: "fillOrderCustomerInformation"
+       description: "Fills in the provided Customer and Address details on the Admin 'Create New Order for' page."
+
+     - name: "orderSelectFlatRateShipping"
+       description: "Selects the 'Flat Rate' Shipping Method on the Admin 'Create New Order for' page."
+
+     - name: "changeShippingMethod"
+       description: "Change Shipping Method on the Admin 'Create New Order for' page."
+
+     - name: "orderSelectFreeShipping"
+       description: "Selects the 'Free Shipping' Shipping Method on the Admin 'Create New Order for' page."
+
+     - name: "verifyBasicOrderInformation"
+       description: "Validates that the provided Customer, Shipping/Billing Address and Customer Group are present and correct on the Admin Orders view page."
+
+     - name: "AssertOrderAddressInformationActionGroup"
+       description: ""
+
+     - name: "verifyCreatedOrderInformation"
+       description: "Validates that the Success Message, Order Status (Pending) and Order ID are present and correct."
+
+     - name: "seeProductInItemsOrdered"
+       description: "Validates that the provided Product is present and correct in the 'Items Ordered' section on the Admin Orders view page."
+
+     - name: "CreateOrderInStoreActionGroup"
+       description: "Goes to the Admin Create Order page. Creates an Order based on the provided Customer, Store View and Product. Validates that the Success Message is present and correct."
+
+     - name: "CreateOrderInStoreChoosingPaymentMethodActionGroup"
+       description: "Goes to the Admin Create Order page. Creates an Order based on the provided Customer, Store View and Product. Validates that the Success Message is present and correct."
+
+     - name: "cancelPendingOrder"
+       description: "Cancels the Pending Order on the Admin Orders view page. Validates that the provided Order Status is present and correct."
+
+     - name: "dontSeeProductInItemsOrdered"
+       description: ""
+
+     - name: "SelectCheckMoneyPaymentMethod"
+       description: "Selects the 'Check / Money Order' Payment Method on the Admin Create New Order page."
+
+     - name: "SelectBankTransferPaymentMethodActionGroup"
+       description: ""
+
+     - name: "SelectCashOnDeliveryPaymentMethodActionGroup"
+       description: ""
+
+     - name: "SelectPurchaseOrderPaymentMethodActionGroup"
+       description: ""
+
+     - name: "CreateOrderActionGroup"
+       description: "Goes to the Admin Create New Order page. Selects the provided Customer. Adds the provided Product to the Order. Clicks on Submit Order. Validates that the Success Message is present and correct."
+
+     - name: "CreateOrderFilteringCustomerByEmailActionGroup"
+       description: ""
+- filename: "AdminOrderFilterByOrderIdAndStatusActionGroup.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/Sales/Test/Mftf/ActionGroup/AdminOrderFilterByOrderIdAndStatusActionGroup.xml"
+  module: "Sales"
+  actiongroups:
+     - name: "AdminOrderFilterByOrderIdAndStatusActionGroup"
+       description: ""
+- filename: "AssertOrderStatusExistsInGridActionGroup.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/Sales/Test/Mftf/ActionGroup/AssertOrderStatusExistsInGridActionGroup.xml"
+  module: "Sales"
+  actiongroups:
+     - name: "AssertOrderStatusExistsInGrid"
+       description: "Validates that the provided Order Status and Label are present in the Admin Orders grid."
+- filename: "AddSimpleProductToOrderActionGroup.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/Sales/Test/Mftf/ActionGroup/AddSimpleProductToOrderActionGroup.xml"
+  module: "Sales"
+  actiongroups:
+     - name: "AddSimpleProductToOrderActionGroup"
+       description: "Adds the provided Simple Product to an Order. Fills in the provided Product Qty. Clicks on 'Add Selected Product(s) to Order'."
+- filename: "AdminCreateStoreViewActionGroup.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/Store/Test/Mftf/ActionGroup/AdminCreateStoreViewActionGroup.xml"
+  module: "Store"
+  actiongroups:
+     - name: "AdminCreateStoreViewActionGroup"
+       description: "Goes to the Admin Store View creation page. Fills in the provided Store View and Store details. Clicks on Save. Validates that the Success Message is present and correct."
+
+     - name: "AdminCreateStoreViewWithoutCheckActionGroup"
+       description: "EXTENDS: AdminCreateStoreViewActionGroup. Removes 'waitForPageReload' and 'seeSavedMessage'."
+
+     - name: "AdminCreateStoreViewActionSaveGroup"
+       description: "Validates that the Success Message is present and correct."
+
+     - name: "navigateToAdminContentManagementPage"
+       description: "Goes to the 'Configuration' page for 'Content Management'."
+
+     - name: "saveStoreConfiguration"
+       description: "Clicks on the Save button."
+
+     - name: "saveStoreConfigurationAndValidateFieldError"
+       description: "Clicks on Save. Validates that the fields are required."
+- filename: "AdminStoreGroupCreateActionGroup.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/Store/Test/Mftf/ActionGroup/AdminStoreGroupCreateActionGroup.xml"
+  module: "Store"
+  actiongroups:
+     - name: "AdminStoreGroupCreateActionGroup"
+       description: "Fills in the provided Website and Store Group details. Clicks on Save. Validates that the Success Message is present and correct."
+
+     - name: "AdminAddCustomWebSiteToStoreGroup"
+       description: "Goes to the Admin Stores grid page. Searches the grid for the provided Store Group. Edits the Store. Adds the provided Website to the Store. Clicks on Save. Validates that the Success Message is present and correct."
+- filename: "AssertStoreGroupInGridActionGroup.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/Store/Test/Mftf/ActionGroup/AssertStoreGroupInGridActionGroup.xml"
+  module: "Store"
+  actiongroups:
+     - name: "AssertStoreGroupInGridActionGroup"
+       description: "Goes to the Admin Stores grid page. Searches the grid for the provided Store Group Name. Validates that the provided Store Group Name is present and correct in the grid."
+- filename: "AssertStoreViewInGridActionGroup.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/Store/Test/Mftf/ActionGroup/AssertStoreViewInGridActionGroup.xml"
+  module: "Store"
+  actiongroups:
+     - name: "AssertStoreViewInGridActionGroup"
+       description: "Goes the Admin Stores grid page. Searches the grid for the provided Store View Name. Validates that the provided Store View Name is present and correct in the grid."
+- filename: "CreateCustomStoreViewActionGroup.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/Store/Test/Mftf/ActionGroup/CreateCustomStoreViewActionGroup.xml"
+  module: "Store"
+  actiongroups:
+     - name: "CreateCustomStoreViewActionGroup"
+       description: "Goes to the Admin Store Views creation page. Fills in the provided Store View Name. Clicks on Save."
+
+     - name: "CreateStoreView"
+       description: "Goes to the Admin Store Views creation page. Fills in the provided Store View, Store Group Name and Store View Status. Clicks on Save. Validates that the Success Message is present and correct."
+- filename: "AdminCreateWebsiteActionGroup.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/Store/Test/Mftf/ActionGroup/AdminCreateWebsiteActionGroup.xml"
+  module: "Store"
+  actiongroups:
+     - name: "AdminCreateWebsiteActionGroup"
+       description: "Goes to the Admin Website creation page. Fills in the provided Website Name and Code. Clicks on Save. Validates that the Success Message is present and correct."
+
+     - name: "AdminGetWebsiteIdActionGroup"
+       description: "Goes to the Admin Stores grid page. Filters the grid for the provided Website. Grabs the Website ID from the URL."
+
+     - name: "AssertWebsiteInGrid"
+       description: "Goes to the Admin Stores grid page. Searches the grid for the provided Website Name. Validates that the Website appears in the grid."
+
+     - name: "AssertWebsiteForm"
+       description: "Clicks on the provided Website Name in the Admin Stores grid. Validates that the URL, Website Name/Code are present and correct."
+- filename: "StoreViewDisabledErrorSaveMessageActionGroup.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/Store/Test/Mftf/ActionGroup/StoreViewDisabledErrorSaveMessageActionGroup.xml"
+  module: "Store"
+  actiongroups:
+     - name: "StoreViewDisabledErrorSaveMessageActionGroup"
+       description: "Goes to the Admin Store View creation page. Fills in the provided Details (Store Group Name, Store View and Store View Status). Validates that the Error Message is present and correct."
+- filename: "ChangeStoreInStoreViewActionGroup.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/Store/Test/Mftf/ActionGroup/ChangeStoreInStoreViewActionGroup.xml"
+  module: "Store"
+  actiongroups:
+     - name: "ChangeStoreInStoreViewActionGroup"
+       description: "Clicks on the 1st row 'Store View' on the Admin Stores grid page. Selects the provided Store drop down menu. Clicks on Save. Validates that the Warning Message is present and correct."
+- filename: "StorefrontSwitchStoreViewActionGroup.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/Store/Test/Mftf/ActionGroup/StorefrontSwitchStoreViewActionGroup.xml"
+  module: "Store"
+  actiongroups:
+     - name: "StorefrontSwitchStoreViewActionGroup"
+       description: "Switch the Storefront to the provided Store View."
+
+     - name: "StorefrontSwitchDefaultStoreViewActionGroup"
+       description: "EXTENDS: StorefrontSwitchStoreViewActionGroup. Clicks on the Default Store View."
+- filename: "DeleteCustomStoreActionGroup.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/Store/Test/Mftf/ActionGroup/DeleteCustomStoreActionGroup.xml"
+  module: "Store"
+  actiongroups:
+     - name: "DeleteCustomStoreActionGroup"
+       description: "Goes to the Admin Stores grid page. Deletes the provided Store Group Name."
+
+     - name: "DeleteCustomStoreBackupEnabledYesActionGroup"
+       description: "Goes to the Admin Stores grid page. Deletes the provided Store Group Name while creating a DB backup. Validates that the Success Messages are present and correct."
+
+     - name: "AssertStoreNotInGrid"
+       description: "Goes to the Admin Stores grid page. Validates that the provided Store Group Name is NOT present in the grid."
+- filename: "AdminWebsitePageActionGroup.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/Store/Test/Mftf/ActionGroup/AdminWebsitePageActionGroup.xml"
+  module: "Store"
+  actiongroups:
+     - name: "AdminGoCreatedWebsitePageActionGroup"
+       description: "Filter website name in grid and go first found website page"
+- filename: "AdminDeleteWebsiteActionGroup.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/Store/Test/Mftf/ActionGroup/AdminDeleteWebsiteActionGroup.xml"
+  module: "Store"
+  actiongroups:
+     - name: "AdminDeleteWebsiteActionGroup"
+       description: "Goes to the Admin Stores grid page. Deletes the provided Website Name."
+- filename: "DeleteCustomWebsiteActionGroup.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/Store/Test/Mftf/ActionGroup/DeleteCustomWebsiteActionGroup.xml"
+  module: "Store"
+  actiongroups:
+     - name: "DeleteCustomWebsiteActionGroup"
+       description: "Goes to the Admin Stores grid page. Searches the grid for the provided Website Name. Deletes the provided Website Name. Validates that the Success Message is present and correct."
+- filename: "AssertStorefrontStoreNotVisibleInFooterActionGroup.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/Store/Test/Mftf/ActionGroup/AssertStorefrontStoreNotVisibleInFooterActionGroup.xml"
+  module: "Store"
+  actiongroups:
+     - name: "AssertStorefrontStoreNotVisibleInFooterActionGroup"
+       description: "Goes to the Storefront. Validates that the provided Store is NOT present in the Footer Switch Store View drop down menu."
+- filename: "SaveStoreConfigurationActionGroup.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/Store/Test/Mftf/ActionGroup/SaveStoreConfigurationActionGroup.xml"
+  module: "Store"
+  actiongroups:
+     - name: "SaveStoreConfigurationActionGroup"
+       description: "Clicks on the Save button."
+- filename: "AssertStoreViewFormActionGroup.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/Store/Test/Mftf/ActionGroup/AssertStoreViewFormActionGroup.xml"
+  module: "Store"
+  actiongroups:
+     - name: "AssertStoreViewFormActionGroup"
+       description: "Validates that the provided Store, Name, Code and Status are present and correct on the Admin Stores creation/edit page."
+- filename: "StoreFrontProductValidationActionGroup.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/Store/Test/Mftf/ActionGroup/StoreFrontProductValidationActionGroup.xml"
+  module: "Store"
+  actiongroups:
+     - name: "StoreFrontProductValidationActionGroup"
+       description: "Goes to the provided Storefront Product page. Validates that the provided Product details are present and correct."
+- filename: "AdminSwitchWebsiteActionGroup.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/Store/Test/Mftf/ActionGroup/AdminSwitchWebsiteActionGroup.xml"
+  module: "Store"
+  actiongroups:
+     - name: "AdminSwitchWebsiteActionGroup"
+       description: "Selects the provided Website from the 'Store View' dropdown menu on the Admin Grid pages."
+- filename: "AssertStoreConfigurationBackendActionGroup.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/Store/Test/Mftf/ActionGroup/AssertStoreConfigurationBackendActionGroup.xml"
+  module: "Store"
+  actiongroups:
+     - name: "AssertStoreConfigurationBackendActionGroup"
+       description: "Goes to the 'Configuration' page. Clicks on the 'Store View' dropdown menu. Validates that the provided Website, Store, Store View 1 and Store View 2 are present and correct."
+- filename: "AssertStoreFrontendActionGroup.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/Store/Test/Mftf/ActionGroup/AssertStoreFrontendActionGroup.xml"
+  module: "Store"
+  actiongroups:
+     - name: "AssertStoreFrontendActionGroup"
+       description: "Goes to the Storefront. Selects the provided Store in the Store View dropdown menu. Validates that the provided Store View #1 is selected. Validates that the provided Store View 2 is present in the dropdown menu."
+- filename: "AssertStorefrontStoreVisibleInHeaderActionGroup.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/Store/Test/Mftf/ActionGroup/AssertStorefrontStoreVisibleInHeaderActionGroup.xml"
+  module: "Store"
+  actiongroups:
+     - name: "AssertStorefrontStoreVisibleInHeaderActionGroup"
+       description: "Goes to the Storefront. Validates that the provided Store is present in the Header Switch Store View drop down menu on the Storefront."
+- filename: "AdminCreateNewStoreGroupActionGroup.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/Store/Test/Mftf/ActionGroup/AdminCreateNewStoreGroupActionGroup.xml"
+  module: "Store"
+  actiongroups:
+     - name: "AdminCreateNewStoreGroupActionGroup"
+       description: "Goes to the Admin Stores creation page. Fills in the provided Details (Website, Store Group Name and Store Group Code). Clicks on Save. Validates that the Success Message is present and correct."
+
+     - name: "CreateCustomStore"
+       description: "Goes to the Admin Stores grid page. Clicks on 'Create Store'. Fills in the provided Details (Website, Store Group Name and Store Group Code). Clicks on Save. Validates that the Success Message is present and correct."
+
+     - name: "AssertStoreGroupInGrid"
+       description: "Goes to the Admin Stores grid page. Searches for the provided Store Group Name. Validates that the provided Store Group Name is present in the grid."
+
+     - name: "EditStoreGroupActionGroup"
+       description: "Edit store group."
+
+     - name: "ChangeDefaultStoreViewActionGroup"
+       description: "Change the default store view for provided store group."
+
+     - name: "AssertDefaultStoreViewActionGroup"
+       description: "Asserts that the provided store view is default in provided store group."
+
+     - name: "AssertStoreGroupForm"
+       description: "Clicks on the 1st Store in the 'Stores' grid. Validates that the provided Details (Website, Store Group Name, Store Group Code and Root Category) are present and correct."
+- filename: "AssertStoreGroupFormActionGroup.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/Store/Test/Mftf/ActionGroup/AssertStoreGroupFormActionGroup.xml"
+  module: "Store"
+  actiongroups:
+     - name: "AssertStoreGroupFormActionGroup"
+       description: "Clicks on the 1st row of the Admin Store grid page. Validates that the provided Website, Store Group Name/Code and Root Category are present and correct."
+- filename: "EditCustomStoreGroupAcceptWarningMessageActionGroup.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/Store/Test/Mftf/ActionGroup/EditCustomStoreGroupAcceptWarningMessageActionGroup.xml"
+  module: "Store"
+  actiongroups:
+     - name: "EditCustomStoreGroupAcceptWarningMessageActionGroup"
+       description: "EXTENDS: CreateCustomStore. Removes 'selectCreateStore'. Clicks on the 1st row. Clicks on Ok."
+- filename: "AssertStorefrontStoreCodeInUrlActionGroup.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/Store/Test/Mftf/ActionGroup/AssertStorefrontStoreCodeInUrlActionGroup.xml"
+  module: "Store"
+  actiongroups:
+     - name: "AssertStorefrontStoreCodeInUrlActionGroup"
+       description: "Validates that the provided Store Code is present in the Storefront URL."
+- filename: "SaveStoreConfigurationAndValidateFieldErrorActionGroup.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/Store/Test/Mftf/ActionGroup/SaveStoreConfigurationAndValidateFieldErrorActionGroup.xml"
+  module: "Store"
+  actiongroups:
+     - name: "SaveStoreConfigurationAndValidateFieldErrorActionGroup"
+       description: "Clicks on Save. Validates that the fields are required."
+- filename: "AdminFilterStoreViewActionGroup.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/Store/Test/Mftf/ActionGroup/AdminFilterStoreViewActionGroup.xml"
+  module: "Store"
+  actiongroups:
+     - name: "AdminFilterStoreViewActionGroup"
+       description: "Filters the Admin Catalog Product page based on the provided Store Group and Custom Store."
+- filename: "AdminSwitchStoreViewActionGroup.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/Store/Test/Mftf/ActionGroup/AdminSwitchStoreViewActionGroup.xml"
+  module: "Store"
+  actiongroups:
+     - name: "AdminSwitchStoreViewActionGroup"
+       description: "Selects the provided Website from the 'Store View' dropdown menu on the Admin Grid pages."
+
+     - name: "AdminSwitchToAllStoreViewActionGroup"
+       description: "EXTENDS: AdminSwitchStoreViewActionGroup. Clicks on the 'All Store Views' drop down menu. Validates that the 'All Store Views' options is present and correct."
+- filename: "AssertStorefrontStoreVisibleInFooterActionGroup.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/Store/Test/Mftf/ActionGroup/AssertStorefrontStoreVisibleInFooterActionGroup.xml"
+  module: "Store"
+  actiongroups:
+     - name: "AssertStorefrontStoreVisibleInFooterActionGroup"
+       description: "Goes to the Storefront. Validates that the provided Store is present in the Footer Switch Store View drop down menu on the Storefront."
+- filename: "AdminDeleteStoreViewActionGroup.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/Store/Test/Mftf/ActionGroup/AdminDeleteStoreViewActionGroup.xml"
+  module: "Store"
+  actiongroups:
+     - name: "AdminDeleteStoreViewActionGroup"
+       description: "Goes to the Admin Stores grid page. Deletes the provided Store without creating a Backup. Validates that the Success Message is present and correct."
+
+     - name: "DeleteCustomStoreViewBackupEnabledYesActionGroup"
+       description: "Goes to the Admin Stores grid page. Deleted the provided Store while creating a Backup. Validates that the Success Messages (Delete/Backup) are present and correct."
+
+     - name: "AssertStoreViewNotInGrid"
+       description: "Goes to the Admin Stores grid page. Searches the grid for the provided Store View name. Validates that it does NOT appear in the grid."
+
+     - name: "AdminSearchStoreViewByNameActionGroup"
+       description: "Goes to the Admin Stores grid page. Clears filters and search by store view name."
+
+     - name: "AdminDeleteStoreViewIfExistsActionGroup"
+       description: "EXTENDS: AdminSearchStoreViewByNameActionGroup. Goes to the Admin Stores grid page. Deletes the provided Store (if exists) without creating a Backup. Validates that the Success Message is present and correct."
+- filename: "StoreFrontSelectDropDownSearchSuggestionActionGroup.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/Search/Test/Mftf/ActionGroup/StoreFrontSelectDropDownSearchSuggestionActionGroup.xml"
+  module: "Search"
+  actiongroups:
+     - name: "StoreFrontSelectDropDownSearchSuggestionActionGroup"
+       description: "Fills the Storefront Quick Search field. Validates that the provided Search Suggestion is present and correct."
+- filename: "AdminEditSearchTermActionGroup.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/Search/Test/Mftf/ActionGroup/AdminEditSearchTermActionGroup.xml"
+  module: "Search"
+  actiongroups:
+     - name: "AdminFillAllSearchTermFieldsActionGroup"
+       description: "Fills in the provided Search Term on the Admin Search Terms grid page."
+- filename: "AdminSearchTermActionGroup.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/Search/Test/Mftf/ActionGroup/AdminSearchTermActionGroup.xml"
+  module: "Search"
+  actiongroups:
+     - name: "searchTermFilterBySearchQuery"
+       description: "Fills in the provided Search Query on the Admin Search Term grid page."
+
+     - name: "deleteSearchTerm"
+       description: "Deletes the Search Terms in the Admin Search Term grid."
+
+     - name: "DeleteAllSearchTerms"
+       description: ""
+- filename: "GenerateOrderReportActionGroup.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/Reports/Test/Mftf/ActionGroup/GenerateOrderReportActionGroup.xml"
+  module: "Reports"
+  actiongroups:
+     - name: "GenerateOrderReportActionGroup"
+       description: "Clicks on 'here' to refresh the grid data. Enters the provided Order From/To Dates. Clicks on 'Show Report'."
+
+     - name: "GenerateOrderReportForNotCancelActionGroup"
+       description: "Clicks on 'here' to refresh the grid data. Enters the provided Order From/To Dates and provided Order Status. Clicks on 'Show Report'."
+- filename: "AdminReviewOrderActionGroup.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/Reports/Test/Mftf/ActionGroup/AdminReviewOrderActionGroup.xml"
+  module: "Reports"
+  actiongroups:
+     - name: "AdminReviewOrderActionGroup"
+       description: "Clicks on 'REPORTS' in the Admin side menu. Clicks on 'Ordered'. Clicks on 'Refresh'. Validates that the provided Product name appears in the list."
+- filename: "setEmailTextLengthLimitActionGroup.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/Wishlist/Test/Mftf/ActionGroup/setEmailTextLengthLimitActionGroup.xml"
+  module: "Wishlist"
+  actiongroups:
+     - name: "setEmailTextLengthLimitActionGroup"
+       description: ""
+- filename: "AssertStorefrontAddToWishListIconIsClickableForGuestUserActionGroup.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/Wishlist/Test/Mftf/ActionGroup/AssertStorefrontAddToWishListIconIsClickableForGuestUserActionGroup.xml"
+  module: "Wishlist"
+  actiongroups:
+     - name: "AssertStorefrontAddToWishListIconIsClickableForGuestUserActionGroup"
+       description: "Assert 'Add to Wish List' icon is clickable in category product listing"
 - filename: "StorefrontCustomerWishlistActionGroup.xml"
-  repo: "https://github.com/magento/magento2/blob/2.3/app/code/Magento/Wishlist/Test/Mftf/ActionGroup/StorefrontCustomerWishlistActionGroup.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/Wishlist/Test/Mftf/ActionGroup/StorefrontCustomerWishlistActionGroup.xml"
   module: "Wishlist"
   actiongroups:
      - name: "StorefrontCustomerAddCategoryProductToWishlistActionGroup"
@@ -6078,492 +5804,1062 @@
 
      - name: "StorefrontAssertCustomerWishlistIsEmpty"
        description: ""
- 
-- filename: "setEmailTextLengthLimitActionGroup.xml"
-  repo: "https://github.com/magento/magento2/blob/2.3/app/code/Magento/Wishlist/Test/Mftf/ActionGroup/setEmailTextLengthLimitActionGroup.xml"
-  module: "Wishlist"
+- filename: "AssertCaptchaVisibleOnCustomerLoginFormActionGroup.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/Captcha/Test/Mftf/ActionGroup/AssertCaptchaVisibleOnCustomerLoginFormActionGroup.xml"
+  module: "Captcha"
   actiongroups:
-     - name: "setEmailTextLengthLimitActionGroup"
+     - name: "AssertCaptchaVisibleOnCustomerLoginFormActionGroup"
+       description: "Validate that the Captcha IS present on the Storefront Customer Login page."
+- filename: "CaptchaFormsDisplayingActionGroup.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/Captcha/Test/Mftf/ActionGroup/CaptchaFormsDisplayingActionGroup.xml"
+  module: "Captcha"
+  actiongroups:
+     - name: "CaptchaFormsDisplayingActionGroup"
+       description: "Navigates to store configuration page through UI and expands the CAPTCHA section under Customers &gt; Customer Configuration."
+- filename: "AssertCaptchaVisibleOnCustomerAccountInfoActionGroup.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/Captcha/Test/Mftf/ActionGroup/AssertCaptchaVisibleOnCustomerAccountInfoActionGroup.xml"
+  module: "Captcha"
+  actiongroups:
+     - name: "AssertCaptchaVisibleOnCustomerAccountInfoActionGroup"
+       description: "Validate that the Captcha IS present on the Storefront Customer Account Information page."
+- filename: "AssertCaptchaVisibleOnCustomerAccountCreatePageActionGroup.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/Captcha/Test/Mftf/ActionGroup/AssertCaptchaVisibleOnCustomerAccountCreatePageActionGroup.xml"
+  module: "Captcha"
+  actiongroups:
+     - name: "AssertCaptchaVisibleOnCustomerAccountCreatePageActionGroup"
+       description: "Validate that the Captcha IS present on the Storefront Create Customer page."
+- filename: "StorefrontFillCustomerLoginFormWithCaptchaActionGroup.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/Captcha/Test/Mftf/ActionGroup/StorefrontFillCustomerLoginFormWithCaptchaActionGroup.xml"
+  module: "Captcha"
+  actiongroups:
+     - name: "StorefrontFillCustomerLoginFormWithCaptchaActionGroup"
+       description: "EXTENDS: StorefrontFillCustomerLoginFormActionGroup. Fills in the Captcha field on the Storefront Customer Login page."
+- filename: "AdminLoginWithCaptchaActionGroup.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/Captcha/Test/Mftf/ActionGroup/AdminLoginWithCaptchaActionGroup.xml"
+  module: "Captcha"
+  actiongroups:
+     - name: "AdminLoginWithCaptchaActionGroup"
+       description: "EXTENDS: LoginAsAdmin. Fills in the Captcha field on the Backend Admin Login page."
+- filename: "AssertCaptchaNotVisibleOnCustomerLoginFormActionGroup.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/Captcha/Test/Mftf/ActionGroup/AssertCaptchaNotVisibleOnCustomerLoginFormActionGroup.xml"
+  module: "Captcha"
+  actiongroups:
+     - name: "AssertCaptchaNotVisibleOnCustomerLoginFormActionGroup"
+       description: "Validate that the Captcha is NOT present on the Backend Admin Login page."
+- filename: "StorefrontFillContactUsFormWithCaptchaActionGroup.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/Captcha/Test/Mftf/ActionGroup/StorefrontFillContactUsFormWithCaptchaActionGroup.xml"
+  module: "Captcha"
+  actiongroups:
+     - name: "StorefrontFillContactUsFormWithCaptchaActionGroup"
+       description: "EXTENDS: StorefrontFillContactUsFormActionGroup. Fills in the Captcha field on the Storefront Contact Us page."
+- filename: "StorefrontFillCustomerAccountCreationFormWithCaptchaActionGroup.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/Captcha/Test/Mftf/ActionGroup/StorefrontFillCustomerAccountCreationFormWithCaptchaActionGroup.xml"
+  module: "Captcha"
+  actiongroups:
+     - name: "StorefrontFillCustomerAccountCreationFormWithCaptchaActionGroup"
+       description: "EXTENDS: StorefrontFillCustomerAccountCreationFormActionGroup. Fills in the Captcha field on the Storefront Create Customer page."
+- filename: "AssertCaptchaVisibleOnContactUsFormActionGroup.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/Captcha/Test/Mftf/ActionGroup/AssertCaptchaVisibleOnContactUsFormActionGroup.xml"
+  module: "Captcha"
+  actiongroups:
+     - name: "AssertCaptchaVisibleOnContactUsFormActionGroup"
+       description: "Validate that the Captcha IS present on the Storefront Contact Us page."
+- filename: "AssertCaptchaVisibleOnAdminLoginFormActionGroup.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/Captcha/Test/Mftf/ActionGroup/AssertCaptchaVisibleOnAdminLoginFormActionGroup.xml"
+  module: "Captcha"
+  actiongroups:
+     - name: "AssertCaptchaVisibleOnAdminLoginFormActionGroup"
+       description: "Validate that the Captcha IS present on the Backend Admin Login page."
+- filename: "StorefrontCustomerChangeEmailWithCaptchaActionGroup.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/Captcha/Test/Mftf/ActionGroup/StorefrontCustomerChangeEmailWithCaptchaActionGroup.xml"
+  module: "Captcha"
+  actiongroups:
+     - name: "StorefrontCustomerChangeEmailWithCaptchaActionGroup"
+       description: "EXTENDS: StorefrontCustomerChangeEmailActionGroup. Fills in the Captcha field on the Storefront Customer Information page."
+- filename: "AdminNavigateToExportPageActionGroup.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/ImportExport/Test/Mftf/ActionGroup/AdminNavigateToExportPageActionGroup.xml"
+  module: "ImportExport"
+  actiongroups:
+     - name: "AdminNavigateToExportPageActionGroup"
        description: ""
- 
-- filename: "GenerateOrderReportActionGroup.xml"
-  repo: "https://github.com/magento/magento2/blob/2.3/app/code/Magento/Reports/Test/Mftf/ActionGroup/GenerateOrderReportActionGroup.xml"
-  module: "Reports"
+- filename: "AdminAssertVisiblePagerActionGroup.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/ImportExport/Test/Mftf/ActionGroup/AdminAssertVisiblePagerActionGroup.xml"
+  module: "ImportExport"
   actiongroups:
-     - name: "GenerateOrderReportActionGroup"
-       description: "Clicks on 'here' to refresh the grid data. Enters the provided Order From/To Dates. Clicks on 'Show Report'."
-
-     - name: "GenerateOrderReportForNotCancelActionGroup"
-       description: "Clicks on 'here' to refresh the grid data. Enters the provided Order From/To Dates and provided Order Status. Clicks on 'Show Report'."
- 
-- filename: "AdminReviewOrderActionGroup.xml"
-  repo: "https://github.com/magento/magento2/blob/2.3/app/code/Magento/Reports/Test/Mftf/ActionGroup/AdminReviewOrderActionGroup.xml"
-  module: "Reports"
-  actiongroups:
-     - name: "AdminReviewOrderActionGroup"
-       description: "Clicks on 'REPORTS' in the Admin side menu. Clicks on 'Ordered'. Clicks on 'Refresh'. Validates that the provided Product name appears in the list."
- 
-- filename: "EditCustomStoreGroupAcceptWarningMessageActionGroup.xml"
-  repo: "https://github.com/magento/magento2/blob/2.3/app/code/Magento/Store/Test/Mftf/ActionGroup/EditCustomStoreGroupAcceptWarningMessageActionGroup.xml"
-  module: "Store"
-  actiongroups:
-     - name: "EditCustomStoreGroupAcceptWarningMessageActionGroup"
-       description: "EXTENDS: CreateCustomStore. Removes 'selectCreateStore'. Clicks on the 1st row. Clicks on Ok."
- 
-- filename: "AssertStorefrontStoreCodeInUrlActionGroup.xml"
-  repo: "https://github.com/magento/magento2/blob/2.3/app/code/Magento/Store/Test/Mftf/ActionGroup/AssertStorefrontStoreCodeInUrlActionGroup.xml"
-  module: "Store"
-  actiongroups:
-     - name: "AssertStorefrontStoreCodeInUrlActionGroup"
-       description: "Validates that the provided Store Code is present in the Storefront URL."
- 
-- filename: "DeleteCustomStoreActionGroup.xml"
-  repo: "https://github.com/magento/magento2/blob/2.3/app/code/Magento/Store/Test/Mftf/ActionGroup/DeleteCustomStoreActionGroup.xml"
-  module: "Store"
-  actiongroups:
-     - name: "DeleteCustomStoreActionGroup"
-       description: "Goes to the Admin Stores grid page. Deletes the provided Store Group Name."
-
-     - name: "DeleteCustomStoreBackupEnabledYesActionGroup"
-       description: "Goes to the Admin Stores grid page. Deletes the provided Store Group Name while creating a DB backup. Validates that the Success Messages are present and correct."
-
-     - name: "AssertStoreNotInGrid"
-       description: "Goes to the Admin Stores grid page. Validates that the provided Store Group Name is NOT present in the grid."
- 
-- filename: "StoreFrontProductValidationActionGroup.xml"
-  repo: "https://github.com/magento/magento2/blob/2.3/app/code/Magento/Store/Test/Mftf/ActionGroup/StoreFrontProductValidationActionGroup.xml"
-  module: "Store"
-  actiongroups:
-     - name: "StoreFrontProductValidationActionGroup"
-       description: "Goes to the provided Storefront Product page. Validates that the provided Product details are present and correct."
- 
-- filename: "AdminSwitchStoreViewActionGroup.xml"
-  repo: "https://github.com/magento/magento2/blob/2.3/app/code/Magento/Store/Test/Mftf/ActionGroup/AdminSwitchStoreViewActionGroup.xml"
-  module: "Store"
-  actiongroups:
-     - name: "AdminSwitchStoreViewActionGroup"
-       description: "Selects the provided Website from the 'Store View' dropdown menu on the Admin Grid pages."
-
-     - name: "AdminSwitchToAllStoreViewActionGroup"
-       description: "EXTENDS: AdminSwitchStoreViewActionGroup. Clicks on the 'All Store Views' drop down menu. Validates that the 'All Store Views' options is present and correct."
- 
-- filename: "AssertStoreGroupFormActionGroup.xml"
-  repo: "https://github.com/magento/magento2/blob/2.3/app/code/Magento/Store/Test/Mftf/ActionGroup/AssertStoreGroupFormActionGroup.xml"
-  module: "Store"
-  actiongroups:
-     - name: "AssertStoreGroupFormActionGroup"
-       description: "Clicks on the 1st row of the Admin Store grid page. Validates that the provided Website, Store Group Name/Code and Root Category are present and correct."
- 
-- filename: "DeleteCustomWebsiteActionGroup.xml"
-  repo: "https://github.com/magento/magento2/blob/2.3/app/code/Magento/Store/Test/Mftf/ActionGroup/DeleteCustomWebsiteActionGroup.xml"
-  module: "Store"
-  actiongroups:
-     - name: "DeleteCustomWebsiteActionGroup"
-       description: "Goes to the Admin Stores grid page. Searches the grid for the provided Website Name. Deletes the provided Website Name. Validates that the Success Message is present and correct."
- 
-- filename: "AdminSwitchWebsiteActionGroup.xml"
-  repo: "https://github.com/magento/magento2/blob/2.3/app/code/Magento/Store/Test/Mftf/ActionGroup/AdminSwitchWebsiteActionGroup.xml"
-  module: "Store"
-  actiongroups:
-     - name: "AdminSwitchWebsiteActionGroup"
-       description: "Selects the provided Website from the 'Store View' dropdown menu on the Admin Grid pages."
- 
-- filename: "AdminFilterStoreViewActionGroup.xml"
-  repo: "https://github.com/magento/magento2/blob/2.3/app/code/Magento/Store/Test/Mftf/ActionGroup/AdminFilterStoreViewActionGroup.xml"
-  module: "Store"
-  actiongroups:
-     - name: "AdminFilterStoreViewActionGroup"
-       description: "Filters the Admin Catalog Product page based on the provided Store Group and Custom Store."
- 
-- filename: "CreateCustomStoreViewActionGroup.xml"
-  repo: "https://github.com/magento/magento2/blob/2.3/app/code/Magento/Store/Test/Mftf/ActionGroup/CreateCustomStoreViewActionGroup.xml"
-  module: "Store"
-  actiongroups:
-     - name: "CreateCustomStoreViewActionGroup"
-       description: "Goes to the Admin Store Views creation page. Fills in the provided Store View Name. Clicks on Save."
-
-     - name: "CreateStoreView"
-       description: "Goes to the Admin Store Views creation page. Fills in the provided Store View, Store Group Name and Store View Status. Clicks on Save. Validates that the Success Message is present and correct."
- 
-- filename: "AssertStoreFrontendActionGroup.xml"
-  repo: "https://github.com/magento/magento2/blob/2.3/app/code/Magento/Store/Test/Mftf/ActionGroup/AssertStoreFrontendActionGroup.xml"
-  module: "Store"
-  actiongroups:
-     - name: "AssertStoreFrontendActionGroup"
-       description: "Goes to the Storefront. Selects the provided Store in the Store View dropdown menu. Validates that the provided Store View #1 is selected. Validates that the provided Store View 2 is present in the dropdown menu."
- 
-- filename: "StorefrontSwitchStoreViewActionGroup.xml"
-  repo: "https://github.com/magento/magento2/blob/2.3/app/code/Magento/Store/Test/Mftf/ActionGroup/StorefrontSwitchStoreViewActionGroup.xml"
-  module: "Store"
-  actiongroups:
-     - name: "StorefrontSwitchStoreViewActionGroup"
-       description: "Switch the Storefront to the provided Store View."
-
-     - name: "StorefrontSwitchDefaultStoreViewActionGroup"
-       description: "EXTENDS: StorefrontSwitchStoreViewActionGroup. Clicks on the Default Store View."
- 
-- filename: "AdminCreateWebsiteActionGroup.xml"
-  repo: "https://github.com/magento/magento2/blob/2.3/app/code/Magento/Store/Test/Mftf/ActionGroup/AdminCreateWebsiteActionGroup.xml"
-  module: "Store"
-  actiongroups:
-     - name: "AdminCreateWebsiteActionGroup"
-       description: "Goes to the Admin Website creation page. Fills in the provided Website Name and Code. Clicks on Save. Validates that the Success Message is present and correct."
-
-     - name: "AdminGetWebsiteIdActionGroup"
-       description: "Goes to the Admin Stores grid page. Filters the grid for the provided Website. Grabs the Website ID from the URL."
-
-     - name: "AssertWebsiteInGrid"
-       description: "Goes to the Admin Stores grid page. Searches the grid for the provided Website Name. Validates that the Website appears in the grid."
-
-     - name: "AssertWebsiteForm"
-       description: "Clicks on the provided Website Name in the Admin Stores grid. Validates that the URL, Website Name/Code are present and correct."
- 
-- filename: "AssertStoreViewFormActionGroup.xml"
-  repo: "https://github.com/magento/magento2/blob/2.3/app/code/Magento/Store/Test/Mftf/ActionGroup/AssertStoreViewFormActionGroup.xml"
-  module: "Store"
-  actiongroups:
-     - name: "AssertStoreViewFormActionGroup"
-       description: "Validates that the provided Store, Name, Code and Status are present and correct on the Admin Stores creation/edit page."
- 
-- filename: "AdminCreateStoreViewActionGroup.xml"
-  repo: "https://github.com/magento/magento2/blob/2.3/app/code/Magento/Store/Test/Mftf/ActionGroup/AdminCreateStoreViewActionGroup.xml"
-  module: "Store"
-  actiongroups:
-     - name: "AdminCreateStoreViewActionGroup"
-       description: "Goes to the Admin Store View creation page. Fills in the provided Store View and Store details. Clicks on Save. Validates that the Success Message is present and correct."
-
-     - name: "AdminCreateStoreViewWithoutCheckActionGroup"
-       description: "EXTENDS: AdminCreateStoreViewActionGroup. Removes 'waitForPageReload' and 'seeSavedMessage'."
-
-     - name: "AdminCreateStoreViewActionSaveGroup"
-       description: "Validates that the Success Message is present and correct."
-
-     - name: "navigateToAdminContentManagementPage"
-       description: "Goes to the 'Configuration' page for 'Content Management'."
-
-     - name: "saveStoreConfiguration"
-       description: "Clicks on the Save button."
-
-     - name: "saveStoreConfigurationAndValidateFieldError"
-       description: "Clicks on Save. Validates that the fields are required."
- 
-- filename: "AssertStorefrontStoreVisibleInFooterActionGroup.xml"
-  repo: "https://github.com/magento/magento2/blob/2.3/app/code/Magento/Store/Test/Mftf/ActionGroup/AssertStorefrontStoreVisibleInFooterActionGroup.xml"
-  module: "Store"
-  actiongroups:
-     - name: "AssertStorefrontStoreVisibleInFooterActionGroup"
-       description: "Goes to the Storefront. Validates that the provided Store is present in the Footer Switch Store View drop down menu on the Storefront."
- 
-- filename: "StoreViewDisabledErrorSaveMessageActionGroup.xml"
-  repo: "https://github.com/magento/magento2/blob/2.3/app/code/Magento/Store/Test/Mftf/ActionGroup/StoreViewDisabledErrorSaveMessageActionGroup.xml"
-  module: "Store"
-  actiongroups:
-     - name: "StoreViewDisabledErrorSaveMessageActionGroup"
-       description: "Goes to the Admin Store View creation page. Fills in the provided Details (Store Group Name, Store View and Store View Status). Validates that the Error Message is present and correct."
- 
-- filename: "AdminDeleteWebsiteActionGroup.xml"
-  repo: "https://github.com/magento/magento2/blob/2.3/app/code/Magento/Store/Test/Mftf/ActionGroup/AdminDeleteWebsiteActionGroup.xml"
-  module: "Store"
-  actiongroups:
-     - name: "AdminDeleteWebsiteActionGroup"
-       description: "Goes to the Admin Stores grid page. Deletes the provided Website Name."
- 
-- filename: "AdminDeleteStoreViewActionGroup.xml"
-  repo: "https://github.com/magento/magento2/blob/2.3/app/code/Magento/Store/Test/Mftf/ActionGroup/AdminDeleteStoreViewActionGroup.xml"
-  module: "Store"
-  actiongroups:
-     - name: "AdminDeleteStoreViewActionGroup"
-       description: "Goes to the Admin Stores grid page. Deletes the provided Store without creating a Backup. Validates that the Success Message is present and correct."
-
-     - name: "DeleteCustomStoreViewBackupEnabledYesActionGroup"
-       description: "Goes to the Admin Stores grid page. Deleted the provided Store while creating a Backup. Validates that the Success Messages (Delete/Backup) are present and correct."
-
-     - name: "AssertStoreViewNotInGrid"
-       description: "Goes to the Admin Stores grid page. Searches the grid for the provided Store View name. Validates that it does NOT appear in the grid."
-
-     - name: "AdminSearchStoreViewByNameActionGroup"
-       description: "Goes to the Admin Stores grid page. Clears filters and search by store view name."
-
-     - name: "AdminDeleteStoreViewIfExistsActionGroup"
-       description: "EXTENDS: AdminSearchStoreViewByNameActionGroup. Goes to the Admin Stores grid page. Deletes the provided Store (if exists) without creating a Backup. Validates that the Success Message is present and correct."
- 
-- filename: "AssertStoreGroupInGridActionGroup.xml"
-  repo: "https://github.com/magento/magento2/blob/2.3/app/code/Magento/Store/Test/Mftf/ActionGroup/AssertStoreGroupInGridActionGroup.xml"
-  module: "Store"
-  actiongroups:
-     - name: "AssertStoreGroupInGridActionGroup"
-       description: "Goes to the Admin Stores grid page. Searches the grid for the provided Store Group Name. Validates that the provided Store Group Name is present and correct in the grid."
- 
-- filename: "ChangeStoreInStoreViewActionGroup.xml"
-  repo: "https://github.com/magento/magento2/blob/2.3/app/code/Magento/Store/Test/Mftf/ActionGroup/ChangeStoreInStoreViewActionGroup.xml"
-  module: "Store"
-  actiongroups:
-     - name: "ChangeStoreInStoreViewActionGroup"
-       description: "Clicks on the 1st row 'Store View' on the Admin Stores grid page. Selects the provided Store drop down menu. Clicks on Save. Validates that the Warning Message is present and correct."
- 
-- filename: "AdminStoreGroupCreateActionGroup.xml"
-  repo: "https://github.com/magento/magento2/blob/2.3/app/code/Magento/Store/Test/Mftf/ActionGroup/AdminStoreGroupCreateActionGroup.xml"
-  module: "Store"
-  actiongroups:
-     - name: "AdminStoreGroupCreateActionGroup"
-       description: "Fills in the provided Website and Store Group details. Clicks on Save. Validates that the Success Message is present and correct."
-
-     - name: "AdminAddCustomWebSiteToStoreGroup"
-       description: "Goes to the Admin Stores grid page. Searches the grid for the provided Store Group. Edits the Store. Adds the provided Website to the Store. Clicks on Save. Validates that the Success Message is present and correct."
- 
-- filename: "AdminWebsitePageActionGroup.xml"
-  repo: "https://github.com/magento/magento2/blob/2.3/app/code/Magento/Store/Test/Mftf/ActionGroup/AdminWebsitePageActionGroup.xml"
-  module: "Store"
-  actiongroups:
-     - name: "AdminGoCreatedWebsitePageActionGroup"
-       description: "Filter website name in grid and go first found website page"
- 
-- filename: "AdminCreateNewStoreGroupActionGroup.xml"
-  repo: "https://github.com/magento/magento2/blob/2.3/app/code/Magento/Store/Test/Mftf/ActionGroup/AdminCreateNewStoreGroupActionGroup.xml"
-  module: "Store"
-  actiongroups:
-     - name: "AdminCreateNewStoreGroupActionGroup"
-       description: "Goes to the Admin Stores creation page. Fills in the provided Details (Website, Store Group Name and Store Group Code). Clicks on Save. Validates that the Success Message is present and correct."
-
-     - name: "CreateCustomStore"
-       description: "Goes to the Admin Stores grid page. Clicks on 'Create Store'. Fills in the provided Details (Website, Store Group Name and Store Group Code). Clicks on Save. Validates that the Success Message is present and correct."
-
-     - name: "AssertStoreGroupInGrid"
-       description: "Goes to the Admin Stores grid page. Searches for the provided Store Group Name. Validates that the provided Store Group Name is present in the grid."
-
-     - name: "EditStoreGroupActionGroup"
-       description: "Edit store group."
-
-     - name: "ChangeDefaultStoreViewActionGroup"
-       description: "Change the default store view for provided store group."
-
-     - name: "AssertDefaultStoreViewActionGroup"
-       description: "Asserts that the provided store view is default in provided store group."
-
-     - name: "AssertStoreGroupForm"
-       description: "Clicks on the 1st Store in the 'Stores' grid. Validates that the provided Details (Website, Store Group Name, Store Group Code and Root Category) are present and correct."
- 
-- filename: "AssertStorefrontStoreNotVisibleInFooterActionGroup.xml"
-  repo: "https://github.com/magento/magento2/blob/2.3/app/code/Magento/Store/Test/Mftf/ActionGroup/AssertStorefrontStoreNotVisibleInFooterActionGroup.xml"
-  module: "Store"
-  actiongroups:
-     - name: "AssertStorefrontStoreNotVisibleInFooterActionGroup"
-       description: "Goes to the Storefront. Validates that the provided Store is NOT present in the Footer Switch Store View drop down menu."
- 
-- filename: "AssertStoreConfigurationBackendActionGroup.xml"
-  repo: "https://github.com/magento/magento2/blob/2.3/app/code/Magento/Store/Test/Mftf/ActionGroup/AssertStoreConfigurationBackendActionGroup.xml"
-  module: "Store"
-  actiongroups:
-     - name: "AssertStoreConfigurationBackendActionGroup"
-       description: "Goes to the 'Configuration' page. Clicks on the 'Store View' dropdown menu. Validates that the provided Website, Store, Store View 1 and Store View 2 are present and correct."
- 
-- filename: "AssertStoreViewInGridActionGroup.xml"
-  repo: "https://github.com/magento/magento2/blob/2.3/app/code/Magento/Store/Test/Mftf/ActionGroup/AssertStoreViewInGridActionGroup.xml"
-  module: "Store"
-  actiongroups:
-     - name: "AssertStoreViewInGridActionGroup"
-       description: "Goes the Admin Stores grid page. Searches the grid for the provided Store View Name. Validates that the provided Store View Name is present and correct in the grid."
- 
-- filename: "AssertStorefrontStoreVisibleInHeaderActionGroup.xml"
-  repo: "https://github.com/magento/magento2/blob/2.3/app/code/Magento/Store/Test/Mftf/ActionGroup/AssertStorefrontStoreVisibleInHeaderActionGroup.xml"
-  module: "Store"
-  actiongroups:
-     - name: "AssertStorefrontStoreVisibleInHeaderActionGroup"
-       description: "Goes to the Storefront. Validates that the provided Store is present in the Header Switch Store View drop down menu on the Storefront."
- 
-- filename: "AdminCreateCartPriceRuleLabelsSectionActionGroup.xml"
-  repo: "https://github.com/magento/magento2/blob/2.3/app/code/Magento/SalesRule/Test/Mftf/ActionGroup/AdminCreateCartPriceRuleLabelsSectionActionGroup.xml"
-  module: "SalesRule"
-  actiongroups:
-     - name: "AdminCreateCartPriceRuleLabelsSectionActionGroup"
-       description: "Fills in the provided Rule details on a Admin Cart Price Rule creation/edit page."
- 
-- filename: "StorefrontAddToTheCartActionGroup.xml"
-  repo: "https://github.com/magento/magento2/blob/2.3/app/code/Magento/SalesRule/Test/Mftf/ActionGroup/StorefrontAddToTheCartActionGroup.xml"
-  module: "SalesRule"
-  actiongroups:
-     - name: "StorefrontAddToTheCartActionGroup"
+     - name: "AdminAssertVisiblePagerActionGroup"
        description: ""
- 
-- filename: "AdminCartPriceRuleActionGroup.xml"
-  repo: "https://github.com/magento/magento2/blob/2.3/app/code/Magento/SalesRule/Test/Mftf/ActionGroup/AdminCartPriceRuleActionGroup.xml"
-  module: "SalesRule"
+- filename: "AdminImportProductsActionGroup.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/ImportExport/Test/Mftf/ActionGroup/AdminImportProductsActionGroup.xml"
+  module: "ImportExport"
   actiongroups:
-     - name: "selectNotLoggedInCustomerGroup"
-       description: "Selects 'NOT LOGGED IN' from the 'Customer Groups' list (Magento 2 B2B). PLEASE NOTE: The value is Hardcoded."
+     - name: "AdminImportProductsActionGroup"
+       description: "Goes to the Admin Import page. Imports the provided File. Validates that the Success Message is present and correct."
 
-     - name: "selectRetailerCustomerGroup"
-       description: "Selects 'Retailer' from the 'Customer Groups' list (Magento 2 B2B). PLEASE NOTE: The value is Hardcoded."
-
-     - name: "SetCartAttributeConditionForCartPriceRuleActionGroup"
-       description: "Sets the provided Cart Attribute Condition (Attribute Name, Operator Type and Value) on the Admin Cart Price Rule creation/edit page."
-
-     - name: "SetConditionForActionsInCartPriceRuleActionGroup"
-       description: "Sets the provided Condition (Actions Aggregator/Value, Child Attribute and Action Value) for Actions on the Admin Cart Price Rule creation/edit page."
- 
-- filename: "AssertCustomerGroupNotOnCartPriceRuleFormActionGroup.xml"
-  repo: "https://github.com/magento/magento2/blob/2.3/app/code/Magento/SalesRule/Test/Mftf/ActionGroup/AssertCustomerGroupNotOnCartPriceRuleFormActionGroup.xml"
-  module: "SalesRule"
-  actiongroups:
-     - name: "AssertCustomerGroupNotOnCartPriceRuleFormActionGroup"
-       description: "Validates that the 'Customer Groups' section does NOT contain the provided Customer Group on the Admin Cart Price Rule creation/edit page."
- 
-- filename: "AssertCartPriceRuleSuccessSaveMessageActionGroup.xml"
-  repo: "https://github.com/magento/magento2/blob/2.3/app/code/Magento/SalesRule/Test/Mftf/ActionGroup/AssertCartPriceRuleSuccessSaveMessageActionGroup.xml"
-  module: "SalesRule"
-  actiongroups:
-     - name: "AssertCartPriceRuleSuccessSaveMessageActionGroup"
-       description: "Clicks on the Save button on the Admin Cart Price Rule creation/edit page. Validates that the Success Message is present and correct."
- 
-- filename: "AdminDeleteCartPriceRuleActionGroup.xml"
-  repo: "https://github.com/magento/magento2/blob/2.3/app/code/Magento/SalesRule/Test/Mftf/ActionGroup/AdminDeleteCartPriceRuleActionGroup.xml"
-  module: "SalesRule"
-  actiongroups:
-     - name: "AdminDeleteCartPriceRuleActionGroup"
-       description: "Goes to the Admin Cart Price Rules grid page. Filters the grid for the provided Rule Name. Deletes the Rule via the grid."
- 
-- filename: "AdminCreateCartPriceRuleActionsSectionActionGroup.xml"
-  repo: "https://github.com/magento/magento2/blob/2.3/app/code/Magento/SalesRule/Test/Mftf/ActionGroup/AdminCreateCartPriceRuleActionsSectionActionGroup.xml"
-  module: "SalesRule"
-  actiongroups:
-     - name: "AdminCreateCartPriceRuleActionsSectionDiscountFieldsActionGroup"
-       description: "Clicks on the 'Actions' section on the Admin Cart Price Rule creation/edit page. Fills in the provided Cart Price Rule details."
-
-     - name: "AdminCreateCartPriceRuleActionsSectionShippingAmountActionGroup"
-       description: "Clicks on the 'Apply to Shipping Amount' toggle."
-
-     - name: "AdminCreateCartPriceRuleActionsSectionSubsequentRulesActionGroup"
-       description: "Clicks on the 'Discard subsequent rules' toggle."
-
-     - name: "AdminCreateCartPriceRuleActionsSectionFreeShippingActionGroup"
-       description: "Selects the provided option in the 'Free Shipping' dropdown menu."
- 
-- filename: "StorefrontSalesRuleActionGroup.xml"
-  repo: "https://github.com/magento/magento2/blob/2.3/app/code/Magento/SalesRule/Test/Mftf/ActionGroup/StorefrontSalesRuleActionGroup.xml"
-  module: "SalesRule"
-  actiongroups:
-     - name: "StorefrontApplyCouponActionGroup"
-       description: "Applies the provided Coupon Code to the Storefront Shopping Cart."
-
-     - name: "StorefrontCancelCouponActionGroup"
-       description: "Cancels the Coupon that is applied to the Storefront Shopping Cart."
-
-     - name: "StorefrontCheckCouponAppliedActionGroup"
-       description: "Validates that the provided Rule and Discount Amount is present and correct on the Storefront Checkout page."
-
-     - name: "VerifyDiscountAmount"
-       description: "Goes to the provided Storefront Product URL. Fills in provided Quantity. Clicks Add to Cart. Goes to Checkout. Validates that the provided Discount Amount is present and correct."
- 
-- filename: "AdminSalesRuleActionGroup.xml"
-  repo: "https://github.com/magento/magento2/blob/2.3/app/code/Magento/SalesRule/Test/Mftf/ActionGroup/AdminSalesRuleActionGroup.xml"
-  module: "SalesRule"
-  actiongroups:
-     - name: "DeleteCartPriceRuleByName"
-       description: "Goes to the Admin Cart Price Rules grid page. Filters the grid based on the provided Rule Name. Deletes the Price Rule via the grid."
- 
-- filename: "AdminCreateCartPriceRuleRuleInfoSectionActionGroup.xml"
-  repo: "https://github.com/magento/magento2/blob/2.3/app/code/Magento/SalesRule/Test/Mftf/ActionGroup/AdminCreateCartPriceRuleRuleInfoSectionActionGroup.xml"
-  module: "SalesRule"
-  actiongroups:
-     - name: "AdminCreateCartPriceRuleRuleInfoSectionActionGroup"
-       description: "Goes to the Admin Cart Price Rule grid page. Clicks on Add New Rule. Fills in the provided Rule details."
- 
-- filename: "StorefrontClickOnMiniCartActionGroup.xml"
-  repo: "https://github.com/magento/magento2/blob/2.3/app/code/Magento/SalesRule/Test/Mftf/ActionGroup/StorefrontClickOnMiniCartActionGroup.xml"
-  module: "SalesRule"
-  actiongroups:
-     - name: "StorefrontClickOnMiniCartActionGroup"
+     - name: "AdminImportProductsWithCheckValidationResultActionGroup"
        description: ""
- 
-- filename: "AdminFilterCartPriceRuleActionGroup.xml"
-  repo: "https://github.com/magento/magento2/blob/2.3/app/code/Magento/SalesRule/Test/Mftf/ActionGroup/AdminFilterCartPriceRuleActionGroup.xml"
-  module: "SalesRule"
-  actiongroups:
-     - name: "AdminFilterCartPriceRuleActionGroup"
-       description: "Filters the Admin Cart Price Rule grid based on the provided Rule Name. Clicks on the 1st row in the grid."
 
-     - name: "AdminCartPriceRuleNotInGridActionGroup"
-       description: "EXTENDS: AdminFilterCartPriceRuleActionGroup. Removes 'goToEditRulePage'. Validates that the Empty Grid message is present and correct."
- 
-- filename: "AdminCreateCartPriceRuleActionGroup.xml"
-  repo: "https://github.com/magento/magento2/blob/2.3/app/code/Magento/SalesRule/Test/Mftf/ActionGroup/AdminCreateCartPriceRuleActionGroup.xml"
-  module: "SalesRule"
-  actiongroups:
-     - name: "AdminCreateCartPriceRuleActionGroup"
-       description: "Goes to the Admin Cart Price Rule grid page. Adds the provided Rule. Validates that the Success Message is present and correct."
-
-     - name: "AdminCreateCartPriceRuleAndStayOnEditActionGroup"
-       description: "EXTENDS: AdminCreateCartPriceRuleActionGroup. Clicks on Save and Continue."
-
-     - name: "AdminCreateCartPriceRuleWithCouponCode"
-       description: "EXTENDS: AdminCreateCartPriceRuleActionGroup. Removes 'selectActionType' and 'fillDiscountAmount'. Adds the provided Coupon Code to a Cart Price Rule."
-
-     - name: "AdminDeleteCartPriceRuleForRetailerActionGroup"
-       description: "Goes to the Admin Cart Price Rules grid page. Removes the 1st Cart Price Rule in the Grid."
-
-     - name: "AdminCreateCartPriceRuleWithConditions"
-       description: "EXTENDS: AdminCreateCartPriceRuleActionGroup. Removes 'fillDiscountAmount'. Adds the 2 provided Conditions (Name, Rule, Rule to Change and Category Name) to a Cart Price Rule."
-
-     - name: "AdminCreateCartPriceRuleActionsWithSubtotalActionGroup"
-       description: "EXTENDS: AdminCreateCartPriceRuleActionGroup. Removes 'fillDiscountAmount'. Adds sub total conditions for free shipping to a Cart Price Rule."
-
-     - name: "AdminCreateMultiWebsiteCartPriceRuleActionGroup"
-       description: "EXTENDS: AdminCreateCartPriceRuleActionGroup. Removes 'clickSaveButton' for the next data changing. Assign cart price rule to 2 websites instead of 1."
-
-     - name: "CreateCartPriceRuleSecondWebsiteActionGroup"
-       description: "Goes to the Admin Cart Price Rule grid page. Clicks on Add New Rule. Fills the provided Rule (Name). Selects 'Second Website' from the 'Websites' menu."
-
-     - name: "AdminInactiveCartPriceRuleActionGroup"
-       description: "EXTENDS: AdminCreateCartPriceRuleActionGroup. Clicks on 'Active'."
-
-     - name: "AdminCreateCartPriceRuleWithConditionIsCategoryActionGroup"
-       description: "EXTENDS: AdminCreateCartPriceRuleActionGroup. Sets the provide Condition (Actions Aggregator/Value, Child Attribute and Action Value) for Actions on the Admin Cart Price Rule creation/edit page."
- 
-- filename: "AdminOpenNewCartPriceRuleFormPageActionGroup.xml"
-  repo: "https://github.com/magento/magento2/blob/2.3/app/code/Magento/SalesRule/Test/Mftf/ActionGroup/AdminOpenNewCartPriceRuleFormPageActionGroup.xml"
-  module: "SalesRule"
-  actiongroups:
-     - name: "AdminOpenNewCartPriceRuleFormPageActionGroup"
-       description: "Goes to the Admin Cart Price Rule creation page."
- 
-- filename: "AssertStorefrontMiniCartItemsActionGroup.xml"
-  repo: "https://github.com/magento/magento2/blob/2.3/app/code/Magento/SalesRule/Test/Mftf/ActionGroup/AssertStorefrontMiniCartItemsActionGroup.xml"
-  module: "SalesRule"
-  actiongroups:
-     - name: "AssertStorefrontMiniCartItemsActionGroup"
+     - name: "AdminCheckDataForImportProductActionGroup"
        description: ""
- 
-- filename: "StorefrontApplyDiscountCodeActionGroup.xml"
-  repo: "https://github.com/magento/magento2/blob/2.3/app/code/Magento/SalesRule/Test/Mftf/ActionGroup/StorefrontApplyDiscountCodeActionGroup.xml"
-  module: "SalesRule"
-  actiongroups:
-     - name: "StorefrontApplyDiscountCodeActionGroup"
-       description: ""
- 
-- filename: "AdminAssertCustomerGroupOnCartPriceRuleFormActionGroup.xml"
-  repo: "https://github.com/magento/magento2/blob/2.3/app/code/Magento/SalesRule/Test/Mftf/ActionGroup/AdminAssertCustomerGroupOnCartPriceRuleFormActionGroup.xml"
-  module: "SalesRule"
-  actiongroups:
-     - name: "AdminAssertCustomerGroupOnCartPriceRuleForm"
-       description: ""
- 
-- filename: "ApplyCartRuleOnStorefrontActionGroup.xml"
-  repo: "https://github.com/magento/magento2/blob/2.3/app/code/Magento/SalesRule/Test/Mftf/ActionGroup/ApplyCartRuleOnStorefrontActionGroup.xml"
-  module: "SalesRule"
-  actiongroups:
-     - name: "ApplyCartRuleOnStorefrontActionGroup"
-       description: "Clicks on Add to Cart on a Storefront Product page. Validates that the Success Message is present and correct. Goes to the Storefront Shopping Cart page. Applies the provided Coupon Code to the Shopping Cart."
- 
-- filename: "StorefrontAssertUpdatedProductPriceInStorefrontProductPageActionGroup.xml"
-  repo: "https://github.com/magento/magento2/blob/2.3/app/code/Magento/CatalogRuleConfigurable/Test/Mftf/ActionGroup/StorefrontAssertUpdatedProductPriceInStorefrontProductPageActionGroup.xml"
-  module: "CatalogRuleConfigurable"
-  actiongroups:
-     - name: "StorefrontAssertUpdatedProductPriceInStorefrontProductPageActionGroup"
-       description: "Validates that the provided Product Name and Price are present on a Storefront Product page."
- 
 - filename: "StorefrontAssertCatalogPriceRuleAppliedToProductOptionActionGroup.xml"
-  repo: "https://github.com/magento/magento2/blob/2.3/app/code/Magento/CatalogRuleConfigurable/Test/Mftf/ActionGroup/StorefrontAssertCatalogPriceRuleAppliedToProductOptionActionGroup.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/CatalogRuleConfigurable/Test/Mftf/ActionGroup/StorefrontAssertCatalogPriceRuleAppliedToProductOptionActionGroup.xml"
   module: "CatalogRuleConfigurable"
   actiongroups:
      - name: "StorefrontAssertCatalogPriceRuleAppliedToProductOptionActionGroup"
        description: "Selects the provided Product Option on a Storefront Product page. Validates the provided Expected Price is present and correct."
+- filename: "StorefrontAssertUpdatedProductPriceInStorefrontProductPageActionGroup.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/CatalogRuleConfigurable/Test/Mftf/ActionGroup/StorefrontAssertUpdatedProductPriceInStorefrontProductPageActionGroup.xml"
+  module: "CatalogRuleConfigurable"
+  actiongroups:
+     - name: "StorefrontAssertUpdatedProductPriceInStorefrontProductPageActionGroup"
+       description: "Validates that the provided Product Name and Price are present on a Storefront Product page."
+- filename: "IndexerActionGroup.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/Indexer/Test/Mftf/ActionGroup/IndexerActionGroup.xml"
+  module: "Indexer"
+  actiongroups:
+     - name: "updateIndexerBySchedule"
+       description: "Goes to the Index Management page. Checks the provided Indexer Name. Selects 'Update by Schedule'. Clicks on Submit."
+
+     - name: "updateIndexerOnSave"
+       description: "Goes to the Index Management page. Checks the provided Indexer Name. Selects 'Update on Save'. Clicks on Submit."
+
+     - name: "AdminReindexAndFlushCache"
+       description: "Run reindex and flush cache."
+- filename: "AdminSwitchAllIndexerToActionModeActionGroup.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/Indexer/Test/Mftf/ActionGroup/AdminSwitchAllIndexerToActionModeActionGroup.xml"
+  module: "Indexer"
+  actiongroups:
+     - name: "AdminSwitchAllIndexerToActionModeActionGroup"
+       description: ""
+- filename: "CliRunReindexUsingCronJobsActionGroup.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/Indexer/Test/Mftf/ActionGroup/CliRunReindexUsingCronJobsActionGroup.xml"
+  module: "Indexer"
+  actiongroups:
+     - name: "CliRunReindexUsingCronJobsActionGroup"
+       description: "Run cron 'index' group which reindex all invalidated indices."
+- filename: "AdminSwitchIndexerToActionModeActionGroup.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/Indexer/Test/Mftf/ActionGroup/AdminSwitchIndexerToActionModeActionGroup.xml"
+  module: "Indexer"
+  actiongroups:
+     - name: "AdminSwitchIndexerToActionModeActionGroup"
+       description: ""
+- filename: "AdminReindexAndFlushCacheActionGroup.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/Indexer/Test/Mftf/ActionGroup/AdminReindexAndFlushCacheActionGroup.xml"
+  module: "Indexer"
+  actiongroups:
+     - name: "AdminReindexAndFlushCache"
+       description: "Run reindex and flush cache."
+- filename: "AdminCurrencyRatesActionGroup.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/CurrencySymbol/Test/Mftf/ActionGroup/AdminCurrencyRatesActionGroup.xml"
+  module: "CurrencySymbol"
+  actiongroups:
+     - name: "AdminImportCurrencyRatesActionGroup"
+       description: ""
+
+     - name: "AdminSaveCurrencyRatesActionGroup"
+       description: ""
+
+     - name: "AdminSetCurrencyRatesActionGroup"
+       description: ""
+- filename: "StorefrontCurrencyRatesActionGroup.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/CurrencySymbol/Test/Mftf/ActionGroup/StorefrontCurrencyRatesActionGroup.xml"
+  module: "CurrencySymbol"
+  actiongroups:
+     - name: "StorefrontSwitchCurrencyActionGroup"
+       description: ""
+
+     - name: "StorefrontSwitchCurrency"
+       description: ""
+- filename: "AdminSetBaseCurrencyActionGroup.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/CurrencySymbol/Test/Mftf/ActionGroup/AdminSetBaseCurrencyActionGroup.xml"
+  module: "CurrencySymbol"
+  actiongroups:
+     - name: "AdminSetBaseCurrencyActionGroup"
+       description: ""
+- filename: "OtherPayPalConfigurationActionGroup.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/Paypal/Test/Mftf/ActionGroup/OtherPayPalConfigurationActionGroup.xml"
+  module: "Paypal"
+  actiongroups:
+     - name: "EnablePayPalConfiguration"
+       description: "Expands the 'OTHER PAYPAL PAYMENT SOLUTIONS' tab on the Admin Configuration page. Enables the provided PayPal Config type for the provided Country Code."
+
+     - name: "EnablePayPalSolutionWithoutSave"
+       description: "Expands the 'OTHER PAYPAL PAYMENT SOLUTIONS' tab on the Admin Configuration page. Enables the provided PayPal Config type for the provided Country Code without saving."
+
+     - name: "CheckEnableOptionPayPalConfiguration"
+       description: "Expands the 'OTHER PAYPAL PAYMENT SOLUTIONS' tab on the Admin Configuration page. Enables the provided PayPal Config type for the provided Country Code."
+- filename: "StorefrontPayPalPaymentActionGroup.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/Paypal/Test/Mftf/ActionGroup/StorefrontPayPalPaymentActionGroup.xml"
+  module: "Paypal"
+  actiongroups:
+     - name: "LoginToPayPalPaymentAccount"
+       description: ""
+- filename: "PayPalExpressCheckoutConfigurationActionGroup.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/Paypal/Test/Mftf/ActionGroup/PayPalExpressCheckoutConfigurationActionGroup.xml"
+  module: "Paypal"
+  actiongroups:
+     - name: "ConfigPayPalExpressCheckout"
+       description: "Goes to the 'Configuration' page for 'Payment Methods'. Fills in the provided PayPal credentials and other details. Clicks on Save."
+
+     - name: "SampleConfigPayPalExpressCheckout"
+       description: "Goes to the 'Configuration' page for 'Payment Methods'. Fills in the provided Sample PayPal credentials and other details. Clicks on Save."
+
+     - name: "CreatePayPalOrderWithSelectedPaymentMethodActionGroup"
+       description: "EXTENDS: CreateOrderToPrintPageActionGroup. Clicks on PayPal. Fills the PayPay details in the modal. PLEASE NOTE: The PayPal Payment credentials are Hardcoded using 'Payer'."
+
+     - name: "addProductToCheckoutPage"
+       description: "Goes to the provided Category page on the Storefront. Adds the 1st Product to the Cart. Goes to Checkout. Select the Shipping Method. Selects PayPal as the Payment Method."
+- filename: "StorefrontPayOrderOnPayPalCheckoutActionGroup.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/Paypal/Test/Mftf/ActionGroup/StorefrontPayOrderOnPayPalCheckoutActionGroup.xml"
+  module: "Paypal"
+  actiongroups:
+     - name: "StorefrontPayOrderOnPayPalCheckoutActionGroup"
+       description: "Verifies product name on Paypal cart and clicks 'Pay Now' on PayPal payment checkout page."
+- filename: "OpenPayPalButtonCheckoutPageActionGroup.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/Paypal/Test/Mftf/ActionGroup/OpenPayPalButtonCheckoutPageActionGroup.xml"
+  module: "Paypal"
+  actiongroups:
+     - name: "OpenPayPalButtonCheckoutPage"
+       description: "Clicks on 'Configure' for 'PayPal Express Checkout' on the Admin Configuration page. Expands the 'Advanced Settings' tab. Expands the 'Frontend Experience Settings' tab. Expands the 'Checkout Page' tab."
+- filename: "AdminUserActionGroup.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/User/Test/Mftf/ActionGroup/AdminUserActionGroup.xml"
+  module: "User"
+  actiongroups:
+     - name: "LoginNewUser"
+       description: "Goes to the Backend Admin Login page. Fill Username and Password. Click on Sign In."
+- filename: "AdminFillNewUserFormRequiredFieldsActionGroup.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/User/Test/Mftf/ActionGroup/AdminFillNewUserFormRequiredFieldsActionGroup.xml"
+  module: "User"
+  actiongroups:
+     - name: "AdminFillNewUserFormRequiredFieldsActionGroup"
+       description: "Fills in the provided User details on the New User creation page."
+- filename: "AdminCreateUserActionGroup.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/User/Test/Mftf/ActionGroup/AdminCreateUserActionGroup.xml"
+  module: "User"
+  actiongroups:
+     - name: "AdminCreateUserActionGroup"
+       description: "Goes to the Admin Users grid page. Clicks on Create User. Fills in the provided Role and User."
+
+     - name: "AdminCreateUserWithRoleActionGroup"
+       description: "Goes to the Admin Users grid page. Clicks on Create User. Fills in the provided Role and User."
+
+     - name: "AdminCreateUserWithApiRoleActionGroup"
+       description: ""
+- filename: "AdminDeleteUserActionGroup.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/User/Test/Mftf/ActionGroup/AdminDeleteUserActionGroup.xml"
+  module: "User"
+  actiongroups:
+     - name: "AdminDeleteUserActionGroup"
+       description: "Goes to the Admin Users grid page. Deletes the provided User. Validates that the Success Message is present and correct."
+
+     - name: "AdminDeleteCustomUserActionGroup"
+       description: "Goes to the Admin Users grid page. Deletes the provided User. Validates that the Success Message is present and correct."
+- filename: "AdminCreateRoleActionGroup.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/User/Test/Mftf/ActionGroup/AdminCreateRoleActionGroup.xml"
+  module: "User"
+  actiongroups:
+     - name: "AdminCreateRoleActionGroup"
+       description: "Goes to the Admin Edit Role page. Fills in the provided User details. Add the provided Role. Clicks on Save."
+
+     - name: "AdminFillUserRoleRequiredData"
+       description: ""
+
+     - name: "AdminAddRestrictedRole"
+       description: ""
+
+     - name: "AdminCreateRole"
+       description: "Clicks on 'Add New Role'. Fills in the provided details (Role, Resource, Scope and Websites). Clicks on Save. Validates that the Success Message is present and correct."
+- filename: "AdminDeleteCreatedUserActionGroup.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/User/Test/Mftf/ActionGroup/AdminDeleteCreatedUserActionGroup.xml"
+  module: "User"
+  actiongroups:
+     - name: "AdminDeleteCreatedUserActionGroup"
+       description: "Goes to the Admin Users grid page. Edits the provided User. Deletes the User. Validates that the Success Message is present and correct."
+
+     - name: "AdminDeleteNewUserActionGroup"
+       description: "Deletes a User that contains the name 'John'. PLEASE NOTE: The Action Group values are Hardcoded."
+- filename: "AdminClickSaveButtonOnUserRoleFormActionGroup.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/User/Test/Mftf/ActionGroup/AdminClickSaveButtonOnUserRoleFormActionGroup.xml"
+  module: "User"
+  actiongroups:
+     - name: "AdminClickSaveButtonOnUserRoleFormActionGroup"
+       description: "Clicks on Save on the Admin Roles creation/edit page."
+- filename: "AdminFillForgotPasswordFormActionGroup.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/User/Test/Mftf/ActionGroup/AdminFillForgotPasswordFormActionGroup.xml"
+  module: "User"
+  actiongroups:
+     - name: "AdminFillForgotPasswordFormActionGroup"
+       description: "Fills in the provided Email Address on the Admin Forgot Password page."
+- filename: "AdminOpenNewUserPageActionGroup.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/User/Test/Mftf/ActionGroup/AdminOpenNewUserPageActionGroup.xml"
+  module: "User"
+  actiongroups:
+     - name: "AdminOpenNewUserPageActionGroup"
+       description: "Goes to the Admin New User page."
+- filename: "AdminFillUserRoleFormActionGroup.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/User/Test/Mftf/ActionGroup/AdminFillUserRoleFormActionGroup.xml"
+  module: "User"
+  actiongroups:
+     - name: "AdminFillUserRoleFormActionGroup"
+       description: "Fills in the provided Role and Current Admin Password on the Admin Roles creation/edit page."
+- filename: "AdminCreateUserWithRoleAndIsActiveActionGroup.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/User/Test/Mftf/ActionGroup/AdminCreateUserWithRoleAndIsActiveActionGroup.xml"
+  module: "User"
+  actiongroups:
+     - name: "AdminCreateUserWithRoleAndIsActiveActionGroup"
+       description: ""
+- filename: "AdminOpenAdminUsersPageActionGroup.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/User/Test/Mftf/ActionGroup/AdminOpenAdminUsersPageActionGroup.xml"
+  module: "User"
+  actiongroups:
+     - name: "AdminOpenAdminUsersPageActionGroup"
+       description: ""
+- filename: "AdminDeleteUserViaCurlActionGroup.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/User/Test/Mftf/ActionGroup/AdminDeleteUserViaCurlActionGroup.xml"
+  module: "User"
+  actiongroups:
+     - name: "AdminDeleteUserViaCurlActionGroup"
+       description: ""
+- filename: "AdminUpdateUserRoleActionGroup.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/User/Test/Mftf/ActionGroup/AdminUpdateUserRoleActionGroup.xml"
+  module: "User"
+  actiongroups:
+     - name: "AdminUpdateUserRoleActionGroup"
+       description: ""
+- filename: "AdminOpenUserEditPageActionGroup.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/User/Test/Mftf/ActionGroup/AdminOpenUserEditPageActionGroup.xml"
+  module: "User"
+  actiongroups:
+     - name: "AdminOpenUserEditPageActionGroup"
+       description: ""
+- filename: "AdminClickSaveButtonOnUserFormActionGroup.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/User/Test/Mftf/ActionGroup/AdminClickSaveButtonOnUserFormActionGroup.xml"
+  module: "User"
+  actiongroups:
+     - name: "AdminClickSaveButtonOnUserFormActionGroup"
+       description: "Clicks on the Save button on the Admin User creation/edit page."
+- filename: "AdminOpenForgotPasswordPageActionGroup.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/User/Test/Mftf/ActionGroup/AdminOpenForgotPasswordPageActionGroup.xml"
+  module: "User"
+  actiongroups:
+     - name: "AdminOpenForgotPasswordPageActionGroup"
+       description: "Goes to the Admin Login page. Clicks on the 'Forgot Password' link."
+- filename: "AssertAdminUserIsInGridActionGroup.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/User/Test/Mftf/ActionGroup/AssertAdminUserIsInGridActionGroup.xml"
+  module: "User"
+  actiongroups:
+     - name: "AssertAdminUserIsInGridActionGroup"
+       description: ""
+- filename: "AdminAddNewUserRoleActionGroup.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/User/Test/Mftf/ActionGroup/AdminAddNewUserRoleActionGroup.xml"
+  module: "User"
+  actiongroups:
+     - name: "AdminAddNewUserRoleActionGroup"
+       description: ""
+
+     - name: "AdminAddNewUserRoleWithCustomRoleScopes"
+       description: ""
+- filename: "AdminDeleteUserRoleActionGroup.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/User/Test/Mftf/ActionGroup/AdminDeleteUserRoleActionGroup.xml"
+  module: "User"
+  actiongroups:
+     - name: "AdminDeleteUserRoleActionGroup"
+       description: ""
+- filename: "AdminDeleteCreatedRoleActionGroup.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/User/Test/Mftf/ActionGroup/AdminDeleteCreatedRoleActionGroup.xml"
+  module: "User"
+  actiongroups:
+     - name: "AdminDeleteCreatedRoleActionGroup"
+       description: ""
+
+     - name: "AdminDeleteRoleByRoleNameActionGroup"
+       description: ""
+- filename: "AssertAdminUserSaveMessageActionGroup.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/User/Test/Mftf/ActionGroup/AssertAdminUserSaveMessageActionGroup.xml"
+  module: "User"
+  actiongroups:
+     - name: "AssertAdminUserSaveMessageActionGroup"
+       description: "Validates that the provided Save Message is present and correct."
+- filename: "AssertUserRoleRestrictedAccessActionGroup.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/User/Test/Mftf/ActionGroup/AssertUserRoleRestrictedAccessActionGroup.xml"
+  module: "User"
+  actiongroups:
+     - name: "AssertUserRoleRestrictedAccessActionGroup"
+       description: ""
+- filename: "AdminOpenCreateRolePageActionGroup.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/User/Test/Mftf/ActionGroup/AdminOpenCreateRolePageActionGroup.xml"
+  module: "User"
+  actiongroups:
+     - name: "AdminOpenCreateRolePageActionGroup"
+       description: "Goes to the Admin Roles edit page."
+- filename: "AdminSubmitForgotPasswordFormActionGroup.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/User/Test/Mftf/ActionGroup/AdminSubmitForgotPasswordFormActionGroup.xml"
+  module: "User"
+  actiongroups:
+     - name: "AdminSubmitForgotPasswordFormActionGroup"
+       description: "Clicks on the Retrieve Password button."
+- filename: "AdminTranslateElementActionGroup.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/Translation/Test/Mftf/ActionGroup/AdminTranslateElementActionGroup.xml"
+  module: "Translation"
+  actiongroups:
+     - name: "AdminTranslateElementActionGroup"
+       description: ""
+- filename: "AssertElementInTranslateInlineModeActionGroup.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/Translation/Test/Mftf/ActionGroup/AssertElementInTranslateInlineModeActionGroup.xml"
+  module: "Translation"
+  actiongroups:
+     - name: "AssertElementInTranslateInlineModeActionGroup"
+       description: ""
+- filename: "AdminNewsletterTemplateActionGroup.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/Newsletter/Test/Mftf/ActionGroup/AdminNewsletterTemplateActionGroup.xml"
+  module: "Newsletter"
+  actiongroups:
+     - name: "SwitchToPreviewIframeActionGroup"
+       description: ""
+- filename: "VerifySubscribedNewsletterDisplayedActionGroup.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/Newsletter/Test/Mftf/ActionGroup/VerifySubscribedNewsletterDisplayedActionGroup.xml"
+  module: "Newsletter"
+  actiongroups:
+     - name: "StorefrontCreateNewAccountNewsletterChecked"
+       description: "EXTENDS: SignUpNewUserFromStorefrontActionGroup. Clicks on 'Sign Up for Newsletter'. Validates that the Subscription Confirmation message is present and correct."
+
+     - name: "StorefrontCreateNewAccountNewsletterUnchecked"
+       description: "EXTENDS: SignUpNewUserFromStorefrontActionGroup. Validates that the you are NOT subscribed message is present and correct."
+
+     - name: "CheckSubscribedNewsletterActionGroup"
+       description: "Goes to the Storefront Newsletter Management page. Validates that the 'Subscription' checkbox is checked."
+- filename: "AdminDeleteCatalogRuleActionGroup.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/CatalogRule/Test/Mftf/ActionGroup/AdminDeleteCatalogRuleActionGroup.xml"
+  module: "CatalogRule"
+  actiongroups:
+     - name: "AdminDeleteCatalogRuleActionGroup"
+       description: "Clicks on the Delete button on a Admin Catalog Price Rule edit page. Clicks on Ok. Validates that the provided Success Message is present and correct."
+- filename: "AdminCatalogPriceRuleSelectCustomerGroupsActionGroup.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/CatalogRule/Test/Mftf/ActionGroup/AdminCatalogPriceRuleSelectCustomerGroupsActionGroup.xml"
+  module: "CatalogRule"
+  actiongroups:
+     - name: "AdminCatalogPriceRuleSelectCustomerGroupsActionGroup"
+       description: "Fill Catalog Price Rule customer groups multiselect on new/edit page."
+- filename: "CatalogSelectCustomerGroupActionGroup.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/CatalogRule/Test/Mftf/ActionGroup/CatalogSelectCustomerGroupActionGroup.xml"
+  module: "CatalogRule"
+  actiongroups:
+     - name: "CatalogSelectCustomerGroupActionGroup"
+       description: "DEPRECATED. Please use AdminCatalogPriceRuleSelectCustomerGroupsActionGroup instead. Selects the provided Customer Group Name on the Admin Catalog Price Rule creation/edit page."
+- filename: "AssertCatalogRuleInGridActionGroup.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/CatalogRule/Test/Mftf/ActionGroup/AssertCatalogRuleInGridActionGroup.xml"
+  module: "CatalogRule"
+  actiongroups:
+     - name: "AssertCatalogRuleInGridActionGroup"
+       description: "Validates that the provided Catalog Rule Name, Status, Websites and Catalog Rule ID are present in the 1st row of the Admin Catalog Price Rule grid."
+- filename: "AdminAssertCustomerGroupOnCatalogPriceRuleFormActionGroup.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/CatalogRule/Test/Mftf/ActionGroup/AdminAssertCustomerGroupOnCatalogPriceRuleFormActionGroup.xml"
+  module: "CatalogRule"
+  actiongroups:
+     - name: "AdminAssertCustomerGroupOnCatalogPriceRuleForm"
+       description: ""
+- filename: "AdminOpenNewCatalogPriceRuleFormPageActionGroup.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/CatalogRule/Test/Mftf/ActionGroup/AdminOpenNewCatalogPriceRuleFormPageActionGroup.xml"
+  module: "CatalogRule"
+  actiongroups:
+     - name: "AdminOpenNewCatalogPriceRuleFormPageActionGroup"
+       description: "Goes to the create Catalog Price Rule page."
+- filename: "AdminCatalogPriceRuleFillMainInfoActionGroup.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/CatalogRule/Test/Mftf/ActionGroup/AdminCatalogPriceRuleFillMainInfoActionGroup.xml"
+  module: "CatalogRule"
+  actiongroups:
+     - name: "AdminCatalogPriceRuleFillMainInfoActionGroup"
+       description: "Fill Catalog Price Rule main info fields: Name, Description, Active (1/0), Priority."
+- filename: "AdminCatalogPriceRuleSaveAndApplyActionGroup.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/CatalogRule/Test/Mftf/ActionGroup/AdminCatalogPriceRuleSaveAndApplyActionGroup.xml"
+  module: "CatalogRule"
+  actiongroups:
+     - name: "AdminCatalogPriceRuleSaveAndApplyActionGroup"
+       description: "Clicks Save and Apply on a Admin Catalog Price Rule creation/edit page. Validates that the Success Message is present. Validates that applied rules success message is present."
+- filename: "AssertCustomerGroupNotOnCatalogPriceRuleFormActionGroup.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/CatalogRule/Test/Mftf/ActionGroup/AssertCustomerGroupNotOnCatalogPriceRuleFormActionGroup.xml"
+  module: "CatalogRule"
+  actiongroups:
+     - name: "AssertCustomerGroupNotOnCatalogPriceRuleFormActionGroup"
+       description: "Validate that the provided Customer Group is not present on the Catalog Price Rules creation/edit page."
+- filename: "AssertCatalogPriceRuleFormActionGroup.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/CatalogRule/Test/Mftf/ActionGroup/AssertCatalogPriceRuleFormActionGroup.xml"
+  module: "CatalogRule"
+  actiongroups:
+     - name: "AssertCatalogPriceRuleFormActionGroup"
+       description: "Validates that the provided Catalog Rule, Status, Websites and Customer Group details are present and correct on a Admin Catalog Price Rule creation/edit page."
+- filename: "CatalogPriceRuleActionGroup.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/CatalogRule/Test/Mftf/ActionGroup/CatalogPriceRuleActionGroup.xml"
+  module: "CatalogRule"
+  actiongroups:
+     - name: "newCatalogPriceRuleByUI"
+       description: "Goes to the Catalog Price Rule grid. Clicks on Add. Fills in the provided Catalog Rule details."
+
+     - name: "createCatalogPriceRule"
+       description: "Clicks on the Add button. Fills Rule Name, Description, Website and Discount Value."
+
+     - name: "AdminCreateCatalogPriceRuleWithConditionActionGroup"
+       description: ""
+
+     - name: "AdminCreateMultipleWebsiteCatalogPriceRule"
+       description: ""
+
+     - name: "CreateCatalogPriceRuleViaTheUi"
+       description: ""
+
+     - name: "CreateCatalogPriceRuleConditionWithAttribute"
+       description: "Add Conditional Requirements to a Catalog Price Rule from the creation/edit page."
+
+     - name: "applyCatalogPriceRules"
+       description: "Goes to the Catalog Price Rule grid page. Clicks on Apply Rules. Validates that the Success Message is present and correct."
+
+     - name: "newCatalogPriceRuleByUIWithConditionIsSKU"
+       description: "EXTENDS: newCatalogPriceRuleByUI. Add a Catalog Price Rule Condition based on the provided SKU."
+
+     - name: "newCatalogPriceRuleByUIWithConditionIsCategory"
+       description: "EXTENDS: newCatalogPriceRuleByUI. Add a Catalog Price Rule Condition based on the provided Category ID."
+
+     - name: "selectGeneralCustomerGroupActionGroup"
+       description: "Selects the 'General' Customer Group for a Catalog Price Rule on the creation/edit page."
+
+     - name: "selectNotLoggedInCustomerGroupActionGroup"
+       description: "Selects the 'NOT LOGGED IN' Customer Group for a Catalog Price Rule on the creation/edit page."
+
+     - name: "OpenCatalogPriceRule"
+       description: ""
+
+     - name: "RemoveCatalogPriceRule"
+       description: ""
+
+     - name: "AdminFillCatalogRuleConditionActionGroup"
+       description: "Clicks on the Conditions tab. Fills in the provided condition for Catalog Price Rule."
+
+     - name: "newCatalogPriceRuleWithInvalidData"
+       description: "Goes to the Catalog Price Rule grid. Clicks on Add. Fills in the provided Catalog Rule details with invalid data."
+- filename: "AdminCreateNewCatalogPriceRuleActionGroup.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/CatalogRule/Test/Mftf/ActionGroup/AdminCreateNewCatalogPriceRuleActionGroup.xml"
+  module: "CatalogRule"
+  actiongroups:
+     - name: "AdminCreateNewCatalogPriceRuleActionGroup"
+       description: "Goes to the Admin Catalog Price Rule creation page. Fills in the provided Catalog Rule details. Selects the provided Customer Group."
+- filename: "AdminSearchCatalogRuleInGridActionGroup.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/CatalogRule/Test/Mftf/ActionGroup/AdminSearchCatalogRuleInGridActionGroup.xml"
+  module: "CatalogRule"
+  actiongroups:
+     - name: "AdminSearchCatalogRuleInGridActionGroup"
+       description: "Goes to the Admin Catalog Price Rules grid page. Searches the grid for the provided Catalog Price Rule name."
+- filename: "CreateCatalogPriceRuleConditionWithAttributeAndOptionActionGroup.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/CatalogRule/Test/Mftf/ActionGroup/CreateCatalogPriceRuleConditionWithAttributeAndOptionActionGroup.xml"
+  module: "CatalogRule"
+  actiongroups:
+     - name: "CreateCatalogPriceRuleConditionWithAttributeAndOptionActionGroup"
+       description: "Adds the provided Attribute Name, Select Value, Index A and Index B details to the 'Conditions' section on the Admin Catalog Price Rule creation/edit page."
+- filename: "AdminSaveAndApplyRulesActionGroup.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/CatalogRule/Test/Mftf/ActionGroup/AdminSaveAndApplyRulesActionGroup.xml"
+  module: "CatalogRule"
+  actiongroups:
+     - name: "AdminSaveAndApplyRulesActionGroup"
+       description: "DEPRECATED. Please use AdminCatalogPriceRuleSaveAndApplyActionGroup instead. Clicks Save on a Admin Catalog Price Rule creation/edit page. Validates that the Success Message is present. Clicks Apply Rules. Validates that the Success Message is present."
+- filename: "AdminOpenCatalogPriceRulePageActionGroup.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/CatalogRule/Test/Mftf/ActionGroup/AdminOpenCatalogPriceRulePageActionGroup.xml"
+  module: "CatalogRule"
+  actiongroups:
+     - name: "AdminOpenCatalogPriceRulePageActionGroup"
+       description: ""
+- filename: "AdminSelectCatalogRuleFromGridActionGroup.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/CatalogRule/Test/Mftf/ActionGroup/AdminSelectCatalogRuleFromGridActionGroup.xml"
+  module: "CatalogRule"
+  actiongroups:
+     - name: "AdminSelectCatalogRuleFromGridActionGroup"
+       description: "Clicks on the Admin Catalog Price Rule row that contains the provided Catalog Price Rule name."
+- filename: "SaveAndApplyCatalogPriceRuleActionGroup.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/CatalogRule/Test/Mftf/ActionGroup/SaveAndApplyCatalogPriceRuleActionGroup.xml"
+  module: "CatalogRule"
+  actiongroups:
+     - name: "SaveAndApplyCatalogPriceRuleActionGroup"
+       description: "Clicks on Save and Apply. Validates that the Success Message is present and correct on the Admin Catalog Price Rule creation/edit page."
+- filename: "AdminCatalogPriceRuleAddSkuConditionActionGroup.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/CatalogRule/Test/Mftf/ActionGroup/AdminCatalogPriceRuleAddSkuConditionActionGroup.xml"
+  module: "CatalogRule"
+  actiongroups:
+     - name: "AdminCatalogPriceRuleAddSkuConditionActionGroup"
+       description: "Create new product SKU based condition in Catalog Price Rule form."
+- filename: "AdminCatalogPriceRuleFillActionsActionGroup.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/CatalogRule/Test/Mftf/ActionGroup/AdminCatalogPriceRuleFillActionsActionGroup.xml"
+  module: "CatalogRule"
+  actiongroups:
+     - name: "AdminCatalogPriceRuleFillActionsActionGroup"
+       description: "Fill Catalog Price Rule actions fields: Apply, Discount Amount, Discard subsequent rules."
+- filename: "AdminCatalogPriceRuleDeleteAllActionGroup.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/CatalogRule/Test/Mftf/ActionGroup/AdminCatalogPriceRuleDeleteAllActionGroup.xml"
+  module: "CatalogRule"
+  actiongroups:
+     - name: "AdminCatalogPriceRuleDeleteAllActionGroup"
+       description: "Open Catalog Price Rule grid and delete all rules one by one. Need to avoid interference with other tests that test catalog price rules."
+- filename: "StorefrontCheckElementColorActionGroup.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/Theme/Test/Mftf/ActionGroup/StorefrontCheckElementColorActionGroup.xml"
+  module: "Theme"
+  actiongroups:
+     - name: "StorefrontCheckElementColorActionGroup"
+       description: "Checks element color on storefront."
+- filename: "StorefrontClickOnHeaderLogoActionGroup.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/Theme/Test/Mftf/ActionGroup/StorefrontClickOnHeaderLogoActionGroup.xml"
+  module: "Theme"
+  actiongroups:
+     - name: "StorefrontClickOnHeaderLogoActionGroup"
+       description: "Goes to the Storefront. Clicks on the Logo."
+- filename: "NavigateToFaviconMediaFolderActionGroup.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/Theme/Test/Mftf/ActionGroup/NavigateToFaviconMediaFolderActionGroup.xml"
+  module: "Theme"
+  actiongroups:
+     - name: "NavigateToFaviconMediaFolderActionGroup"
+       description: "Navigates to the Favicon Media folder in the 'Media Gallery'. Clicks on the provided Store Folder."
+- filename: "AdminChangeStorefrontThemeActionGroup.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/Theme/Test/Mftf/ActionGroup/AdminChangeStorefrontThemeActionGroup.xml"
+  module: "Theme"
+  actiongroups:
+     - name: "AdminChangeStorefrontThemeActionGroup"
+       description: ""
+- filename: "ClickSaveActionGroup.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/Backend/Test/Mftf/ActionGroup/ClickSaveActionGroup.xml"
+  module: "Backend"
+  actiongroups:
+     - name: "ClickSaveButtonActionGroup"
+       description: ""
+- filename: "SetWebsiteCountryOptionsToDefaultActionGroup.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/Backend/Test/Mftf/ActionGroup/SetWebsiteCountryOptionsToDefaultActionGroup.xml"
+  module: "Backend"
+  actiongroups:
+     - name: "SetWebsiteCountryOptionsToDefaultActionGroup"
+       description: "Sets the Website Country configuration setting to the Default values."
+- filename: "AssertAdminPageIsNot404ActionGroup.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/Backend/Test/Mftf/ActionGroup/AssertAdminPageIsNot404ActionGroup.xml"
+  module: "Backend"
+  actiongroups:
+     - name: "AssertAdminPageIsNot404ActionGroup"
+       description: "Validates that the '404 Error' message is present and correct in the Admin Page Header."
+- filename: "LogoutActionGroup.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/Backend/Test/Mftf/ActionGroup/LogoutActionGroup.xml"
+  module: "Backend"
+  actiongroups:
+     - name: "logout"
+       description: "Logout of the Backend Admin. PLEASE NOTE: This Action Group does NOT validate that you are Logged Out."
+- filename: "LoginAdminWithCredentialsActionGroup.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/Backend/Test/Mftf/ActionGroup/LoginAdminWithCredentialsActionGroup.xml"
+  module: "Backend"
+  actiongroups:
+     - name: "LoginAdminWithCredentialsActionGroup"
+       description: "Login to Backend Admin using provided Admin credentials. PLEASE NOTE: This Action Group does NOT validate that you are Logged In."
+- filename: "SortByIdDescendingActionGroup.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/Backend/Test/Mftf/ActionGroup/SortByIdDescendingActionGroup.xml"
+  module: "Backend"
+  actiongroups:
+     - name: "SortByIdDescendingActionGroup"
+       description: "Sorts a Backend Admin Grid by descending order for the ID column."
+- filename: "AssertMessageOnAdminLoginActionGroup.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/Backend/Test/Mftf/ActionGroup/AssertMessageOnAdminLoginActionGroup.xml"
+  module: "Backend"
+  actiongroups:
+     - name: "AssertMessageOnAdminLoginActionGroup"
+       description: "Validate Backend Admin Login status message is present and correct."
+- filename: "AssertMessageInAdminPanelActionGroup.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/Backend/Test/Mftf/ActionGroup/AssertMessageInAdminPanelActionGroup.xml"
+  module: "Backend"
+  actiongroups:
+     - name: "AssertMessageInAdminPanelActionGroup"
+       description: "Validates that the provided Message appears in the provided Message Type on an Admin page."
+- filename: "SetAdminAccountActionGroup.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/Backend/Test/Mftf/ActionGroup/SetAdminAccountActionGroup.xml"
+  module: "Backend"
+  actiongroups:
+     - name: "SetAdminAccountActionGroup"
+       description: "Update the Interface Language configuration setting using provided Interface Language."
+- filename: "AdminNavigateMenuActionGroup.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/Backend/Test/Mftf/ActionGroup/AdminNavigateMenuActionGroup.xml"
+  module: "Backend"
+  actiongroups:
+     - name: "AdminNavigateMenuActionGroup"
+       description: "Open Backend Admin side Navigation Menu. Click on Sub-Navigation Menu item."
+- filename: "AdminFilterLegacyGridActionGroup.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/Backend/Test/Mftf/ActionGroup/AdminFilterLegacyGridActionGroup.xml"
+  module: "Backend"
+  actiongroups:
+     - name: "AdminFilterLegacyGridActionGroup"
+       description: ""
+- filename: "AdminAssertPageTitleActionGroup.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/Backend/Test/Mftf/ActionGroup/AdminAssertPageTitleActionGroup.xml"
+  module: "Backend"
+  actiongroups:
+     - name: "AdminAssertPageTitleActionGroup"
+       description: "Validate Backend Admin Grid Page Title is present and correct."
+- filename: "LoginActionGroup.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/Backend/Test/Mftf/ActionGroup/LoginActionGroup.xml"
+  module: "Backend"
+  actiongroups:
+     - name: "LoginActionGroup"
+       description: "Login to Backend Admin using ENV Admin credentials. PLEASE NOTE: This Action Group does NOT validate that you are Logged In."
+- filename: "AdminResetLegacyGridFilterActionGroup.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/Backend/Test/Mftf/ActionGroup/AdminResetLegacyGridFilterActionGroup.xml"
+  module: "Backend"
+  actiongroups:
+     - name: "AdminResetLegacyGridFilterActionGroup"
+       description: ""
+- filename: "AssertAdminUserIsInGridActionGroup.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/Backend/Test/Mftf/ActionGroup/AssertAdminUserIsInGridActionGroup.xml"
+  module: "Backend"
+  actiongroups:
+     - name: "AssertAdminUserIsInGridActionGroup"
+       description: ""
+- filename: "AssertAdminDashboardPageIsVisibleActionGroup.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/Backend/Test/Mftf/ActionGroup/AssertAdminDashboardPageIsVisibleActionGroup.xml"
+  module: "Backend"
+  actiongroups:
+     - name: "AssertAdminDashboardPageIsVisibleActionGroup"
+       description: "Validate the Backend Admin Dashboard URI is correct. Validate the Backend Admin Dashboard Title is present and correct."
+- filename: "AdminSetStoreInformationConfigurationActionGroup.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/Backend/Test/Mftf/ActionGroup/AdminSetStoreInformationConfigurationActionGroup.xml"
+  module: "Backend"
+  actiongroups:
+     - name: "AdminSetStoreInformationConfigurationActionGroup"
+       description: "Set Store Information configurations"
+- filename: "SecondaryGridActionGroup.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/Backend/Test/Mftf/ActionGroup/SecondaryGridActionGroup.xml"
+  module: "Backend"
+  actiongroups:
+     - name: "deleteEntitySecondaryGrid"
+       description: "This Action Group deletes an item from a grid based on provided Name. After Searching, the First Row is clicked."
+- filename: "AssertAdminSuccessLoginActionGroup.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/Backend/Test/Mftf/ActionGroup/AssertAdminSuccessLoginActionGroup.xml"
+  module: "Backend"
+  actiongroups:
+     - name: "AssertAdminSuccessLoginActionGroup"
+       description: "Wait for the current Admin Name to appear in the Backend Admin."
+- filename: "AssertOrderGraphImageOnDashboardActionGroup.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/Backend/Test/Mftf/ActionGroup/AssertOrderGraphImageOnDashboardActionGroup.xml"
+  module: "Backend"
+  actiongroups:
+     - name: "AssertOrderGraphImageOnDashboardActionGroup"
+       description: ""
+- filename: "AdminClickFormActionButtonActionGroup.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/Backend/Test/Mftf/ActionGroup/AdminClickFormActionButtonActionGroup.xml"
+  module: "Backend"
+  actiongroups:
+     - name: "AdminClickFormActionButtonActionGroup"
+       description: ""
+- filename: "LoginAsAdminActionGroup.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/Backend/Test/Mftf/ActionGroup/LoginAsAdminActionGroup.xml"
+  module: "Backend"
+  actiongroups:
+     - name: "LoginAsAdmin"
+       description: "Login to Backend Admin using provided User Data. PLEASE NOTE: This Action Group does NOT validate that you are Logged In."
+- filename: "AssertUserRoleRestrictedAccessActionGroup.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/Backend/Test/Mftf/ActionGroup/AssertUserRoleRestrictedAccessActionGroup.xml"
+  module: "Backend"
+  actiongroups:
+     - name: "AssertUserRoleRestrictedAccessActionGroup"
+       description: ""
+- filename: "AdminCreateWidgetActionGroup.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/Widget/Test/Mftf/ActionGroup/AdminCreateWidgetActionGroup.xml"
+  module: "Widget"
+  actiongroups:
+     - name: "AdminCreateWidgetActionGroup"
+       description: "Goes to the Admin Widget creation page. Creates the provided Widget."
+
+     - name: "AdminFillSpecificPageWidgetMainFieldsActionGroup"
+       description: "Fill widget main fields and widget layout by index for specified page DisplayOn option"
+
+     - name: "AdminCreateProductsListWidgetActionGroup"
+       description: "EXTENDS: AdminCreateWidgetActionGroup. Creates a Product List Widget. Validates that the Success Message is present and correct."
+
+     - name: "AdminCreateDynamicBlocksRotatorWidgetActionGroup"
+       description: "EXTENDS: AdminCreateWidgetActionGroup. Creates a Dynamic Block Rotate Widget."
+
+     - name: "AdminDeleteWidgetActionGroup"
+       description: "Goes to the Admin Widget grid page. Deletes the provided Widget. Validates that the Success Message is present and correct."
+
+     - name: "AdminCreateProductLinkWidgetActionGroup"
+       description: "EXTENDS: AdminCreateWidgetActionGroup. Creates a Product List Widget using the provided Product. Validates that the Success Message is present and correct."
+- filename: "AdminCreateAndSaveWidgetActionGroup.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/Widget/Test/Mftf/ActionGroup/AdminCreateAndSaveWidgetActionGroup.xml"
+  module: "Widget"
+  actiongroups:
+     - name: "AdminCreateAndSaveWidgetActionGroup"
+       description: "EXTENDS: AdminCreateWidgetActionGroup. Clicks on Save. Validates that the Success Message is present and correct."
+- filename: "AdminWidgetActionGroup.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/Widget/Test/Mftf/ActionGroup/AdminWidgetActionGroup.xml"
+  module: "Widget"
+  actiongroups:
+     - name: "AdminCreateWidgetWithBlockActionGroup"
+       description: "Goes to the Admin Widgets creation page. Creates the provided Widget which includes the provided Block. Clicks on Save. Validates that the Success Message is preset and correct."
+- filename: "AdminSystemMessagesActionGroup.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/AdminNotification/Test/Mftf/ActionGroup/AdminSystemMessagesActionGroup.xml"
+  module: "AdminNotification"
+  actiongroups:
+     - name: "AdminSystemMessagesWarningActionGroup"
+       description: "Check warning system message exists."
+- filename: "AdminNavigateToVariablePageActionGroup.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/Variable/Test/Mftf/ActionGroup/AdminNavigateToVariablePageActionGroup.xml"
+  module: "Variable"
+  actiongroups:
+     - name: "AdminNavigateToVariablePageByCodeActionGroup"
+       description: ""
+- filename: "CreateCustomVariableActionGroup.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/Variable/Test/Mftf/ActionGroup/CreateCustomVariableActionGroup.xml"
+  module: "Variable"
+  actiongroups:
+     - name: "CreateCustomVariableActionGroup"
+       description: "Goes to the Custom Variable creation page. Fills in the Custom Variable details. PLEASE NOTE: The Custom Variable details are Hardcoded using 'customVariable'."
+
+     - name: "DeleteCustomVariableActionGroup"
+       description: "Goes to the Custom Variable grid page. Deletes the Custom Variable. PLEASE NOTE: The Custom Variable that is deleted is Hardcoded using 'customVariable'."
+- filename: "AdminOpenVariablesGridPageActionGroup.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/Variable/Test/Mftf/ActionGroup/AdminOpenVariablesGridPageActionGroup.xml"
+  module: "Variable"
+  actiongroups:
+     - name: "AdminOpenVariablesGridPageActionGroup"
+       description: ""
+- filename: "AssertAdminCustomVariableInGridActionGroup.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/Variable/Test/Mftf/ActionGroup/AssertAdminCustomVariableInGridActionGroup.xml"
+  module: "Variable"
+  actiongroups:
+     - name: "AssertAdminCustomVariableInGridActionGroup"
+       description: ""
+- filename: "AssertAdminCustomVariableFormActionGroup.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/Variable/Test/Mftf/ActionGroup/AssertAdminCustomVariableFormActionGroup.xml"
+  module: "Variable"
+  actiongroups:
+     - name: "AssertAdminCustomVariableFormActionGroup"
+       description: ""
+- filename: "AdminFillVariableFormActionGroup.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/Variable/Test/Mftf/ActionGroup/AdminFillVariableFormActionGroup.xml"
+  module: "Variable"
+  actiongroups:
+     - name: "AdminFillVariableFormActionGroup"
+       description: ""
+- filename: "AdminOpenNewVariablePageActionGroup.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/Variable/Test/Mftf/ActionGroup/AdminOpenNewVariablePageActionGroup.xml"
+  module: "Variable"
+  actiongroups:
+     - name: "AdminOpenNewVariablePageActionGroup"
+       description: ""
+- filename: "AdminFilterVariableGridActionGroup.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/Variable/Test/Mftf/ActionGroup/AdminFilterVariableGridActionGroup.xml"
+  module: "Variable"
+  actiongroups:
+     - name: "AdminFilterVariableGridActionGroup"
+       description: ""
+- filename: "StorefrontAssertPersistentRegistrationPageFieldsActionGroup.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/Persistent/Test/Mftf/ActionGroup/StorefrontAssertPersistentRegistrationPageFieldsActionGroup.xml"
+  module: "Persistent"
+  actiongroups:
+     - name: "StorefrontAssertPersistentRegistrationPageFields"
+       description: ""
+- filename: "StorefrontPersistentAssertCustomerWelcomeMessageActionGroup.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/Persistent/Test/Mftf/ActionGroup/StorefrontPersistentAssertCustomerWelcomeMessageActionGroup.xml"
+  module: "Persistent"
+  actiongroups:
+     - name: "StorefrontAssertPersistentCustomerWelcomeMessageActionGroup"
+       description: ""
+
+     - name: "StorefrontAssertPersistentCustomerWelcomeMessageNotPresentActionGroup"
+       description: ""
+- filename: "StorefrontCustomerActionGroup.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/Persistent/Test/Mftf/ActionGroup/StorefrontCustomerActionGroup.xml"
+  module: "Persistent"
+  actiongroups:
+     - name: "CustomerLoginOnStorefrontWithRememberMeChecked"
+       description: "EXTENDS: LoginToStorefrontActionGroup. Checks the 'Remember Me' checkbox."
+
+     - name: "CustomerLoginOnStorefrontWithRememberMeUnChecked"
+       description: "EXTENDS: LoginToStorefrontActionGroup. Uncheck the 'Remember Me' checkbox."
+
+     - name: "StorefrontRegisterCustomerRememberMe"
+       description: ""
+
+     - name: "StorefrontCreateCustomerOnRegisterPageDoNotRememberMe"
+       description: ""
+- filename: "AssertLinkPresenceOnGroupedProductPageActionGroup.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/GroupedProduct/Test/Mftf/ActionGroup/AssertLinkPresenceOnGroupedProductPageActionGroup.xml"
+  module: "GroupedProduct"
+  actiongroups:
+     - name: "AssertLinkPresenceOnGroupedProductPage"
+       description: "Validates that the provided Product Name is present and correct on a Storefront Grouped Product page."
+- filename: "VerifyProductTypeOrderActionGroup.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/GroupedProduct/Test/Mftf/ActionGroup/VerifyProductTypeOrderActionGroup.xml"
+  module: "GroupedProduct"
+  actiongroups:
+     - name: "VerifyProductTypeOrder"
+       description: "Checks that Grouped is in the correct order in comparison to other product types on the add product dropdown."
+- filename: "StorefrontAddGroupedProductWithTwoLinksToCartActionGroup.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/GroupedProduct/Test/Mftf/ActionGroup/StorefrontAddGroupedProductWithTwoLinksToCartActionGroup.xml"
+  module: "GroupedProduct"
+  actiongroups:
+     - name: "StorefrontAddGroupedProductWithTwoLinksToCartActionGroup"
+       description: "Adding to the Shopping Cart single Grouped product, with 2 associated from the Product page"
+- filename: "AdminGroupedProductActionGroup.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/GroupedProduct/Test/Mftf/ActionGroup/AdminGroupedProductActionGroup.xml"
+  module: "GroupedProduct"
+  actiongroups:
+     - name: "checkRequiredFieldsInGroupedProductForm"
+       description: "Clears the Product Name and SKU fields when adding a Grouped Product and then verifies that they are required after attempting to Save."
+
+     - name: "fillGroupedProductForm"
+       description: "Fills in the provided Product Name and SKU on the Grouped Product creation/edit page."
+
+     - name: "viewGroupedProductInAdminGrid"
+       description: "Goes to the Admin Products grid page. Filters the grid for the provided Product. Validates that the provided Product appears in the grid."
+
+     - name: "fillDefaultQuantityForLinkedToGroupProductInGrid"
+       description: "Fills the provided Qty for a Product linked to a Grouped Product."
+
+     - name: "AdminAssignProductToGroup"
+       description: "Adds the provided Product to a Grouped Product on an Admin Grouped Product creation/edit page."
+- filename: "StorefrontAddThreeGroupedProductToTheCartActionGroup.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/GroupedProduct/Test/Mftf/ActionGroup/StorefrontAddThreeGroupedProductToTheCartActionGroup.xml"
+  module: "GroupedProduct"
+  actiongroups:
+     - name: "StorefrontAddThreeGroupedProductToTheCartActionGroup"
+       description: "Goes to the provided URL for a Grouped Product. Validates that the provided Products and Quantities are present and correct."
+- filename: "FillGroupedProductFormActionGroup.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/GroupedProduct/Test/Mftf/ActionGroup/FillGroupedProductFormActionGroup.xml"
+  module: "GroupedProduct"
+  actiongroups:
+     - name: "FillGroupedProductFormActionGroup"
+       description: "Fills in the provided Product Name and SKU on the Grouped Product creation/edit page."
+- filename: "AdminAssignProductToGroupActionGroup.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/GroupedProduct/Test/Mftf/ActionGroup/AdminAssignProductToGroupActionGroup.xml"
+  module: "GroupedProduct"
+  actiongroups:
+     - name: "AdminAssignProductToGroupActionGroup"
+       description: "Adds the provided Product to a Grouped Product on an Admin Grouped Product creation/edit page."
+- filename: "AdminOrderGroupedProductActionGroup.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/GroupedProduct/Test/Mftf/ActionGroup/AdminOrderGroupedProductActionGroup.xml"
+  module: "GroupedProduct"
+  actiongroups:
+     - name: "AdminOrderConfigureGroupedProduct"
+       description: ""
+- filename: "AdminElasticConnectionTestActionGroup.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/Elasticsearch6/Test/Mftf/ActionGroup/AdminElasticConnectionTestActionGroup.xml"
+  module: "Elasticsearch6"
+  actiongroups:
+     - name: "AdminElasticConnectionTestActionGroup"
+       description: "Check ElasticSearch connection after enabling."
+- filename: "StorefrontCatalogSearchTermActionGroup.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/CatalogSearch/Test/Mftf/ActionGroup/StorefrontCatalogSearchTermActionGroup.xml"
+  module: "CatalogSearch"
+  actiongroups:
+     - name: "AssertSearchTermNotOnFrontend"
+       description: "Goes to the Storefront. Fills the Search field with the provided Search Query. Clicks on Search. Validates that there are no results."
+
+     - name: "AssertSearchTermOnFrontend"
+       description: "Fills the Storefront Search field with the provided Search Query. Clicks on Search. Validates that the URL is correct."
+- filename: "StorefrontQuickSearchCheckProductNameInGridActionGroup.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/CatalogSearch/Test/Mftf/ActionGroup/StorefrontQuickSearchCheckProductNameInGridActionGroup.xml"
+  module: "CatalogSearch"
+  actiongroups:
+     - name: "StorefrontQuickSearchCheckProductNameInGridActionGroup"
+       description: "Validates that the provided Product Name appears at the correct index on the Storefront Quick Search page."
+- filename: "AdminSetMinimalQueryLengthActionGroup.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/CatalogSearch/Test/Mftf/ActionGroup/AdminSetMinimalQueryLengthActionGroup.xml"
+  module: "CatalogSearch"
+  actiongroups:
+     - name: "SetMinimalQueryLengthActionGroup"
+       description: "Goes to the 'Configuration' page for 'Catalog'. Sets the Minimal Query Length. CLicks on the Save button."
+- filename: "StorefrontFillFormAdvancedSearchWithCustomDropDownAttributeActionGroup.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/CatalogSearch/Test/Mftf/ActionGroup/StorefrontFillFormAdvancedSearchWithCustomDropDownAttributeActionGroup.xml"
+  module: "CatalogSearch"
+  actiongroups:
+     - name: "StorefrontFillFormAdvancedSearchWithCustomDropDownAttributeActionGroup"
+       description: "Fills in the advanced search form and select the attribute."
+- filename: "AdminCatalogSearchTermActionGroup.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/CatalogSearch/Test/Mftf/ActionGroup/AdminCatalogSearchTermActionGroup.xml"
+  module: "CatalogSearch"
+  actiongroups:
+     - name: "AssertSearchTermSaveSuccessMessage"
+       description: "Goes to the Catalog Search Term grid page. Adds the provided Search Term. Validates that the Success Message is present and correct."
+
+     - name: "AssertSearchTermSuccessDeleteMessage"
+       description: "Goes to the Catalog Search Term grid page. Deletes the provided Search Term. Validates that the Success Message is present and correct."
+
+     - name: "AssertSearchTermNotInGrid"
+       description: "Goes to the Catalog Search Term grid page. Searches for the provided Search Term. Validates that it is NOT present in the grid."
+- filename: "StorefrontFillFormAdvancedSearchActionGroup.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/CatalogSearch/Test/Mftf/ActionGroup/StorefrontFillFormAdvancedSearchActionGroup.xml"
+  module: "CatalogSearch"
+  actiongroups:
+     - name: "StorefrontFillFormAdvancedSearchActionGroup"
+       description: ""
+- filename: "StorefrontOpenProductFromQuickSearchActionGroup.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/CatalogSearch/Test/Mftf/ActionGroup/StorefrontOpenProductFromQuickSearchActionGroup.xml"
+  module: "CatalogSearch"
+  actiongroups:
+     - name: "StorefrontOpenProductFromQuickSearchActionGroup"
+       description: "Clicks on the provided Product Name from the Storefront Quick Search Results page."
+- filename: "StorefrontCatalogSearchActionGroup.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/CatalogSearch/Test/Mftf/ActionGroup/StorefrontCatalogSearchActionGroup.xml"
+  module: "CatalogSearch"
+  actiongroups:
+     - name: "StorefrontCheckQuickSearchActionGroup"
+       description: "Submits Form POST for the Storefront Search feature. Validates that the URL is correct. Validates that the Title is present and correct."
+
+     - name: "StorefrontCheckQuickSearchStringActionGroup"
+       description: "Fill the Storefront Search field. Submits the Form. Validates that the provided Search Phrase is present and correct."
+
+     - name: "StorefrontQuickSearchTooShortStringActionGroup"
+       description: "Fill the Storefront Search field. Submits the Form. Validates that 'Minimum Search query length' warning appears."
+
+     - name: "StorefrontQuickSearchRelatedSearchTermsAppearsActionGroup"
+       description: ""
+
+     - name: "StorefrontOpenProductFromQuickSearch"
+       description: "Clicks on the provided Product Name from the Storefront Quick Search Results page."
+
+     - name: "StorefrontAddToCartFromQuickSearch"
+       description: "Adds the provided Product Name to the Shopping Cart from the Storefront Quick Search Results page. Validates that the Success Message is present and correct."
+
+     - name: "StorefrontQuickSearchCheckProductNameInGrid"
+       description: "Validates that the provided Product Name appears at the correct index on the Storefront Quick Search page."
+
+     - name: "StorefrontQuickSearchSeeProductByName"
+       description: ""
+
+     - name: "StorefrontQuickSearchCheckProductNameNotInGrid"
+       description: "Validates that the provided Product Name does NOT appear on the Storefront Quick Search page."
+
+     - name: "StorefrontOpenAdvancedSearchActionGroup"
+       description: "Clicks on 'Advanced Search' in the Storefront Footer. Validates that the URL and Title are present and correct."
+
+     - name: "StorefrontCheckAdvancedSearchResultActionGroup"
+       description: "Validates that the URL and Title are present and correct on the Storefront Advanced Search Results page."
+
+     - name: "StorefrontSelectSearchFilterCategoryActionGroup"
+       description: "Clicks on Category Filter. Clicks on the provided Category."
+
+     - name: "GoToStoreViewAdvancedCatalogSearchActionGroup"
+       description: "Goes to the Storefront 'Advanced Search' page."
+
+     - name: "StorefrontAdvancedCatalogSearchByProductNameActionGroup"
+       description: "Fills the Product Name field on the Storefront 'Advanced Search' page. Clicks on the Submit button."
+
+     - name: "StorefrontAdvancedCatalogSearchByProductSkuActionGroup"
+       description: "Fills the Product SKU field on the Storefront 'Advanced Search' page. Clicks on the Submit button."
+
+     - name: "StorefrontAdvancedCatalogSearchByDescriptionActionGroup"
+       description: "Fills the Product Description field on the Storefront 'Advanced Search' page. Clicks on the Submit button."
+
+     - name: "StorefrontAdvancedCatalogSearchByShortDescriptionActionGroup"
+       description: "Fills the Product Short Description field on the Storefront 'Advanced Search' page. Clicks on the Submit button."
+
+     - name: "StorefrontAdvancedCatalogSearchByProductNameAndPriceActionGroup"
+       description: "Fills the Product Name, Price From and Price To fields on the Storefront 'Advanced Search' page. Clicks on the Submit button."
+
+     - name: "StorefrontAdvancedCatalogSearchByProductNameAndDescriptionActionGroup"
+       description: "Fills the Product Name and Description fields on the Storefront 'Advanced Search' page. Clicks on the Submit button."
+
+     - name: "StorefrontCheckSearchIsEmpty"
+       description: "Validates that the 'No Results' message is present and correct on the Storefront Search Results page. PLEASE NOTE: The expected message is Hardcoded."
+- filename: "StorefrontQuickSearchWithPaginationActionGroup.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/CatalogSearch/Test/Mftf/ActionGroup/StorefrontQuickSearchWithPaginationActionGroup.xml"
+  module: "CatalogSearch"
+  actiongroups:
+     - name: "StorefrontQuickSearchWithPaginationActionGroup"
+       description: "Navigate to catalog search page with prepared GET params to get search results with particular page number."

--- a/src/_data/codebase/v2_3/mftf/functional-tests.yml
+++ b/src/_data/codebase/v2_3/mftf/functional-tests.yml
@@ -1,174 +1,1274 @@
- 
-- filename: "StorefrontElasticsearch6SearchInvalidValueTest.xml"
-  repo: "https://github.com/magento/magento2/blob/2.3/app/code/Magento/Elasticsearch6/Test/Mftf/Test/StorefrontElasticsearch6SearchInvalidValueTest.xml"
-  module: "Elasticsearch6"
+- filename: "StorefrontVerifyNoXssInjectionOnUpdateCustomerInformationAddAddressTest.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/Customer/Test/Mftf/Test/StorefrontVerifyNoXssInjectionOnUpdateCustomerInformationAddAddressTest.xml"
+  module: "Customer"
   tests:
-    - testname: "StorefrontElasticsearch6SearchInvalidValueTest"
-      title: "Elasticsearch: try to search by invalid value of 'Searchable' attribute"
-      description: "Elasticsearch: try to search by invalid value of 'Searchable' attribute"
- 
-- filename: "StorefrontElasticSearchForChineseLocaleTest.xml"
-  repo: "https://github.com/magento/magento2/blob/2.3/app/code/Magento/Elasticsearch6/Test/Mftf/Test/StorefrontElasticSearchForChineseLocaleTest.xml"
-  module: "Elasticsearch6"
+    - testname: "StorefrontVerifyNoXssInjectionOnUpdateCustomerInformationAddAddressTest"
+      title: "[Security] Verify No XSS Injection on Update Customer Information Add Address"
+      description: "Test log in to Storefront and Verify No XSS Injection on Update Customer Information Add Address"
+- filename: "AdminCheckDefaultValueDisableAutoGroupChangeIsNoTest.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/Customer/Test/Mftf/Test/AdminCheckDefaultValueDisableAutoGroupChangeIsNoTest.xml"
+  module: "Customer"
   tests:
-    - testname: "StorefrontElasticSearch6ForChineseLocaleTest"
-      title: "Elastic search for Chinese locale"
-      description: "Elastic search for Chinese locale"
- 
-- filename: "AdminGridFilterDeleteAndVerifyErrorMessageTest.xml"
-  repo: "https://github.com/magento/magento2/blob/2.3/app/code/Magento/Ui/Test/Mftf/Test/AdminGridFilterDeleteAndVerifyErrorMessageTest.xml"
-  module: "Ui"
+    - testname: "AdminCheckDefaultValueDisableAutoGroupChangeIsNoTest"
+      title: "Check settings Default Value for Disable Automatic Group Changes Based on VAT ID is No"
+      description: "Check settings Default Value for Disable Automatic Group Changes Based on VAT ID is No"
+- filename: "StorefrontPersistedCustomerLoginTest.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/Customer/Test/Mftf/Test/StorefrontPersistedCustomerLoginTest.xml"
+  module: "Customer"
   tests:
-    - testname: "AdminGridFilterDeleteAndVerifyErrorMessageTest"
-      title: "Grid Filter Delete and Verify Error Message"
-      description: "Test log in to uI and Delete Grid Filter Test"
- 
-- filename: "AdminCategoryWithRestrictedUrlKeyNotCreatedTest.xml"
-  repo: "https://github.com/magento/magento2/blob/2.3/app/code/Magento/CatalogUrlRewrite/Test/Mftf/Test/AdminCategoryWithRestrictedUrlKeyNotCreatedTest.xml"
-  module: "CatalogUrlRewrite"
+    - testname: "StorefrontPersistedCustomerLoginTest"
+      title: "Persisted customer should be able to login from storefront"
+      description: "Persisted customer should be able to login from storefront"
+- filename: "AdminCreateNewCustomerTest.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/Customer/Test/Mftf/Test/AdminCreateNewCustomerTest.xml"
+  module: "Customer"
   tests:
-    - testname: "AdminCategoryWithRestrictedUrlKeyNotCreatedTest"
-      title: "Category with restricted Url Key cannot be created"
-      description: "Category with restricted Url Key cannot be created"
- 
-- filename: "AdminUrlForProductRewrittenCorrectlyTest.xml"
-  repo: "https://github.com/magento/magento2/blob/2.3/app/code/Magento/CatalogUrlRewrite/Test/Mftf/Test/AdminUrlForProductRewrittenCorrectlyTest.xml"
-  module: "CatalogUrlRewrite"
+    - testname: "AdminCreateNewCustomerTest"
+      title: "Create customer, new via backend"
+      description: "Login as admin and create a new customer"
+- filename: "AdminCreateCustomerWithoutAddressTest.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/Customer/Test/Mftf/Test/AdminCreateCustomerWithoutAddressTest.xml"
+  module: "Customer"
   tests:
-    - testname: "AdminUrlForProductRewrittenCorrectlyTest"
-      title: "Check that URL for product rewritten correctly"
-      description: "Check that URL for product rewritten correctly"
- 
-- filename: "RewriteStoreLevelUrlKeyOfChildCategoryTest.xml"
-  repo: "https://github.com/magento/magento2/blob/2.3/app/code/Magento/CatalogUrlRewrite/Test/Mftf/Test/RewriteStoreLevelUrlKeyOfChildCategoryTest.xml"
-  module: "CatalogUrlRewrite"
+    - testname: "AdminCreateCustomerWithoutAddressTest"
+      title: "Create customer, without address"
+      description: "Login as admin and create a customer without address"
+- filename: "VerifyDisabledCustomerGroupFieldTest.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/Customer/Test/Mftf/Test/VerifyDisabledCustomerGroupFieldTest.xml"
+  module: "Customer"
   tests:
-    - testname: "RewriteStoreLevelUrlKeyOfChildCategoryTest"
-      title: "Rewriting Store-level URL key of child category"
-      description: "Rewriting Store-level URL key of child category"
- 
-- filename: "BraintreeCreditCardOnCheckoutTest.xml"
-  repo: "https://github.com/magento/magento2/blob/2.3/app/code/Magento/Braintree/Test/Mftf/Test/BraintreeCreditCardOnCheckoutTest.xml"
-  module: "Braintree"
+    - testname: "VerifyDisabledCustomerGroupFieldTest"
+      title: "Check that field is disabled in system Customer Group"
+      description: "Checks that customer_group_code field is disabled in NOT LOGGED IN Customer Group"
+- filename: "StorefrontUpdateCustomerAddressUKTest.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/Customer/Test/Mftf/Test/StorefrontUpdateCustomerAddressUKTest.xml"
+  module: "Customer"
   tests:
-    - testname: "BraintreeCreditCardOnCheckoutTest"
-      title: "Use saved for Braintree credit card on checkout with selecting billing address"
-      description: "Use saved for Braintree credit card on checkout with selecting billing address"
- 
-- filename: "AdminRemoveProductWeeeAttributeOptionTest.xml"
-  repo: "https://github.com/magento/magento2/blob/2.3/app/code/Magento/Weee/Test/Mftf/Test/AdminRemoveProductWeeeAttributeOptionTest.xml"
-  module: "Weee"
+    - testname: "StorefrontUpdateCustomerAddressUKTest"
+      title: "Update Customer Address (UK) in Storefront"
+      description: "Test log in to Storefront and Update Customer Address (UK) in Storefront"
+- filename: "AdminVerifyCustomerAddressRequiredFieldsTest.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/Customer/Test/Mftf/Test/AdminVerifyCustomerAddressRequiredFieldsTest.xml"
+  module: "Customer"
   tests:
-    - testname: "AdminRemoveProductWeeeAttributeOptionTest"
-      title: "Weee attribute options can be removed in product page"
-      description: "Weee attribute options can be removed in product page"
- 
-- filename: "AdminFixedTaxValSavedForSpecificWebsiteTest.xml"
-  repo: "https://github.com/magento/magento2/blob/2.3/app/code/Magento/Weee/Test/Mftf/Test/AdminFixedTaxValSavedForSpecificWebsiteTest.xml"
-  module: "Weee"
+    - testname: "AdminVerifyCustomerAddressRequiredFieldsTest"
+      title: "Create customer, verify required fields on Addresses tab"
+      description: "Login as admin and verify required fields on Address tab"
+- filename: "StorefrontAddCustomerAddressTest.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/Customer/Test/Mftf/Test/StorefrontAddCustomerAddressTest.xml"
+  module: "Customer"
   tests:
-    - testname: "AdminFixedTaxValSavedForSpecificWebsiteTest"
-      title: "Fixed Product Tax value is saved correctly for Specific Website"
-      description: "Fixed Product Tax value is saved correctly for Specific Website"
- 
-- filename: "AdminSwitchWYSIWYGOptionsTest.xml"
-  repo: "https://github.com/magento/magento2/blob/2.3/app/code/Magento/Tinymce3/Test/Mftf/Test/AdminSwitchWYSIWYGOptionsTest.xml"
-  module: "Tinymce3"
+    - testname: "StorefrontAddNewCustomerAddressTest"
+      title: "Storefront - My account - Address Book - add new address"
+      description: "Storefront user should be able to create a new address via the storefront"
+
+    - testname: "StorefrontAddCustomerDefaultAddressTest"
+      title: "Storefront - My account - Address Book - add new default billing/shipping address"
+      description: "Storefront user should be able to create a new default address via the storefront"
+
+    - testname: "StorefrontAddCustomerNonDefaultAddressTest"
+      title: "Storefront - My account - Address Book - add new non default billing/shipping address"
+      description: "Storefront user should be able to create a new non default address via the storefront"
+- filename: "StorefrontCreateExistingCustomerTest.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/Customer/Test/Mftf/Test/StorefrontCreateExistingCustomerTest.xml"
+  module: "Customer"
   tests:
-    - testname: "AdminSwitchWYSIWYGOptionsTest"
-      title: "Admin should able to switch between versions of TinyMCE"
-      description: "Admin should able to switch between versions of TinyMCE"
- 
-- filename: "DefaultConfigForUPSTypeTest.xml"
-  repo: "https://github.com/magento/magento2/blob/2.3/app/code/Magento/Ups/Test/Mftf/Test/DefaultConfigForUPSTypeTest.xml"
-  module: "Ups"
+    - testname: "StorefrontCreateExistingCustomerTest"
+      title: "Attempt to register customer on storefront with existing email"
+      description: "Attempt to register customer on storefront with existing email"
+- filename: "AddingProductWithExpiredSessionTest.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/Customer/Test/Mftf/Test/AddingProductWithExpiredSessionTest.xml"
+  module: "Customer"
   tests:
-    - testname: "DefaultConfigForUPSTypeTest"
-      title: "Default Configuration for UPS Type"
-      description: "Default Configuration for UPS Type"
- 
+    - testname: "AddingProductWithExpiredSessionTest"
+      title: "Adding a product to cart from category page with an expired session"
+      description: "Adding a product to cart from category page with an expired session"
+- filename: "AdminVerifyCreateCustomerRequiredFieldsTest.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/Customer/Test/Mftf/Test/AdminVerifyCreateCustomerRequiredFieldsTest.xml"
+  module: "Customer"
+  tests:
+    - testname: "AdminVerifyCreateCustomerRequiredFieldsTest"
+      title: "Create customer, verify required fields on Account Information tab"
+      description: "Login as admin and verify required fields on account information section"
+- filename: "AdminCustomersCustomerGroupsNavigateMenuTest.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/Customer/Test/Mftf/Test/AdminCustomersCustomerGroupsNavigateMenuTest.xml"
+  module: "Customer"
+  tests:
+    - testname: "AdminCustomersCustomerGroupsNavigateMenuTest"
+      title: "Admin customers customer groups navigate menu test"
+      description: "Admin should be able to navigate to Customers &gt; Customer Groups"
+- filename: "StorefrontCreateCustomerTest.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/Customer/Test/Mftf/Test/StorefrontCreateCustomerTest.xml"
+  module: "Customer"
+  tests:
+    - testname: "StorefrontCreateCustomerTest"
+      title: "Admin should be able to create a customer via the storefront"
+      description: "Admin should be able to create a customer via the storefront"
+- filename: "AdminCreateCustomerWithCountryUSATest.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/Customer/Test/Mftf/Test/AdminCreateCustomerWithCountryUSATest.xml"
+  module: "Customer"
+  tests:
+    - testname: "AdminCreateCustomerWithCountryUSATest"
+      title: "Create customer, from USA"
+      description: "Login as admin and create customer with USA address"
+- filename: "AdminEditDefaultBillingShippingCustomerAddressTest.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/Customer/Test/Mftf/Test/AdminEditDefaultBillingShippingCustomerAddressTest.xml"
+  module: "Customer"
+  tests:
+    - testname: "AdminEditDefaultBillingShippingCustomerAddressTest"
+      title: "Edit default billing/shipping customer address"
+      description: "Edit default billing/shipping customer address on customer addresses tab"
+- filename: "AdminUpdateCustomerTest.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/Customer/Test/Mftf/Test/AdminUpdateCustomerTest.xml"
+  module: "Customer"
+  tests:
+    - testname: "AdminUpdateCustomerInfoFromDefaultToNonDefaultTest"
+      title: "Update Customer Info from Default to Non-Default in Admin"
+      description: "Update Customer Info from Default to Non-Default in Admin"
+
+    - testname: "AdminUpdateCustomerAddressNoZipNoStateTest"
+      title: "Update Customer Address, without zip/state required, default billing/shipping checked in Admin"
+      description: "Update Customer Address, without zip/state required, default billing/shipping checked in Admin"
+
+    - testname: "AdminUpdateCustomerAddressNoBillingNoShippingTest"
+      title: "Update Customer Address, default billing/shipping unchecked in Admin"
+      description: "Update Customer Address, default billing/shipping unchecked in Admin"
+
+    - testname: "AdminDeleteCustomerAddressTest"
+      title: "Delete Customer Address in Admin"
+      description: "Delete Customer Address in Admin"
+- filename: "AdminPanelIsFrozenIfStorefrontIsOpenedViaCustomerViewTest.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/Customer/Test/Mftf/Test/AdminPanelIsFrozenIfStorefrontIsOpenedViaCustomerViewTest.xml"
+  module: "Customer"
+  tests:
+    - testname: "AdminPanelIsFrozenIfStorefrontIsOpenedViaCustomerViewTest"
+      title: "Place an order and click print"
+      description: "Admin panel is not frozen if Storefront is opened via Customer View"
+- filename: "AdminCreateCustomerTest.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/Customer/Test/Mftf/Test/AdminCreateCustomerTest.xml"
+  module: "Customer"
+  tests:
+    - testname: "AdminCreateCustomerTest"
+      title: "Admin should be able to create a customer"
+      description: "Admin should be able to create a customer"
+- filename: "AdminCreateNewCustomerOnStorefrontTest.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/Customer/Test/Mftf/Test/AdminCreateNewCustomerOnStorefrontTest.xml"
+  module: "Customer"
+  tests:
+    - testname: "AdminCreateNewCustomerOnStorefrontTest"
+      title: "Create New Customer on Storefront"
+      description: "Test log in to Create New Customer and Create New Customer on Storefront"
+- filename: "StorefrontDeleteCustomerAddressTest.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/Customer/Test/Mftf/Test/StorefrontDeleteCustomerAddressTest.xml"
+  module: "Customer"
+  tests:
+    - testname: "StorefrontDeleteCustomerAddressTest"
+      title: "User should be able to delete Customer address successfully from storefront"
+      description: "User should be able to delete Customer address successfully from storefront"
+- filename: "AdminCustomersNowOnlineNavigateMenuTest.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/Customer/Test/Mftf/Test/AdminCustomersNowOnlineNavigateMenuTest.xml"
+  module: "Customer"
+  tests:
+    - testname: "AdminCustomersNowOnlineNavigateMenuTest"
+      title: "Admin customers now online navigate menu test"
+      description: "Admin should be able to navigate to Customers &gt; Now Online"
+- filename: "StorefrontUpdateCustomerPasswordTest.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/Customer/Test/Mftf/Test/StorefrontUpdateCustomerPasswordTest.xml"
+  module: "Customer"
+  tests:
+    - testname: "StorefrontUpdateCustomerPasswordValidCurrentPasswordTest"
+      title: "Update Customer Password on Storefront, Valid Current Password"
+      description: "Update Customer Password on Storefront, Valid Current Password"
+
+    - testname: "StorefrontUpdateCustomerPasswordInvalidCurrentPasswordTest"
+      title: "Update Customer Password on Storefront, Invalid Current Password"
+      description: "Update Customer Password on Storefront, Invalid Current Password"
+
+    - testname: "StorefrontUpdateCustomerPasswordInvalidConfirmationPasswordTest"
+      title: "Update Customer Password on Storefront, Invalid Confirmation Password"
+      description: "Update Customer Password on Storefront, Invalid Confirmation Password"
+
+    - testname: "StorefrontUpdateCustomerPasswordRedirectOnLoginPage"
+      title: "Update Customer Password on Storefront Redirect on Login Page"
+      description: "Update Customer Password on Storefront Redirect on Login Page"
+- filename: "AdminDeleteCustomerTest.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/Customer/Test/Mftf/Test/AdminDeleteCustomerTest.xml"
+  module: "Customer"
+  tests:
+    - testname: "AdminDeleteCustomerTest"
+      title: "DeleteCustomerBackendEntityTestVariation1"
+      description: "Login as admin and delete the customer"
+- filename: "AdminDeleteCustomerAddressesFromTheGridViaMassActionsTest.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/Customer/Test/Mftf/Test/AdminDeleteCustomerAddressesFromTheGridViaMassActionsTest.xml"
+  module: "Customer"
+  tests:
+    - testname: "AdminDeleteCustomerAddressesFromTheGridViaMassActionsTest"
+      title: "Admin delete customer addresses from the grid via mass actions"
+      description: "Admin delete customer addresses from the grid via mass actions"
+- filename: "AdminSetCustomerDefaultBillingAddressTest.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/Customer/Test/Mftf/Test/AdminSetCustomerDefaultBillingAddressTest.xml"
+  module: "Customer"
+  tests:
+    - testname: "AdminSetCustomerDefaultBillingAddressTest"
+      title: "Admin should be able to set customer default billing address"
+      description: "Admin should be able to set customer default billing address from customer addresses grid row actions"
+- filename: "AdminCreateRetailCustomerGroupTest.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/Customer/Test/Mftf/Test/AdminCreateRetailCustomerGroupTest.xml"
+  module: "Customer"
+  tests:
+    - testname: "AdminCreateRetailCustomerGroupTest"
+      title: "Create retail customer group"
+      description: "Create retail customer group"
+- filename: "AdminAddNewDefaultBillingShippingCustomerAddressTest.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/Customer/Test/Mftf/Test/AdminAddNewDefaultBillingShippingCustomerAddressTest.xml"
+  module: "Customer"
+  tests:
+    - testname: "AdminAddNewDefaultBillingShippingCustomerAddressTest"
+      title: "Add new default billing/shipping customer address"
+      description: "Add new default billing/shipping customer address on customer addresses tab"
+- filename: "AdminCreateCustomerWithCountryPolandTest.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/Customer/Test/Mftf/Test/AdminCreateCustomerWithCountryPolandTest.xml"
+  module: "Customer"
+  tests:
+    - testname: "AdminCreateCustomerWithCountryPolandTest"
+      title: "Create customer, from Poland"
+      description: "Login as admin and create customer with Poland address"
+- filename: "StorefrontCheckTaxAddingValidVATIdTest.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/Customer/Test/Mftf/Test/StorefrontCheckTaxAddingValidVATIdTest.xml"
+  module: "Customer"
+  tests:
+    - testname: "StorefrontCheckTaxAddingValidVATIdTest"
+      title: "Check tax adding when it's changed to 'Valid VAT ID - Intra-Union'"
+      description: "Tax should be applied"
+- filename: "StorefrontUpdateCustomerAddressTest.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/Customer/Test/Mftf/Test/StorefrontUpdateCustomerAddressTest.xml"
+  module: "Customer"
+  tests:
+    - testname: "StorefrontUpdateCustomerDefaultBillingAddressFromBlockTest"
+      title: "Add default customer address via the Storefront6"
+      description: "Storefront user should be able to create a new default address via the storefront"
+
+    - testname: "StorefrontUpdateCustomerDefaultShippingAddressFromBlockTest"
+      title: "Add default customer address via the Storefront611"
+      description: "Storefront user should be able to create a new default address via the storefront"
+
+    - testname: "StorefrontUpdateCustomerAddressFromGridTest"
+      title: "Add default customer address via the Storefront7"
+      description: "Storefront user should be able to create a new default address via the storefront2"
+- filename: "AdminExactMatchSearchInCustomerGridTest.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/Customer/Test/Mftf/Test/AdminExactMatchSearchInCustomerGridTest.xml"
+  module: "Customer"
+  tests:
+    - testname: "AdminExactMatchSearchInCustomerGridTest"
+      title: "Admin customer grid exact match searching"
+      description: "Admin customer grid exact match searching with quotes in keyword"
+- filename: "AdminVerifyCustomerAddressStateContainValuesOnceTest.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/Customer/Test/Mftf/Test/AdminVerifyCustomerAddressStateContainValuesOnceTest.xml"
+  module: "Customer"
+  tests:
+    - testname: "AdminVerifyCustomerAddressStateContainValuesOnceTest"
+      title: "State/Province dropdown contain values once"
+      description: "When editing a customer in the backend from the Magento Admin Panel the State/Province should only be listed once"
+- filename: "AdminDeleteCustomerAddressesFromTheGridTest.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/Customer/Test/Mftf/Test/AdminDeleteCustomerAddressesFromTheGridTest.xml"
+  module: "Customer"
+  tests:
+    - testname: "AdminDeleteCustomerAddressesFromTheGridTest"
+      title: "Admin delete customer addresses from the grid"
+      description: "Admin delete customer addresses from the grid"
+- filename: "AdminChangeAllCustomersGroupViaGridTest.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/Customer/Test/Mftf/Test/AdminChangeAllCustomersGroupViaGridTest.xml"
+  module: "Customer"
+  tests:
+    - testname: "AdminChangeAllCustomersGroupViaGridTest"
+      title: "Change all customers' group via grid"
+      description: "Select All customers to change their group"
+- filename: "AllowedCountriesRestrictionApplyOnBackendTest.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/Customer/Test/Mftf/Test/AllowedCountriesRestrictionApplyOnBackendTest.xml"
+  module: "Customer"
+  tests:
+    - testname: "AllowedCountriesRestrictionApplyOnBackendTest"
+      title: "Country filter on Customers page when allowed countries restriction for a default website is applied"
+      description: "Country filter on Customers page when allowed countries restriction for a default website is applied"
+- filename: "AdminCheckDefaultValueDisableAutoGroupChangeIsYesTest.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/Customer/Test/Mftf/Test/AdminCheckDefaultValueDisableAutoGroupChangeIsYesTest.xml"
+  module: "Customer"
+  tests:
+    - testname: "AdminCheckDefaultValueDisableAutoGroupChangeIsYesTest"
+      title: "Check settings Default Value for Disable Automatic Group Changes Based on VAT ID is Yes"
+      description: "Check settings Default Value for Disable Automatic Group Changes Based on VAT ID is Yes"
+- filename: "AdminDeleteDefaultBillingCustomerAddressTest.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/Customer/Test/Mftf/Test/AdminDeleteDefaultBillingCustomerAddressTest.xml"
+  module: "Customer"
+  tests:
+    - testname: "AdminDeleteDefaultBillingCustomerAddressTest"
+      title: "Admin delete default billing customer address"
+      description: "Admin delete default billing customer address"
+- filename: "StorefrontLoginWithIncorrectCredentialsTest.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/Customer/Test/Mftf/Test/StorefrontLoginWithIncorrectCredentialsTest.xml"
+  module: "Customer"
+  tests:
+    - testname: "StorefrontLoginWithIncorrectCredentialsTest"
+      title: "Customer Login on Storefront with Incorrect Credentials"
+      description: "Customer Login on Storefront with Incorrect Credentials"
+- filename: "AdminChangeSingleCustomerGroupViaGridTest.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/Customer/Test/Mftf/Test/AdminChangeSingleCustomerGroupViaGridTest.xml"
+  module: "Customer"
+  tests:
+    - testname: "AdminChangeSingleCustomerGroupViaGridTest"
+      title: "Change a single customer group via grid"
+      description: "From the selection of All Customers select a single customer to change their group"
+- filename: "AdminChangeCustomerGenderInCustomersGridTest.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/Customer/Test/Mftf/Test/AdminChangeCustomerGenderInCustomersGridTest.xml"
+  module: "Customer"
+  tests:
+    - testname: "AdminChangeCustomerGenderInCustomersGridTest"
+      title: "Gender attribute blank value is saved in direct edits from customer grid"
+      description: "Check that gender attribute blank value can be saved on customers grid"
+- filename: "ChangeCustomerGroupTest.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/Customer/Test/Mftf/Test/ChangeCustomerGroupTest.xml"
+  module: "Customer"
+  tests:
+    - testname: "ChangingSingleCustomerGroupViaGrid"
+      title: "DEPRECATED Change a single customer group via grid"
+      description: "From the selection of All Customers select a single customer to change their group"
+
+    - testname: "ChangingAllCustomerGroupViaGrid"
+      title: "DEPRECATED Change all customers' group via grid"
+      description: "Select All customers to change their group"
+- filename: "StorefrontUpdateCustomerAddressChinaTest.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/Customer/Test/Mftf/Test/StorefrontUpdateCustomerAddressChinaTest.xml"
+  module: "Customer"
+  tests:
+    - testname: "StorefrontUpdateCustomerAddressChinaTest"
+      title: "Update customer address on storefront with china address"
+      description: "Update customer address on storefront with china address and verify you can select a region"
+- filename: "AdminCreateNewCustomerOnStorefrontSignupNewsletterTest.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/Customer/Test/Mftf/Test/AdminCreateNewCustomerOnStorefrontSignupNewsletterTest.xml"
+  module: "Customer"
+  tests:
+    - testname: "AdminCreateNewCustomerOnStorefrontSignupNewsletterTest"
+      title: "Create New Customer on Storefront, Sign-up Newsletter"
+      description: "Test log in to Create New Customer and Create New Customer on Storefront, Sign-up Newsletter"
+- filename: "AdminCreateTaxClassCustomerGroupTest.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/Customer/Test/Mftf/Test/AdminCreateTaxClassCustomerGroupTest.xml"
+  module: "Customer"
+  tests:
+    - testname: "AdminCreateTaxClassCustomerGroupTest"
+      title: "Create tax class customer group"
+      description: "Create tax class customer group"
+- filename: "StorefrontClearAllCompareProductsTest.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/Customer/Test/Mftf/Test/StorefrontClearAllCompareProductsTest.xml"
+  module: "Customer"
+  tests:
+    - testname: "StorefrontClearAllCompareProductsTest"
+      title: "Clear all products from the 'Compare Products' list"
+      description: "You should be able to remove all Products in the 'Compare Products' list."
+- filename: "AdminSearchCustomerAddressByKeywordTest.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/Customer/Test/Mftf/Test/AdminSearchCustomerAddressByKeywordTest.xml"
+  module: "Customer"
+  tests:
+    - testname: "AdminSearchCustomerAddressByKeywordTest"
+      title: "Admin search customer address by keyword"
+      description: "Admin search customer address by keyword"
+- filename: "AdminCustomersAllCustomersNavigateMenuTest.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/Customer/Test/Mftf/Test/AdminCustomersAllCustomersNavigateMenuTest.xml"
+  module: "Customer"
+  tests:
+    - testname: "AdminCustomersAllCustomersNavigateMenuTest"
+      title: "Admin customers all customers navigate menu test"
+      description: "Admin should be able to navigate to Customers &gt; All Customers"
+- filename: "StorefrontForgotPasswordTest.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/Customer/Test/Mftf/Test/StorefrontForgotPasswordTest.xml"
+  module: "Customer"
+  tests:
+    - testname: "StorefrontCustomerForgotPasswordTest"
+      title: "Forgot Password on Storefront validates customer email input"
+      description: "Forgot Password on Storefront validates customer email input"
+- filename: "AdminCreateCustomerWithPrefixTest.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/Customer/Test/Mftf/Test/AdminCreateCustomerWithPrefixTest.xml"
+  module: "Customer"
+  tests:
+    - testname: "AdminCreateCustomerWithPrefixTest"
+      title: "Create customer, with prefix"
+      description: "Login as admin and create a customer with name prefix and suffix"
+- filename: "StorefrontVerifySecureURLRedirectCustomerTest.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/Customer/Test/Mftf/Test/StorefrontVerifySecureURLRedirectCustomerTest.xml"
+  module: "Customer"
+  tests:
+    - testname: "StorefrontVerifySecureURLRedirectCustomer"
+      title: "Verify Secure URLs For Storefront Customer Pages"
+      description: "Verify that the Secure URL configuration applies to the Customer pages on the Storefront"
+- filename: "StorefrontUpdateCustomerAddressBelgiumTest.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/Customer/Test/Mftf/Test/StorefrontUpdateCustomerAddressBelgiumTest.xml"
+  module: "Customer"
+  tests:
+    - testname: "StorefrontUpdateCustomerAddressBelgiumTest"
+      title: "Update customer address on storefront with Belgium address"
+      description: "Update customer address on storefront with Belgium address and verify you can select a region"
+- filename: "StorefrontUpdateCustomerAddressFranceTest.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/Customer/Test/Mftf/Test/StorefrontUpdateCustomerAddressFranceTest.xml"
+  module: "Customer"
+  tests:
+    - testname: "StorefrontUpdateCustomerAddressFranceTest"
+      title: "Update Customer Address (France) in Storefront"
+      description: "Test log in to Storefront and Update Customer Address (France) in Storefront"
+- filename: "AdminCreateCustomerWithCustomGroupTest.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/Customer/Test/Mftf/Test/AdminCreateCustomerWithCustomGroupTest.xml"
+  module: "Customer"
+  tests:
+    - testname: "AdminCreateCustomerWithCustomGroupTest"
+      title: "Create customer, with custom group"
+      description: "Login as admin and create customer with custom group"
+- filename: "SearchByEmailInCustomerGridTest.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/Customer/Test/Mftf/Test/SearchByEmailInCustomerGridTest.xml"
+  module: "Customer"
+  tests:
+    - testname: "SearchByEmailInCustomerGridTest"
+      title: "Admin customer grid email searching"
+      description: "Admin customer grid searching by email in keyword"
+- filename: "DeleteCustomerGroupTest.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/Customer/Test/Mftf/Test/DeleteCustomerGroupTest.xml"
+  module: "Customer"
+  tests:
+    - testname: "DeleteCustomerGroupTest"
+      title: "Delete Customer Group in Admin Panel"
+      description: "Admin should be able to delete a Customer Group"
+- filename: "PasswordAutocompleteOffTest.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/Customer/Test/Mftf/Test/PasswordAutocompleteOffTest.xml"
+  module: "Customer"
+  tests:
+    - testname: "PasswordAutocompleteOffTest"
+      title: "[Security] Autocomplete attribute with off value is added to password input"
+      description: "[Security] Autocomplete attribute with off value is added to password input"
+- filename: "StorefrontResetCustomerPasswordFailedTest.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/Customer/Test/Mftf/Test/StorefrontResetCustomerPasswordFailedTest.xml"
+  module: "Customer"
+  tests:
+    - testname: "StorefrontResetCustomerPasswordFailedTest"
+      title: "Customer tries to reset password several times"
+      description: "Customer tries to reset password several times"
+- filename: "StorefrontLockCustomerOnLoginPageTest.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/Customer/Test/Mftf/Test/StorefrontLockCustomerOnLoginPageTest.xml"
+  module: "Customer"
+  tests:
+    - testname: "StorefrontLockCustomerOnLoginPageTest"
+      title: "Lock customer on Storefront with after many attempts to log in with incorrect credentials"
+      description: "Lock customer on Storefront with after many attempts to log in with incorrect credentials"
+- filename: "EndToEndB2CLoggedInUserTest.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/Customer/Test/Mftf/Test/EndToEndB2CLoggedInUserTest.xml"
+  module: "Customer"
+  tests:
+    - testname: "EndToEndB2CLoggedInUserTest"
+      title: "You should be able to pass End to End B2C Logged In User scenario"
+      description: "New user signup and browses catalog, searches for product, adds product to cart, adds product to wishlist, compares products, uses coupon code and checks out."
+- filename: "AdminSetCustomerDefaultShippingAddressTest.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/Customer/Test/Mftf/Test/AdminSetCustomerDefaultShippingAddressTest.xml"
+  module: "Customer"
+  tests:
+    - testname: "AdminSetCustomerDefaultShippingAddressTest"
+      title: "Admin should be able to set customer default shipping address"
+      description: "Admin should be able to set customer default shipping address from customer addresses grid row actions"
+- filename: "AdminResetCustomerPasswordTest.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/Customer/Test/Mftf/Test/AdminResetCustomerPasswordTest.xml"
+  module: "Customer"
+  tests:
+    - testname: "AdminResetCustomerPasswordTest"
+      title: "Admin should be able to reset customer password"
+      description: "Admin should be able to reset customer password"
+- filename: "AdminCreateCustomerGroupAlreadyExistsTest.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/Customer/Test/Mftf/Test/AdminCreateCustomerGroupAlreadyExistsTest.xml"
+  module: "Customer"
+  tests:
+    - testname: "AdminCreateCustomerGroupAlreadyExistsTest"
+      title: "Create customer group already exists"
+      description: "Create customer group already exists"
+- filename: "AdminCreateCustomerRetailerWithoutAddressTest.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/Customer/Test/Mftf/Test/AdminCreateCustomerRetailerWithoutAddressTest.xml"
+  module: "Customer"
+  tests:
+    - testname: "AdminCreateCustomerRetailerWithoutAddressTest"
+      title: "Create customer, retailer without address"
+      description: "Login as admin and create customer retailer without address"
+- filename: "YoutubeVideoWindowOnProductPageTest.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/ProductVideo/Test/Mftf/Test/YoutubeVideoWindowOnProductPageTest.xml"
+  module: "ProductVideo"
+  tests:
+    - testname: "YoutubeVideoWindowOnProductPageTest"
+      title: "Youtube video window on the product page"
+      description: "Check Youtube video window on the product page"
+- filename: "AdminAddDefaultVideoSimpleProductTest.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/ProductVideo/Test/Mftf/Test/AdminAddDefaultVideoSimpleProductTest.xml"
+  module: "ProductVideo"
+  tests:
+    - testname: "AdminAddDefaultVideoSimpleProductTest"
+      title: ""
+      description: ""
+- filename: "AdminRemoveDefaultVideoSimpleProductTest.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/ProductVideo/Test/Mftf/Test/AdminRemoveDefaultVideoSimpleProductTest.xml"
+  module: "ProductVideo"
+  tests:
+    - testname: "AdminRemoveDefaultVideoSimpleProductTest"
+      title: ""
+      description: ""
+- filename: "AdminValidateUrlOnGetVideoInformationTest.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/ProductVideo/Test/Mftf/Test/AdminValidateUrlOnGetVideoInformationTest.xml"
+  module: "ProductVideo"
+  tests:
+    - testname: "AdminValidateUrlOnGetVideoInformationTest"
+      title: "Admin validates the url when getting video information"
+      description: "Testing for a required video url when getting video information"
 - filename: "AdminCheckInputFieldsDisabledAfterAppConfigDumpTest.xml"
-  repo: "https://github.com/magento/magento2/blob/2.3/app/code/Magento/Ups/Test/Mftf/Test/AdminCheckInputFieldsDisabledAfterAppConfigDumpTest.xml"
-  module: "Ups"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/Dhl/Test/Mftf/Test/AdminCheckInputFieldsDisabledAfterAppConfigDumpTest.xml"
+  module: "Dhl"
   tests:
     - testname: "AdminCheckInputFieldsDisabledAfterAppConfigDumpTest"
       title: ""
       description: ""
- 
-- filename: "StorefrontVerifySecureURLRedirectContactTest.xml"
-  repo: "https://github.com/magento/magento2/blob/2.3/app/code/Magento/Contact/Test/Mftf/Test/StorefrontVerifySecureURLRedirectContactTest.xml"
-  module: "Contact"
+- filename: "AdminMarketingReviewsNavigateMenuTest.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/Review/Test/Mftf/Test/AdminMarketingReviewsNavigateMenuTest.xml"
+  module: "Review"
   tests:
-    - testname: "StorefrontVerifySecureURLRedirectContact"
-      title: "Verify Secure URLs For Storefront Contact Pages"
-      description: "Verify that the Secure URL configuration applies to the Contact pages on the Storefront"
- 
-- filename: "AdminCheckInputFieldsDisabledAfterAppConfigDumpTest.xml"
-  repo: "https://github.com/magento/magento2/blob/2.3/app/code/Magento/Usps/Test/Mftf/Test/AdminCheckInputFieldsDisabledAfterAppConfigDumpTest.xml"
-  module: "Usps"
+    - testname: "AdminMarketingReviewsNavigateMenuTest"
+      title: "Admin marketing reviews navigate menu test"
+      description: "Admin should be able to navigate to Marketing &gt; Reviews"
+- filename: "StorefrontVerifySecureURLRedirectReviewTest.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/Review/Test/Mftf/Test/StorefrontVerifySecureURLRedirectReviewTest.xml"
+  module: "Review"
   tests:
-    - testname: "AdminCheckInputFieldsDisabledAfterAppConfigDumpTest"
+    - testname: "StorefrontVerifySecureURLRedirectReview"
+      title: "Verify Secure URLs For Storefront Review Pages"
+      description: "Verify that the Secure URL configuration applies to the Review pages on the Storefront"
+- filename: "AdminReportsByCustomersNavigateMenuTest.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/Review/Test/Mftf/Test/AdminReportsByCustomersNavigateMenuTest.xml"
+  module: "Review"
+  tests:
+    - testname: "AdminReportsByCustomersNavigateMenuTest"
+      title: "Admin reports by customers navigate menu test"
+      description: "Admin should be able to navigate to Reports &gt; By Customers"
+- filename: "AdminVerifyNewRatingFormSingleStoreModeNoTest.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/Review/Test/Mftf/Test/AdminVerifyNewRatingFormSingleStoreModeNoTest.xml"
+  module: "Review"
+  tests:
+    - testname: "AdminVerifyNewRatingFormSingleStoreModeNoTest"
+      title: "Verify New Rating Form if single store mode is No"
+      description: "New Rating Form should have Default store view field if single store mode is No"
+- filename: "AdminReportsByProductsNavigateMenuTest.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/Review/Test/Mftf/Test/AdminReportsByProductsNavigateMenuTest.xml"
+  module: "Review"
+  tests:
+    - testname: "AdminReportsByProductsNavigateMenuTest"
+      title: "Admin reports by products navigate menu test"
+      description: "Admin should be able to navigate to Reports &gt; By Products"
+- filename: "AdminVerifyNewRatingFormSingleStoreModeYesTest.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/Review/Test/Mftf/Test/AdminVerifyNewRatingFormSingleStoreModeYesTest.xml"
+  module: "Review"
+  tests:
+    - testname: "AdminVerifyNewRatingFormSingleStoreModeYesTest"
+      title: "Verify New Rating Form if single store mode is Yes"
+      description: "New Rating Form should not have Default store view field if single store mode is Yes"
+- filename: "AdminStoresRatingNavigateMenuTest.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/Review/Test/Mftf/Test/AdminStoresRatingNavigateMenuTest.xml"
+  module: "Review"
+  tests:
+    - testname: "AdminStoresRatingNavigateMenuTest"
+      title: "Admin stores rating navigate menu test"
+      description: "Admin should be able to navigate to Stores &gt; Rating"
+- filename: "AdminSignifydConfigDependentOnActiveFieldTest.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/Signifyd/Test/Mftf/Test/AdminSignifydConfigDependentOnActiveFieldTest.xml"
+  module: "Signifyd"
+  tests:
+    - testname: "AdminSignifydConfigDependentOnActiveFieldTest"
+      title: "Signifyd config dependent on active field"
+      description: "Signifyd system configs dependent by Enable this Solution field."
+- filename: "AdminEncryptionKeyAutoGenerateKeyTest.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/EncryptionKey/Test/Mftf/Test/AdminEncryptionKeyAutoGenerateKeyTest.xml"
+  module: "EncryptionKey"
+  tests:
+    - testname: "AdminEncryptionKeyAutoGenerateKeyTest"
+      title: "Change Encryption Key by Auto Generate Key"
+      description: "Change Encryption Key by Auto Generate Key"
+- filename: "AdminEncryptionKeyManualGenerateKeyTest.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/EncryptionKey/Test/Mftf/Test/AdminEncryptionKeyManualGenerateKeyTest.xml"
+  module: "EncryptionKey"
+  tests:
+    - testname: "AdminEncryptionKeyManualGenerateKeyTest"
+      title: "Change Encryption Key by Manual Key"
+      description: "Change Encryption Key by Manual Key"
+- filename: "StorefrontCustomerCheckoutWithNewCustomerRegistrationAndDisableGuestCheckoutTest.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/Checkout/Test/Mftf/Test/StorefrontCustomerCheckoutWithNewCustomerRegistrationAndDisableGuestCheckoutTest.xml"
+  module: "Checkout"
+  tests:
+    - testname: "StorefrontCustomerCheckoutWithNewCustomerRegistrationAndDisableGuestCheckoutTest"
+      title: "Verify customer checkout by following new customer registration when guest checkout is disabled"
+      description: "Customer is redirected to checkout on login, follow the new Customer registration when guest checkout is disabled"
+- filename: "StorefrontAddTwoBundleMultiSelectOptionsToTheShoppingCartTest.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/Checkout/Test/Mftf/Test/StorefrontAddTwoBundleMultiSelectOptionsToTheShoppingCartTest.xml"
+  module: "Checkout"
+  tests:
+    - testname: "StorefrontAddTwoBundleMultiSelectOptionsToTheShoppingCartTest"
+      title: "Add two products to the cart from multi select options of a bundle product"
+      description: "Add two products to the cart from multi select options of a bundle product."
+- filename: "StorefrontUKCustomerCheckoutWithCouponTest.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/Checkout/Test/Mftf/Test/StorefrontUKCustomerCheckoutWithCouponTest.xml"
+  module: "Checkout"
+  tests:
+    - testname: "StorefrontUKCustomerCheckoutWithCouponTest"
+      title: "Verify UK customer checkout with Virtual and Downloadable products using coupon"
+      description: "Checkout as UK Customer with virtual product and downloadable product using coupon"
+- filename: "CheckNotVisibleProductInMinicartTest.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/Checkout/Test/Mftf/Test/CheckNotVisibleProductInMinicartTest.xml"
+  module: "Checkout"
+  tests:
+    - testname: "CheckNotVisibleProductInMinicartTest"
+      title: "Not visible individually product in mini-shopping cart."
+      description: "To be sure that product in mini-shopping cart remains visible after admin makes it not visible individually"
+- filename: "StorefrontProductQuantityChangesInBackendAfterCustomerCheckoutTest.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/Checkout/Test/Mftf/Test/StorefrontProductQuantityChangesInBackendAfterCustomerCheckoutTest.xml"
+  module: "Checkout"
+  tests:
+    - testname: "StorefrontProductQuantityChangesInBackendAfterCustomerCheckoutTest"
+      title: "Verify product quantity changes in backend after customer checkout"
+      description: "Checkout as UK customer with bank transfer payment method and verify product quantity reduced after order processed "
+- filename: "StorefrontCustomerCheckoutWithoutRegionTest.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/Checkout/Test/Mftf/Test/StorefrontCustomerCheckoutWithoutRegionTest.xml"
+  module: "Checkout"
+  tests:
+    - testname: "StorefrontCustomerCheckoutWithoutRegionTest"
+      title: "Shipping address is not validated in checkout when proceeding step as logged in user with default shipping address"
+      description: "Shouldn't be able to place an order as a customer without state if it's required."
+- filename: "StorefrontDeleteSimpleAndVirtualProductFromMiniShoppingCartTest.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/Checkout/Test/Mftf/Test/StorefrontDeleteSimpleAndVirtualProductFromMiniShoppingCartTest.xml"
+  module: "Checkout"
+  tests:
+    - testname: "StorefrontDeleteSimpleAndVirtualProductFromMiniShoppingCartTest"
+      title: "Storefront Delete Simple And Virtual Product From Mini Shopping Cart Test"
+      description: "Test log in to Shopping Cart and Delete Simple And Virtual Product From Mini Shopping Cart Test"
+- filename: "StorefrontPersistentDataForGuestCustomerWithPhysicalQuoteTest.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/Checkout/Test/Mftf/Test/StorefrontPersistentDataForGuestCustomerWithPhysicalQuoteTest.xml"
+  module: "Checkout"
+  tests:
+    - testname: "StorefrontPersistentDataForGuestCustomerWithPhysicalQuoteTest"
+      title: "Persistent Data for Guest Customer with physical quote"
+      description: "One can use Persistent Data for Guest Customer with physical quote"
+- filename: "DeleteDownloadableProductFromShoppingCartTest.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/Checkout/Test/Mftf/Test/DeleteDownloadableProductFromShoppingCartTest.xml"
+  module: "Checkout"
+  tests:
+    - testname: "DeleteDownloadableProductFromShoppingCartTest"
+      title: "Delete downloadable product from shopping cart test"
+      description: "Delete downloadable product from shopping cart"
+- filename: "StorefrontAddOneBundleMultiSelectOptionToTheShoppingCartTest.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/Checkout/Test/Mftf/Test/StorefrontAddOneBundleMultiSelectOptionToTheShoppingCartTest.xml"
+  module: "Checkout"
+  tests:
+    - testname: "StorefrontAddOneBundleMultiSelectOptionToTheShoppingCartTest"
+      title: "Select one multi select option of a bundle product and add to the shopping cart"
+      description: "Select one multi select option of a bundle product and add to the shopping cart "
+- filename: "StorefrontApplyPromoCodeDuringCheckoutTest.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/Checkout/Test/Mftf/Test/StorefrontApplyPromoCodeDuringCheckoutTest.xml"
+  module: "Checkout"
+  tests:
+    - testname: "StorefrontApplyPromoCodeDuringCheckoutTest"
+      title: "Storefront apply promo code during checkout test"
+      description: "Apply promo code during checkout for physical product"
+- filename: "StorefrontAddDownloadableProductToShoppingCartTest.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/Checkout/Test/Mftf/Test/StorefrontAddDownloadableProductToShoppingCartTest.xml"
+  module: "Checkout"
+  tests:
+    - testname: "StorefrontAddDownloadableProductToShoppingCartTest"
+      title: "Create Downloadable product with two links and add to the shopping cart"
+      description: "Create Downloadable product with two links and add to the shopping cart"
+- filename: "DeleteVirtualProductFromShoppingCartTest.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/Checkout/Test/Mftf/Test/DeleteVirtualProductFromShoppingCartTest.xml"
+  module: "Checkout"
+  tests:
+    - testname: "DeleteVirtualProductFromShoppingCartTest"
+      title: "Delete virtual product from shopping cart test"
+      description: "Delete virtual product from shopping cart"
+- filename: "DeleteBundleDynamicProductFromShoppingCartTest.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/Checkout/Test/Mftf/Test/DeleteBundleDynamicProductFromShoppingCartTest.xml"
+  module: "Checkout"
+  tests:
+    - testname: "DeleteBundleDynamicProductFromShoppingCartTest"
+      title: "Delete bundle dynamic product from shopping cart test"
+      description: "Delete bundle dynamic product from shopping cart"
+- filename: "StoreFrontCheckCustomerInfoCreatedByGuestTest.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/Checkout/Test/Mftf/Test/StoreFrontCheckCustomerInfoCreatedByGuestTest.xml"
+  module: "Checkout"
+  tests:
+    - testname: "StoreFrontCheckCustomerInfoCreatedByGuestTest"
+      title: "Check Customer Information Created By Guest"
+      description: "Check customer information after placing the order as the guest who created an account"
+- filename: "StorefrontProductNameMinicartOnCheckoutPageDifferentStoreViewsTest.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/Checkout/Test/Mftf/Test/StorefrontProductNameMinicartOnCheckoutPageDifferentStoreViewsTest.xml"
+  module: "Checkout"
+  tests:
+    - testname: "StorefrontProductNameMinicartOnCheckoutPageDifferentStoreViewsTest"
+      title: "Checking Product name in Minicart and on Checkout page with different store views"
+      description: "Checking Product name in Minicart and on Checkout page with different store views"
+- filename: "StorefrontUSCustomerCheckoutWithCouponAndBankTransferPaymentMethodTest.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/Checkout/Test/Mftf/Test/StorefrontUSCustomerCheckoutWithCouponAndBankTransferPaymentMethodTest.xml"
+  module: "Checkout"
+  tests:
+    - testname: "StorefrontUSCustomerCheckoutWithCouponAndBankTransferPaymentMethodTest"
+      title: "Verify US customer checkout using coupon and bank transfer payment method"
+      description: "Checkout as US customer using coupon and bank transfer payment method"
+- filename: "StorefrontDeleteBundleProductFromMiniShoppingCartTest.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/Checkout/Test/Mftf/Test/StorefrontDeleteBundleProductFromMiniShoppingCartTest.xml"
+  module: "Checkout"
+  tests:
+    - testname: "StorefrontDeleteBundleProductFromMiniShoppingCartTest"
+      title: "Storefront Delete Bundle Product From Mini Shopping Cart Test"
+      description: "Test log in to Shopping Cart and Delete Bundle Product From Mini Shopping Cart Test"
+- filename: "StorefrontDeleteDownloadableProductFromMiniShoppingCartTest.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/Checkout/Test/Mftf/Test/StorefrontDeleteDownloadableProductFromMiniShoppingCartTest.xml"
+  module: "Checkout"
+  tests:
+    - testname: "StorefrontDeleteDownloadableProductFromMiniShoppingCartTest"
+      title: "Storefront Delete Downloadable Product From Mini Shopping Cart Test"
+      description: "Test log in to Shopping Cart and Delete Downloadable Product From Mini Shopping Cart Test"
+- filename: "StorefrontCheckVirtualProductCountDisplayWithCustomDisplayConfigurationTest.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/Checkout/Test/Mftf/Test/StorefrontCheckVirtualProductCountDisplayWithCustomDisplayConfigurationTest.xml"
+  module: "Checkout"
+  tests:
+    - testname: "StorefrontCheckVirtualProductCountDisplayWithCustomDisplayConfigurationTest"
+      title: "Verify virtual products count in mini cart and summary block with custom display configuration"
+      description: "Verify virtual products count in mini cart and summary block with custom display configuration"
+- filename: "StoreFrontAddProductWithAllTypesOfCustomOptionToTheShoppingCartWithoutAnySelectedOptionTest.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/Checkout/Test/Mftf/Test/StoreFrontAddProductWithAllTypesOfCustomOptionToTheShoppingCartWithoutAnySelectedOptionTest.xml"
+  module: "Checkout"
+  tests:
+    - testname: "StoreFrontAddProductWithAllTypesOfCustomOptionToTheShoppingCartWithoutAnySelectedOptionTest"
+      title: "Add simple product with all types of custom options to cart without selecting any options"
+      description: "Add simple product with all types of custom options to cart without selecting any options"
+- filename: "ConfiguringInstantPurchaseFunctionalityTest.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/Checkout/Test/Mftf/Test/ConfiguringInstantPurchaseFunctionalityTest.xml"
+  module: "Checkout"
+  tests:
+    - testname: "ConfiguringInstantPurchaseFunctionalityTest"
+      title: "Configuring instant purchase functionality test"
+      description: "Configuring instant purchase"
+- filename: "StorefrontCheckoutWithSpecialPriceProductsTest.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/Checkout/Test/Mftf/Test/StorefrontCheckoutWithSpecialPriceProductsTest.xml"
+  module: "Checkout"
+  tests:
+    - testname: "StorefrontCheckoutWithSpecialPriceProductsTest"
+      title: "Verify customer checkout with special price simple and configurable products"
+      description: "Create simple and configurable product with special prices and verify customer checkout"
+- filename: "StorefrontUpdateShoppingCartSimpleWithCustomOptionsProductQtyTest.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/Checkout/Test/Mftf/Test/StorefrontUpdateShoppingCartSimpleWithCustomOptionsProductQtyTest.xml"
+  module: "Checkout"
+  tests:
+    - testname: "StorefrontUpdateShoppingCartSimpleWithCustomOptionsProductQtyTest"
+      title: "Check updating shopping cart while updating qty of items with custom options"
+      description: "Check updating shopping cart while updating qty of items with custom options"
+- filename: "OnePageCheckoutUsingSignInLinkTest.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/Checkout/Test/Mftf/Test/OnePageCheckoutUsingSignInLinkTest.xml"
+  module: "Checkout"
+  tests:
+    - testname: "OnePageCheckoutUsingSignInLinkTest"
+      title: "OnePageCheckout using sign in link test"
+      description: "Checkout using 'Sign In' link"
+- filename: "EndToEndB2CGuestUserTest.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/Checkout/Test/Mftf/Test/EndToEndB2CGuestUserTest.xml"
+  module: "Checkout"
+  tests:
+    - testname: "EndToEndB2CGuestUserTest"
       title: ""
       description: ""
- 
-- filename: "ProductsListWidgetTest.xml"
-  repo: "https://github.com/magento/magento2/blob/2.3/app/code/Magento/Widget/Test/Mftf/Test/ProductsListWidgetTest.xml"
-  module: "Widget"
+
+    - testname: "EndToEndB2CGuestUserMysqlTest"
+      title: ""
+      description: ""
+- filename: "IdentityOfDefaultBillingAndShippingAddressTest.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/Checkout/Test/Mftf/Test/IdentityOfDefaultBillingAndShippingAddressTest.xml"
+  module: "Checkout"
   tests:
-    - testname: "ProductsListWidgetTest"
-      title: "Admin should be able to set Products List Widget"
-      description: "Admin should be able to set Products List Widget"
- 
+    - testname: "IdentityOfDefaultBillingAndShippingAddressTest"
+      title: "Checking assignment of default billing address after placing an orde"
+      description: "In 'Address book' field 'Default Billing Address' should be the same as 'Default Shipping Address'"
+- filename: "StorefrontOnePageCheckoutJsValidationTest.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/Checkout/Test/Mftf/Test/StorefrontOnePageCheckoutJsValidationTest.xml"
+  module: "Checkout"
+  tests:
+    - testname: "StorefrontOnePageCheckoutJsValidationTest"
+      title: "Js validation error messages must be absent for required fields after checkout start."
+      description: "Js validation error messages must be absent for required fields after checkout start."
+- filename: "StorefrontDeleteSimpleProductFromMiniShoppingCartTest.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/Checkout/Test/Mftf/Test/StorefrontDeleteSimpleProductFromMiniShoppingCartTest.xml"
+  module: "Checkout"
+  tests:
+    - testname: "StorefrontDeleteSimpleProductFromMiniShoppingCartTest"
+      title: "Storefront Delete Simple Product From Mini Shopping Cart Test"
+      description: "Test log in to Shopping Cart and Delete Simple Product From Mini Shopping Cart Test"
+- filename: "CheckoutSpecificDestinationsTest.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/Checkout/Test/Mftf/Test/CheckoutSpecificDestinationsTest.xml"
+  module: "Checkout"
+  tests:
+    - testname: "CheckoutSpecificDestinationsTest"
+      title: "Check that top destinations can be removed after a selection was previously saved"
+      description: "Check that top destinations can be removed after a selection was previously saved"
+- filename: "OnePageCheckoutAsCustomerUsingDefaultAddressTest.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/Checkout/Test/Mftf/Test/OnePageCheckoutAsCustomerUsingDefaultAddressTest.xml"
+  module: "Checkout"
+  tests:
+    - testname: "OnePageCheckoutAsCustomerUsingDefaultAddressTest"
+      title: "OnePageCheckout as customer using default address test"
+      description: "Checkout as customer using default address"
+- filename: "DeleteConfigurableProductFromShoppingCartTest.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/Checkout/Test/Mftf/Test/DeleteConfigurableProductFromShoppingCartTest.xml"
+  module: "Checkout"
+  tests:
+    - testname: "DeleteConfigurableProductFromShoppingCartTest"
+      title: "Delete configurable product from shopping cart test"
+      description: "Delete configurable product from shopping cart"
+- filename: "StorefrontGuestCheckoutForSpecificCountriesTest.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/Checkout/Test/Mftf/Test/StorefrontGuestCheckoutForSpecificCountriesTest.xml"
+  module: "Checkout"
+  tests:
+    - testname: "StorefrontGuestCheckoutForSpecificCountriesTest"
+      title: "Storefront guest checkout for specific countries test"
+      description: "Checkout flow if shipping rates are not available"
+- filename: "StorefrontAddBundleDynamicProductToShoppingCartTest.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/Checkout/Test/Mftf/Test/StorefrontAddBundleDynamicProductToShoppingCartTest.xml"
+  module: "Checkout"
+  tests:
+    - testname: "StorefrontAddBundleDynamicProductToShoppingCartTest"
+      title: "Add bundle dynamic product to the cart"
+      description: "Add bundle dynamic product to the cart"
+- filename: "StorefrontRefreshPageDuringGuestCheckoutTest.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/Checkout/Test/Mftf/Test/StorefrontRefreshPageDuringGuestCheckoutTest.xml"
+  module: "Checkout"
+  tests:
+    - testname: "StorefrontRefreshPageDuringGuestCheckoutTest"
+      title: "Storefront refresh page during guest checkout test"
+      description: "Address is not lost for guest checkout if guest refresh page during checkout"
+- filename: "StorefrontMissingPagerShoppingCartWith20ProductsTest.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/Checkout/Test/Mftf/Test/StorefrontMissingPagerShoppingCartWith20ProductsTest.xml"
+  module: "Checkout"
+  tests:
+    - testname: "StorefrontMissingPagerShoppingCartWith20ProductsTest"
+      title: "Test if the cart pager is missing with 20 cart items."
+      description: "Test if the cart pager is missing with 20 cart items."
+- filename: "AddressStateFieldForUKCustomerRemainOptionAfterRefreshTest.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/Checkout/Test/Mftf/Test/AddressStateFieldForUKCustomerRemainOptionAfterRefreshTest.xml"
+  module: "Checkout"
+  tests:
+    - testname: "AddressStateFieldForUKCustomerRemainOptionAfterRefreshTest"
+      title: "Address State Field For UK Customers Remain Option even After Browser Refresh"
+      description: "Address State Field For UK Customers Remain Option even After Browser Refresh"
+- filename: "StorefrontAddGroupedProductToShoppingCartTest.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/Checkout/Test/Mftf/Test/StorefrontAddGroupedProductToShoppingCartTest.xml"
+  module: "Checkout"
+  tests:
+    - testname: "StorefrontAddGroupedProductToShoppingCartTest"
+      title: "Create grouped product with three simple product and Add grouped product to the cart"
+      description: "Create grouped product with three simple product and Add grouped product to the cart"
+- filename: "StorefrontAddProductWithAllTypesOfCustomOptionToTheShoppingCartTest.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/Checkout/Test/Mftf/Test/StorefrontAddProductWithAllTypesOfCustomOptionToTheShoppingCartTest.xml"
+  module: "Checkout"
+  tests:
+    - testname: "StorefrontAddProductWithAllTypesOfCustomOptionToTheShoppingCartTest"
+      title: "Create a simple products with all types of oprtions and add it to the cart"
+      description: "Create a simple products with all types of oprtions and add it to the cart"
+- filename: "UpdateProductFromMiniShoppingCartEntityTest.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/Checkout/Test/Mftf/Test/UpdateProductFromMiniShoppingCartEntityTest.xml"
+  module: "Checkout"
+  tests:
+    - testname: "UpdateProductFromMiniShoppingCartEntityTest"
+      title: "Check updating product from mini shopping cart"
+      description: "Update Product Qty on Mini Shopping Cart"
+- filename: "StorefrontCheckoutDisabledBundleProductTest.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/Checkout/Test/Mftf/Test/StorefrontCheckoutDisabledBundleProductTest.xml"
+  module: "Checkout"
+  tests:
+    - testname: "StorefrontCheckoutDisabledBundleProductTest"
+      title: "Customer should be able to checkout if there is at least one available product in the cart"
+      description: "Customer should be able to checkout if there is at least one available product in the cart"
+- filename: "StorefrontCustomerCheckoutTest.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/Checkout/Test/Mftf/Test/StorefrontCustomerCheckoutTest.xml"
+  module: "Checkout"
+  tests:
+    - testname: "StorefrontCustomerCheckoutTest"
+      title: "DEPRECATED Customer Checkout via the Admin"
+      description: "Should be able to place an order as a customer."
+
+    - testname: "StorefrontCustomerCheckoutTestWithMultipleAddressesAndTaxRates"
+      title: "Customer Checkout with multiple addresses and tax rates"
+      description: "Should be able to place an order as a customer with multiple addresses and tax rates."
+
+    - testname: "StorefrontCustomerCheckoutTestWithRestrictedCountriesForPayment"
+      title: "Checkout via Customer Checkout with restricted countries for payment"
+      description: "Should be able to place an order as a Customer with restricted countries for payment."
+- filename: "StorefrontCheckCartItemDisplayWithDefaultDisplayLimitAndDefaultTotalQuantityTest.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/Checkout/Test/Mftf/Test/StorefrontCheckCartItemDisplayWithDefaultDisplayLimitAndDefaultTotalQuantityTest.xml"
+  module: "Checkout"
+  tests:
+    - testname: "StorefrontCheckCartItemDisplayWithDefaultDisplayLimitAndDefaultTotalQuantityTest"
+      title: "Add 10 items to the cart and check cart display with default display limit"
+      description: "Add 10 items to the cart and check cart display with default display limit"
+- filename: "OnePageCheckoutAsCustomerUsingNonDefaultAddressTest.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/Checkout/Test/Mftf/Test/OnePageCheckoutAsCustomerUsingNonDefaultAddressTest.xml"
+  module: "Checkout"
+  tests:
+    - testname: "OnePageCheckoutAsCustomerUsingNonDefaultAddressTest"
+      title: "OnePageCheckout as customer using non default address test"
+      description: "Checkout as customer using non default address"
+- filename: "StorefrontValidateEmailOnCheckoutTest.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/Checkout/Test/Mftf/Test/StorefrontValidateEmailOnCheckoutTest.xml"
+  module: "Checkout"
+  tests:
+    - testname: "StorefrontValidateEmailOnCheckoutTest"
+      title: "Guest e-mail address validation on Checkout process"
+      description: "Guest should not be able to place an order when invalid e-mail address provided"
+- filename: "OnePageCheckoutAsCustomerUsingNewAddressTest.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/Checkout/Test/Mftf/Test/OnePageCheckoutAsCustomerUsingNewAddressTest.xml"
+  module: "Checkout"
+  tests:
+    - testname: "OnePageCheckoutAsCustomerUsingNewAddressTest"
+      title: "OnePageCheckout as customer using new address test"
+      description: "Checkout as customer using new address"
+- filename: "StorefrontGuestCheckoutUsingFreeShippingAndTaxesTest.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/Checkout/Test/Mftf/Test/StorefrontGuestCheckoutUsingFreeShippingAndTaxesTest.xml"
+  module: "Checkout"
+  tests:
+    - testname: "StorefrontGuestCheckoutUsingFreeShippingAndTaxesTest"
+      title: "Verify guest checkout using free shipping and tax variations"
+      description: "Verify guest checkout using free shipping and tax variations"
+- filename: "StorefrontCheckCartItemDisplayWhenMoreItemsAddedToTheCartThanDefaultDisplayLimitTest.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/Checkout/Test/Mftf/Test/StorefrontCheckCartItemDisplayWhenMoreItemsAddedToTheCartThanDefaultDisplayLimitTest.xml"
+  module: "Checkout"
+  tests:
+    - testname: "StorefrontCheckCartItemDisplayWhenMoreItemsAddedToTheCartThanDefaultDisplayLimitTest"
+      title: "Add 11 Simple product to the cart and check cart display with default display limit"
+      description: "Add 11 Simple product to the cart and check cart display with default display limit"
+- filename: "StorefrontCheckSimpleProductCartItemDisplayWithDefaultLimitationTest.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/Checkout/Test/Mftf/Test/StorefrontCheckSimpleProductCartItemDisplayWithDefaultLimitationTest.xml"
+  module: "Checkout"
+  tests:
+    - testname: "StorefrontCheckSimpleProductCartItemDisplayWithDefaultLimitationTest"
+      title: "Add 10 SimpleProducts to the cart and check cart display with default display limit"
+      description: "Add 10 SimpleProducts to the cart and check cart display with default display limit"
+- filename: "NoErrorCartCheckoutForProductsDeletedFromMiniCartTest.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/Checkout/Test/Mftf/Test/NoErrorCartCheckoutForProductsDeletedFromMiniCartTest.xml"
+  module: "Checkout"
+  tests:
+    - testname: "NoErrorCartCheckoutForProductsDeletedFromMiniCartTest"
+      title: "Delete product from Checkout"
+      description: "No error from cart should be thrown for product deleted from minicart"
+- filename: "StorefrontUpdatePriceInShoppingCartAfterProductSaveTest.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/Checkout/Test/Mftf/Test/StorefrontUpdatePriceInShoppingCartAfterProductSaveTest.xml"
+  module: "Checkout"
+  tests:
+    - testname: "StorefrontUpdatePriceInShoppingCartAfterProductSaveTest"
+      title: "Update price in shopping cart after product save"
+      description: "Price in shopping cart should be updated after product save with changed price"
+- filename: "ZeroSubtotalOrdersWithProcessingStatusTest.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/Checkout/Test/Mftf/Test/ZeroSubtotalOrdersWithProcessingStatusTest.xml"
+  module: "Checkout"
+  tests:
+    - testname: "ZeroSubtotalOrdersWithProcessingStatusTest"
+      title: "Checking status of Zero Subtotal Orders with 'Processing' New Order Status"
+      description: "Created order should be in Processing status"
+- filename: "EditShippingAddressOnePageCheckoutTest.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/Checkout/Test/Mftf/Test/EditShippingAddressOnePageCheckoutTest.xml"
+  module: "Checkout"
+  tests:
+    - testname: "EditShippingAddressOnePageCheckoutTest"
+      title: "Edit Shipping Address on Checkout Page."
+      description: "Edit Shipping Address on Checkout Page."
+- filename: "StorefrontCustomerLoginDuringCheckoutTest.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/Checkout/Test/Mftf/Test/StorefrontCustomerLoginDuringCheckoutTest.xml"
+  module: "Checkout"
+  tests:
+    - testname: "StorefrontCustomerLoginDuringCheckoutTest"
+      title: "Storefront customer login during checkout test"
+      description: "Logging during checkout for customer without addresses in address book"
+- filename: "StorefrontCheckPagerShoppingCartWithMoreThan20ProductsTest.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/Checkout/Test/Mftf/Test/StorefrontCheckPagerShoppingCartWithMoreThan20ProductsTest.xml"
+  module: "Checkout"
+  tests:
+    - testname: "StorefrontCheckPagerShoppingCartWithMoreThan20ProductsTest"
+      title: "Test if the cart pager is visible with more than 20 cart items and the pager disappears if an item is removed from cart."
+      description: "Test if the cart pager is visible with more than 20 cart items and the pager disappears if an item is removed from cart."
+- filename: "StorefrontRegionUpdatesAfterChangingCountryAndLeavingRegionSelectUnselectedTest.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/Checkout/Test/Mftf/Test/StorefrontRegionUpdatesAfterChangingCountryAndLeavingRegionSelectUnselectedTest.xml"
+  module: "Checkout"
+  tests:
+    - testname: "StorefrontRegionUpdatesAfterChangingCountryAndLeavingRegionSelectUnselectedTest"
+      title: "Region updates after changing country "
+      description: "Region dupdates after changing country and leaving region select unselected"
+- filename: "StorefrontCheckoutWithDifferentShippingAndBillingAddressAndProductWithTierPricesTest.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/Checkout/Test/Mftf/Test/StorefrontCheckoutWithDifferentShippingAndBillingAddressAndProductWithTierPricesTest.xml"
+  module: "Checkout"
+  tests:
+    - testname: "StorefrontCheckoutWithDifferentShippingAndBillingAddressAndProductWithTierPricesTest"
+      title: "Verify checkout with different shipping and billing address and product with tier prices"
+      description: "Checkout as a customer with different shipping and billing address and  product with tier prices"
+- filename: "OnePageCheckoutWithAllProductTypesTest.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/Checkout/Test/Mftf/Test/OnePageCheckoutWithAllProductTypesTest.xml"
+  module: "Checkout"
+  tests:
+    - testname: "OnePageCheckoutWithAllProductTypesTest"
+      title: "OnePageCheckout with all product types test"
+      description: "Checkout with all product types"
+- filename: "StorefrontGuestCheckoutTest.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/Checkout/Test/Mftf/Test/StorefrontGuestCheckoutTest.xml"
+  module: "Checkout"
+  tests:
+    - testname: "StorefrontGuestCheckoutTest"
+      title: "Guest Checkout - guest should be able to place an order"
+      description: "Should be able to place an order as a Guest"
+
+    - testname: "StorefrontGuestCheckoutWithSidebarDisabledTest"
+      title: "Guest Checkout when Cart sidebar disabled"
+      description: "Should be able to place an order as a Guest when Cart sidebar is disabled"
+
+    - testname: "StorefrontGuestCheckoutTestWithRestrictedCountriesForPayment"
+      title: "Checkout via Guest Checkout with restricted countries for payment"
+      description: "Should be able to place an order as a Guest with restricted countries for payment."
+- filename: "DeleteGroupedProductFromShoppingCartTest.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/Checkout/Test/Mftf/Test/DeleteGroupedProductFromShoppingCartTest.xml"
+  module: "Checkout"
+  tests:
+    - testname: "DeleteGroupedProductFromShoppingCartTest"
+      title: "Delete grouped product from shopping cart test"
+      description: "Delete grouped product from shopping cart"
+- filename: "ShoppingCartAndMiniShoppingCartPerCustomerTest.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/Checkout/Test/Mftf/Test/ShoppingCartAndMiniShoppingCartPerCustomerTest.xml"
+  module: "Checkout"
+  tests:
+    - testname: "ShoppingCartAndMiniShoppingCartPerCustomerTest"
+      title: "Shopping cart and mini shopping cart per customer test"
+      description: "Shopping cart and mini shopping cart per customer with enabled cached"
+- filename: "StoreFrontUpdateShoppingCartWhileUpdateMinicartTest.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/Checkout/Test/Mftf/Test/StoreFrontUpdateShoppingCartWhileUpdateMinicartTest.xml"
+  module: "Checkout"
+  tests:
+    - testname: "StoreFrontUpdateShoppingCartWhileUpdateMinicartTest"
+      title: "Check updating shopping cart while updating items from minicart"
+      description: "Check updating shopping cart while updating items from minicart"
+- filename: "DefaultBillingAddressShouldBeCheckedOnPaymentPageTest.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/Checkout/Test/Mftf/Test/DefaultBillingAddressShouldBeCheckedOnPaymentPageTest.xml"
+  module: "Checkout"
+  tests:
+    - testname: "DefaultBillingAddressShouldBeCheckedOnPaymentPageTest"
+      title: "The default billing address should be used on checkout"
+      description: "Default billing address should be preselected on payments page on checkout if it exist"
+- filename: "StorefrontAddConfigurableProductToShoppingCartTest.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/Checkout/Test/Mftf/Test/StorefrontAddConfigurableProductToShoppingCartTest.xml"
+  module: "Checkout"
+  tests:
+    - testname: "StorefrontAddConfigurableProductToShoppingCartTest"
+      title: "Create configurable product with three options and add configurable product to the cart"
+      description: "Create configurable product with three options and add configurable product to the cart"
+- filename: "AdminCheckConfigsChangesIsNotAffectedStartedCheckoutProcessTest.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/Checkout/Test/Mftf/Test/AdminCheckConfigsChangesIsNotAffectedStartedCheckoutProcessTest.xml"
+  module: "Checkout"
+  tests:
+    - testname: "AdminCheckConfigsChangesAreNotAffectedStartedCheckoutProcessTest"
+      title: "Admin check configs changes are not affected started checkout process test"
+      description: "Changes in admin for shipping rates are not affecting checkout process that has been started"
+- filename: "StorefrontOnePageCheckoutDataWhenChangeQtyTest.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/Checkout/Test/Mftf/Test/StorefrontOnePageCheckoutDataWhenChangeQtyTest.xml"
+  module: "Checkout"
+  tests:
+    - testname: "StorefrontOnePageCheckoutDataWhenChangeQtyTest"
+      title: "One page Checkout Customer data when changing Product Qty"
+      description: "One page Checkout Customer data when changing Product Qty"
+- filename: "AddressStateFieldShouldNotAcceptJustIntegerValuesTest.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/Checkout/Test/Mftf/Test/AddressStateFieldShouldNotAcceptJustIntegerValuesTest.xml"
+  module: "Checkout"
+  tests:
+    - testname: "AddressStateFieldShouldNotAcceptJustIntegerValuesTest"
+      title: "Guest Checkout - address State field should not allow just integer values"
+      description: "Address State field should not allow just integer values"
+- filename: "StorefrontCustomerCheckoutDisabledProductAndCouponTest.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/Checkout/Test/Mftf/Test/StorefrontCustomerCheckoutDisabledProductAndCouponTest.xml"
+  module: "Checkout"
+  tests:
+    - testname: "StorefrontCustomerCheckoutDisabledProductAndCouponTest"
+      title: "Customer can login if product in his cart was disabled"
+      description: "Customer can login with disabled product in the cart and a coupon applied"
+- filename: "StorefrontGuestCheckoutWithCouponAndZeroSubtotalTest.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/Checkout/Test/Mftf/Test/StorefrontGuestCheckoutWithCouponAndZeroSubtotalTest.xml"
+  module: "Checkout"
+  tests:
+    - testname: "StorefrontGuestCheckoutWithCouponAndZeroSubtotalTest"
+      title: "Verify guest checkout with virtual product using coupon for not logged in customers with Zero Subtotal"
+      description: "Checkout with virtual product using coupon for not logged in customers with Zero Subtotal"
+- filename: "StorefrontDeleteProductsWithCartItemsDisplayDefaultLimitationFromMiniShoppingCartTest.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/Checkout/Test/Mftf/Test/StorefrontDeleteProductsWithCartItemsDisplayDefaultLimitationFromMiniShoppingCartTest.xml"
+  module: "Checkout"
+  tests:
+    - testname: "StorefrontDeleteProductsWithCartItemsDisplayDefaultLimitationFromMiniShoppingCartTest"
+      title: "Storefront Delete Products With Cart Items Display Default Limitation From Mini Shopping Cart Test"
+      description: "Test log in to Shopping Cart and Delete Products With Cart Items Display Default Limitation From Mini Shopping Cart Test"
+- filename: "StorefrontVerifySecureURLRedirectCheckoutTest.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/Checkout/Test/Mftf/Test/StorefrontVerifySecureURLRedirectCheckoutTest.xml"
+  module: "Checkout"
+  tests:
+    - testname: "StorefrontVerifySecureURLRedirectCheckout"
+      title: "Verify Secure URLs For Storefront Checkout Pages"
+      description: "Verify that the Secure URL configuration applies to the Checkout pages on the Storefront"
+- filename: "CheckCheckoutSuccessPageTest.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/Checkout/Test/Mftf/Test/CheckCheckoutSuccessPageTest.xml"
+  module: "Checkout"
+  tests:
+    - testname: "CheckCheckoutSuccessPageAsRegisterCustomer"
+      title: "Customer Checkout"
+      description: "To be sure that other elements of Success page are shown for placed order as registered Customer."
+
+    - testname: "CheckCheckoutSuccessPageAsGuest"
+      title: "Guest Checkout - elements of success page are presented for placed order as guest"
+      description: "To be sure that other elements of Success page are presented for placed order as Guest"
+- filename: "StorefrontCustomerCheckoutOnLoginWhenGuestCheckoutIsDisabledTest.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/Checkout/Test/Mftf/Test/StorefrontCustomerCheckoutOnLoginWhenGuestCheckoutIsDisabledTest.xml"
+  module: "Checkout"
+  tests:
+    - testname: "StorefrontCustomerCheckoutOnLoginWhenGuestCheckoutIsDisabledTest"
+      title: "Verify customer is redirected to checkout on login when guest checkout is disabled"
+      description: "Customer is redirected to checkout on login when guest checkout is disabled"
+- filename: "StoreFrontFreeShippingRecalculationAfterCouponCodeAddedTest.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/Checkout/Test/Mftf/Test/StoreFrontFreeShippingRecalculationAfterCouponCodeAddedTest.xml"
+  module: "Checkout"
+  tests:
+    - testname: "StoreFrontFreeShippingRecalculationAfterCouponCodeAddedTest"
+      title: "Checkout Free Shipping Recalculation after Coupon Code Added"
+      description: "User should be able to do checkout free shipping recalculation after adding coupon code"
+- filename: "StorefrontCheckCartAndCheckoutItemsCountTest.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/Checkout/Test/Mftf/Test/StorefrontCheckCartAndCheckoutItemsCountTest.xml"
+  module: "Checkout"
+  tests:
+    - testname: "StorefrontCartItemsCountDisplayItemsQuantities"
+      title: "Checkout order summary has wrong item count - display items quantities"
+      description: "Items count in shopping cart and on checkout page should be consistent with settings 'checkout/cart_link/use_qty'"
+
+    - testname: "StorefrontCartItemsCountDisplayUniqueItems"
+      title: "Checkout order summary has wrong item count - display unique items"
+      description: "Items count in shopping cart and on checkout page should be consistent with settings 'checkout/cart_link/use_qty'"
+- filename: "StorefrontCheckoutWithDifferentShippingAndBillingAddressAndRegisterCustomerAfterCheckoutTest.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/Checkout/Test/Mftf/Test/StorefrontCheckoutWithDifferentShippingAndBillingAddressAndRegisterCustomerAfterCheckoutTest.xml"
+  module: "Checkout"
+  tests:
+    - testname: "StorefrontCheckoutWithDifferentShippingAndBillingAddressAndRegisterCustomerAfterCheckoutTest"
+      title: "Verify UK customer checkout with different billing and shipping address and register customer after checkout"
+      description: "Checkout as UK customer with different shipping/billing address and register checkout method"
+- filename: "EndToEndB2CLoggedInUserTest.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/Checkout/Test/Mftf/Test/EndToEndB2CLoggedInUserTest.xml"
+  module: "Checkout"
+  tests:
+    - testname: "EndToEndB2CLoggedInUserTest"
+      title: ""
+      description: ""
+- filename: "StorefrontShoppingCartCheckCustomerDefaultShippingAddressForVirtualQuoteTest.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/Checkout/Test/Mftf/Test/StorefrontShoppingCartCheckCustomerDefaultShippingAddressForVirtualQuoteTest.xml"
+  module: "Checkout"
+  tests:
+    - testname: "StorefrontShoppingCartCheckCustomerDefaultShippingAddressForVirtualQuoteTest"
+      title: "Estimator in Shopping cart must be pre-filled by Customer default shipping address for virtual quote"
+      description: "Estimator in Shopping cart must be pre-filled by Customer default shipping address for virtual quote"
+- filename: "StorefrontNotApplicableShippingMethodInReviewAndPaymentStepTest.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/Checkout/Test/Mftf/Test/StorefrontNotApplicableShippingMethodInReviewAndPaymentStepTest.xml"
+  module: "Checkout"
+  tests:
+    - testname: "StorefrontNotApplicableShippingMethodInReviewAndPaymentStepTest"
+      title: "DEPRECATED. Not applicable Shipping Method In Review and Payment Step"
+      description: "User should not be able to place order when free shipping declined after applying coupon code"
+- filename: "StorefrontCustomerCheckoutProcessTest.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/Checkout/Test/Mftf/Test/StorefrontCustomerCheckoutProcessTest.xml"
+  module: "Checkout"
+  tests:
+    - testname: "StorefrontCustomerCheckoutProcessTest"
+      title: "Customer Checkout via Storefront"
+      description: "Should be able to place an order as a customer."
+- filename: "StorefrontAddBundleDynamicProductToShoppingCartWithDisableMiniCartSidebarTest.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/Checkout/Test/Mftf/Test/StorefrontAddBundleDynamicProductToShoppingCartWithDisableMiniCartSidebarTest.xml"
+  module: "Checkout"
+  tests:
+    - testname: "StorefrontAddBundleDynamicProductToShoppingCartWithDisableMiniCartSidebarTest"
+      title: "Create Grouped product and verify mini cart action with disabled and enable Mini Cart Sidebar"
+      description: "Create Grouped product and verify mini cart action with disabled and enable Mini Cart Sidebar"
+- filename: "StorefrontGuestCheckoutDataPersistTest.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/Checkout/Test/Mftf/Test/StorefrontGuestCheckoutDataPersistTest.xml"
+  module: "Checkout"
+  tests:
+    - testname: "StorefrontGuestCheckoutDataPersistTest"
+      title: "Check that checkout data persist after cart update"
+      description: "Checkout data should be persist after updating cart"
+- filename: "StorefrontCustomerPlaceOrderWithNewAddressesThatWasEditedTest.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/Checkout/Test/Mftf/Test/StorefrontCustomerPlaceOrderWithNewAddressesThatWasEditedTest.xml"
+  module: "Checkout"
+  tests:
+    - testname: "StorefrontCustomerPlaceOrderWithNewAddressesThatWasEditedTest"
+      title: "Customer can place order with new addresses that was edited during checkout with several conditions"
+      description: "Customer can place order with new addresses."
+- filename: "StorefrontDeleteConfigurableProductFromMiniShoppingCartTest.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/Checkout/Test/Mftf/Test/StorefrontDeleteConfigurableProductFromMiniShoppingCartTest.xml"
+  module: "Checkout"
+  tests:
+    - testname: "StorefrontDeleteConfigurableProductFromMiniShoppingCartTest"
+      title: "Storefront Delete Configurable Product From Mini Shopping Cart Test"
+      description: "Test log in to Shopping Cart and Delete Configurable Product From Mini Shopping Cart Test"
+- filename: "StorefrontShoppingCartPagerForOneItemPerPageAnd2ProductsTest.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/Checkout/Test/Mftf/Test/StorefrontShoppingCartPagerForOneItemPerPageAnd2ProductsTest.xml"
+  module: "Checkout"
+  tests:
+    - testname: "StorefrontShoppingCartPagerForOneItemPerPageAnd2ProductsTest"
+      title: "Test if the cart pager is visible with 2 cart items and one item per page."
+      description: "Test if the cart pager is visible with 2 cart items and one item per page."
+- filename: "StorefrontUKGuestCheckoutWithConditionProductQuantityEqualsToOrderedQuantityTest.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/Checkout/Test/Mftf/Test/StorefrontUKGuestCheckoutWithConditionProductQuantityEqualsToOrderedQuantityTest.xml"
+  module: "Checkout"
+  tests:
+    - testname: "StorefrontUKGuestCheckoutWithConditionProductQuantityEqualsToOrderedQuantityTest"
+      title: "Checkout as UK guest with condition available product quantity equals to ordered product quantity"
+      description: "Checkout as UK guest with condition available product quantity equals to ordered product quantity"
+- filename: "StorefrontUpdateShoppingCartSimpleProductQtyTest.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/Checkout/Test/Mftf/Test/StorefrontUpdateShoppingCartSimpleProductQtyTest.xml"
+  module: "Checkout"
+  tests:
+    - testname: "StorefrontUpdateShoppingCartSimpleProductQtyTest"
+      title: "Check updating shopping cart while updating items qty"
+      description: "Check updating shopping cart while updating items qty"
+- filename: "StorefrontShippingMethodIsNotApplicableInReviewAndPaymentStepTest.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/Checkout/Test/Mftf/Test/StorefrontShippingMethodIsNotApplicableInReviewAndPaymentStepTest.xml"
+  module: "Checkout"
+  tests:
+    - testname: "StorefrontShippingMethodIsNotApplicableInReviewAndPaymentStepTest"
+      title: "Not applicable Shipping Method In Review and Payment Step"
+      description: "User should not be able to place order when free shipping declined after applying coupon code"
+- filename: "DeleteBundleFixedProductFromShoppingCartTest.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/Checkout/Test/Mftf/Test/DeleteBundleFixedProductFromShoppingCartTest.xml"
+  module: "Checkout"
+  tests:
+    - testname: "DeleteBundleFixedProductFromShoppingCartTest"
+      title: "Delete bundle fixed product from shopping cart test"
+      description: "Delete bundle fixed product from shopping cart"
+- filename: "StorefrontCheckCartAndSummaryBlockItemDisplayWithDefaultDisplayLimitationTest.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/Checkout/Test/Mftf/Test/StorefrontCheckCartAndSummaryBlockItemDisplayWithDefaultDisplayLimitationTest.xml"
+  module: "Checkout"
+  tests:
+    - testname: "StorefrontCheckCartAndSummaryBlockItemDisplayWithDefaultDisplayLimitationTest"
+      title: "Add 10 items to the cart and check cart and summary block display with default display limit"
+      description: "Add 10 items to the cart and check cart and summary block display with default display limit"
+- filename: "AdminCheckResultsOfColorAndOtherFiltersTest.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/LayeredNavigation/Test/Mftf/Test/AdminCheckResultsOfColorAndOtherFiltersTest.xml"
+  module: "LayeredNavigation"
+  tests:
+    - testname: "AdminCheckResultsOfColorAndOtherFiltersTest"
+      title: ""
+      description: ""
+- filename: "AdminSpecifyLayerNavigationConfigurationTest.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/LayeredNavigation/Test/Mftf/Test/AdminSpecifyLayerNavigationConfigurationTest.xml"
+  module: "LayeredNavigation"
+  tests:
+    - testname: "AdminSpecifyLayerNavigationConfigurationTest"
+      title: "Admin should be able to uncheck Default Value checkbox for dependent field"
+      description: "Admin should be able to uncheck Default Value checkbox for dependent field"
 - filename: "NewProductsListWidgetTest.xml"
-  repo: "https://github.com/magento/magento2/blob/2.3/app/code/Magento/Widget/Test/Mftf/Test/NewProductsListWidgetTest.xml"
-  module: "Widget"
-  tests:
-    - testname: "NewProductsListWidgetTest"
-      title: "Admin should be able to set products as new so that they show up in the Catalog New Products List Widget"
-      description: "Admin should be able to set products as new so that they show up in the Catalog New Products List Widget"
- 
-- filename: "AdminContentWidgetsNavigateMenuTest.xml"
-  repo: "https://github.com/magento/magento2/blob/2.3/app/code/Magento/Widget/Test/Mftf/Test/AdminContentWidgetsNavigateMenuTest.xml"
-  module: "Widget"
-  tests:
-    - testname: "AdminContentWidgetsNavigateMenuTest"
-      title: "Admin content widgets navigate menu test"
-      description: "Admin should be able to navigate to Content &gt; Widgets"
- 
-- filename: "AdminCreatingShippingLabelTest.xml"
-  repo: "https://github.com/magento/magento2/blob/2.3/app/code/Magento/Fedex/Test/Mftf/Test/AdminCreatingShippingLabelTest.xml"
-  module: "Fedex"
-  tests:
-    - testname: "AdminCreatingShippingLabelTest"
-      title: "Creating shipping label"
-      description: "Creating shipping label"
- 
-- filename: "AdminCheckInputFieldsDisabledAfterAppConfigDumpTest.xml"
-  repo: "https://github.com/magento/magento2/blob/2.3/app/code/Magento/Fedex/Test/Mftf/Test/AdminCheckInputFieldsDisabledAfterAppConfigDumpTest.xml"
-  module: "Fedex"
-  tests:
-    - testname: "AdminCheckInputFieldsDisabledAfterAppConfigDumpTest"
-      title: ""
-      description: ""
- 
-- filename: "AdminFrontendAreaSessionMustNotAffectAdminAreaTest.xml"
-  repo: "https://github.com/magento/magento2/blob/2.3/app/code/Magento/PageCache/Test/Mftf/Test/AdminFrontendAreaSessionMustNotAffectAdminAreaTest.xml"
-  module: "PageCache"
-  tests:
-    - testname: "AdminFrontendAreaSessionMustNotAffectAdminAreaTest"
-      title: "Frontend area session must not affect admin area"
-      description: "Frontend area session must not affect admin area"
- 
-- filename: "FlushStaticFilesCacheButtonVisibilityTest.xml"
-  repo: "https://github.com/magento/magento2/blob/2.3/app/code/Magento/PageCache/Test/Mftf/Test/FlushStaticFilesCacheButtonVisibilityTest.xml"
-  module: "PageCache"
-  tests:
-    - testname: "FlushStaticFilesCacheButtonVisibilityTest"
-      title: "Check visibility of flush static files cache button"
-      description: "Flush Static Files Cache button visibility"
- 
-- filename: "NewProductsListWidgetTest.xml"
-  repo: "https://github.com/magento/magento2/blob/2.3/app/code/Magento/PageCache/Test/Mftf/Test/NewProductsListWidgetTest.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/PageCache/Test/Mftf/Test/NewProductsListWidgetTest.xml"
   module: "PageCache"
   tests:
     - testname: "NewProductsListWidgetSimpleProductTest"
@@ -194,833 +1294,5966 @@
     - testname: "NewProductsListWidgetDownloadableProductTest"
       title: ""
       description: ""
- 
-- filename: "AdminCreateOrderWithBundleProductTest.xml"
-  repo: "https://github.com/magento/magento2/blob/2.3/app/code/Magento/Sales/Test/Mftf/Test/AdminCreateOrderWithBundleProductTest.xml"
-  module: "Sales"
-  tests:
-    - testname: "AdminCreateOrderWithBundleProductTest"
-      title: "Create Order in Admin and update bundle product configuration"
-      description: "Add bundle product with bundle option items with default quantity 2 to order in Admin and check price in product grid"
- 
-- filename: "AdminCreateOrderForCustomerWithTwoAddressesTaxableAndNonTaxableTest.xml"
-  repo: "https://github.com/magento/magento2/blob/2.3/app/code/Magento/Sales/Test/Mftf/Test/AdminCreateOrderForCustomerWithTwoAddressesTaxableAndNonTaxableTest.xml"
-  module: "Sales"
-  tests:
-    - testname: "AdminCreateOrderForCustomerWithTwoAddressesTaxableAndNonTaxableTest"
-      title: "Tax should not be displayed for non taxable address"
-      description: "Tax should not be displayed for non taxable address when switching from taxable address"
- 
-- filename: "AdminCreateCreditMemoConfigurableProductTest.xml"
-  repo: "https://github.com/magento/magento2/blob/2.3/app/code/Magento/Sales/Test/Mftf/Test/AdminCreateCreditMemoConfigurableProductTest.xml"
-  module: "Sales"
-  tests:
-    - testname: "AdminCreateCreditMemoConfigurableProductTest"
-      title: "Create Credit Memo for Offline Payment Methods"
-      description: "Create CreditMemo return to stock only one unit of configurable product"
- 
-- filename: "AdminStoresOrderStatusNavigateMenuTest.xml"
-  repo: "https://github.com/magento/magento2/blob/2.3/app/code/Magento/Sales/Test/Mftf/Test/AdminStoresOrderStatusNavigateMenuTest.xml"
-  module: "Sales"
-  tests:
-    - testname: "AdminStoresOrderStatusNavigateMenuTest"
-      title: "Admin stores order status navigate menu test"
-      description: "Admin should be able to navigate to Stores &gt; Order Status"
- 
-- filename: "AdminCancelTheCreatedOrderWithZeroSubtotalCheckoutTest.xml"
-  repo: "https://github.com/magento/magento2/blob/2.3/app/code/Magento/Sales/Test/Mftf/Test/AdminCancelTheCreatedOrderWithZeroSubtotalCheckoutTest.xml"
-  module: "Sales"
-  tests:
-    - testname: "AdminCancelTheCreatedOrderWithZeroSubtotalCheckoutTest"
-      title: "Cancel the created order with zero subtotal checkout"
-      description: "Create an order with Zero Subtotal checkout and cancel the order"
- 
-- filename: "CreateInvoiceWithCashOnDeliveryPaymentMethodTest.xml"
-  repo: "https://github.com/magento/magento2/blob/2.3/app/code/Magento/Sales/Test/Mftf/Test/CreateInvoiceWithCashOnDeliveryPaymentMethodTest.xml"
-  module: "Sales"
-  tests:
-    - testname: "CreateInvoiceWithCashOnDeliveryPaymentMethodTest"
-      title: "Create invoice with cash on delivery payment method test"
-      description: "Create invoice with cash on delivery payment method"
- 
-- filename: "AdminCreateOrderStatusTest.xml"
-  repo: "https://github.com/magento/magento2/blob/2.3/app/code/Magento/Sales/Test/Mftf/Test/AdminCreateOrderStatusTest.xml"
-  module: "Sales"
-  tests:
-    - testname: "AdminCreateOrderStatusTest"
-      title: "Create custom order status"
-      description: "Tests opening admin order status page, create a new order status with success message"
- 
-- filename: "AdminCreateOrderWithSimpleProductTest.xml"
-  repo: "https://github.com/magento/magento2/blob/2.3/app/code/Magento/Sales/Test/Mftf/Test/AdminCreateOrderWithSimpleProductTest.xml"
-  module: "Sales"
-  tests:
-    - testname: "AdminCreateOrderWithSimpleProductTest"
-      title: "Create Order in Admin with simple product"
-      description: "Create order with simple product and assert if it gets out of stock after ordering it."
- 
-- filename: "AdminCreateCreditMemoBankTransferPaymentTest.xml"
-  repo: "https://github.com/magento/magento2/blob/2.3/app/code/Magento/Sales/Test/Mftf/Test/AdminCreateCreditMemoBankTransferPaymentTest.xml"
-  module: "Sales"
-  tests:
-    - testname: "AdminCreateCreditMemoBankTransferPaymentTest"
-      title: "Create Credit Memo with Bank Transfer Payment"
-      description: "Create Credit Memo with Bank Transfer Payment and assert 0 shipping refund"
- 
-- filename: "AdminReorderWithCatalogPriceTest.xml"
-  repo: "https://github.com/magento/magento2/blob/2.3/app/code/Magento/Sales/Test/Mftf/Test/AdminReorderWithCatalogPriceTest.xml"
-  module: "Sales"
-  tests:
-    - testname: "AdminReorderWithCatalogPriceTest"
-      title: "Reorder doesn't show discount price in Order Totals block"
-      description: "Reorder doesn't show discount price in Order Totals block"
- 
-- filename: "AdminProductInTheShoppingCartCouldBeReachedByAdminDuringOrderCreationWithMultiWebsiteConfigTest.xml"
-  repo: "https://github.com/magento/magento2/blob/2.3/app/code/Magento/Sales/Test/Mftf/Test/AdminProductInTheShoppingCartCouldBeReachedByAdminDuringOrderCreationWithMultiWebsiteConfigTest.xml"
-  module: "Sales"
-  tests:
-    - testname: "AdminProductInTheShoppingCartCouldBeReachedByAdminDuringOrderCreationWithMultiWebsiteConfigTest"
-      title: "Product in the shopping cart could be reached by admin during order creation with multi website config"
-      description: "Product in the shopping cart could be reached by admin during order creation with multi website config"
- 
-- filename: "AdminCreateCreditMemoWithPurchaseOrderTest.xml"
-  repo: "https://github.com/magento/magento2/blob/2.3/app/code/Magento/Sales/Test/Mftf/Test/AdminCreateCreditMemoWithPurchaseOrderTest.xml"
-  module: "Sales"
-  tests:
-    - testname: "AdminCreateCreditMemoWithPurchaseOrderTest"
-      title: "Create Credit Memo with purchase order payment method"
-      description: "Create Credit Memo with purchase order payment payment and assert 0 shipping refund"
- 
-- filename: "AdminSalesShipmentsNavigateMenuTest.xml"
-  repo: "https://github.com/magento/magento2/blob/2.3/app/code/Magento/Sales/Test/Mftf/Test/AdminSalesShipmentsNavigateMenuTest.xml"
-  module: "Sales"
-  tests:
-    - testname: "AdminSalesShipmentsNavigateMenuTest"
-      title: "Admin sales shipments navigate menu test"
-      description: "Admin should be able to navigate to Sales &gt; Shipments"
- 
-- filename: "AdminCreateInvoiceTest.xml"
-  repo: "https://github.com/magento/magento2/blob/2.3/app/code/Magento/Sales/Test/Mftf/Test/AdminCreateInvoiceTest.xml"
-  module: "Sales"
-  tests:
-    - testname: "AdminCreateInvoiceTest"
-      title: "Admin should be able to create an invoice"
-      description: "Admin should be able to create an invoice"
- 
-- filename: "AdminCreateCreditMemoWithCashOnDeliveryTest.xml"
-  repo: "https://github.com/magento/magento2/blob/2.3/app/code/Magento/Sales/Test/Mftf/Test/AdminCreateCreditMemoWithCashOnDeliveryTest.xml"
-  module: "Sales"
-  tests:
-    - testname: "AdminCreateCreditMemoWithCashOnDeliveryTest"
-      title: "Create Credit Memo with cash on delivery payment method"
-      description: "Create Credit Memo with cash on delivery payment and assert 0 shipping refund"
- 
-- filename: "StorefrontOrderPagerIsAbsentTest.xml"
-  repo: "https://github.com/magento/magento2/blob/2.3/app/code/Magento/Sales/Test/Mftf/Test/StorefrontOrderPagerIsAbsentTest.xml"
-  module: "Sales"
-  tests:
-    - testname: "StorefrontOrderPagerIsAbsentTest"
-      title: "Pager is absent for 20 order items"
-      description: "Pager is disabled for orders with less than 20 items"
- 
-- filename: "AddConfigurableProductToOrderFromShoppingCartTest.xml"
-  repo: "https://github.com/magento/magento2/blob/2.3/app/code/Magento/Sales/Test/Mftf/Test/AddConfigurableProductToOrderFromShoppingCartTest.xml"
-  module: "Sales"
-  tests:
-    - testname: "AddConfigurableProductToOrderFromShoppingCartTest"
-      title: "Add configurable product to order from shopping cart test"
-      description: "Add configurable product to order from shopping cart"
- 
-- filename: "AssignCustomOrderStatusVisibleOnStorefrontTest.xml"
-  repo: "https://github.com/magento/magento2/blob/2.3/app/code/Magento/Sales/Test/Mftf/Test/AssignCustomOrderStatusVisibleOnStorefrontTest.xml"
-  module: "Sales"
-  tests:
-    - testname: "AssignCustomOrderStatusVisibleOnStorefrontTest"
-      title: "Assign custom order status visible on storefront test"
-      description: "Assign custom order status visible on storefront"
- 
-- filename: "AdminSaveInAddressBookCheckboxStateTest.xml"
-  repo: "https://github.com/magento/magento2/blob/2.3/app/code/Magento/Sales/Test/Mftf/Test/AdminSaveInAddressBookCheckboxStateTest.xml"
-  module: "Sales"
-  tests:
-    - testname: "AdminSaveInAddressBookCheckboxStateTest"
-      title: "The state of 'Save in address book' check-box inside 'Shipping Address' section on 'create Order' Admin page"
-      description: "The state of 'Save in address book' check-box inside 'Shipping Address' section on 'create Order' Admin page"
- 
-- filename: "AdminMassOrdersCancelCompleteAndClosedTest.xml"
-  repo: "https://github.com/magento/magento2/blob/2.3/app/code/Magento/Sales/Test/Mftf/Test/AdminMassOrdersCancelCompleteAndClosedTest.xml"
-  module: "Sales"
-  tests:
-    - testname: "AdminMassOrdersCancelCompleteAndClosedTest"
-      title: "Mass cancel orders in status  Complete, Closed"
-      description: "Try to cancel orders in status Complete, Closed"
- 
-- filename: "CreateInvoiceAndCheckInvoiceOrderTest.xml"
-  repo: "https://github.com/magento/magento2/blob/2.3/app/code/Magento/Sales/Test/Mftf/Test/CreateInvoiceAndCheckInvoiceOrderTest.xml"
-  module: "Sales"
-  tests:
-    - testname: "CreateInvoiceAndCheckInvoiceOrderTest"
-      title: "Create invoice and check invoice order test"
-      description: "Create invoice for offline payment methods and check invoice order on admin dashboard"
- 
-- filename: "AdminMassOrdersCancelProcessingAndClosedTest.xml"
-  repo: "https://github.com/magento/magento2/blob/2.3/app/code/Magento/Sales/Test/Mftf/Test/AdminMassOrdersCancelProcessingAndClosedTest.xml"
-  module: "Sales"
-  tests:
-    - testname: "AdminMassOrdersCancelProcessingAndClosedTest"
-      title: "Mass cancel orders in status  Processing, Closed"
-      description: "Try to cancel orders in status Processing, Closed"
- 
-- filename: "StorefrontOrderPagerDisplayedTest.xml"
-  repo: "https://github.com/magento/magento2/blob/2.3/app/code/Magento/Sales/Test/Mftf/Test/StorefrontOrderPagerDisplayedTest.xml"
-  module: "Sales"
-  tests:
-    - testname: "StorefrontOrderPagerDisplayedTest"
-      title: "Pager is displayed for 21 order items"
-      description: "Pager is displayed for 21 order items"
- 
-- filename: "AdminCancelTheCreatedOrderWithCashOnDeliveryPaymentMethodTest.xml"
-  repo: "https://github.com/magento/magento2/blob/2.3/app/code/Magento/Sales/Test/Mftf/Test/AdminCancelTheCreatedOrderWithCashOnDeliveryPaymentMethodTest.xml"
-  module: "Sales"
-  tests:
-    - testname: "AdminCancelTheCreatedOrderWithCashOnDeliveryPaymentMethodTest"
-      title: "Cancel the created order with cash on delivery payment method"
-      description: "Create an order with cash on delivery payment method and cancel the order"
- 
-- filename: "AdminCorrectnessInvoicedItemInBundleProductTest.xml"
-  repo: "https://github.com/magento/magento2/blob/2.3/app/code/Magento/Sales/Test/Mftf/Test/AdminCorrectnessInvoicedItemInBundleProductTest.xml"
-  module: "Sales"
-  tests:
-    - testname: "AdminCorrectnessInvoicedItemInBundleProductTest"
-      title: "Check correctness of invoiced items in a Bundle Product"
-      description: "Check correctness of invoiced items in a Bundle Product"
- 
-- filename: "AdminMassOrdersHoldOnPendingAndProcessingTest.xml"
-  repo: "https://github.com/magento/magento2/blob/2.3/app/code/Magento/Sales/Test/Mftf/Test/AdminMassOrdersHoldOnPendingAndProcessingTest.xml"
-  module: "Sales"
-  tests:
-    - testname: "AdminMassOrdersHoldOnPendingAndProcessingTest"
-      title: "Mass put orders in statuses Pending, Processing on Hold"
-      description: "Put orders in statuses Pending, Processing on Hold"
- 
-- filename: "AdminFreeShippingNotAvailableIfMinimumOrderAmountNotMatchOrderTotalTest.xml"
-  repo: "https://github.com/magento/magento2/blob/2.3/app/code/Magento/Sales/Test/Mftf/Test/AdminFreeShippingNotAvailableIfMinimumOrderAmountNotMatchOrderTotalTest.xml"
-  module: "Sales"
-  tests:
-    - testname: "AdminFreeShippingNotAvailableIfMinimumOrderAmountNotMatchOrderTotalTest"
-      title: "Free Shipping is not available in Admin if Minimum Order Amount does not match Order total"
-      description: "Admin should not be able place order with Free Shipping method if Minimum Order Amount does not match Order total"
- 
-- filename: "AdminSalesTransactionsNavigateMenuTest.xml"
-  repo: "https://github.com/magento/magento2/blob/2.3/app/code/Magento/Sales/Test/Mftf/Test/AdminSalesTransactionsNavigateMenuTest.xml"
-  module: "Sales"
-  tests:
-    - testname: "AdminSalesTransactionsNavigateMenuTest"
-      title: "Admin sales transactions navigate menu test"
-      description: "Admin should be able to navigate to Sales &gt; Transactions"
- 
-- filename: "AdminCreateOrderStatusDuplicatingLabelTest.xml"
-  repo: "https://github.com/magento/magento2/blob/2.3/app/code/Magento/Sales/Test/Mftf/Test/AdminCreateOrderStatusDuplicatingLabelTest.xml"
-  module: "Sales"
-  tests:
-    - testname: "AdminCreateOrderStatusDuplicatingLabelTest"
-      title: "Create order status with duplicating label"
-      description: "Create an order status and get success message"
- 
-- filename: "AdminHoldCreatedOrderTest.xml"
-  repo: "https://github.com/magento/magento2/blob/2.3/app/code/Magento/Sales/Test/Mftf/Test/AdminHoldCreatedOrderTest.xml"
-  module: "Sales"
-  tests:
-    - testname: "AdminHoldCreatedOrderTest"
-      title: "Hold the created order"
-      description: "Create an order and hold the order"
- 
-- filename: "AdminSalesCreditMemosNavigateMenuTest.xml"
-  repo: "https://github.com/magento/magento2/blob/2.3/app/code/Magento/Sales/Test/Mftf/Test/AdminSalesCreditMemosNavigateMenuTest.xml"
-  module: "Sales"
-  tests:
-    - testname: "AdminSalesCreditMemosNavigateMenuTest"
-      title: "Admin sales credit memos navigate menu test"
-      description: "Admin should be able to navigate to Sales &gt; Credit Memos"
- 
-- filename: "CheckXSSVulnerabilityDuringOrderCreationTest.xml"
-  repo: "https://github.com/magento/magento2/blob/2.3/app/code/Magento/Sales/Test/Mftf/Test/CheckXSSVulnerabilityDuringOrderCreationTest.xml"
-  module: "Sales"
-  tests:
-    - testname: "CheckXSSVulnerabilityDuringOrderCreationTest"
-      title: "Check XSS vulnerability during order creation test"
-      description: "Order should not be created with XSS vulnerability in email address"
- 
-- filename: "AdminCreateOrderWithSelectedShoppingCartItemsTest.xml"
-  repo: "https://github.com/magento/magento2/blob/2.3/app/code/Magento/Sales/Test/Mftf/Test/AdminCreateOrderWithSelectedShoppingCartItemsTest.xml"
-  module: "Sales"
-  tests:
-    - testname: "AdminCreateOrderWithSelectedShoppingCartItemsTest"
-      title: "Shopping cart items must not be added to the order unless they were moved manually"
-      description: "Shopping cart items must not be added to the order unless they were moved manually"
- 
-- filename: "AdminMassOrdersUpdateCancelPendingOrderTest.xml"
-  repo: "https://github.com/magento/magento2/blob/2.3/app/code/Magento/Sales/Test/Mftf/Test/AdminMassOrdersUpdateCancelPendingOrderTest.xml"
-  module: "Sales"
-  tests:
-    - testname: "AdminMassOrdersUpdateCancelPendingOrderTest"
-      title: "Mass cancel orders in status Pending"
-      description: "Mass cancel orders in status Pending"
- 
-- filename: "MoveLastOrderedConfigurableProductOnOrderPageTest.xml"
-  repo: "https://github.com/magento/magento2/blob/2.3/app/code/Magento/Sales/Test/Mftf/Test/MoveLastOrderedConfigurableProductOnOrderPageTest.xml"
-  module: "Sales"
-  tests:
-    - testname: "MoveLastOrderedConfigurableProductOnOrderPageTest"
-      title: "Move last ordered configurable product on order page test"
-      description: "Move last ordered configurable product on order page"
- 
-- filename: "AdminAvailabilityCreditMemoWithNoPaymentTest.xml"
-  repo: "https://github.com/magento/magento2/blob/2.3/app/code/Magento/Sales/Test/Mftf/Test/AdminAvailabilityCreditMemoWithNoPaymentTest.xml"
-  module: "Sales"
-  tests:
-    - testname: "AdminAvailabilityCreditMemoWithNoPaymentTest"
-      title: "Checking availability of 'Credit memo' button for order with no payment required"
-      description: "*Credit Memo* button should be displayed"
- 
-- filename: "AdminCheckingDateAfterChangeInterfaceLocaleTest.xml"
-  repo: "https://github.com/magento/magento2/blob/2.3/app/code/Magento/Sales/Test/Mftf/Test/AdminCheckingDateAfterChangeInterfaceLocaleTest.xml"
-  module: "Sales"
-  tests:
-    - testname: "AdminCheckingDateAfterChangeInterfaceLocaleTest"
-      title: "Checking date format in orders grid column after changing admin interface locale"
-      description: "Checking date format in orders grid column after changing admin interface locale"
- 
-- filename: "MoveRecentlyViewedConfigurableProductOnOrderPageTest.xml"
-  repo: "https://github.com/magento/magento2/blob/2.3/app/code/Magento/Sales/Test/Mftf/Test/MoveRecentlyViewedConfigurableProductOnOrderPageTest.xml"
-  module: "Sales"
-  tests:
-    - testname: "MoveRecentlyViewedConfigurableProductOnOrderPageTest"
-      title: "Move recently viewed configurable product on order page test"
-      description: "Move recently viewed configurable product on order page"
- 
-- filename: "EndToEndB2CAdminTest.xml"
-  repo: "https://github.com/magento/magento2/blob/2.3/app/code/Magento/Sales/Test/Mftf/Test/EndToEndB2CAdminTest.xml"
-  module: "Sales"
-  tests:
-    - testname: "EndToEndB2CAdminTest"
-      title: ""
-      description: ""
- 
-- filename: "MoveLastOrderedSimpleProductOnOrderPageTest.xml"
-  repo: "https://github.com/magento/magento2/blob/2.3/app/code/Magento/Sales/Test/Mftf/Test/MoveLastOrderedSimpleProductOnOrderPageTest.xml"
-  module: "Sales"
-  tests:
-    - testname: "MoveLastOrderedSimpleProductOnOrderPageTest"
-      title: "Move last ordered simple product on order page test"
-      description: "Move last ordered simple product on order page"
- 
-- filename: "AdminCreateOrderWithMinimumAmountEnabledTest.xml"
-  repo: "https://github.com/magento/magento2/blob/2.3/app/code/Magento/Sales/Test/Mftf/Test/AdminCreateOrderWithMinimumAmountEnabledTest.xml"
-  module: "Sales"
-  tests:
-    - testname: "AdminCreateOrderWithMinimumAmountEnabledTest"
-      title: "Admin order is not restricted by 'Minimum Order Amount' configuration."
-      description: "Admin should be able to create an order regardless of the minimum order amount."
- 
-- filename: "MoveConfigurableProductsInComparedOnOrderPageTest.xml"
-  repo: "https://github.com/magento/magento2/blob/2.3/app/code/Magento/Sales/Test/Mftf/Test/MoveConfigurableProductsInComparedOnOrderPageTest.xml"
-  module: "Sales"
-  tests:
-    - testname: "MoveConfigurableProductsInComparedOnOrderPageTest"
-      title: "Move configurable products in compared on order page test"
-      description: "Move configurable products in compared on order page test"
- 
-- filename: "CreateOrderFromEditCustomerPageTest.xml"
-  repo: "https://github.com/magento/magento2/blob/2.3/app/code/Magento/Sales/Test/Mftf/Test/CreateOrderFromEditCustomerPageTest.xml"
-  module: "Sales"
-  tests:
-    - testname: "CreateOrderFromEditCustomerPageTest"
-      title: "Create order from edit customer page and add products to wish list and shopping cart"
-      description: "Create an order from edit customer page and add products to the wish list and shopping cart "
- 
-- filename: "AdminCancelTheCreatedOrderWithPurchaseOrderPaymentMethodTest.xml"
-  repo: "https://github.com/magento/magento2/blob/2.3/app/code/Magento/Sales/Test/Mftf/Test/AdminCancelTheCreatedOrderWithPurchaseOrderPaymentMethodTest.xml"
-  module: "Sales"
-  tests:
-    - testname: "AdminCancelTheCreatedOrderWithPurchaseOrderPaymentMethodTest"
-      title: "Cancel the created order with purchase order payment method"
-      description: "Create an order using Purchase Order payment method and cancel the order"
- 
-- filename: "AdminMassOrdersHoldOnCompleteTest.xml"
-  repo: "https://github.com/magento/magento2/blob/2.3/app/code/Magento/Sales/Test/Mftf/Test/AdminMassOrdersHoldOnCompleteTest.xml"
-  module: "Sales"
-  tests:
-    - testname: "AdminMassOrdersHoldOnCompleteTest"
-      title: "Try to put order in status Complete on Hold"
-      description: "Try to put order in status Complete on Hold"
- 
-- filename: "AdminSubmitsOrderWithAndWithoutEmailTest.xml"
-  repo: "https://github.com/magento/magento2/blob/2.3/app/code/Magento/Sales/Test/Mftf/Test/AdminSubmitsOrderWithAndWithoutEmailTest.xml"
-  module: "Sales"
-  tests:
-    - testname: "AdminSubmitsOrderWithAndWithoutEmailTest"
-      title: "Email is required to create an order from Admin Panel"
-      description: "Admin should not be able to submit orders without an email address"
- 
-- filename: "AdminCancelTheCreatedOrderWithBankTransferPaymentMethodTest.xml"
-  repo: "https://github.com/magento/magento2/blob/2.3/app/code/Magento/Sales/Test/Mftf/Test/AdminCancelTheCreatedOrderWithBankTransferPaymentMethodTest.xml"
-  module: "Sales"
-  tests:
-    - testname: "AdminCancelTheCreatedOrderWithBankTransferPaymentMethodTest"
-      title: "Cancel the created order with bank transfer payment method"
-      description: "Created an order with bank transfer payment method and cancel the order"
- 
-- filename: "AdminMassOrdersReleasePendingOrderTest.xml"
-  repo: "https://github.com/magento/magento2/blob/2.3/app/code/Magento/Sales/Test/Mftf/Test/AdminMassOrdersReleasePendingOrderTest.xml"
-  module: "Sales"
-  tests:
-    - testname: "AdminMassOrdersReleasePendingOrderTest"
-      title: "Try to Release order in status Pending"
-      description: "Try to Release order in status Pending"
- 
-- filename: "AdminCreateOrderStatusDuplicatingCodeTest.xml"
-  repo: "https://github.com/magento/magento2/blob/2.3/app/code/Magento/Sales/Test/Mftf/Test/AdminCreateOrderStatusDuplicatingCodeTest.xml"
-  module: "Sales"
-  tests:
-    - testname: "AdminCreateOrderStatusDuplicatingCodeTest"
-      title: "Create order status with duplicating code"
-      description: "Receive error when creating order status with the code which is already exist"
- 
-- filename: "AdminUnassignCustomOrderStatusTest.xml"
-  repo: "https://github.com/magento/magento2/blob/2.3/app/code/Magento/Sales/Test/Mftf/Test/AdminUnassignCustomOrderStatusTest.xml"
-  module: "Sales"
-  tests:
-    - testname: "AdminUnassignCustomOrderStatusTest"
-      title: "Admin Unassign Custom Order Status Test"
-      description: "Test log in to Sales and Unassign Custom Order Status Test"
- 
-- filename: "AdminSubmitConfigurableProductOrderTest.xml"
-  repo: "https://github.com/magento/magento2/blob/2.3/app/code/Magento/Sales/Test/Mftf/Test/AdminSubmitConfigurableProductOrderTest.xml"
-  module: "Sales"
-  tests:
-    - testname: "AdminSubmitConfigurableProductOrderTest"
-      title: "Create Order in Admin and update product configuration"
-      description: "Create Order in Admin and update product configuration"
- 
-- filename: "CreditMemoTotalAfterShippingDiscountTest.xml"
-  repo: "https://github.com/magento/magento2/blob/2.3/app/code/Magento/Sales/Test/Mftf/Test/CreditMemoTotalAfterShippingDiscountTest.xml"
-  module: "Sales"
-  tests:
-    - testname: "CreditMemoTotalAfterShippingDiscountTest"
-      title: "Verify credit memo grand total after shipping discount is applied via Cart Price Rule"
-      description: "Verify credit memo grand total after shipping discount is applied via Cart Price Rule"
- 
-- filename: "AdminCreateOrderAddProductCheckboxTest.xml"
-  repo: "https://github.com/magento/magento2/blob/2.3/app/code/Magento/Sales/Test/Mftf/Test/AdminCreateOrderAddProductCheckboxTest.xml"
-  module: "Sales"
-  tests:
-    - testname: "AdminCreateOrderAddProductCheckboxTest"
-      title: "Create Order in Admin and Add Product"
-      description: "Create order in Admin panel, add product by clicking checkbox, and verify it is checked"
- 
-- filename: "StorefrontPrintOrderGuestTest.xml"
-  repo: "https://github.com/magento/magento2/blob/2.3/app/code/Magento/Sales/Test/Mftf/Test/StorefrontPrintOrderGuestTest.xml"
-  module: "Sales"
-  tests:
-    - testname: "StorefrontPrintOrderGuestTest"
-      title: "Print Order from Guest on Frontend"
-      description: "Print Order from Guest on Frontend"
- 
-- filename: "MoveRecentlyViewedBundleFixedProductOnOrderPageTest.xml"
-  repo: "https://github.com/magento/magento2/blob/2.3/app/code/Magento/Sales/Test/Mftf/Test/MoveRecentlyViewedBundleFixedProductOnOrderPageTest.xml"
-  module: "Sales"
-  tests:
-    - testname: "MoveRecentlyViewedBundleFixedProductOnOrderPageTest"
-      title: "Move recently viewed bundle fixed product on order page test"
-      description: "Move recently viewed bundle fixed product on order page"
- 
-- filename: "CreateInvoiceWithPurchaseOrderPaymentMethodTest.xml"
-  repo: "https://github.com/magento/magento2/blob/2.3/app/code/Magento/Sales/Test/Mftf/Test/CreateInvoiceWithPurchaseOrderPaymentMethodTest.xml"
-  module: "Sales"
-  tests:
-    - testname: "CreateInvoiceWithPurchaseOrderPaymentMethodTest"
-      title: "Create invoice with purchase order payment method test"
-      description: "Create invoice with purchase order payment method"
- 
-- filename: "AdminCheckingCreditMemoUpdateTotalsTest.xml"
-  repo: "https://github.com/magento/magento2/blob/2.3/app/code/Magento/Sales/Test/Mftf/Test/AdminCheckingCreditMemoUpdateTotalsTest.xml"
-  module: "Sales"
-  tests:
-    - testname: "AdminCheckingCreditMemoTotalsTest"
-      title: "Checking Credit Memo Update Totals button"
-      description: "Checking Credit Memo Update Totals button"
- 
-- filename: "AdminCreateOrderAndCheckTheReorderTest.xml"
-  repo: "https://github.com/magento/magento2/blob/2.3/app/code/Magento/Sales/Test/Mftf/Test/AdminCreateOrderAndCheckTheReorderTest.xml"
-  module: "Sales"
-  tests:
-    - testname: "AdminCreateOrderAndCheckTheReorderTest"
-      title: "'Reorder' button is not visible for customer if ordered item is out of stock"
-      description: "'Reorder' button is not visible for customer if ordered item is out of stock"
- 
-- filename: "AdminOrdersReleaseInUnholdStatusTest.xml"
-  repo: "https://github.com/magento/magento2/blob/2.3/app/code/Magento/Sales/Test/Mftf/Test/AdminOrdersReleaseInUnholdStatusTest.xml"
-  module: "Sales"
-  tests:
-    - testname: "AdminOrdersReleaseInUnholdStatusTest"
-      title: "Release order in status On Hold"
-      description: "Release order in status On Hold"
- 
-- filename: "CreateInvoiceWithZeroSubtotalCheckoutTest.xml"
-  repo: "https://github.com/magento/magento2/blob/2.3/app/code/Magento/Sales/Test/Mftf/Test/CreateInvoiceWithZeroSubtotalCheckoutTest.xml"
-  module: "Sales"
-  tests:
-    - testname: "CreateInvoiceWithZeroSubtotalCheckoutTest"
-      title: "Create invoice with zero subtotal checkout test"
-      description: "Create invoice with with zero subtotal checkout"
- 
-- filename: "AdminSubmitsOrderWithAndWithoutFieldsValidationTest.xml"
-  repo: "https://github.com/magento/magento2/blob/2.3/app/code/Magento/Sales/Test/Mftf/Test/AdminSubmitsOrderWithAndWithoutFieldsValidationTest.xml"
-  module: "Sales"
-  tests:
-    - testname: "AdminSubmitsOrderWithAndWithoutFieldsValidationTest"
-      title: "Fields validation is required to create an order from Admin Panel"
-      description: "Admin should not be able to submit orders without invalid address fields"
- 
-- filename: "AdminCancelTheCreatedOrderWithProductQtyWithoutStockDecreaseTest.xml"
-  repo: "https://github.com/magento/magento2/blob/2.3/app/code/Magento/Sales/Test/Mftf/Test/AdminCancelTheCreatedOrderWithProductQtyWithoutStockDecreaseTest.xml"
-  module: "Sales"
-  tests:
-    - testname: "AdminCancelTheCreatedOrderWithProductQtyWithoutStockDecreaseTest"
-      title: "Cancel the created order with product quantity without stock decrease"
-      description: "Create an order with product quantity without stock decrease, cancel the order and verify product quantity in backend"
- 
-- filename: "CreateInvoiceWithShipmentAndCheckInvoicedOrderTest.xml"
-  repo: "https://github.com/magento/magento2/blob/2.3/app/code/Magento/Sales/Test/Mftf/Test/CreateInvoiceWithShipmentAndCheckInvoicedOrderTest.xml"
-  module: "Sales"
-  tests:
-    - testname: "CreateInvoiceWithShipmentAndCheckInvoicedOrderTest"
-      title: "Create invoice with shipment and check invoiced order test"
-      description: "Create invoice with shipment for offline payment methods and check invoiced order on admin dashboard"
- 
-- filename: "AdminSalesInvoicesNavigateMenuTest.xml"
-  repo: "https://github.com/magento/magento2/blob/2.3/app/code/Magento/Sales/Test/Mftf/Test/AdminSalesInvoicesNavigateMenuTest.xml"
-  module: "Sales"
-  tests:
-    - testname: "AdminSalesInvoicesNavigateMenuTest"
-      title: "Admin sales invoices navigate menu test"
-      description: "Admin should be able to navigate to Sales &gt; Invoices"
- 
-- filename: "AssignCustomOrderStatusNotVisibleOnStorefrontTest.xml"
-  repo: "https://github.com/magento/magento2/blob/2.3/app/code/Magento/Sales/Test/Mftf/Test/AssignCustomOrderStatusNotVisibleOnStorefrontTest.xml"
-  module: "Sales"
-  tests:
-    - testname: "AssignCustomOrderStatusNotVisibleOnStorefrontTest"
-      title: "Assign custom order status not visible on storefront test"
-      description: "Assign custom order status not visible on storefront"
- 
-- filename: "AddSimpleProductToOrderFromShoppingCartTest.xml"
-  repo: "https://github.com/magento/magento2/blob/2.3/app/code/Magento/Sales/Test/Mftf/Test/AddSimpleProductToOrderFromShoppingCartTest.xml"
-  module: "Sales"
-  tests:
-    - testname: "AddSimpleProductToOrderFromShoppingCartTest"
-      title: "Add simple product to order from shopping cart test"
-      description: "Add simple product to order from shopping cart"
- 
-- filename: "AdminCancelTheCreatedOrderWithCheckMoneyOrderPaymentMethodTest.xml"
-  repo: "https://github.com/magento/magento2/blob/2.3/app/code/Magento/Sales/Test/Mftf/Test/AdminCancelTheCreatedOrderWithCheckMoneyOrderPaymentMethodTest.xml"
-  module: "Sales"
-  tests:
-    - testname: "AdminCancelTheCreatedOrderWithCheckMoneyOrderPaymentMethodTest"
-      title: "Cancel the created order with check/money order payment method"
-      description: " Create an order with check/money order payment method and cancel the order"
- 
-- filename: "MoveSimpleProductsInComparedOnOrderPageTest.xml"
-  repo: "https://github.com/magento/magento2/blob/2.3/app/code/Magento/Sales/Test/Mftf/Test/MoveSimpleProductsInComparedOnOrderPageTest.xml"
-  module: "Sales"
-  tests:
-    - testname: "MoveSimpleProductsInComparedOnOrderPageTest"
-      title: "Move simple products in compared on order page test"
-      description: "Move simple products in compared on order page test"
- 
-- filename: "StorefrontVerifySecureURLRedirectSalesTest.xml"
-  repo: "https://github.com/magento/magento2/blob/2.3/app/code/Magento/Sales/Test/Mftf/Test/StorefrontVerifySecureURLRedirectSalesTest.xml"
-  module: "Sales"
-  tests:
-    - testname: "StorefrontVerifySecureURLRedirectSales"
-      title: "Verify Secure URLs For Storefront Sales Pages"
-      description: "Verify that the Secure URL configuration applies to the Sales pages on the Storefront"
- 
-- filename: "AdminCreateCreditMemoPartialRefundTest.xml"
-  repo: "https://github.com/magento/magento2/blob/2.3/app/code/Magento/Sales/Test/Mftf/Test/AdminCreateCreditMemoPartialRefundTest.xml"
-  module: "Sales"
-  tests:
-    - testname: "AdminCreateCreditMemoPartialRefundTest"
-      title: "Create Credit Memo for Offline Payment Methods"
-      description: "Assert items return to stock (partial refund)"
- 
-- filename: "AdminSalesOrdersNavigateMenuTest.xml"
-  repo: "https://github.com/magento/magento2/blob/2.3/app/code/Magento/Sales/Test/Mftf/Test/AdminSalesOrdersNavigateMenuTest.xml"
-  module: "Sales"
-  tests:
-    - testname: "AdminSalesOrdersNavigateMenuTest"
-      title: "Admin sales orders navigate menu test"
-      description: "Admin should be able to navigate to Sales &gt; Orders"
- 
-- filename: "AdminSubmitsOrderPaymentMethodValidationTest.xml"
-  repo: "https://github.com/magento/magento2/blob/2.3/app/code/Magento/Sales/Test/Mftf/Test/AdminSubmitsOrderPaymentMethodValidationTest.xml"
-  module: "Sales"
-  tests:
-    - testname: "AdminSubmitsOrderPaymentMethodValidationTest"
-      title: "UI validation for Payment methods when creating an order from admin"
-      description: "Admin should not be able to submit orders without selecting a payment method when there is more than one"
- 
-- filename: "YoutubeVideoWindowOnProductPageTest.xml"
-  repo: "https://github.com/magento/magento2/blob/2.3/app/code/Magento/ProductVideo/Test/Mftf/Test/YoutubeVideoWindowOnProductPageTest.xml"
-  module: "ProductVideo"
-  tests:
-    - testname: "YoutubeVideoWindowOnProductPageTest"
-      title: "Youtube video window on the product page"
-      description: "Check Youtube video window on the product page"
- 
-- filename: "AdminValidateUrlOnGetVideoInformationTest.xml"
-  repo: "https://github.com/magento/magento2/blob/2.3/app/code/Magento/ProductVideo/Test/Mftf/Test/AdminValidateUrlOnGetVideoInformationTest.xml"
-  module: "ProductVideo"
-  tests:
-    - testname: "AdminValidateUrlOnGetVideoInformationTest"
-      title: "Admin validates the url when getting video information"
-      description: "Testing for a required video url when getting video information"
- 
+- filename: "AdminFrontendAreaSessionMustNotAffectAdminAreaTest.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/PageCache/Test/Mftf/Test/AdminFrontendAreaSessionMustNotAffectAdminAreaTest.xml"
+  module: "PageCache"
+  tests:
+    - testname: "AdminFrontendAreaSessionMustNotAffectAdminAreaTest"
+      title: "Frontend area session must not affect admin area"
+      description: "Frontend area session must not affect admin area"
+- filename: "FlushStaticFilesCacheButtonVisibilityTest.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/PageCache/Test/Mftf/Test/FlushStaticFilesCacheButtonVisibilityTest.xml"
+  module: "PageCache"
+  tests:
+    - testname: "FlushStaticFilesCacheButtonVisibilityTest"
+      title: "Check visibility of flush static files cache button"
+      description: "Flush Static Files Cache button visibility"
+- filename: "DeleteUsedInConfigurableProductAttributeTest.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/Catalog/Test/Mftf/Test/DeleteUsedInConfigurableProductAttributeTest.xml"
+  module: "Catalog"
+  tests:
+    - testname: "DeleteUsedInConfigurableProductAttributeTest"
+      title: "Admin should not be able to delete product attribute used in configurable product"
+      description: "Admin should not be able to delete product attribute used in configurable product"
+- filename: "StorefrontPurchaseProductCustomOptionsDifferentStoreViewsTest.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/Catalog/Test/Mftf/Test/StorefrontPurchaseProductCustomOptionsDifferentStoreViewsTest.xml"
+  module: "Catalog"
+  tests:
+    - testname: "StorefrontPurchaseProductCustomOptionsDifferentStoreViewsTest"
+      title: "Admin should be able to sell products with different variants of their own"
+      description: "Admin should be able to sell products with different variants of their own"
+- filename: "AdminUpdateVirtualProductWithTierPriceInStockVisibleInCategoryAndSearch2Test.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/Catalog/Test/Mftf/Test/AdminUpdateVirtualProductWithTierPriceInStockVisibleInCategoryAndSearch2Test.xml"
+  module: "Catalog"
+  tests:
+    - testname: "AdminUpdateVirtualProductWithTierPriceInStockVisibleInCategoryAndSearch2Test"
+      title: "Update Virtual Product with Tier Price (In Stock) Visible in Category and Search"
+      description: "Test log in to Update Virtual Product and Update Virtual Product with Tier Price (In Stock) Visible in Category and Search"
+- filename: "AdminMassProductPriceUpdateTest.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/Catalog/Test/Mftf/Test/AdminMassProductPriceUpdateTest.xml"
+  module: "Catalog"
+  tests:
+    - testname: "AdminMassProductPriceUpdateTest"
+      title: "Mass update simple product price"
+      description: "Login as admin and update mass product price"
+- filename: "AdminUpdateSimpleProductWithRegularPriceInStockNotVisibleIndividuallyTest.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/Catalog/Test/Mftf/Test/AdminUpdateSimpleProductWithRegularPriceInStockNotVisibleIndividuallyTest.xml"
+  module: "Catalog"
+  tests:
+    - testname: "AdminUpdateSimpleProductWithRegularPriceInStockNotVisibleIndividuallyTest"
+      title: "Update Simple Product with Regular Price (In Stock) Not Visible Individually"
+      description: "Test log in to Update Simple Product and Update Simple Product with Regular Price (In Stock) Not Visible Individually"
+- filename: "VerifyChildCategoriesShouldNotIncludeInMenuTest.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/Catalog/Test/Mftf/Test/VerifyChildCategoriesShouldNotIncludeInMenuTest.xml"
+  module: "Catalog"
+  tests:
+    - testname: "VerifyChildCategoriesShouldNotIncludeInMenuTest"
+      title: "Customer should not see categories that are not included in the menu"
+      description: "Customer should not see categories that are not included in the menu"
+- filename: "AdminStoresProductNavigateMenuTest.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/Catalog/Test/Mftf/Test/AdminStoresProductNavigateMenuTest.xml"
+  module: "Catalog"
+  tests:
+    - testname: "AdminStoresProductNavigateMenuTest"
+      title: "Admin stores product navigate menu test"
+      description: "Admin should be able to navigate to Stores &gt; Product"
+- filename: "AdminBackorderAllowedAddProductToCartTest.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/Catalog/Test/Mftf/Test/AdminBackorderAllowedAddProductToCartTest.xml"
+  module: "Catalog"
+  tests:
+    - testname: "AdminBackorderAllowedAddProductToCartTest"
+      title: "Add Product to Cart, Backorder Allowed"
+      description: "Customer should be able to add products to cart when that products quantity is zero"
+- filename: "AdvanceCatalogSearchSimpleProductTest.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/Catalog/Test/Mftf/Test/AdvanceCatalogSearchSimpleProductTest.xml"
+  module: "Catalog"
+  tests:
+    - testname: "AdvanceCatalogSearchSimpleProductByNameTest"
+      title: "Guest customer should be able to advance search simple product with product name"
+      description: "Guest customer should be able to advance search simple product with product name"
+
+    - testname: "AdvanceCatalogSearchSimpleProductBySkuTest"
+      title: "Guest customer should be able to advance search simple product with product sku"
+      description: "Guest customer should be able to advance search simple product with product sku"
+
+    - testname: "AdvanceCatalogSearchSimpleProductByDescriptionTest"
+      title: "Guest customer should be able to advance search simple product with product description"
+      description: "Guest customer should be able to advance search simple product with product description"
+
+    - testname: "AdvanceCatalogSearchSimpleProductByShortDescriptionTest"
+      title: "Guest customer should be able to advance search simple product with product short description"
+      description: "Guest customer should be able to advance search simple product with product short description"
+
+    - testname: "AdvanceCatalogSearchSimpleProductByPriceTest"
+      title: "Guest customer should be able to advance search simple product with product price"
+      description: "Guest customer should be able to advance search simple product with product price"
+- filename: "AdminUpdateFlatCategoryIncludeInNavigationTest.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/Catalog/Test/Mftf/Test/AdminUpdateFlatCategoryIncludeInNavigationTest.xml"
+  module: "Catalog"
+  tests:
+    - testname: "AdminUpdateFlatCategoryAndIncludeInMenuTest"
+      title: "Flat Catalog - Update Category, Include in Navigation Menu"
+      description: "Login as admin and update flat category by enabling Include in Menu"
+- filename: "AdminCreateVirtualProductOutOfStockWithTierPriceTest.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/Catalog/Test/Mftf/Test/AdminCreateVirtualProductOutOfStockWithTierPriceTest.xml"
+  module: "Catalog"
+  tests:
+    - testname: "AdminCreateVirtualProductOutOfStockWithTierPriceTest"
+      title: "Create virtual product out of stock with tier price"
+      description: "Test log in to Create virtual product and Create virtual product out of stock with tier price"
+- filename: "AdvanceCatalogSearchVirtualProductTest.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/Catalog/Test/Mftf/Test/AdvanceCatalogSearchVirtualProductTest.xml"
+  module: "Catalog"
+  tests:
+    - testname: "AdvanceCatalogSearchVirtualProductByNameTest"
+      title: "Guest customer should be able to advance search virtual product with product name"
+      description: "Guest customer should be able to advance search virtual product with product name"
+
+    - testname: "AdvanceCatalogSearchVirtualProductBySkuTest"
+      title: "Guest customer should be able to advance search virtual product with product sku"
+      description: "Guest customer should be able to advance search virtual product with product sku"
+
+    - testname: "AdvanceCatalogSearchVirtualProductByDescriptionTest"
+      title: "Guest customer should be able to advance search virtual product with product description"
+      description: "Guest customer should be able to advance search virtual product with product description"
+
+    - testname: "AdvanceCatalogSearchVirtualProductByShortDescriptionTest"
+      title: "Guest customer should be able to advance search virtual product with product short description"
+      description: "Guest customer should be able to advance search virtual product with product short description"
+
+    - testname: "AdvanceCatalogSearchVirtualProductByPriceTest"
+      title: "Guest customer should be able to advance search virtual product with product price"
+      description: "Guest customer should be able to advance search virtual product with product price"
+- filename: "AdminSimpleProductEditUiTest.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/Catalog/Test/Mftf/Test/AdminSimpleProductEditUiTest.xml"
+  module: "Catalog"
+  tests:
+    - testname: "AdminSimpleProductUiValidationTest"
+      title: "UI elements on the simple product edit screen should be organized as expected"
+      description: "Admin should be able to use simple product UI in expected manner"
+- filename: "AdminCheckInactiveIncludeInMenuCategoryAndSubcategoryIsNotVisibleInNavigationTest.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/Catalog/Test/Mftf/Test/AdminCheckInactiveIncludeInMenuCategoryAndSubcategoryIsNotVisibleInNavigationTest.xml"
+  module: "Catalog"
+  tests:
+    - testname: "AdminCheckInactiveIncludeInMenuCategoryAndSubcategoryIsNotVisibleInNavigationTest"
+      title: "Active Category and subcategory are not visible on navigation menu, Include in Menu = No"
+      description: "Login as admin and verify inactive include in menu category and subcategory is not visible in navigation menu"
+- filename: "AdminMassUpdateProductAttributesGlobalScopeTest.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/Catalog/Test/Mftf/Test/AdminMassUpdateProductAttributesGlobalScopeTest.xml"
+  module: "Catalog"
+  tests:
+    - testname: "AdminMassUpdateProductAttributesGlobalScopeTest"
+      title: "Admin should be able to mass update product attributes in global scope"
+      description: "Admin should be able to mass update product attributes in global scope"
+- filename: "TieredPricingAndQuantityIncrementsWorkWithDecimalinventoryTest.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/Catalog/Test/Mftf/Test/TieredPricingAndQuantityIncrementsWorkWithDecimalinventoryTest.xml"
+  module: "Catalog"
+  tests:
+    - testname: "TieredPricingAndQuantityIncrementsWorkWithDecimalinventoryTest"
+      title: "Tiered pricing and quantity increments work with decimal inventory"
+      description: "Tiered pricing and quantity increments work with decimal inventory"
+- filename: "VerifyCategoryProductAndProductCategoryPartialReindexTest.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/Catalog/Test/Mftf/Test/VerifyCategoryProductAndProductCategoryPartialReindexTest.xml"
+  module: "Catalog"
+  tests:
+    - testname: "VerifyCategoryProductAndProductCategoryPartialReindexTest"
+      title: "Verify Category Product and Product Category partial reindex"
+      description: "Verify that Merchant Developer can use console commands to perform partial reindex for Category Products, Product Categories, and Catalog Search"
+- filename: "AdminCreateDropdownProductAttributeTest.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/Catalog/Test/Mftf/Test/AdminCreateDropdownProductAttributeTest.xml"
+  module: "Catalog"
+  tests:
+    - testname: "AdminCreateDropdownProductAttributeTest"
+      title: "Admin should be able to create dropdown product attribute"
+      description: "Admin should be able to create dropdown product attribute"
+- filename: "AdminGridPageNumberAfterSaveAndCloseActionTest.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/Catalog/Test/Mftf/Test/AdminGridPageNumberAfterSaveAndCloseActionTest.xml"
+  module: "Catalog"
+  tests:
+    - testname: "AdminGridPageNumberAfterSaveAndCloseActionTest"
+      title: "Checking Catalog grid page number after Save and Close action"
+      description: "Checking Catalog grid page number after Save and Close action"
+- filename: "StorefrontAdvanceCatalogSearchSimpleProductBySkuWithHyphenTest.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/Catalog/Test/Mftf/Test/StorefrontAdvanceCatalogSearchSimpleProductBySkuWithHyphenTest.xml"
+  module: "Catalog"
+  tests:
+    - testname: "StorefrontAdvanceCatalogSearchSimpleProductBySkuWithHyphenTest"
+      title: "Guest customer should be able to advance search simple product with product sku that contains hyphen"
+      description: "Guest customer should be able to advance search simple product with product sku that contains hyphen"
+- filename: "NewProductsListWidgetSimpleProductTest.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/Catalog/Test/Mftf/Test/NewProductsListWidgetSimpleProductTest.xml"
+  module: "Catalog"
+  tests:
+    - testname: "NewProductsListWidgetSimpleProductTest"
+      title: "Admin should be able to set Simple Product as new so that it shows up in the Catalog New Products List Widget"
+      description: "Admin should be able to set Simple Product as new so that it shows up in the Catalog New Products List Widget"
 - filename: "AdminAddDefaultVideoSimpleProductTest.xml"
-  repo: "https://github.com/magento/magento2/blob/2.3/app/code/Magento/ProductVideo/Test/Mftf/Test/AdminAddDefaultVideoSimpleProductTest.xml"
-  module: "ProductVideo"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/Catalog/Test/Mftf/Test/AdminAddDefaultVideoSimpleProductTest.xml"
+  module: "Catalog"
   tests:
     - testname: "AdminAddDefaultVideoSimpleProductTest"
-      title: ""
-      description: ""
- 
+      title: "Admin should be able to add default product video for a Simple Product"
+      description: "Admin should be able to add default product video for a Simple Product"
+- filename: "AdminUpdateSimpleProductWithRegularPriceInStockWithCustomOptionsTest.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/Catalog/Test/Mftf/Test/AdminUpdateSimpleProductWithRegularPriceInStockWithCustomOptionsTest.xml"
+  module: "Catalog"
+  tests:
+    - testname: "AdminUpdateSimpleProductWithRegularPriceInStockWithCustomOptionsTest"
+      title: "Update Simple Product with Regular Price (In Stock) with Custom Options"
+      description: "Test log in to Update Simple Product and Update Simple Product with Regular Price (In Stock) with Custom Options"
+- filename: "AdminDisableProductOnChangingAttributeSetTest.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/Catalog/Test/Mftf/Test/AdminDisableProductOnChangingAttributeSetTest.xml"
+  module: "Catalog"
+  tests:
+    - testname: "AdminDisableProductOnChangingAttributeSetTest"
+      title: "Verify product status while changing attribute set"
+      description: "Value set for enabled product has to be shown when attribute set is changed"
+- filename: "AdminUpdateVirtualProductWithTierPriceInStockVisibleInCategoryAndSearchTest.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/Catalog/Test/Mftf/Test/AdminUpdateVirtualProductWithTierPriceInStockVisibleInCategoryAndSearchTest.xml"
+  module: "Catalog"
+  tests:
+    - testname: "UpdateVirtualProductWithTierPriceInStockVisibleInCategoryAndSearchTest"
+      title: "DEPRECATED. Update Virtual Product with Tier Price (In Stock) Visible in Category and Search"
+      description: "Test log in to Update Virtual Product and Update Virtual Product with Tier Price (In Stock) Visible in Category and Search"
+- filename: "AdminCheckOutOfStockProductIsNotVisibleInCategoryTest.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/Catalog/Test/Mftf/Test/AdminCheckOutOfStockProductIsNotVisibleInCategoryTest.xml"
+  module: "Catalog"
+  tests:
+    - testname: "AdminCheckOutOfStockProductIsNotVisibleInCategoryTest"
+      title: "Out of Stock Product is Not Visible in Category"
+      description: "Login as admin and check out of stock product is not visible in category"
+- filename: "AdminMultipleWebsitesUseDefaultValuesTest.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/Catalog/Test/Mftf/Test/AdminMultipleWebsitesUseDefaultValuesTest.xml"
+  module: "Catalog"
+  tests:
+    - testname: "AdminMultipleWebsitesUseDefaultValuesTest"
+      title: "Use Default Value checkboxes should be checked for new website scope"
+      description: "Use Default Value checkboxes for product attribute should be checked for new website scope"
+- filename: "AdminUpdateCategoryAndCheckDefaultUrlKeyOnStoreViewTest.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/Catalog/Test/Mftf/Test/AdminUpdateCategoryAndCheckDefaultUrlKeyOnStoreViewTest.xml"
+  module: "Catalog"
+  tests:
+    - testname: "AdminUpdateCategoryAndCheckDefaultUrlKeyOnStoreViewTest"
+      title: "Update category, check default URL key on the custom store view"
+      description: "Login as admin and update category and check default URL Key on custom store view"
+- filename: "AdminRestrictedUserAddCategoryFromProductPageTest.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/Catalog/Test/Mftf/Test/AdminRestrictedUserAddCategoryFromProductPageTest.xml"
+  module: "Catalog"
+  tests:
+    - testname: "AdminRestrictedUserAddCategoryFromProductPageTest"
+      title: "Adding new category from product page by restricted user"
+      description: "Adding new category from product page by restricted user"
+- filename: "AdminSimpleSetEditRelatedProductsTest.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/Catalog/Test/Mftf/Test/AdminSimpleSetEditRelatedProductsTest.xml"
+  module: "Catalog"
+  tests:
+    - testname: "AdminSimpleSetEditRelatedProductsTest"
+      title: "Admin should be able to set/edit Related Products information when editing a simple product"
+      description: "Admin should be able to set/edit Related Products information when editing a simple product"
+- filename: "StorefrontProductsCompareWithEmptyAttributeTest.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/Catalog/Test/Mftf/Test/StorefrontProductsCompareWithEmptyAttributeTest.xml"
+  module: "Catalog"
+  tests:
+    - testname: "StorefrontProductsCompareWithEmptyAttributeTest"
+      title: "Product attribute is not visible on product compare page if it is empty"
+      description: "Product attribute should not be visible on the product compare page if it is empty for all products that are being compared, not even displayed as N/A"
 - filename: "AdminRemoveDefaultVideoSimpleProductTest.xml"
-  repo: "https://github.com/magento/magento2/blob/2.3/app/code/Magento/ProductVideo/Test/Mftf/Test/AdminRemoveDefaultVideoSimpleProductTest.xml"
-  module: "ProductVideo"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/Catalog/Test/Mftf/Test/AdminRemoveDefaultVideoSimpleProductTest.xml"
+  module: "Catalog"
   tests:
     - testname: "AdminRemoveDefaultVideoSimpleProductTest"
+      title: "Admin should be able to remove default product video from a Simple Product"
+      description: "Admin should be able to remove default product video from a Simple Product"
+- filename: "AdminCreateCategoryFromProductPageTest.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/Catalog/Test/Mftf/Test/AdminCreateCategoryFromProductPageTest.xml"
+  module: "Catalog"
+  tests:
+    - testname: "AdminCreateCategoryFromProductPageTest"
+      title: "Admin should be able to create category from the product page"
+      description: "Admin should be able to create category from the product page"
+- filename: "AdminCatalogProductsNavigateMenuTest.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/Catalog/Test/Mftf/Test/AdminCatalogProductsNavigateMenuTest.xml"
+  module: "Catalog"
+  tests:
+    - testname: "AdminCatalogProductsNavigateMenuTest"
+      title: "Admin catalog products navigate menu test"
+      description: "Admin should be able to navigate to Catalog &gt; Products"
+- filename: "AdminDeleteProductsImageInCaseOfMultipleStoresTest.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/Catalog/Test/Mftf/Test/AdminDeleteProductsImageInCaseOfMultipleStoresTest.xml"
+  module: "Catalog"
+  tests:
+    - testname: "AdminDeleteProductsImageInCaseOfMultipleStoresTest"
+      title: "Delete products image in case of multiple stores"
+      description: "Delete products image in case of multiple stores"
+- filename: "VerifyTinyMCEv4IsNativeWYSIWYGOnProductTest.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/Catalog/Test/Mftf/Test/VerifyTinyMCEv4IsNativeWYSIWYGOnProductTest.xml"
+  module: "Catalog"
+  tests:
+    - testname: "VerifyTinyMCEv4IsNativeWYSIWYGOnProductTest"
+      title: "Admin should see TinyMCEv4.6 is the native WYSIWYG on Product Page"
+      description: "Admin should see TinyMCEv4.6 is the native WYSIWYG on Product Page"
+- filename: "AdminCreateVirtualProductFillingRequiredFieldsOnlyTest.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/Catalog/Test/Mftf/Test/AdminCreateVirtualProductFillingRequiredFieldsOnlyTest.xml"
+  module: "Catalog"
+  tests:
+    - testname: "AdminCreateVirtualProductFillingRequiredFieldsOnlyTest"
+      title: "Create virtual product filling required fields only"
+      description: "Test log in to Create virtual product and Create virtual product filling required fields only"
+- filename: "AdminVirtualProductSetEditContentTest.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/Catalog/Test/Mftf/Test/AdminVirtualProductSetEditContentTest.xml"
+  module: "Catalog"
+  tests:
+    - testname: "AdminVirtualProductSetEditContentTest"
+      title: "Admin should be able to set/edit product Content when editing a virtual product"
+      description: "Admin should be able to set/edit product Content when editing a virtual product"
+- filename: "AdminUpdateSimpleProductTieredPriceTest.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/Catalog/Test/Mftf/Test/AdminUpdateSimpleProductTieredPriceTest.xml"
+  module: "Catalog"
+  tests:
+    - testname: "AdminUpdateSimpleProductTieredPriceTest"
+      title: "Update Simple Product Tiered Price"
+      description: "Test log in to Update Simple Product and Update Simple Product Tiered Price"
+- filename: "AdminUpdateSimpleProductWithRegularPriceInStockUnassignFromCategoryTest.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/Catalog/Test/Mftf/Test/AdminUpdateSimpleProductWithRegularPriceInStockUnassignFromCategoryTest.xml"
+  module: "Catalog"
+  tests:
+    - testname: "AdminUpdateSimpleProductWithRegularPriceInStockUnassignFromCategoryTest"
+      title: "Update Simple Product with Regular Price (In Stock) Unassign from Category"
+      description: "Test log in to Update Simple Product and Update Simple Product with Regular Price (In Stock) Unassign from Category"
+- filename: "AdminCreateCategoryTest.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/Catalog/Test/Mftf/Test/AdminCreateCategoryTest.xml"
+  module: "Catalog"
+  tests:
+    - testname: "AdminCreateCategoryTest"
+      title: "Admin should be able to create a Category"
+      description: "Admin should be able to create a Category"
+
+    - testname: "AdminConfigDefaultCategoryLayoutFromConfigurationSettingTest"
+      title: "Admin should be able to configure the default layout for Category Page from System Configuration"
+      description: "Admin should be able to configure the default layout for Category Page from System Configuration"
+
+    - testname: "AdminCategoryFormDisplaySettingsUIValidationTest"
+      title: "Category should not be saved once layered navigation price step field is left empty"
+      description: "Once the Config setting is unchecked Category should not be saved with layered navigation price field left empty"
+- filename: "AdminCreateCategoryWithCustomRootCategoryTest.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/Catalog/Test/Mftf/Test/AdminCreateCategoryWithCustomRootCategoryTest.xml"
+  module: "Catalog"
+  tests:
+    - testname: "AdminCreateCategoryWithCustomRootCategoryTest"
+      title: "Create category in the custom root category that is used for custom website"
+      description: "Login as admin and create a root category with nested sub category and verify category in store front "
+- filename: "AdminAssignProductAttributeToAttributeSetTest.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/Catalog/Test/Mftf/Test/AdminAssignProductAttributeToAttributeSetTest.xml"
+  module: "Catalog"
+  tests:
+    - testname: "AdminAssignProductAttributeToAttributeSetTest"
+      title: "Admin should be able to assign attributes to an attribute set"
+      description: "Admin should be able to assign attributes to an attribute set"
+- filename: "AdminSimpleProductSetEditContentTest.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/Catalog/Test/Mftf/Test/AdminSimpleProductSetEditContentTest.xml"
+  module: "Catalog"
+  tests:
+    - testname: "AdminSimpleProductSetEditContentTest"
+      title: "Admin should be able to set/edit product Content when editing a simple product"
+      description: "Admin should be able to set/edit product Content when editing a simple product"
+- filename: "AdminCreateDuplicateProductTest.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/Catalog/Test/Mftf/Test/AdminCreateDuplicateProductTest.xml"
+  module: "Catalog"
+  tests:
+    - testname: "AdminCreateDuplicateProductTest"
+      title: "Create Duplicate Product With Existed Subcategory Name And UrlKey"
+      description: "Login as admin and create duplicate Product"
+- filename: "AdminCreateProductDuplicateUrlkeyTest.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/Catalog/Test/Mftf/Test/AdminCreateProductDuplicateUrlkeyTest.xml"
+  module: "Catalog"
+  tests:
+    - testname: "AdminCreateProductDuplicateUrlkeyTest"
+      title: "Admin should see an error when trying to save a product with a duplicate URL key"
+      description: "Admin should see an error when trying to save a product with a duplicate URL key"
+
+    - testname: "AdminCreateProductDuplicateProductTest"
+      title: "No validation errors when trying to duplicate product twice"
+      description: "No validation errors when trying to duplicate product twice"
+- filename: "StorefrontCategoryHighlightedAndProductDisplayedTest.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/Catalog/Test/Mftf/Test/StorefrontCategoryHighlightedAndProductDisplayedTest.xml"
+  module: "Catalog"
+  tests:
+    - testname: "StorefrontCategoryHighlightedAndProductDisplayedTest"
+      title: "Сheck that current category is highlighted and all products displayed for it"
+      description: "Сheck that current category is highlighted and all products displayed for it"
+- filename: "StoreFrontRecentlyViewedAtStoreViewLevelTest.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/Catalog/Test/Mftf/Test/StoreFrontRecentlyViewedAtStoreViewLevelTest.xml"
+  module: "Catalog"
+  tests:
+    - testname: "StoreFrontRecentlyViewedAtStoreViewLevelTest"
+      title: "Recently Viewed Product at store view level"
+      description: "Recently Viewed Product should not be displayed on second store view, if configured as, Per Store View "
+- filename: "AdminCreateNewAttributeFromProductPageTest.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/Catalog/Test/Mftf/Test/AdminCreateNewAttributeFromProductPageTest.xml"
+  module: "Catalog"
+  tests:
+    - testname: "AdminCreateNewAttributeFromProductPageTest"
+      title: "We should validate the form when the user click Save in New Attribute Set"
+      description: "Admin should be able to create product attribute and validate the form when the user click Save in New Attribute Set"
+- filename: "AdminVirtualSetEditRelatedProductsTest.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/Catalog/Test/Mftf/Test/AdminVirtualSetEditRelatedProductsTest.xml"
+  module: "Catalog"
+  tests:
+    - testname: "AdminVirtualSetEditRelatedProductsTest"
+      title: "Admin should be able to set/edit Related Products information when editing a virtual product"
+      description: "Admin should be able to set/edit Related Products information when editing a virtual product"
+- filename: "AdminConfigureProductImagePlaceholderTest.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/Catalog/Test/Mftf/Test/AdminConfigureProductImagePlaceholderTest.xml"
+  module: "Catalog"
+  tests:
+    - testname: "AdminConfigureProductImagePlaceholderTest"
+      title: "Admin is able to configure product placeholder images"
+      description: "Admin should be able to configure the images used for product image placeholders. The configured placeholders should be seen on the frontend when an image has no image."
+- filename: "AdminAddDefaultImageVirtualProductTest.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/Catalog/Test/Mftf/Test/AdminAddDefaultImageVirtualProductTest.xml"
+  module: "Catalog"
+  tests:
+    - testname: "AdminAddRemoveProductImageVirtualProductTest"
+      title: "Admin should be able to add default images for a Virtual Product"
+      description: "Admin should be able to add default images for a Virtual Product"
+- filename: "AdminCreateNewGroupForAttributeSetTest.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/Catalog/Test/Mftf/Test/AdminCreateNewGroupForAttributeSetTest.xml"
+  module: "Catalog"
+  tests:
+    - testname: "AdminCreateNewGroupForAttributeSetTest"
+      title: "Admin should be able to create new group in an Attribute Set"
+      description: "The test verifies creating a new group in an attribute set and a validation message in case of empty group name"
+- filename: "AdminMassUpdateProductStatusStoreViewScopeTest.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/Catalog/Test/Mftf/Test/AdminMassUpdateProductStatusStoreViewScopeTest.xml"
+  module: "Catalog"
+  tests:
+    - testname: "AdminMassUpdateProductStatusStoreViewScopeTest"
+      title: "Admin should be able to mass update product statuses in store view scope"
+      description: "Admin should be able to mass update product statuses in store view scope"
+
+    - testname: "AdminMassUpdateProductStatusStoreViewScopeMysqlTest"
+      title: "Admin should be able to mass update product statuses in store view scope using the Mysql search engine"
+      description: "Admin should be able to mass update product statuses in store view scope using the Mysql search engine"
+- filename: "AdminCreateInactiveInMenuFlatCategoryTest.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/Catalog/Test/Mftf/Test/AdminCreateInactiveInMenuFlatCategoryTest.xml"
+  module: "Catalog"
+  tests:
+    - testname: "AdminCreateInactiveInMenuFlatCategoryTest"
+      title: "Flat Catalog - Exclude Category from Navigation Menu"
+      description: "Login as admin and create inactive Include In Menu flat category and verify category is not displayed in Navigation Menu"
+- filename: "AdminUpdateFlatCategoryNameAndDescriptionTest.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/Catalog/Test/Mftf/Test/AdminUpdateFlatCategoryNameAndDescriptionTest.xml"
+  module: "Catalog"
+  tests:
+    - testname: "AdminUpdateFlatCategoryNameAndDescriptionTest"
+      title: "Flat Catalog - Update Category Name and Description"
+      description: "Login as admin and update flat category name and description"
+- filename: "AdminCreateRootCategoryRequiredFieldsTest.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/Catalog/Test/Mftf/Test/AdminCreateRootCategoryRequiredFieldsTest.xml"
+  module: "Catalog"
+  tests:
+    - testname: "AdminCreateRootCategoryRequiredFieldsTest"
+      title: "Create Root Category from Category Page"
+      description: "Create Root Category from Category Page"
+- filename: "EndToEndB2CGuestUserTest.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/Catalog/Test/Mftf/Test/EndToEndB2CGuestUserTest.xml"
+  module: "Catalog"
+  tests:
+    - testname: "EndToEndB2CGuestUserTest"
+      title: "You should be able to pass End to End B2C Guest User scenario"
+      description: "User browses catalog, searches for product, adds product to cart, adds product to wishlist, compares products, uses coupon code and checks out."
+
+    - testname: "EndToEndB2CGuestUserMysqlTest"
+      title: "You should be able to pass End to End B2C Guest User scenario using the Mysql search engine"
+      description: "User browses catalog, searches for product, adds product to cart, adds product to wishlist, compares products, uses coupon code and checks out using the Mysql search engine."
+- filename: "AdminMassUpdateProductAttributesStoreViewScopeTest.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/Catalog/Test/Mftf/Test/AdminMassUpdateProductAttributesStoreViewScopeTest.xml"
+  module: "Catalog"
+  tests:
+    - testname: "AdminMassUpdateProductAttributesStoreViewScopeTest"
+      title: "Admin should be able to mass update product attributes in store view scope"
+      description: "Admin should be able to mass update product attributes in store view scope"
+
+    - testname: "AdminMassUpdateProductAttributesStoreViewScopeMysqlTest"
+      title: "Admin should be able to mass update product attributes in store view scope using the Mysql search engine"
+      description: "Admin should be able to mass update product attributes in store view scope using the Mysql search engine"
+- filename: "AdminProductGridFilteringByCustomAttributeTest.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/Catalog/Test/Mftf/Test/AdminProductGridFilteringByCustomAttributeTest.xml"
+  module: "Catalog"
+  tests:
+    - testname: "AdminProductGridFilteringByCustomAttributeTest"
+      title: "Sorting the product grid by custom product attribute"
+      description: "Sorting the product grid by custom product attribute should sort Alphabetically instead of value id"
+- filename: "AdminUpdateVirtualProductWithRegularPriceOutOfStockVisibleInCategoryAndSearchTest.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/Catalog/Test/Mftf/Test/AdminUpdateVirtualProductWithRegularPriceOutOfStockVisibleInCategoryAndSearchTest.xml"
+  module: "Catalog"
+  tests:
+    - testname: "AdminUpdateVirtualProductWithRegularPriceOutOfStockVisibleInCategoryAndSearchTest"
+      title: "Update Virtual Product with Regular Price (Out of Stock) Visible in Category and Search"
+      description: "Test log in to Update Virtual Product and Update Virtual Product with Regular Price (Out of Stock) Visible in Category and Search"
+- filename: "AdminCheckOutOfStockProductIsVisibleInCategoryTest.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/Catalog/Test/Mftf/Test/AdminCheckOutOfStockProductIsVisibleInCategoryTest.xml"
+  module: "Catalog"
+  tests:
+    - testname: "AdminCheckOutOfStockProductIsVisibleInCategoryTest"
+      title: "Out of Stock Product is Visible in Category"
+      description: "Login as admin and check out of stock product is visible in category"
+- filename: "AdminDeleteSystemProductAttributeTest.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/Catalog/Test/Mftf/Test/AdminDeleteSystemProductAttributeTest.xml"
+  module: "Catalog"
+  tests:
+    - testname: "AdminDeleteSystemProductAttributeTest"
+      title: "Delete System Product Attribute"
+      description: "Admin should not be able to see Delete Attribute button"
+- filename: "StorefrontSpecialPriceForDifferentTimezonesForWebsitesTest.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/Catalog/Test/Mftf/Test/StorefrontSpecialPriceForDifferentTimezonesForWebsitesTest.xml"
+  module: "Catalog"
+  tests:
+    - testname: "StorefrontSpecialPriceForDifferentTimezonesForWebsitesTest"
+      title: "Check that special price displayed when 'default config' scope timezone does not match 'website' scope timezone"
+      description: "Check that special price displayed when 'default config' scope timezone does not match 'website' scope timezone"
+- filename: "AdminUpdateSimpleProductNameToVerifyDataOverridingOnStoreViewLevelTest.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/Catalog/Test/Mftf/Test/AdminUpdateSimpleProductNameToVerifyDataOverridingOnStoreViewLevelTest.xml"
+  module: "Catalog"
+  tests:
+    - testname: "AdminUpdateSimpleProductNameToVerifyDataOverridingOnStoreViewLevelTest"
+      title: "Update Simple Product Name to Verify Data Overriding on Store View Level"
+      description: "Test log in to Update Simple Product and Update Simple Product Name to Verify Data Overriding on Store View Level"
+- filename: "AdminSortingByWebsitesTest.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/Catalog/Test/Mftf/Test/AdminSortingByWebsitesTest.xml"
+  module: "Catalog"
+  tests:
+    - testname: "AdminSortingByWebsitesTest"
+      title: "Sorting by websites in Admin"
+      description: "Sorting products by websites in Admin"
+- filename: "StorefrontRememberCategoryPaginationTest.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/Catalog/Test/Mftf/Test/StorefrontRememberCategoryPaginationTest.xml"
+  module: "Catalog"
+  tests:
+    - testname: "StorefrontRememberCategoryPaginationTest"
+      title: "Verify that Number of Products per page retained when visiting a different category"
+      description: "Verify that Number of Products per page retained when visiting a different category"
+- filename: "AdminMoveCategoryToAnotherPositionInCategoryTreeTest.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/Catalog/Test/Mftf/Test/AdminMoveCategoryToAnotherPositionInCategoryTreeTest.xml"
+  module: "Catalog"
+  tests:
+    - testname: "AdminMoveCategoryToAnotherPositionInCategoryTreeTest"
+      title: "Move Category to Another Position in Category Tree"
+      description: "Test log in to Move Category and Move Category to Another Position in Category Tree"
+- filename: "AdminDeleteProductAttributeTest.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/Catalog/Test/Mftf/Test/AdminDeleteProductAttributeTest.xml"
+  module: "Catalog"
+  tests:
+    - testname: "DeleteProductAttributeTest"
+      title: "Delete Product Attribute"
+      description: "Admin should able to delete a product attribute"
+- filename: "AdminAddDefaultImageSimpleProductTest.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/Catalog/Test/Mftf/Test/AdminAddDefaultImageSimpleProductTest.xml"
+  module: "Catalog"
+  tests:
+    - testname: "AdminAddDefaultImageSimpleProductTest"
+      title: "Admin should be able to add default image for a Simple Product"
+      description: "Admin should be able to add default images for a Simple Product"
+- filename: "AdminTierPriceNotAvailableForProductOptionsWithoutTierPriceTest.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/Catalog/Test/Mftf/Test/AdminTierPriceNotAvailableForProductOptionsWithoutTierPriceTest.xml"
+  module: "Catalog"
+  tests:
+    - testname: "AdminTierPriceNotAvailableForProductOptionsWithoutTierPriceTest"
+      title: "Check that 'tier price' block not available for simple product from options without 'tier price'"
+      description: "Check that 'tier price' block not available for simple product from options without 'tier price'"
+- filename: "AdminUpdateSimpleProductPriceToVerifyDataOverridingOnStoreViewLevelTest.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/Catalog/Test/Mftf/Test/AdminUpdateSimpleProductPriceToVerifyDataOverridingOnStoreViewLevelTest.xml"
+  module: "Catalog"
+  tests:
+    - testname: "AdminUpdateSimpleProductPriceToVerifyDataOverridingOnStoreViewLevelTest"
+      title: "Update Simple Product Price to Verify Data Overriding on Store View Level"
+      description: "Test log in to Update Simple Product and Update Simple Product Price to Verify Data Overriding on Store View Level"
+- filename: "AdminUpdateSimpleProductWithRegularPriceInStockEnabledFlatTest.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/Catalog/Test/Mftf/Test/AdminUpdateSimpleProductWithRegularPriceInStockEnabledFlatTest.xml"
+  module: "Catalog"
+  tests:
+    - testname: "AdminUpdateSimpleProductWithRegularPriceInStockEnabledFlatTest"
+      title: "Update Simple Product with Regular Price (In Stock) Enabled Flat"
+      description: "Test log in to Update Simple Product and Update Simple Product with Regular Price (In Stock) Enabled Flat"
+- filename: "AdminNavigateMultipleUpSellProductsTest.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/Catalog/Test/Mftf/Test/AdminNavigateMultipleUpSellProductsTest.xml"
+  module: "Catalog"
+  tests:
+    - testname: "AdminNavigateMultipleUpSellProductsTest"
+      title: "Promote Multiple Products (Simple, Configurable) as Up-Sell Products"
+      description: "Login as admin and add simple and configurable Products as Up-Sell products"
+- filename: "AdminCreateVirtualProductWithCustomOptionsSuiteAndImportOptionsTest.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/Catalog/Test/Mftf/Test/AdminCreateVirtualProductWithCustomOptionsSuiteAndImportOptionsTest.xml"
+  module: "Catalog"
+  tests:
+    - testname: "AdminCreateVirtualProductWithCustomOptionsSuiteAndImportOptionsTest"
+      title: "Create virtual product with custom options suite and import options"
+      description: "Test log in to Create virtual product and Create virtual product with custom options suite and import options"
+- filename: "AdminUpdateCategoryWithProductsTest.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/Catalog/Test/Mftf/Test/AdminUpdateCategoryWithProductsTest.xml"
+  module: "Catalog"
+  tests:
+    - testname: "AdminUpdateCategoryWithProductsTest"
+      title: "Update category, sort products by default sorting"
+      description: "Login as admin, update category and sort products"
+- filename: "AdminDeleteRootCategoryAssignedToStoreTest.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/Catalog/Test/Mftf/Test/AdminDeleteRootCategoryAssignedToStoreTest.xml"
+  module: "Catalog"
+  tests:
+    - testname: "AdminDeleteRootCategoryAssignedToStoreTest"
+      title: "Cannot delete root category assigned to some store"
+      description: "Login as admin and root category can not be deleted when category is assigned with any store."
+- filename: "AdminUpdateSimpleProductWithRegularPriceInStockVisibleInCatalogOnlyTest.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/Catalog/Test/Mftf/Test/AdminUpdateSimpleProductWithRegularPriceInStockVisibleInCatalogOnlyTest.xml"
+  module: "Catalog"
+  tests:
+    - testname: "AdminUpdateSimpleProductWithRegularPriceInStockVisibleInCatalogOnlyTest"
+      title: "Update Simple Product with Regular Price (In Stock) Visible in Catalog Only"
+      description: "Test log in to Update Simple Product and Update Simple Product with Regular Price (In Stock) Visible in Catalog Only"
+- filename: "AdminProductCategoryIndexerInUpdateOnScheduleModeTest.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/Catalog/Test/Mftf/Test/AdminProductCategoryIndexerInUpdateOnScheduleModeTest.xml"
+  module: "Catalog"
+  tests:
+    - testname: "AdminProductCategoryIndexerInUpdateOnScheduleModeTest"
+      title: "Product Categories Indexer in Update on Schedule mode"
+      description: "The test verifies that in Update on Schedule mode if displaying of category products on Storefront changes due to product properties change,             the changes are NOT applied immediately, but applied only after cron runs (twice)."
+- filename: "AdminRemoveCustomOptionsFromProductTest.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/Catalog/Test/Mftf/Test/AdminRemoveCustomOptionsFromProductTest.xml"
+  module: "Catalog"
+  tests:
+    - testname: "AdminRemoveCustomOptionsFromProductTest"
+      title: "Remove custom options from product"
+      description: "Remove custom options from product"
+- filename: "AdminRemoveDefaultImageVirtualProductTest.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/Catalog/Test/Mftf/Test/AdminRemoveDefaultImageVirtualProductTest.xml"
+  module: "Catalog"
+  tests:
+    - testname: "AdminRemoveDefaultImageVirtualProductTest"
+      title: "Admin should be able to remove default images from a Virtual Product"
+      description: "Admin should be able to remove default images from a Virtual Product"
+- filename: "AdminDeleteConfigurableChildProductsTest.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/Catalog/Test/Mftf/Test/AdminDeleteConfigurableChildProductsTest.xml"
+  module: "Catalog"
+  tests:
+    - testname: "AdminDeleteConfigurableChildProductsTest"
+      title: "Configurable Product should not be visible on storefront after child products are deleted"
+      description: "Login as admin, delete configurable child product and verify product displays out of stock in store front"
+- filename: "AdminCreateAndEditVirtualProductSettingsTest.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/Catalog/Test/Mftf/Test/AdminCreateAndEditVirtualProductSettingsTest.xml"
+  module: "Catalog"
+  tests:
+    - testname: "AdminCreateAndEditVirtualProductSettingsTest"
+      title: "Admin should be able to set/edit other product information when creating/editing a virtual product"
+      description: "Admin should be able to set/edit other product information when creating/editing a virtual product"
+- filename: "StorefrontCatalogNavigationMenuUIDesktopTest.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/Catalog/Test/Mftf/Test/StorefrontCatalogNavigationMenuUIDesktopTest.xml"
+  module: "Catalog"
+  tests:
+    - testname: "StorefrontCatalogNavigationMenuUIDesktopTest"
+      title: "Storefront Catalog Navigation Menu UI, desktop"
+      description: "Verify UI of Navigation Menu functionality on Storefront"
+- filename: "AdminCheckSubCategoryIsNotVisibleInNavigationMenuTest.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/Catalog/Test/Mftf/Test/AdminCheckSubCategoryIsNotVisibleInNavigationMenuTest.xml"
+  module: "Catalog"
+  tests:
+    - testname: "AdminCheckSubCategoryIsNotVisibleInNavigationMenuTest"
+      title: "Active category is visible on navigation menu while subcategory is not visible on navigation menu, Include in Menu = Yes"
+      description: "Login as admin and verify subcategory is not visible in navigation menu"
+- filename: "AdminUpdateCategoryAndMakeInactiveTest.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/Catalog/Test/Mftf/Test/AdminUpdateCategoryAndMakeInactiveTest.xml"
+  module: "Catalog"
+  tests:
+    - testname: "AdminUpdateCategoryAndMakeInactiveTest"
+      title: "Update category, make inactive"
+      description: "Login as admin and update category and  make it Inactive"
+- filename: "DisplayRefreshCacheAfterChangingCategoryPageLayoutTest.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/Catalog/Test/Mftf/Test/DisplayRefreshCacheAfterChangingCategoryPageLayoutTest.xml"
+  module: "Catalog"
+  tests:
+    - testname: "DisplayRefreshCacheAfterChangingCategoryPageLayoutTest"
+      title: "'Refresh cache' admin notification is displayed when changing category page layout"
+      description: "'Refresh cache' message is not displayed when changing category page layout"
+- filename: "AdminRequiredFieldsHaveRequiredFieldIndicatorTest.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/Catalog/Test/Mftf/Test/AdminRequiredFieldsHaveRequiredFieldIndicatorTest.xml"
+  module: "Catalog"
+  tests:
+    - testname: "AdminRequiredFieldsHaveRequiredFieldIndicatorTest"
+      title: "Required fields should have the required asterisk indicator "
+      description: "Verify that Required fields should have the required indicator icon next to the field name"
+- filename: "AdminUpdateVirtualProductWithRegularPriceInStockWithCustomOptionsVisibleInSearchOnlyTest.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/Catalog/Test/Mftf/Test/AdminUpdateVirtualProductWithRegularPriceInStockWithCustomOptionsVisibleInSearchOnlyTest.xml"
+  module: "Catalog"
+  tests:
+    - testname: "AdminUpdateVirtualProductWithRegularPriceInStockWithCustomOptionsVisibleInSearchOnlyTest"
+      title: "Update Virtual Product with Regular Price (In Stock) with Custom Options Visible in Search Only"
+      description: "Test log in to Update Virtual Product and Update Virtual Product with Regular Price (In Stock) with Custom Options Visible in Search Only"
+- filename: "AdminShouldBeAbleToAssociateSimpleProductToWebsitesTest.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/Catalog/Test/Mftf/Test/AdminShouldBeAbleToAssociateSimpleProductToWebsitesTest.xml"
+  module: "Catalog"
+  tests:
+    - testname: "AdminShouldBeAbleToAssociateSimpleProductToWebsitesTest"
+      title: "Admin should be able to associate simple product to websites"
+      description: "Admin should be able to associate simple product to websites"
+- filename: "AdminAddImageToWYSIWYGCatalogTest.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/Catalog/Test/Mftf/Test/AdminAddImageToWYSIWYGCatalogTest.xml"
+  module: "Catalog"
+  tests:
+    - testname: "AdminAddImageToWYSIWYGCatalogTest"
+      title: "Admin should be able to add image to WYSIWYG Editor on Catalog Page"
+      description: "Admin should be able to add image to WYSIWYG Editor on Catalog Page"
+- filename: "AdminRemoveImageFromCategoryTest.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/Catalog/Test/Mftf/Test/AdminRemoveImageFromCategoryTest.xml"
+  module: "Catalog"
+  tests:
+    - testname: "AdminRemoveImageFromCategoryTest"
+      title: "Admin should be able to remove image from a Category"
+      description: "Admin should be able to remove image from a Category"
+- filename: "StorefrontEnsureThatAccordionAnchorIsVisibleOnViewportOnceClickedTest.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/Catalog/Test/Mftf/Test/StorefrontEnsureThatAccordionAnchorIsVisibleOnViewportOnceClickedTest.xml"
+  module: "Catalog"
+  tests:
+    - testname: "StorefrontEnsureThatAccordionAnchorIsVisibleOnViewportOnceClickedTest"
+      title: "Ensure that accordion anchor is visible on viewport once clicked"
+      description: "Ensure that accordion anchor is visible on viewport once clicked"
+- filename: "DeleteCategoriesTest.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/Catalog/Test/Mftf/Test/DeleteCategoriesTest.xml"
+  module: "Catalog"
+  tests:
+    - testname: "DeleteCategoriesTest"
+      title: "Admin should be able to delete the default root category and subcategories and still see products in the storefront"
+      description: "Admin should be able to delete the default root category and subcategories and still see products in the storefront"
+- filename: "StorefrontPurchaseProductWithCustomOptionsTest.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/Catalog/Test/Mftf/Test/StorefrontPurchaseProductWithCustomOptionsTest.xml"
+  module: "Catalog"
+  tests:
+    - testname: "StorefrontPurchaseProductWithCustomOptionsTest"
+      title: "Admin should be able to sell products with custom options of different types"
+      description: "Admin should be able to sell products with custom options of different types"
+- filename: "AdminCatalogCategoriesNavigateMenuTest.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/Catalog/Test/Mftf/Test/AdminCatalogCategoriesNavigateMenuTest.xml"
+  module: "Catalog"
+  tests:
+    - testname: "AdminCatalogCategoriesNavigateMenuTest"
+      title: "Admin catalog categories navigate menu test"
+      description: "Admin should be able to navigate to Catalog &gt; Categories"
+- filename: "StorefrontCheckDefaultNumberProductsToDisplayTest.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/Catalog/Test/Mftf/Test/StorefrontCheckDefaultNumberProductsToDisplayTest.xml"
+  module: "Catalog"
+  tests:
+    - testname: "StorefrontCheckDefaultNumbersProductsToDisplayTest"
+      title: "Check default numbers: products to display"
+      description: "Check default numbers: products to display"
+- filename: "AdminDeleteRootCategoryTest.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/Catalog/Test/Mftf/Test/AdminDeleteRootCategoryTest.xml"
+  module: "Catalog"
+  tests:
+    - testname: "AdminDeleteRootCategoryTest"
+      title: "Can delete a root category not assigned to any store"
+      description: "Login as admin and delete a root category not assigned to any store"
+- filename: "AdminCreateProductAttributeRequiredTextFieldTest.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/Catalog/Test/Mftf/Test/AdminCreateProductAttributeRequiredTextFieldTest.xml"
+  module: "Catalog"
+  tests:
+    - testname: "AdminCreateProductAttributeRequiredTextFieldTest"
+      title: "Create Custom Product Attribute Text Field (Required) from Product Page"
+      description: "Login as admin and create product attribute with Text Field and Required option"
+- filename: "AdminProductTypeSwitchingOnEditingTest.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/Catalog/Test/Mftf/Test/AdminProductTypeSwitchingOnEditingTest.xml"
+  module: "Catalog"
+  tests:
+    - testname: "AdminVirtualProductTypeSwitchingToDownloadableProductTest"
+      title: "Virtual product type switching on editing to Downloadable product"
+      description: "Virtual product type switching on editing to Downloadable product"
+
+    - testname: "AdminDownloadableProductTypeSwitchingToSimpleProductTest"
+      title: "Downloadable product type switching on editing to Simple product"
+      description: "Downloadable product type switching on editing to Simple product"
+- filename: "AdminUpdateSimpleProductWithRegularPriceInStockVisibleInSearchOnlyTest.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/Catalog/Test/Mftf/Test/AdminUpdateSimpleProductWithRegularPriceInStockVisibleInSearchOnlyTest.xml"
+  module: "Catalog"
+  tests:
+    - testname: "AdminUpdateSimpleProductWithRegularPriceInStockVisibleInSearchOnlyTest"
+      title: "Update Simple Product with Regular Price (In Stock) Visible in Search Only"
+      description: "Test log in to Update Simple Product and Update Simple Product with Regular Price (In Stock) Visible in Search Only"
+- filename: "StorefrontProductWithEmptyAttributeTest.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/Catalog/Test/Mftf/Test/StorefrontProductWithEmptyAttributeTest.xml"
+  module: "Catalog"
+  tests:
+    - testname: "StorefrontProductWithEmptyAttributeTest"
+      title: "Product attribute is not visible on storefront if it is empty"
+      description: "Product attribute should not be visible on storefront if it is empty"
+- filename: "AdminCreateMultipleSelectProductAttributeVisibleInStorefrontAdvancedSearchFormTest.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/Catalog/Test/Mftf/Test/AdminCreateMultipleSelectProductAttributeVisibleInStorefrontAdvancedSearchFormTest.xml"
+  module: "Catalog"
+  tests:
+    - testname: "AdminCreateMultipleSelectProductAttributeVisibleInStorefrontAdvancedSearchFormTest"
+      title: "Create product attribute of type Multiple Select and check its visibility on frontend in Advanced Search form"
+      description: "Admin should be able to create product attribute of type Multiple Select and check its visibility on frontend in Advanced Search form"
+- filename: "AdminUpdateCategoryNameWithStoreViewTest.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/Catalog/Test/Mftf/Test/AdminUpdateCategoryNameWithStoreViewTest.xml"
+  module: "Catalog"
+  tests:
+    - testname: "AdminUpdateCategoryNameWithStoreViewTest"
+      title: "Update category, with custom store view"
+      description: "Login as admin and update category name with custom Store View"
+- filename: "AdminUpdateSimpleProductWithRegularPriceInStockVisibleInCatalogAndSearchTest.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/Catalog/Test/Mftf/Test/AdminUpdateSimpleProductWithRegularPriceInStockVisibleInCatalogAndSearchTest.xml"
+  module: "Catalog"
+  tests:
+    - testname: "AdminUpdateSimpleProductWithRegularPriceInStockVisibleInCatalogAndSearchTest"
+      title: "Update Simple Product with Regular Price (In Stock) Visible in Catalog and Search"
+      description: "Test log in to Update Simple Product and Update Simple Product with Regular Price (In Stock) Visible in Catalog and Search"
+- filename: "AdminRemoveDefaultVideoVirtualProductTest.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/Catalog/Test/Mftf/Test/AdminRemoveDefaultVideoVirtualProductTest.xml"
+  module: "Catalog"
+  tests:
+    - testname: "AdminRemoveDefaultVideoVirtualProductTest"
+      title: "Admin should be able to remove default product video from a Virtual Product"
+      description: "Admin should be able to remove default product video from a Virtual Product"
+- filename: "AdminCheckInactiveAndNotIncludeInMenuCategoryAndSubcategoryIsNotVisibleInNavigationTest.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/Catalog/Test/Mftf/Test/AdminCheckInactiveAndNotIncludeInMenuCategoryAndSubcategoryIsNotVisibleInNavigationTest.xml"
+  module: "Catalog"
+  tests:
+    - testname: "AdminCheckInactiveAndNotIncludeInMenuCategoryAndSubcategoryIsNotVisibleInNavigationTest"
+      title: "Inactive Category and subcategory are not visible on navigation menu, Include in Menu = No"
+      description: "Login as admin and verify inactive and inactive include in menu category and subcategory is not visible in navigation menu"
+- filename: "AdminDeleteDropdownProductAttributeFromAttributeSetTest.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/Catalog/Test/Mftf/Test/AdminDeleteDropdownProductAttributeFromAttributeSetTest.xml"
+  module: "Catalog"
+  tests:
+    - testname: "AdminDeleteDropdownProductAttributeFromAttributeSetTest"
+      title: "Delete Product Attribute, Dropdown Type, from Attribute Set"
+      description: "Login as admin and delete dropdown type product attribute from attribute set"
+- filename: "AdminUpdateVirtualProductWithSpecialPriceOutOfStockVisibleInCategoryAndSearchTest.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/Catalog/Test/Mftf/Test/AdminUpdateVirtualProductWithSpecialPriceOutOfStockVisibleInCategoryAndSearchTest.xml"
+  module: "Catalog"
+  tests:
+    - testname: "UpdateVirtualProductWithSpecialPriceOutOfStockVisibleInCategoryAndSearchTest"
+      title: "Update Virtual Product with Special Price (Out of Stock) Visible in Category and Search"
+      description: "Test log in to Update Virtual Product and Update Virtual Product with Special Price (Out of Stock) Visible in Category and Search"
+- filename: "AdminUpdateSimpleProductWithRegularPriceOutOfStockTest.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/Catalog/Test/Mftf/Test/AdminUpdateSimpleProductWithRegularPriceOutOfStockTest.xml"
+  module: "Catalog"
+  tests:
+    - testname: "AdminUpdateSimpleProductWithRegularPriceOutOfStockTest"
+      title: "Update Simple Product with Regular Price (Out of Stock)"
+      description: "Test log in to Update Simple Product and Update Simple Product with Regular Price (Out of Stock)"
+- filename: "AdminAddImageForCategoryTest.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/Catalog/Test/Mftf/Test/AdminAddImageForCategoryTest.xml"
+  module: "Catalog"
+  tests:
+    - testname: "AdminAddImageForCategoryTest"
+      title: "Admin should be able to add image to a Category"
+      description: "Admin should be able to add image to a Category"
+- filename: "AdminAddDefaultVideoVirtualProductTest.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/Catalog/Test/Mftf/Test/AdminAddDefaultVideoVirtualProductTest.xml"
+  module: "Catalog"
+  tests:
+    - testname: "AdminAddDefaultVideoVirtualProductTest"
+      title: "Admin should be able to add default product video for a Virtual Product"
+      description: "Admin should be able to add default product video for a Virtual Product"
+- filename: "AdminMassUpdateProductAttributesMissingRequiredFieldTest.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/Catalog/Test/Mftf/Test/AdminMassUpdateProductAttributesMissingRequiredFieldTest.xml"
+  module: "Catalog"
+  tests:
+    - testname: "AdminMassUpdateProductAttributesMissingRequiredFieldTest"
+      title: "Mass update product attributes - missing required field"
+      description: "Mass update product attributes - missing required field"
+- filename: "AdminAddImageToWYSIWYGProductTest.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/Catalog/Test/Mftf/Test/AdminAddImageToWYSIWYGProductTest.xml"
+  module: "Catalog"
+  tests:
+    - testname: "AdminAddImageToWYSIWYGProductTest"
+      title: "Admin should be able to add image to WYSIWYG Editor on Product Page"
+      description: "Admin should be able to add image to WYSIWYG Editor on Product Page"
+- filename: "AdminAddInStockProductToTheCartTest.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/Catalog/Test/Mftf/Test/AdminAddInStockProductToTheCartTest.xml"
+  module: "Catalog"
+  tests:
+    - testname: "AdminAddInStockProductToTheCartTest"
+      title: "Add In Stock Product to Cart"
+      description: "Login as admin and add In Stock product to the cart"
+- filename: "AdminCreateCategoryWithAnchorFieldTest.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/Catalog/Test/Mftf/Test/AdminCreateCategoryWithAnchorFieldTest.xml"
+  module: "Catalog"
+  tests:
+    - testname: "AdminCreateCategoryWithAnchorFieldTest"
+      title: "Create anchor subcategory with all fields"
+      description: "Login as admin and create anchor subcategory with all fields"
+- filename: "AdminImportCustomizableOptionToProductWithSKUTest.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/Catalog/Test/Mftf/Test/AdminImportCustomizableOptionToProductWithSKUTest.xml"
+  module: "Catalog"
+  tests:
+    - testname: "AdminImportCustomizableOptionToProductWithSKUTest"
+      title: "Import customizable options to a product with existing SKU"
+      description: "Import customizable options to a product with existing SKU"
+- filename: "AdminCreateProductAttributeFromProductPageTest.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/Catalog/Test/Mftf/Test/AdminCreateProductAttributeFromProductPageTest.xml"
+  module: "Catalog"
+  tests:
+    - testname: "AdminCreateProductAttributeFromProductPageTest"
+      title: "Create Product Attribute from Product Page"
+      description: "Login as admin and create new product attribute from product page with Text Field"
+- filename: "StoreFrontProductsDisplayUsingElasticSearchTest.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/Catalog/Test/Mftf/Test/StoreFrontProductsDisplayUsingElasticSearchTest.xml"
+  module: "Catalog"
+  tests:
+    - testname: "StoreFrontProductsDisplayUsingElasticSearchTest"
+      title: "Display All Products on a Page"
+      description: "Set Up Elastic Search and Display all Products on Page"
+- filename: "AdminUpdateTopCategoryUrlWithNoRedirectTest.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/Catalog/Test/Mftf/Test/AdminUpdateTopCategoryUrlWithNoRedirectTest.xml"
+  module: "Catalog"
+  tests:
+    - testname: "AdminUpdateTopCategoryUrlWithNoRedirectTest"
+      title: "Update top category url and do not create redirect"
+      description: "Login as admin and update top category url and do not create redirect"
+- filename: "AdminCheckConfigurableProductPriceWithOutOfStockChildProductTest.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/Catalog/Test/Mftf/Test/AdminCheckConfigurableProductPriceWithOutOfStockChildProductTest.xml"
+  module: "Catalog"
+  tests:
+    - testname: "AdminCheckConfigurableProductPriceWithOutOfStockChildProductTest"
+      title: "Check Price for Configurable Product when Child is Out of Stock"
+      description: "Login as admin and check the configurable product price when one child product is out of stock "
+- filename: "CheckTierPricingOfProductsTest.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/Catalog/Test/Mftf/Test/CheckTierPricingOfProductsTest.xml"
+  module: "Catalog"
+  tests:
+    - testname: "CheckTierPricingOfProductsTest"
+      title: "Checking 'Tier Pricing' of Products and 'Price' (without discount) in the Order of B2B Store View"
+      description: "Checking 'Tier Pricing' of Products and 'Price' (without discount) in the Order of B2B Store View"
+- filename: "AdminCreateVirtualProductWithTierPriceTest.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/Catalog/Test/Mftf/Test/AdminCreateVirtualProductWithTierPriceTest.xml"
+  module: "Catalog"
+  tests:
+    - testname: "AdminCreateVirtualProductWithTierPriceTest"
+      title: "Create virtual product with tier price"
+      description: "Test log in to Create virtual product and Create virtual product with tier price"
+- filename: "SimpleProductTwoCustomOptionsTest.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/Catalog/Test/Mftf/Test/SimpleProductTwoCustomOptionsTest.xml"
+  module: "Catalog"
+  tests:
+    - testname: "SimpleProductTwoCustomOptionsTest"
+      title: "Admin should be able to create simple product with two custom options"
+      description: "Admin should be able to create simple product with two custom options"
+- filename: "AdminUpdateVirtualProductWithTierPriceOutOfStockVisibleInCategoryAndSearchTest.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/Catalog/Test/Mftf/Test/AdminUpdateVirtualProductWithTierPriceOutOfStockVisibleInCategoryAndSearchTest.xml"
+  module: "Catalog"
+  tests:
+    - testname: "AdminUpdateVirtualProductWithTierPriceOutOfStockVisibleInCategoryAndSearchTest"
+      title: "Update Virtual Product with Tier Price (Out of Stock) Visible in Category and Search"
+      description: "Test log in to Update Virtual Product and Update Virtual Product with Tier Price (Out of Stock) Visible in Category and Search"
+- filename: "AdminCreateInactiveFlatCategoryAndUpdateAsInactiveTest.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/Catalog/Test/Mftf/Test/AdminCreateInactiveFlatCategoryAndUpdateAsInactiveTest.xml"
+  module: "Catalog"
+  tests:
+    - testname: "AdminCreateInactiveFlatCategoryAndUpdateAsInactiveTest"
+      title: "Flat Catalog - Update Inactive Category as Inactive, Should Not be Visible on Storefront"
+      description: "Login as admin and create inactive flat category and update category as inactive and verify category is not visible in store front"
+- filename: "AdminProductStatusAttributeDisabledByDefaultTest.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/Catalog/Test/Mftf/Test/AdminProductStatusAttributeDisabledByDefaultTest.xml"
+  module: "Catalog"
+  tests:
+    - testname: "AdminProductStatusAttributeDisabledByDefaultTest"
+      title: "Verify the default option value for product Status attribute is set correctly during product creation"
+      description: "The default option value for product Status attribute is set correctly during product creation"
+- filename: "AdminRemoveImageAffectsAllScopesTest.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/Catalog/Test/Mftf/Test/AdminRemoveImageAffectsAllScopesTest.xml"
+  module: "Catalog"
+  tests:
+    - testname: "AdminRemoveImageAffectsAllScopesTest"
+      title: "Effect of product images changes in default scope to other scopes"
+      description: "Product image should be deleted from all scopes"
+- filename: "AdminCreateSimpleProductWithCountryOfManufactureAttributeSKUMaskTest.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/Catalog/Test/Mftf/Test/AdminCreateSimpleProductWithCountryOfManufactureAttributeSKUMaskTest.xml"
+  module: "Catalog"
+  tests:
+    - testname: "AdminCreateSimpleProductWithCountryOfManufactureAttributeSKUMaskTest"
+      title: "Create simple product with (Country of Manufacture) Attribute SKU Mask"
+      description: "Test log in to Create simple product and Create simple product with (Country of Manufacture) Attribute SKU Mask"
+- filename: "EndToEndB2CAdminTest.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/Catalog/Test/Mftf/Test/EndToEndB2CAdminTest.xml"
+  module: "Catalog"
+  tests:
+    - testname: "EndToEndB2CAdminTest"
+      title: "Pass End to End B2C Admin scenario"
+      description: "Admin creates products, creates and manages categories, creates promotions, creates an order, processes an order, processes a return, uses admin grids"
+- filename: "AdminCheckCustomAttributeValuesAfterProductSaveTest.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/Catalog/Test/Mftf/Test/AdminCheckCustomAttributeValuesAfterProductSaveTest.xml"
+  module: "Catalog"
+  tests:
+    - testname: "AdminCheckCustomAttributeValuesAfterProductSaveTest"
+      title: "Saving custom attribute values using UI"
+      description: "Checks that saved custom attribute values are reflected on the product's edit page"
+- filename: "AdminUpdateVirtualProductWithSpecialPriceInStockVisibleInCategoryAndSearchTest.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/Catalog/Test/Mftf/Test/AdminUpdateVirtualProductWithSpecialPriceInStockVisibleInCategoryAndSearchTest.xml"
+  module: "Catalog"
+  tests:
+    - testname: "AdminUpdateVirtualProductWithSpecialPriceInStockVisibleInCategoryAndSearchTest"
+      title: "Update Virtual Product with Special Price (In Stock) Visible in Category and Search"
+      description: "Test log in to Update Virtual Product and Update Virtual Product with Special Price (In Stock) Visible in Category and Search"
+- filename: "AdminProductImageAssignmentForMultipleStoresTest.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/Catalog/Test/Mftf/Test/AdminProductImageAssignmentForMultipleStoresTest.xml"
+  module: "Catalog"
+  tests:
+    - testname: "AdminProductImageAssignmentForMultipleStoresTest"
+      title: "Product image assignment for multiple stores"
+      description: "Product image assignment for multiple stores"
+- filename: "AdminMoveCategoryFromParentAnchoredCategoryTest.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/Catalog/Test/Mftf/Test/AdminMoveCategoryFromParentAnchoredCategoryTest.xml"
+  module: "Catalog"
+  tests:
+    - testname: "AdminMoveCategoryFromParentAnchoredCategoryTest"
+      title: "Move default subcategory with anchored parent to default subcategory"
+      description: "Login as admin,move subcategory with anchored parent to default subcategory"
+- filename: "AdminMoveAnchoredCategoryToDefaultCategoryTest.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/Catalog/Test/Mftf/Test/AdminMoveAnchoredCategoryToDefaultCategoryTest.xml"
+  module: "Catalog"
+  tests:
+    - testname: "AdminMoveAnchoredCategoryToDefaultCategoryTest"
+      title: "Move default anchored subcategory with anchored parent to default subcategory"
+      description: "Login as admin,move anchored subcategory with anchored parent to default subcategory"
+- filename: "VerifyDefaultWYSIWYGToolbarOnProductTest.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/Catalog/Test/Mftf/Test/VerifyDefaultWYSIWYGToolbarOnProductTest.xml"
+  module: "Catalog"
+  tests:
+    - testname: "VerifyDefaultWYSIWYGToolbarOnProductTest"
+      title: "Admin should be able to see default toolbar display on Description content area"
+      description: "Admin should be able to see default toolbar display on Description content area"
+
+    - testname: "Verifydefaultcontrolsonproductshortdescription"
+      title: "Admin should be able to see default toolbar display on Short Description content area"
+      description: "Admin should be able to see default toolbar display on Short Description content area"
+- filename: "AdminMassChangeProductsStatusTest.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/Catalog/Test/Mftf/Test/AdminMassChangeProductsStatusTest.xml"
+  module: "Catalog"
+  tests:
+    - testname: "AdminMassChangeProductsStatusTest"
+      title: "Admin should be able to mass change products status"
+      description: "Admin should be able to mass change products status"
+- filename: "AdminUpdateVirtualProductWithTierPriceInStockVisibleInCategoryOnlyTest.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/Catalog/Test/Mftf/Test/AdminUpdateVirtualProductWithTierPriceInStockVisibleInCategoryOnlyTest.xml"
+  module: "Catalog"
+  tests:
+    - testname: "AdminUpdateVirtualProductWithTierPriceInStockVisibleInCategoryOnlyTest"
+      title: "Update Virtual Product with Tier Price (In Stock) Visible in Category Only"
+      description: "Test log in to Update Virtual Product and Update Virtual Product with Tier Price (In Stock) Visible in Category Only"
+- filename: "AdminUpdateTopCategoryUrlWithRedirectTest.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/Catalog/Test/Mftf/Test/AdminUpdateTopCategoryUrlWithRedirectTest.xml"
+  module: "Catalog"
+  tests:
+    - testname: "AdminUpdateTopCategoryUrlWithRedirectTest"
+      title: "Update top category url and create redirect"
+      description: "Login as admin and update top category url and create redirect"
+- filename: "AdminUpdateVirtualProductWithRegularPriceOutOfStockVisibleInCategoryOnlyTest.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/Catalog/Test/Mftf/Test/AdminUpdateVirtualProductWithRegularPriceOutOfStockVisibleInCategoryOnlyTest.xml"
+  module: "Catalog"
+  tests:
+    - testname: "AdminUpdateVirtualProductWithRegularPriceOutOfStockVisibleInCategoryOnlyTest"
+      title: "Update Virtual Product with Regular Price (Out of Stock) Visible in Category Only"
+      description: "Test log in to Update Virtual Product and Update Virtual Product with Regular Price (Out of Stock) Visible in Category Only"
+- filename: "AdminDeleteVirtualProductTest.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/Catalog/Test/Mftf/Test/AdminDeleteVirtualProductTest.xml"
+  module: "Catalog"
+  tests:
+    - testname: "AdminDeleteVirtualProductTest"
+      title: "Delete Virtual Product"
+      description: "Admin should be able to delete a virtual product"
+- filename: "AdminMoveProductBetweenCategoriesTest.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/Catalog/Test/Mftf/Test/AdminMoveProductBetweenCategoriesTest.xml"
+  module: "Catalog"
+  tests:
+    - testname: "AdminMoveProductBetweenCategoriesTest"
+      title: "Move Product between Categories (Cron is ON, 'Update by Schedule' Mode)"
+      description: "Verifies correctness of showing data (products, categories) on Storefront after moving an anchored category in terms of products/categories association"
+- filename: "AdminFilterByNameByStoreViewOnProductGridTest.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/Catalog/Test/Mftf/Test/AdminFilterByNameByStoreViewOnProductGridTest.xml"
+  module: "Catalog"
+  tests:
+    - testname: "AdminFilterByNameByStoreViewOnProductGridTest"
+      title: "Product grid filtering by store view level attribute"
+      description: "Verify that products grid can be filtered on all store view level by attribute"
+- filename: "AdminMoveAnchoredCategoryTest.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/Catalog/Test/Mftf/Test/AdminMoveAnchoredCategoryTest.xml"
+  module: "Catalog"
+  tests:
+    - testname: "AdminMoveAnchoredCategoryTest"
+      title: "Admin should be able to move a category via categories tree and changes should be applied on frontend without a forced cache cleaning"
+      description: "Admin should be able to move a category via categories tree and changes should be applied on frontend without a forced cache cleaning"
+- filename: "AdminCreateCategoryWithFiveNestingTest.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/Catalog/Test/Mftf/Test/AdminCreateCategoryWithFiveNestingTest.xml"
+  module: "Catalog"
+  tests:
+    - testname: "AdminCreateCategoryWithFiveNestingTest"
+      title: "Create category with five nesting"
+      description: "Login as admin and create nested sub category and verify the subcategory displayed in store front page  "
+- filename: "AdminCreateRootCategoryAndSubcategoriesTest.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/Catalog/Test/Mftf/Test/AdminCreateRootCategoryAndSubcategoriesTest.xml"
+  module: "Catalog"
+  tests:
+    - testname: "AdminCreateRootCategoryAndSubcategoriesTest"
+      title: "Admin should be able to create a Root Category and a Subcategory"
+      description: "Admin should be able to create a Root Category and a Subcategory"
+- filename: "AdminRemoveDefaultImageSimpleProductTest.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/Catalog/Test/Mftf/Test/AdminRemoveDefaultImageSimpleProductTest.xml"
+  module: "Catalog"
+  tests:
+    - testname: "AdminRemoveDefaultImageSimpleProductTest"
+      title: "Admin should be able to remove default images from a Simple Product"
+      description: "Admin should be able to remove default images from a Simple Product"
+- filename: "AdminCreateTextEditorProductAttributeTest.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/Catalog/Test/Mftf/Test/AdminCreateTextEditorProductAttributeTest.xml"
+  module: "Catalog"
+  tests:
+    - testname: "AdminCreateTextEditorProductAttributeTest"
+      title: "Admin create text editor product attribute test"
+      description: "Create text editor product attribute with TinyMCE4 enabled"
+- filename: "AdminUpdateCategoryWithInactiveIncludeInMenuTest.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/Catalog/Test/Mftf/Test/AdminUpdateCategoryWithInactiveIncludeInMenuTest.xml"
+  module: "Catalog"
+  tests:
+    - testname: "AdminUpdateCategoryWithInactiveIncludeInMenuTest"
+      title: "Update category, name description urlkey metatitle exclude from menu"
+      description: "Login as admin and update category name, description, urlKey, metatitle and exclude from menu"
+- filename: "AdminCreateCategoryWithRequiredFieldsTest.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/Catalog/Test/Mftf/Test/AdminCreateCategoryWithRequiredFieldsTest.xml"
+  module: "Catalog"
+  tests:
+    - testname: "AdminCreateCategoryWithRequiredFieldsTest"
+      title: "Create Category from Category page with Required Fields Only"
+      description: "Login as an admin and create a category with required fields."
+- filename: "StorefrontForthLevelCategoryTest.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/Catalog/Test/Mftf/Test/StorefrontForthLevelCategoryTest.xml"
+  module: "Catalog"
+  tests:
+    - testname: "StorefrontForthLevelCategoryTest"
+      title: "Storefront forth level category test"
+      description: "When the submenu was created in the third stage follow, the submenu works"
+- filename: "AdminCreateSimpleProductTest.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/Catalog/Test/Mftf/Test/AdminCreateSimpleProductTest.xml"
+  module: "Catalog"
+  tests:
+    - testname: "AdminCreateSimpleProductTest"
+      title: "Admin should be able to create a Simple Product"
+      description: "Admin should be able to create a Simple Product"
+
+    - testname: "AdminConfigDefaultProductLayoutFromConfigurationSettingTest"
+      title: "Admin should be able to configure a default layout for Product Page from System Configuration"
+      description: "Admin should be able to configure a default layout for Product Page from System Configuration"
+
+    - testname: "AdminCreateSimpleProductZeroPriceTest"
+      title: "Admin should be able to create a product with zero price"
+      description: "Admin should be able to create a product with zero price"
+
+    - testname: "AdminCreateSimpleProductNegativePriceTest"
+      title: "Admin should not be able to create a product with a negative price"
+      description: "Admin should not be able to create a product with a negative price"
+- filename: "NewProductsListWidgetVirtualProductTest.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/Catalog/Test/Mftf/Test/NewProductsListWidgetVirtualProductTest.xml"
+  module: "Catalog"
+  tests:
+    - testname: "NewProductsListWidgetVirtualProductTest"
+      title: "Admin should be able to set Virtual Product as new so that it shows up in the Catalog New Products List Widget"
+      description: "Admin should be able to set Virtual Product as new so that it shows up in the Catalog New Products List Widget"
+- filename: "AdminVerifyProductOrderTest.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/Catalog/Test/Mftf/Test/AdminVerifyProductOrderTest.xml"
+  module: "Catalog"
+  tests:
+    - testname: "AdminVerifyProductOrder"
+      title: "Admin should see product types in specified order"
+      description: "Product Type Order should be Simple -&gt; Configurable -&gt; Grouped -&gt; Virtual -&gt; Bundle -&gt; Downloadable -&gt; EE"
+- filename: "AdminCreateInactiveFlatCategoryTest.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/Catalog/Test/Mftf/Test/AdminCreateInactiveFlatCategoryTest.xml"
+  module: "Catalog"
+  tests:
+    - testname: "AdminCreateInactiveFlatCategoryTest"
+      title: "Flat Catalog - Create Category as Inactive, Should Not be Visible on Storefront"
+      description: "Login as admin and create flat Inactive category and verify category is not visible in store front"
+- filename: "AdminCreateAndEditSimpleProductSettingsTest.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/Catalog/Test/Mftf/Test/AdminCreateAndEditSimpleProductSettingsTest.xml"
+  module: "Catalog"
+  tests:
+    - testname: "AdminCreateAndEditSimpleProductSettingsTest"
+      title: "Admin should be able to set/edit other product information when creating/editing a simple product"
+      description: "Admin should be able to set/edit product information when creating/editing a simple product"
+- filename: "AdminCheckPaginationInStorefrontTest.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/Catalog/Test/Mftf/Test/AdminCheckPaginationInStorefrontTest.xml"
+  module: "Catalog"
+  tests:
+    - testname: "AdminCheckPaginationInStorefrontTest"
+      title: "Verify that pagination works when Flat Category is enabled"
+      description: "Login as admin, create flat catalog product and check pagination"
+- filename: "AddOutOfStockProductToCompareListTest.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/Catalog/Test/Mftf/Test/AddOutOfStockProductToCompareListTest.xml"
+  module: "Catalog"
+  tests:
+    - testname: "AddOutOfStockProductToCompareListTest"
+      title: "Add Product that is Out of Stock product to Product Comparison"
+      description: "Customer should be able to add Product that is Out Of Stock to the Product Comparison"
+- filename: "AdminUnassignProductAttributeFromAttributeSetTest.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/Catalog/Test/Mftf/Test/AdminUnassignProductAttributeFromAttributeSetTest.xml"
+  module: "Catalog"
+  tests:
+    - testname: "AdminUnassignProductAttributeFromAttributeSetTest"
+      title: "Admin should be able to unassign attributes from an attribute set"
+      description: "Admin should be able to unassign attributes from an attribute set"
+- filename: "AdminMoveCategoryAndCheckUrlRewritesTest.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/Catalog/Test/Mftf/Test/AdminMoveCategoryAndCheckUrlRewritesTest.xml"
+  module: "Catalog"
+  tests:
+    - testname: "AdminMoveCategoryAndCheckUrlRewritesTest"
+      title: "URL Rewrites for subcategories during creation and move"
+      description: "Login as admin, move category from one to another and check category url rewrites"
+- filename: "AdminCloneProductWithDuplicateUrlTest.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/Catalog/Test/Mftf/Test/AdminCloneProductWithDuplicateUrlTest.xml"
+  module: "Catalog"
+  tests:
+    - testname: "AdminCloneProductWithDuplicateUrlTest"
+      title: "Cloning a product with duplicate URL key"
+      description: "Check product cloning with duplicate URL key"
+- filename: "AdminCreateNewAttributeFromProductTest.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/Catalog/Test/Mftf/Test/AdminCreateNewAttributeFromProductTest.xml"
+  module: "Catalog"
+  tests:
+    - testname: "AdminCreateNewAttributeFromProductTest"
+      title: "Check that New Attribute from Product is create"
+      description: "Check that New Attribute from Product is create"
+- filename: "SaveProductWithCustomOptionsSecondWebsiteTest.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/Catalog/Test/Mftf/Test/SaveProductWithCustomOptionsSecondWebsiteTest.xml"
+  module: "Catalog"
+  tests:
+    - testname: "SaveProductWithCustomOptionsAdditionalWebsiteTest"
+      title: "You should be able to save a product with custom options assigned to a different website"
+      description: "Custom Options should not be split when saving the product after assigning to a different website"
+- filename: "AdminSimpleProductImagesTest.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/Catalog/Test/Mftf/Test/AdminSimpleProductImagesTest.xml"
+  module: "Catalog"
+  tests:
+    - testname: "AdminSimpleProductImagesTest"
+      title: "Admin should be able to add images of different types and sizes to Simple Product"
+      description: "Admin should be able to add images of different types and sizes to Simple Product"
+
+    - testname: "AdminSimpleProductRemoveImagesTest"
+      title: "Admin should be able to remove Product Images assigned as Base, Small and Thumbnail from Simple Product"
+      description: "Admin should be able to remove Product Images assigned as Base, Small and Thumbnail from Simple Product"
+- filename: "AdminUpdateCategoryUrlKeyWithStoreViewTest.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/Catalog/Test/Mftf/Test/AdminUpdateCategoryUrlKeyWithStoreViewTest.xml"
+  module: "Catalog"
+  tests:
+    - testname: "AdminUpdateCategoryUrlKeyWithStoreViewTest"
+      title: "Update category, URL key with custom store view"
+      description: "Login as admin and update category URL Key with store view"
+- filename: "AdminUpdateSimpleProductWithRegularPriceInStockDisabledProductTest.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/Catalog/Test/Mftf/Test/AdminUpdateSimpleProductWithRegularPriceInStockDisabledProductTest.xml"
+  module: "Catalog"
+  tests:
+    - testname: "AdminUpdateSimpleProductWithRegularPriceInStockDisabledProductTest"
+      title: "Update Simple Product with Regular Price (In Stock), Disabled Product"
+      description: "Test log in to Update Simple Product and Update Simple Product with Regular Price (In Stock), Disabled Product"
+- filename: "AdminCreateCategoryWithInactiveIncludeInMenuTest.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/Catalog/Test/Mftf/Test/AdminCreateCategoryWithInactiveIncludeInMenuTest.xml"
+  module: "Catalog"
+  tests:
+    - testname: "AdminCreateCategoryWithInactiveIncludeInMenuTest"
+      title: "Create not included in menu subcategory"
+      description: "Login as admin and create category with inactivated include in menu option"
+- filename: "AdminCreateVirtualProductWithoutManageStockTest.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/Catalog/Test/Mftf/Test/AdminCreateVirtualProductWithoutManageStockTest.xml"
+  module: "Catalog"
+  tests:
+    - testname: "AdminCreateVirtualProductWithoutManageStockTest"
+      title: "Create virtual product without manage stock"
+      description: "Test log in to Create virtual product and Create virtual product without manage stock"
+- filename: "AddToCartCrossSellTest.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/Catalog/Test/Mftf/Test/AddToCartCrossSellTest.xml"
+  module: "Catalog"
+  tests:
+    - testname: "AddToCartCrossSellTest"
+      title: "Admin should be able to add cross-sell to products."
+      description: "Create products, add products to cross sells, and check that they appear in the Shopping Cart page."
+- filename: "AdminUpdateVirtualProductWithRegularPriceOutOfStockVisibleInSearchOnlyTest.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/Catalog/Test/Mftf/Test/AdminUpdateVirtualProductWithRegularPriceOutOfStockVisibleInSearchOnlyTest.xml"
+  module: "Catalog"
+  tests:
+    - testname: "AdminUpdateVirtualProductWithRegularPriceOutOfStockVisibleInSearchOnlyTest"
+      title: "Update Virtual Product with Regular Price (Out of Stock) Visible in Search Only"
+      description: "Test log in to Update Virtual Product and Update Virtual Product with Regular Price (Out of Stock) Visible in Search Only"
+- filename: "AdminUpdateFlatCategoryAndAddProductsTest.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/Catalog/Test/Mftf/Test/AdminUpdateFlatCategoryAndAddProductsTest.xml"
+  module: "Catalog"
+  tests:
+    - testname: "AdminUpdateFlatCategoryAndAddProductsTest"
+      title: "Flat Catalog - Assign Simple Product to Category"
+      description: "Login as admin, update flat category by adding a simple product"
+- filename: "AdminDeleteAttributeSetTest.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/Catalog/Test/Mftf/Test/AdminDeleteAttributeSetTest.xml"
+  module: "Catalog"
+  tests:
+    - testname: "AdminDeleteAttributeSetTest"
+      title: "Delete Attribute Set"
+      description: "Admin should be able to delete an attribute set"
+- filename: "EndToEndB2CLoggedInUserTest.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/Catalog/Test/Mftf/Test/EndToEndB2CLoggedInUserTest.xml"
+  module: "Catalog"
+  tests:
+    - testname: "EndToEndB2CLoggedInUserTest"
       title: ""
       description: ""
- 
-- filename: "CheckShoppingCartBehaviorAfterSessionExpiredTest.xml"
-  repo: "https://github.com/magento/magento2/blob/2.3/app/code/Magento/Persistent/Test/Mftf/Test/CheckShoppingCartBehaviorAfterSessionExpiredTest.xml"
-  module: "Persistent"
+- filename: "AdminUpdateCategoryStoreUrlKeyTest.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/Catalog/Test/Mftf/Test/AdminUpdateCategoryStoreUrlKeyTest.xml"
+  module: "Catalog"
   tests:
-    - testname: "CheckShoppingCartBehaviorAfterSessionExpiredTest"
-      title: "Checking behavior with the persistent shopping cart after the session is expired"
-      description: "Checking behavior with the persistent shopping cart after the session is expired"
- 
-- filename: "StorefrontCorrectWelcomeMessageAfterCustomerIsLoggedOutTest.xml"
-  repo: "https://github.com/magento/magento2/blob/2.3/app/code/Magento/Persistent/Test/Mftf/Test/StorefrontCorrectWelcomeMessageAfterCustomerIsLoggedOutTest.xml"
-  module: "Persistent"
+    - testname: "AdminUpdateCategoryStoreUrlKeyTest"
+      title: "SEO-friendly URL should update regardless of scope or redirect change."
+      description: "SEO-friendly URL should update regardless of scope or redirect change."
+- filename: "AdminCreateCustomProductAttributeWithDropdownFieldTest.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/Catalog/Test/Mftf/Test/AdminCreateCustomProductAttributeWithDropdownFieldTest.xml"
+  module: "Catalog"
   tests:
-    - testname: "StorefrontCorrectWelcomeMessageAfterCustomerIsLoggedOutTest"
-      title: "Checking welcome message for persistent customer after logout"
-      description: "Checking welcome message for persistent customer after logout"
- 
-- filename: "StorefrontVerifyThatInformationAboutViewingComparisonWishlistIsPersistedUnderLongTermCookieTest.xml"
-  repo: "https://github.com/magento/magento2/blob/2.3/app/code/Magento/Persistent/Test/Mftf/Test/StorefrontVerifyThatInformationAboutViewingComparisonWishlistIsPersistedUnderLongTermCookieTest.xml"
-  module: "Persistent"
+    - testname: "AdminCreateCustomProductAttributeWithDropdownFieldTest"
+      title: "Create Custom Product Attribute Dropdown Field (Not Required) from Product Page"
+      description: "login as admin and create configurable product attribute with Dropdown field"
+- filename: "AdminDeleteSimpleProductTest.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/Catalog/Test/Mftf/Test/AdminDeleteSimpleProductTest.xml"
+  module: "Catalog"
   tests:
-    - testname: "StorefrontVerifyThatInformationAboutViewingComparisonWishlistIsPersistedUnderLongTermCookieTest"
-      title: "Verify that information about viewing, comparison, wishlist and last ordered items is persisted under long-term cookie"
-      description: "Verify that information about viewing, comparison, wishlist and last ordered items is persisted under long-term cookie"
- 
-- filename: "ShippingQuotePersistedForGuestTest.xml"
-  repo: "https://github.com/magento/magento2/blob/2.3/app/code/Magento/Persistent/Test/Mftf/Test/ShippingQuotePersistedForGuestTest.xml"
-  module: "Persistent"
+    - testname: "AdminDeleteSimpleProductTest"
+      title: "Delete Simple Product"
+      description: "Admin should be able to delete a simple product"
+- filename: "AdminDeleteRootSubCategoryTest.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/Catalog/Test/Mftf/Test/AdminDeleteRootSubCategoryTest.xml"
+  module: "Catalog"
   tests:
-    - testname: "ShippingQuotePersistedForGuestTest"
-      title: "Estimate Shipping and Tax block sections on shipping cart saving correctly for Guest."
-      description: "Verify that 'Estimate Shipping and Tax' block sections on shipping cart saving correctly for Guest after switching to another page. And check that the shopping cart is cleared after reset persistent cookie."
- 
-- filename: "GuestCheckoutWithEnabledPersistentTest.xml"
-  repo: "https://github.com/magento/magento2/blob/2.3/app/code/Magento/Persistent/Test/Mftf/Test/GuestCheckoutWithEnabledPersistentTest.xml"
-  module: "Persistent"
+    - testname: "AdminDeleteRootSubCategoryTest"
+      title: "Can delete a subcategory"
+      description: "Login as admin and delete a root sub category"
+- filename: "AdminCreateCategoryWithInactiveCategoryTest.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/Catalog/Test/Mftf/Test/AdminCreateCategoryWithInactiveCategoryTest.xml"
+  module: "Catalog"
   tests:
-    - testname: "GuestCheckoutWithEnabledPersistentTest"
-      title: "Guest Checkout with Enabled Persistent"
-      description: "Checkout data must be restored after page checkout reload."
- 
-- filename: "StorefrontVerifyShoppingCartPersistenceUnderLongTermCookieTest.xml"
-  repo: "https://github.com/magento/magento2/blob/2.3/app/code/Magento/Persistent/Test/Mftf/Test/StorefrontVerifyShoppingCartPersistenceUnderLongTermCookieTest.xml"
-  module: "Persistent"
+    - testname: "AdminCreateCategoryWithInactiveCategoryTest"
+      title: "Create disabled subcategory"
+      description: "Login as admin and create category with inactivated enable category option"
+- filename: "AdminCreateSimpleProductWithUnicodeTest.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/Catalog/Test/Mftf/Test/AdminCreateSimpleProductWithUnicodeTest.xml"
+  module: "Catalog"
   tests:
-    - testname: "StorefrontVerifyShoppingCartPersistenceUnderLongTermCookieTest"
-      title: "Verify Shopping Cart Persistence under long-term cookie"
-      description: "Verify Shopping Cart Persistence under long-term cookie"
- 
-- filename: "StorefrontButtonsInlineTranslationTest.xml"
-  repo: "https://github.com/magento/magento2/blob/2.3/app/code/Magento/Translation/Test/Mftf/Test/StorefrontButtonsInlineTranslationTest.xml"
-  module: "Translation"
+    - testname: "AdminCreateSimpleProductWithUnicodeTest"
+      title: "Admin should be able to create a unicode named simple product"
+      description: "Admin should be able to create a unicode named simple product"
+- filename: "AdminProductGridFilteringByDateAttributeTest.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/Catalog/Test/Mftf/Test/AdminProductGridFilteringByDateAttributeTest.xml"
+  module: "Catalog"
   tests:
-    - testname: "StorefrontButtonsInlineTranslationTest"
-      title: "[Inline Translation] Buttons inline translation"
-      description: "[Inline Translation] Buttons inline translation"
- 
-- filename: "AdminInlineTranslationOnCheckoutTest.xml"
-  repo: "https://github.com/magento/magento2/blob/2.3/app/code/Magento/Translation/Test/Mftf/Test/AdminInlineTranslationOnCheckoutTest.xml"
-  module: "Translation"
+    - testname: "AdminProductGridFilteringByDateAttributeTest"
+      title: "Verify Set Product as new Filter input on Product Grid doesn't getreset to currentDate"
+      description: "Data input in the new from date filter field should not change"
+- filename: "AdminDeleteProductWithCustomOptionTest.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/Catalog/Test/Mftf/Test/AdminDeleteProductWithCustomOptionTest.xml"
+  module: "Catalog"
   tests:
-    - testname: "AdminInlineTranslationOnCheckoutTest"
-      title: "[Inline Translation] Inline translate on Checkout"
-      description: "As merchant I want to be able to rename text labels on Checkout steps"
- 
-- filename: "AdminCreateCustomVariableEntityTest.xml"
-  repo: "https://github.com/magento/magento2/blob/2.3/app/code/Magento/Variable/Test/Mftf/Test/AdminCreateCustomVariableEntityTest.xml"
-  module: "Variable"
+    - testname: "AdminDeleteProductWithCustomOptionTest"
+      title: "Delete Product with Custom Option"
+      description: "Admin should be able to delete a product with custom option"
+- filename: "VerifyTinyMCEv4IsNativeWYSIWYGOnCatalogTest.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/Catalog/Test/Mftf/Test/VerifyTinyMCEv4IsNativeWYSIWYGOnCatalogTest.xml"
+  module: "Catalog"
   tests:
-    - testname: "AdminCreateCustomVariableEntityTest"
-      title: "Admin Create Custom Variable"
-      description: "Test for creating a custom variable."
- 
-- filename: "AdminSystemCustomVariablesNavigateMenuTest.xml"
-  repo: "https://github.com/magento/magento2/blob/2.3/app/code/Magento/Variable/Test/Mftf/Test/AdminSystemCustomVariablesNavigateMenuTest.xml"
-  module: "Variable"
+    - testname: "VerifyTinyMCEv4IsNativeWYSIWYGOnCatalogTest"
+      title: "Admin should see TinyMCEv4.6 is the native WYSIWYG on Catalog Page"
+      description: "Admin should see TinyMCEv4.6 is the native WYSIWYG on Catalog Page"
+- filename: "AdminApplyTierPriceToProductTest.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/Catalog/Test/Mftf/Test/AdminApplyTierPriceToProductTest.xml"
+  module: "Catalog"
   tests:
-    - testname: "AdminSystemCustomVariablesNavigateMenuTest"
-      title: "Admin system custom variables navigate menu test"
-      description: "Admin should be able to navigate to System &gt; Custom Variables"
- 
+    - testname: "AdminApplyTierPriceToProductTest"
+      title: "You should be able to apply tier price to a product."
+      description: "You should be able to apply tier price to a product."
+
+    - testname: "AdminApplyTierPriceToProductWithPercentageDiscountTest"
+      title: "You should be able to apply tier price to a product with float percent discount."
+      description: "You should be able to apply tier price to a product with float percent discount."
+- filename: "AdminCreateVirtualProductWithTierPriceForGeneralGroupTest.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/Catalog/Test/Mftf/Test/AdminCreateVirtualProductWithTierPriceForGeneralGroupTest.xml"
+  module: "Catalog"
+  tests:
+    - testname: "AdminCreateVirtualProductWithTierPriceForGeneralGroupTest"
+      title: "Create virtual product with tier price for General group"
+      description: "Test log in to Create virtual product and Create virtual product with tier price for General group"
+- filename: "AdminCreateAttributeSetEntityTest.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/Catalog/Test/Mftf/Test/AdminCreateAttributeSetEntityTest.xml"
+  module: "Catalog"
+  tests:
+    - testname: "AdminCreateAttributeSetEntityTest"
+      title: "Create attribute set with new product attribute"
+      description: "Admin should be able to create attribute set with new product attribute"
+- filename: "ProductAvailableAfterEnablingSubCategoriesTest.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/Catalog/Test/Mftf/Test/ProductAvailableAfterEnablingSubCategoriesTest.xml"
+  module: "Catalog"
+  tests:
+    - testname: "ProductAvailableAfterEnablingSubCategoriesTest"
+      title: "Check that parent categories are showing products after enabling subcategories after fully reindex"
+      description: "Check that parent categories are showing products after enabling subcategories after fully reindex"
+- filename: "AdminEditTextEditorProductAttributeTest.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/Catalog/Test/Mftf/Test/AdminEditTextEditorProductAttributeTest.xml"
+  module: "Catalog"
+  tests:
+    - testname: "AdminEditTextEditorProductAttributeTest"
+      title: "Admin are able to change Input Type of Text Editor product attribute"
+      description: "Admin are able to change Input Type of Text Editor product attribute"
+- filename: "AdminCheckInactiveCategoryAndSubcategoryIsNotVisibleInNavigationMenuTest.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/Catalog/Test/Mftf/Test/AdminCheckInactiveCategoryAndSubcategoryIsNotVisibleInNavigationMenuTest.xml"
+  module: "Catalog"
+  tests:
+    - testname: "AdminCheckInactiveCategoryAndSubcategoryIsNotVisibleInNavigationMenuTest"
+      title: "Inactive Category and subcategory are not visible on navigation menu, Include in Menu = Yes"
+      description: "Login as admin and verify inactive category and subcategory is not visible in navigation menu"
+- filename: "AdminStoresAttributeSetNavigateMenuTest.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/Catalog/Test/Mftf/Test/AdminStoresAttributeSetNavigateMenuTest.xml"
+  module: "Catalog"
+  tests:
+    - testname: "AdminStoresAttributeSetNavigateMenuTest"
+      title: "Admin stores attribute set navigate menu test"
+      description: "Admin should be able to navigate to Stores &gt; Attribute Set"
+- filename: "CreateProductAttributeEntityTest.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/Catalog/Test/Mftf/Test/CreateProductAttributeEntityTest.xml"
+  module: "Catalog"
+  tests:
+    - testname: "CreateProductAttributeEntityTextFieldTest"
+      title: "Admin should be able to create a TextField product attribute"
+      description: "Admin should be able to create a TextField product attribute"
+
+    - testname: "CreateProductAttributeEntityDateTest"
+      title: "Admin should be able to create a Date product attribute"
+      description: "Admin should be able to create a Date product attribute"
+
+    - testname: "CreateProductAttributeEntityPriceTest"
+      title: "Admin should be able to create a Price product attribute"
+      description: "Admin should be able to create a Price product attribute"
+
+    - testname: "CreateProductAttributeEntityDropdownTest"
+      title: "Admin should be able to create a Dropdown product attribute"
+      description: "Admin should be able to create a Dropdown product attribute"
+
+    - testname: "CreateProductAttributeEntityDropdownWithSingleQuoteTest"
+      title: "Admin should be able to create a Dropdown product attribute containing a single quote"
+      description: "Admin should be able to create a Dropdown product attribute containing a single quote"
+
+    - testname: "CreateProductAttributeEntityMultiSelectTest"
+      title: "Admin should be able to create a MultiSelect product attribute"
+      description: "Admin should be able to create a MultiSelect product attribute"
+- filename: "AdminCreateDuplicateCategoryTest.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/Catalog/Test/Mftf/Test/AdminCreateDuplicateCategoryTest.xml"
+  module: "Catalog"
+  tests:
+    - testname: "AdminCreateDuplicateCategoryTest"
+      title: "Create Duplicate Category With Already Existed UrlKey"
+      description: "Login as admin and create duplicate category"
+- filename: "StorefrontAdvanceCatalogSearchVirtualProductBySkuWithHyphenTest.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/Catalog/Test/Mftf/Test/StorefrontAdvanceCatalogSearchVirtualProductBySkuWithHyphenTest.xml"
+  module: "Catalog"
+  tests:
+    - testname: "StorefrontAdvanceCatalogSearchVirtualProductBySkuWithHyphenTest"
+      title: "Guest customer should be able to advance search virtual product with product sku that contains hyphen"
+      description: "Guest customer should be able to advance search virtual product with product sku that contains hyphen"
+- filename: "AdminCheckConfigurableProductPriceWithDisabledChildProductTest.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/Catalog/Test/Mftf/Test/AdminCheckConfigurableProductPriceWithDisabledChildProductTest.xml"
+  module: "Catalog"
+  tests:
+    - testname: "AdminCheckConfigurableProductPriceWithDisabledChildProductTest"
+      title: "Check Price for Configurable Product when One Child is Disabled, Others are Enabled"
+      description: "Login as admin and check the configurable product price when one child product is disabled "
+- filename: "AdminDeleteTextFieldProductAttributeFromAttributeSetTest.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/Catalog/Test/Mftf/Test/AdminDeleteTextFieldProductAttributeFromAttributeSetTest.xml"
+  module: "Catalog"
+  tests:
+    - testname: "AdminDeleteTextFieldProductAttributeFromAttributeSetTest"
+      title: "Delete Product Attribute, Text Field, from Attribute Set"
+      description: "Login as admin and delete Text Field type product attribute from attribute set"
+- filename: "AdminUpdateVirtualProductWithRegularPriceInStockVisibleInCategoryOnlyTest.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/Catalog/Test/Mftf/Test/AdminUpdateVirtualProductWithRegularPriceInStockVisibleInCategoryOnlyTest.xml"
+  module: "Catalog"
+  tests:
+    - testname: "AdminUpdateVirtualProductWithRegularPriceInStockVisibleInCategoryOnlyTest"
+      title: "Update Virtual Product with Regular Price (In Stock) Visible in Category Only"
+      description: "Test log in to Update Virtual Product and Update Virtual Product with Regular Price (In Stock) Visible in Category Only"
+- filename: "AdminCreateDropdownProductAttributeVisibleInStorefrontAdvancedSearchFormTest.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/Catalog/Test/Mftf/Test/AdminCreateDropdownProductAttributeVisibleInStorefrontAdvancedSearchFormTest.xml"
+  module: "Catalog"
+  tests:
+    - testname: "AdminCreateDropdownProductAttributeVisibleInStorefrontAdvancedSearchFormTest"
+      title: "AdminCreateDropdownProductAttributeVisibleInStorefrontAdvancedSearchFormTest"
+      description: "Admin should able to create product Dropdown attribute and check its visibility on frontend in Advanced Search form"
+- filename: "AdminFilteringCategoryProductsUsingScopeSelectorTest.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/Catalog/Test/Mftf/Test/AdminFilteringCategoryProductsUsingScopeSelectorTest.xml"
+  module: "Catalog"
+  tests:
+    - testname: "AdminFilteringCategoryProductsUsingScopeSelectorTest"
+      title: "Filtering Category Products using scope selector"
+      description: "Filtering Category Products using scope selector"
+- filename: "TrackingScriptTest.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/AdminAnalytics/Test/Mftf/Test/TrackingScriptTest.xml"
+  module: "AdminAnalytics"
+  tests:
+    - testname: "TrackingScriptTest"
+      title: "Checks to see if the tracking script is in the dom of admin and if setting is turned to no it checks if the tracking script in the dom was removed"
+      description: "Checks to see if the tracking script is in the dom of admin and if setting is turned to no it checks if the tracking script in the dom was removed"
+- filename: "StorefrontCategoryRulesShouldApplyToGroupedProductWithInvisibleIndividualProductTest.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/SalesRule/Test/Mftf/Test/StorefrontCategoryRulesShouldApplyToGroupedProductWithInvisibleIndividualProductTest.xml"
+  module: "SalesRule"
+  tests:
+    - testname: "StorefrontCategoryRulesShouldApplyToGroupedProductWithInvisibleIndividualProductTest"
+      title: "Category rules should apply to grouped product with invisible individual products"
+      description: "Category rules should apply to grouped product with invisible individual products"
+- filename: "AdminCreateCartPriceRuleWithMatchingTotalWeightAndVerifyRuleConditionIsAppliedTest.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/SalesRule/Test/Mftf/Test/AdminCreateCartPriceRuleWithMatchingTotalWeightAndVerifyRuleConditionIsAppliedTest.xml"
+  module: "SalesRule"
+  tests:
+    - testname: "AdminCreateCartPriceRuleWithMatchingTotalWeightAndVerifyRuleConditionIsAppliedTest"
+      title: "Create Cart Price Rule With Matching Total Weight And Verify Rule Condition Is Applied"
+      description: "Test log in to Cart Price Rules and Create Cart Price Rule With Matching Total Weight And Verify Rule Condition Is Applied"
+- filename: "AdminCreateCartPriceRuleForGeneratedCouponTest.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/SalesRule/Test/Mftf/Test/AdminCreateCartPriceRuleForGeneratedCouponTest.xml"
+  module: "SalesRule"
+  tests:
+    - testname: "AdminCreateCartPriceRuleForGeneratedCouponTest"
+      title: "Admin should be able to create a cart price rule for auto generated coupon codes"
+      description: "Admin should be able to create a cart price rule for auto generated coupon codes"
+- filename: "AdminCreateFixedAmountWholeCartDiscountTest.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/SalesRule/Test/Mftf/Test/AdminCreateFixedAmountWholeCartDiscountTest.xml"
+  module: "SalesRule"
+  tests:
+    - testname: "AdminCreateFixedAmountWholeCartDiscountTest"
+      title: "Admin should be able to create a cart price rule of type Fixed amount discount for whole cart"
+      description: "Admin should be able to create a cart price rule of type Fixed amount discount for whole cart"
+- filename: "StorefrontCartTotalValueWithFullDiscountUsingCartRuleTest.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/SalesRule/Test/Mftf/Test/StorefrontCartTotalValueWithFullDiscountUsingCartRuleTest.xml"
+  module: "SalesRule"
+  tests:
+    - testname: "StorefrontCartTotalValueWithFullDiscountUsingCartRuleTest"
+      title: "Cart Total value when 100% discount applied through Cart Rule"
+      description: "Cart Total value when 100% discount applied through Cart Rule"
+- filename: "EndToEndB2CGuestUserTest.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/SalesRule/Test/Mftf/Test/EndToEndB2CGuestUserTest.xml"
+  module: "SalesRule"
+  tests:
+    - testname: "EndToEndB2CGuestUserTest"
+      title: ""
+      description: ""
+
+    - testname: "EndToEndB2CGuestUserMysqlTest"
+      title: ""
+      description: ""
+- filename: "StorefrontCategoryRulesShouldApplyToComplexProductsTest.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/SalesRule/Test/Mftf/Test/StorefrontCategoryRulesShouldApplyToComplexProductsTest.xml"
+  module: "SalesRule"
+  tests:
+    - testname: "StorefrontCategoryRulesShouldApplyToComplexProductsTest"
+      title: "Category rules should apply to complex products"
+      description: "Sales rules filtering on category should apply to all products, including complex products."
+- filename: "AdminCreateFixedAmountDiscountTest.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/SalesRule/Test/Mftf/Test/AdminCreateFixedAmountDiscountTest.xml"
+  module: "SalesRule"
+  tests:
+    - testname: "AdminCreateFixedAmountDiscountTest"
+      title: "Admin should be able to create a cart price rule of type Fixed amount discount"
+      description: "Admin should be able to create a cart price rule of type Fixed amount discount"
+- filename: "AdminDeleteInactiveSalesRuleAndVerifyDeleteMessageTest.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/SalesRule/Test/Mftf/Test/AdminDeleteInactiveSalesRuleAndVerifyDeleteMessageTest.xml"
+  module: "SalesRule"
+  tests:
+    - testname: "AdminDeleteInactiveSalesRuleAndVerifyDeleteMessageTest"
+      title: "Delete Inactive Sales Rule And Verify Delete Message"
+      description: "Test log in to Cart Price Rule and Delete Inactive Sales Rule Test"
+- filename: "AdminCreatePercentOfProductPriceTest.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/SalesRule/Test/Mftf/Test/AdminCreatePercentOfProductPriceTest.xml"
+  module: "SalesRule"
+  tests:
+    - testname: "AdminCreatePercentOfProductPriceTest"
+      title: "Admin should be able to create a cart price rule of type Percent of product price discount"
+      description: "Admin should be able to create a cart price rule of type Percent of product price discount"
+- filename: "AdminMarketingCartPriceRulesNavigateMenuTest.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/SalesRule/Test/Mftf/Test/AdminMarketingCartPriceRulesNavigateMenuTest.xml"
+  module: "SalesRule"
+  tests:
+    - testname: "AdminMarketingCartPriceRulesNavigateMenuTest"
+      title: "Admin marketing cart price rules navigate menu test"
+      description: "Admin should be able to navigate to Marketing &gt; Cart Price Rules"
+- filename: "AdminDeleteActiveSalesRuleWithPercentPriceAndVerifyDeleteMessageTest.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/SalesRule/Test/Mftf/Test/AdminDeleteActiveSalesRuleWithPercentPriceAndVerifyDeleteMessageTest.xml"
+  module: "SalesRule"
+  tests:
+    - testname: "AdminDeleteActiveSalesRuleWithPercentPriceAndVerifyDeleteMessageTest"
+      title: "Delete Active Sales Rule With Percent Price And Verify Delete Message"
+      description: "Test log in to Cart Price Rule and Delete Active Sales Rule Test"
+- filename: "AdminCreateCartPriceRuleForCouponCodeTest.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/SalesRule/Test/Mftf/Test/AdminCreateCartPriceRuleForCouponCodeTest.xml"
+  module: "SalesRule"
+  tests:
+    - testname: "AdminCreateCartPriceRuleForCouponCodeTest"
+      title: "Admin should be able to create a cart price rule for a specific coupon code"
+      description: "Admin should be able to create a cart price rule for a specific coupon code"
+- filename: "AdminCreateInvalidRuleTest.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/SalesRule/Test/Mftf/Test/AdminCreateInvalidRuleTest.xml"
+  module: "SalesRule"
+  tests:
+    - testname: "AdminCreateInvalidRuleTest"
+      title: "Admin can not create rule with invalid data"
+      description: "Admin can not create rule with invalid data"
+- filename: "AdminCreateCartPriceRuleEmptyFromDateTest.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/SalesRule/Test/Mftf/Test/AdminCreateCartPriceRuleEmptyFromDateTest.xml"
+  module: "SalesRule"
+  tests:
+    - testname: "AdminCreateCartPriceRuleEmptyFromDateTest"
+      title: "Admin should be able to create a cart price rule with no starting date"
+      description: "Admin should be able to create a cart price rule without specifying the from_date and it should be set with the current date"
+- filename: "StorefrontAutoGeneratedCouponCodeTest.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/SalesRule/Test/Mftf/Test/StorefrontAutoGeneratedCouponCodeTest.xml"
+  module: "SalesRule"
+  tests:
+    - testname: "StorefrontAutoGeneratedCouponCodeTest"
+      title: "[Cart Price Rule] Auto generated coupon code considers 'Uses per Coupon' and 'Uses per Customer' options"
+      description: "[Cart Price Rule] Auto generated coupon code considers 'Uses per Coupon' and 'Uses per Customer' options"
+- filename: "AdminDeleteActiveSalesRuleWithComplexConditionsAndVerifyDeleteMessageTest.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/SalesRule/Test/Mftf/Test/AdminDeleteActiveSalesRuleWithComplexConditionsAndVerifyDeleteMessageTest.xml"
+  module: "SalesRule"
+  tests:
+    - testname: "AdminDeleteActiveSalesRuleWithComplexConditionsAndVerifyDeleteMessageTest"
+      title: "Delete Active Sales Rule With Complex Conditions And Verify Delete Message"
+      description: "Test log in to Cart Price Rule and Delete Active Sales Rule With Complex Conditions Test"
+- filename: "AdminCreateCartPriceRuleAndVerifyRuleConditionIsNotAppliedTest.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/SalesRule/Test/Mftf/Test/AdminCreateCartPriceRuleAndVerifyRuleConditionIsNotAppliedTest.xml"
+  module: "SalesRule"
+  tests:
+    - testname: "AdminCreateCartPriceRuleAndVerifyRuleConditionIsNotAppliedTest"
+      title: "Create Cart Price Rule And Verify Rule Condition Is Not Applied"
+      description: "Test log in to Cart Price Rules and Create Cart Price Rule And Verify Rule Condition Is Not Applied"
+- filename: "AdminCartRulesAppliedForProductInCartTest.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/SalesRule/Test/Mftf/Test/AdminCartRulesAppliedForProductInCartTest.xml"
+  module: "SalesRule"
+  tests:
+    - testname: "AdminCartRulesAppliedForProductInCartTest"
+      title: "Check that cart rules applied for product in cart"
+      description: "Check that cart rules applied for product in cart"
+- filename: "AdminCreateBuyXGetYFreeTest.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/SalesRule/Test/Mftf/Test/AdminCreateBuyXGetYFreeTest.xml"
+  module: "SalesRule"
+  tests:
+    - testname: "AdminCreateBuyXGetYFreeTest"
+      title: "Admin should be able to create a cart price rule of type Buy X get Y free"
+      description: "Admin should be able to create a cart price rule of type Buy X get Y free"
+- filename: "AdminCreateCartPriceRuleWithMatchingCategoryAndVerifyRuleConditionIsAppliedTest.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/SalesRule/Test/Mftf/Test/AdminCreateCartPriceRuleWithMatchingCategoryAndVerifyRuleConditionIsAppliedTest.xml"
+  module: "SalesRule"
+  tests:
+    - testname: "AdminCreateCartPriceRuleWithMatchingCategoryAndVerifyRuleConditionIsAppliedTest"
+      title: "Create Cart Price Rule With Matching Category And Verify Rule Condition Is Applied"
+      description: "Test log in to Cart Price Rules and Create Cart Price Rule With Matching Category And Verify Rule Condition Is Applied"
+- filename: "CartPriceRuleForConfigurableProductTest.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/SalesRule/Test/Mftf/Test/CartPriceRuleForConfigurableProductTest.xml"
+  module: "SalesRule"
+  tests:
+    - testname: "CartPriceRuleForConfigurableProductTest"
+      title: "Checking Cart Price Rule for configurable products"
+      description: "Checking Cart Price Rule for configurable products"
+- filename: "StorefrontCartRuleCouponForFreeShippingTest.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/SalesRule/Test/Mftf/Test/StorefrontCartRuleCouponForFreeShippingTest.xml"
+  module: "SalesRule"
+  tests:
+    - testname: "StorefrontCartRuleCouponForFreeShippingTest"
+      title: "Create Cart Price Rule for Free Shipping And Verify Coupon Code will shown in Order's totals"
+      description: "Test that Coupon Code of Cart Price Rule without discount for Product price but with Free shipping will shown in Order's totals"
+- filename: "DeleteCustomerGroupTest.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/SalesRule/Test/Mftf/Test/DeleteCustomerGroupTest.xml"
+  module: "SalesRule"
+  tests:
+    - testname: "DeleteCustomerGroupTest"
+      title: ""
+      description: ""
+- filename: "EndToEndB2CLoggedInUserTest.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/SalesRule/Test/Mftf/Test/EndToEndB2CLoggedInUserTest.xml"
+  module: "SalesRule"
+  tests:
+    - testname: "EndToEndB2CLoggedInUserTest"
+      title: ""
+      description: ""
+- filename: "AdminCreateCartPriceRuleAndVerifyRuleConditionAndFreeShippingIsAppliedTest.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/SalesRule/Test/Mftf/Test/AdminCreateCartPriceRuleAndVerifyRuleConditionAndFreeShippingIsAppliedTest.xml"
+  module: "SalesRule"
+  tests:
+    - testname: "AdminCreateCartPriceRuleAndVerifyRuleConditionAndFreeShippingIsAppliedTest"
+      title: "Create Cart Price Rule And Verify Rule Condition And Free Shipping Is Applied"
+      description: "Test log in to Cart Price Rules and Create Cart Price Rule And Verify Rule Condition And Free Shipping Is Applied"
+- filename: "AdminCreateCartPriceRuleForMatchingSubtotalAndVerifyRuleConditionIsAppliedTest.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/SalesRule/Test/Mftf/Test/AdminCreateCartPriceRuleForMatchingSubtotalAndVerifyRuleConditionIsAppliedTest.xml"
+  module: "SalesRule"
+  tests:
+    - testname: "AdminCreateCartPriceRuleForMatchingSubtotalAndVerifyRuleConditionIsAppliedTest"
+      title: "Create Cart Price Rule For Matching Subtotal And Verify Rule Condition Is Applied"
+      description: "Test log in to Cart Price Rules and Create Cart Price Rule For Matching Subtotal And Verify Rule Condition Is Applied"
+- filename: "PriceRuleCategoryNestingTest.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/SalesRule/Test/Mftf/Test/PriceRuleCategoryNestingTest.xml"
+  module: "SalesRule"
+  tests:
+    - testname: "PriceRuleCategoryNestingTest"
+      title: "Category nesting level must be the same as were created in categories."
+      description: "Category nesting level must be the same as were created in categories."
+- filename: "AdminRemoveProductWeeeAttributeOptionTest.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/Weee/Test/Mftf/Test/AdminRemoveProductWeeeAttributeOptionTest.xml"
+  module: "Weee"
+  tests:
+    - testname: "AdminRemoveProductWeeeAttributeOptionTest"
+      title: "Weee attribute options can be removed in product page"
+      description: "Weee attribute options can be removed in product page"
+- filename: "StorefrontFPTTaxInformationInShoppingCartForGuestPhysicalQuoteTest.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/Weee/Test/Mftf/Test/StorefrontFPTTaxInformationInShoppingCartForGuestPhysicalQuoteTest.xml"
+  module: "Weee"
+  tests:
+    - testname: "StorefrontFPTTaxInformationInShoppingCartForGuestPhysicalQuoteTest"
+      title: "Tax information are updating/recalculating on fly in shopping cart for Guest (physical quote)"
+      description: "Tax information are updating/recalculating on fly in shopping cart for Guest (physical quote)"
+- filename: "StorefrontFPTTaxInformationInShoppingCartForCustomerVirtualQuoteTest.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/Weee/Test/Mftf/Test/StorefrontFPTTaxInformationInShoppingCartForCustomerVirtualQuoteTest.xml"
+  module: "Weee"
+  tests:
+    - testname: "StorefrontFPTTaxInformationInShoppingCartForCustomerVirtualQuoteTest"
+      title: "Tax information are updating/recalculating on fly in shopping cart for Customer with default addresses (virtual quote)"
+      description: "Tax information are updating/recalculating on fly in shopping cart for Customer with default addresses (virtual quote)"
+- filename: "AdminFixedTaxValSavedForSpecificWebsiteTest.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/Weee/Test/Mftf/Test/AdminFixedTaxValSavedForSpecificWebsiteTest.xml"
+  module: "Weee"
+  tests:
+    - testname: "AdminFixedTaxValSavedForSpecificWebsiteTest"
+      title: "Fixed Product Tax value is saved correctly for Specific Website"
+      description: "Fixed Product Tax value is saved correctly for Specific Website"
+- filename: "StorefrontFPTTaxInformationInShoppingCartForGuestVirtualQuoteTest.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/Weee/Test/Mftf/Test/StorefrontFPTTaxInformationInShoppingCartForGuestVirtualQuoteTest.xml"
+  module: "Weee"
+  tests:
+    - testname: "StorefrontFPTTaxInformationInShoppingCartForGuestVirtualQuoteTest"
+      title: "Tax information are updating/recalculating on fly in shopping cart for Guest (virtual quote)"
+      description: "Tax information are updating/recalculating on fly in shopping cart for Guest (virtual quote)"
+- filename: "StorefrontFPTTaxInformationInShoppingCartForCustomerPhysicalQuoteTest.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/Weee/Test/Mftf/Test/StorefrontFPTTaxInformationInShoppingCartForCustomerPhysicalQuoteTest.xml"
+  module: "Weee"
+  tests:
+    - testname: "StorefrontFPTTaxInformationInShoppingCartForCustomerPhysicalQuoteTest"
+      title: "Tax information are updating/recalculating on fly in shopping cart for Customer with default addresses (physical quote)"
+      description: "Tax information are updating/recalculating on fly in shopping cart for Customer with default addresses (physical quote)"
 - filename: "CheckingCountryDropDownWithOneAllowedCountryTest.xml"
-  repo: "https://github.com/magento/magento2/blob/2.3/app/code/Magento/Config/Test/Mftf/Test/CheckingCountryDropDownWithOneAllowedCountryTest.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/Config/Test/Mftf/Test/CheckingCountryDropDownWithOneAllowedCountryTest.xml"
   module: "Config"
   tests:
     - testname: "CheckingCountryDropDownWithOneAllowedCountryTest"
       title: "Checking country drop-down with one allowed country"
       description: "Check country drop-down with one allowed country"
- 
 - filename: "ConfigurationTest.xml"
-  repo: "https://github.com/magento/magento2/blob/2.3/app/code/Magento/Config/Test/Mftf/Test/ConfigurationTest.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/Config/Test/Mftf/Test/ConfigurationTest.xml"
   module: "Config"
   tests:
     - testname: "VerifyAllowDynamicMediaURLsSettingIsRemoved"
       title: "Verify that Allow Dynamic Media URLs setting is removed from configuration page"
       description: "Verify that Allow Dynamic Media URLs setting is removed from configuration page"
- 
-- filename: "AdminUserLockWhenEditingUserTest.xml"
-  repo: "https://github.com/magento/magento2/blob/2.3/app/code/Magento/Security/Test/Mftf/Test/AdminUserLockWhenEditingUserTest.xml"
-  module: "Security"
+- filename: "AdminCreateTaxRuleWithZipRangeTest.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/Tax/Test/Mftf/Test/AdminCreateTaxRuleWithZipRangeTest.xml"
+  module: "Tax"
   tests:
-    - testname: "AdminUserLockWhenEditingUserTest"
-      title: "Lock admin user when creating new user."
-      description: "Runs Lock admin user when editing existing user test."
- 
-- filename: "AdminUserLockWhenCreatingNewUserTest.xml"
-  repo: "https://github.com/magento/magento2/blob/2.3/app/code/Magento/Security/Test/Mftf/Test/AdminUserLockWhenCreatingNewUserTest.xml"
-  module: "Security"
+    - testname: "AdminCreateTaxRuleWithZipRangeTest"
+      title: "Create tax rule, with zip range"
+      description: "Test log in to Create Tax Rule and Create tax rule with Zip Range"
+- filename: "UpdateDecimalTaxRateEntityTest.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/Tax/Test/Mftf/Test/UpdateDecimalTaxRateEntityTest.xml"
+  module: "Tax"
   tests:
-    - testname: "AdminUserLockWhenCreatingNewUserTest"
-      title: "Lock admin user when creating new user"
-      description: "Runs Lock admin user when creating new user test."
- 
-- filename: "StorefrontCheckNecessaryLogicToActionClassForCookieMessagesTest.xml"
-  repo: "https://github.com/magento/magento2/blob/2.3/app/code/Magento/Security/Test/Mftf/Test/StorefrontCheckNecessaryLogicToActionClassForCookieMessagesTest.xml"
-  module: "Security"
+    - testname: "UpdateDecimalTaxRateEntityTest"
+      title: "Update tax rate, decimal rate"
+      description: "Test log in to Tax Rate and Update Decimal Tax Rate"
+- filename: "StorefrontTaxQuoteCheckoutTest.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/Tax/Test/Mftf/Test/StorefrontTaxQuoteCheckoutTest.xml"
+  module: "Tax"
   tests:
-    - testname: "StorefrontCheckNecessaryLogicToActionClassForCookieMessagesTest"
-      title: "Storefront check necessary logic to action class for cookie messages test"
-      description: "Check necessary logic to action class for cookie messages"
- 
-- filename: "AdminLockAdminUserWhenCreatingNewRoleTest.xml"
-  repo: "https://github.com/magento/magento2/blob/2.3/app/code/Magento/Security/Test/Mftf/Test/AdminLockAdminUserWhenCreatingNewRoleTest.xml"
-  module: "Security"
+    - testname: "StorefrontTaxQuoteCheckoutGuestVirtual"
+      title: "Tax for Virtual Product Quote should be recalculated according to inputted data on Checkout flow for Guest Customer"
+      description: "Tax for Virtual Product Quote should be recalculated according to inputted data on Checkout flow for Guest Customer"
+
+    - testname: "StorefrontTaxQuoteCheckoutLoggedInSimple"
+      title: "Tax for Simple Product Quote should be recalculated according to inputted data on Checkout flow for Logged in Customer"
+      description: "Tax for Simple Product Quote should be recalculated according to inputted data on Checkout flow for Logged in Customer"
+
+    - testname: "StorefrontTaxQuoteCheckoutGuestSimple"
+      title: "Tax for Simple Product Quote should be recalculated according to inputted data on Checkout flow for Guest Customer"
+      description: "Tax for Simple Product Quote should be recalculated according to inputted data on Checkout flow for Guest Customer"
+
+    - testname: "StorefrontTaxQuoteCheckoutLoggedInVirtual"
+      title: "Tax for Virtual Product Quote should be recalculated according to inputted data on Checkout flow for Logged in Customer"
+      description: "Tax for Virtual Product Quote should be recalculated according to inputted data on Checkout flow for Logged in Customer"
+- filename: "StorefrontTaxInformationInShoppingCartForGuestVirtualQuoteTest.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/Tax/Test/Mftf/Test/StorefrontTaxInformationInShoppingCartForGuestVirtualQuoteTest.xml"
+  module: "Tax"
   tests:
-    - testname: "AdminLockAdminUserWhenCreatingNewRoleTest"
-      title: "Lock admin user when creating new admin role"
-      description: "Runs Lock admin user when creating new admin role test."
- 
-- filename: "AdminLockAdminUserWhenCreatingNewIntegrationTest.xml"
-  repo: "https://github.com/magento/magento2/blob/2.3/app/code/Magento/Security/Test/Mftf/Test/AdminLockAdminUserWhenCreatingNewIntegrationTest.xml"
-  module: "Security"
+    - testname: "StorefrontTaxInformationInShoppingCartForGuestVirtualQuoteTest"
+      title: "DEPRECATED. Tax information are updating/recalculating on fly in shopping cart for Guest (virtual quote)"
+      description: "Tax information are updating/recalculating on fly in shopping cart for Guest (virtual quote)"
+- filename: "StorefrontTaxQuoteCartTest.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/Tax/Test/Mftf/Test/StorefrontTaxQuoteCartTest.xml"
+  module: "Tax"
   tests:
-    - testname: "AdminLockAdminUserWhenCreatingNewIntegrationTest"
-      title: "Lock admin user when creating new integration"
-      description: "Runs Lock admin user when creating new integration test."
- 
-- filename: "StorefrontGuestCheckoutDisabledProductTest.xml"
-  repo: "https://github.com/magento/magento2/blob/2.3/app/code/Magento/Quote/Test/Mftf/Test/StorefrontGuestCheckoutDisabledProductTest.xml"
-  module: "Quote"
+    - testname: "StorefrontTaxQuoteCartLoggedInSimple"
+      title: "Tax for Simple Product Quote should be recalculated in Shopping Cart for Logged in Customer with Default Address"
+      description: "Tax for Simple Product Quote should be recalculated in Shopping Cart for Logged in Customer with Default Address"
+
+    - testname: "StorefrontTaxQuoteCartLoggedInVirtual"
+      title: "Tax for Virtual Product Quote should be recalculated in Shopping Cart for Logged in Customer with Default Address"
+      description: "Tax for Virtual Product Quote should be recalculated in Shopping Cart for Logged in Customer with Default Address"
+
+    - testname: "StorefrontTaxQuoteCartGuestSimple"
+      title: "Tax for Simple Product Quote should be recalculated in Shopping Cart for Guest Customer"
+      description: "Tax for Simple Product Quote should be recalculated in Shopping Cart for Guest Customer#anch"
+
+    - testname: "StorefrontTaxQuoteCartGuestVirtual"
+      title: "Tax for Virtual Product Quote should be recalculated in Shopping Cart for Guest Customer"
+      description: "Tax for Virtual Product Quote should be recalculated in Shopping Cart for Guest Customer"
+- filename: "AdminCreateTaxRuleWithCustomerAndProductTaxClassTest.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/Tax/Test/Mftf/Test/AdminCreateTaxRuleWithCustomerAndProductTaxClassTest.xml"
+  module: "Tax"
   tests:
-    - testname: "StorefrontGuestCheckoutDisabledProductTest"
-      title: "Remove item from cart if product disabled"
-      description: "Remove item from cart if simple or configurable product is disabled"
- 
-- filename: "StorefrontProductWithMapAssignedConfigProductIsCorrectTest.xml"
-  repo: "https://github.com/magento/magento2/blob/2.3/app/code/Magento/Msrp/Test/Mftf/Test/StorefrontProductWithMapAssignedConfigProductIsCorrectTest.xml"
-  module: "Msrp"
+    - testname: "AdminCreateTaxRuleWithCustomerAndProductTaxClassTest"
+      title: "Create tax rule, with customer and product tax class"
+      description: "Test log in to Tax Rule and Create tax rule with customer and product tax class"
+- filename: "AdminTaxCalcWithApplyTaxOnSettingTest.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/Tax/Test/Mftf/Test/AdminTaxCalcWithApplyTaxOnSettingTest.xml"
+  module: "Tax"
   tests:
-    - testname: "StorefrontProductWithMapAssignedConfigProductIsCorrectTest"
-      title: "Check that simple products with MAP assigned to configurable product displayed correctly"
-      description: "Check that simple products with MAP assigned to configurable product displayed correctly"
- 
-- filename: "AdminStoresTermsAndConditionsNavigateMenuTest.xml"
-  repo: "https://github.com/magento/magento2/blob/2.3/app/code/Magento/CheckoutAgreements/Test/Mftf/Test/AdminStoresTermsAndConditionsNavigateMenuTest.xml"
-  module: "CheckoutAgreements"
+    - testname: "AdminTaxCalcWithApplyTaxOnSettingTest"
+      title: "Tax calculation process following 'Apply Tax On' setting"
+      description: "Tax calculation process following 'Apply Tax On' setting"
+- filename: "UpdateAnyRegionTaxRateEntityTest.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/Tax/Test/Mftf/Test/UpdateAnyRegionTaxRateEntityTest.xml"
+  module: "Tax"
   tests:
-    - testname: "AdminStoresTermsAndConditionsNavigateMenuTest"
-      title: "Admin stores terms and conditions navigate menu test"
-      description: "Admin should be able to navigate to Stores &gt; Terms and Conditions"
- 
+    - testname: "UpdateAnyRegionTaxRateEntityTest"
+      title: "Update tax rate, any region"
+      description: "Test log in to Tax Rate and Update Any Region"
+- filename: "AdminSystemImportExportTaxRatesNavigateMenuTest.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/Tax/Test/Mftf/Test/AdminSystemImportExportTaxRatesNavigateMenuTest.xml"
+  module: "Tax"
+  tests:
+    - testname: "AdminSystemImportExportTaxRatesNavigateMenuTest"
+      title: "Admin system import export tax rates navigate menu test"
+      description: "Admin should be able to navigate to System &gt; Import/Export Tax Rates"
+- filename: "AdminStoresTaxRulesNavigateMenuTest.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/Tax/Test/Mftf/Test/AdminStoresTaxRulesNavigateMenuTest.xml"
+  module: "Tax"
+  tests:
+    - testname: "AdminStoresTaxRulesNavigateMenuTest"
+      title: "Admin stores tax rules navigate menu test"
+      description: "Admin should be able to navigate to Stores &gt; Tax Rules"
+- filename: "AdminUpdateTaxRuleWithFixedZipUtahTest.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/Tax/Test/Mftf/Test/AdminUpdateTaxRuleWithFixedZipUtahTest.xml"
+  module: "Tax"
+  tests:
+    - testname: "AdminUpdateTaxRuleWithFixedZipUtahTest"
+      title: "Update tax rule, fixed zip Utah"
+      description: "Test log in to Update tax rule and Update tax rule with fixed zip Utah"
+- filename: "Update01TaxRateEntityTest.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/Tax/Test/Mftf/Test/Update01TaxRateEntityTest.xml"
+  module: "Tax"
+  tests:
+    - testname: "Update01TaxRateEntityTest"
+      title: "Update tax rate, 0.1 rate"
+      description: "Test log in to Tax Rate and Update 0.1 Rate"
+- filename: "AdminCreateTaxRuleWithNewAndExistingTaxRateAndCustomerAndProductTaxClassTest.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/Tax/Test/Mftf/Test/AdminCreateTaxRuleWithNewAndExistingTaxRateAndCustomerAndProductTaxClassTest.xml"
+  module: "Tax"
+  tests:
+    - testname: "AdminCreateTaxRuleWithNewAndExistingTaxRateAndCustomerAndProductTaxClassTest"
+      title: "Test log in to Create Tax Rule and Create Tax Rule with New and Existing Tax Rate, Customer Tax Class, Product Tax Class"
+      description: "Test log in to Create tax rule and Create tax rule with New and Existing Tax Rate, Customer Tax Class, Product Tax Class"
+- filename: "AdminCreateTaxRateZipCodeRangeTest.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/Tax/Test/Mftf/Test/AdminCreateTaxRateZipCodeRangeTest.xml"
+  module: "Tax"
+  tests:
+    - testname: "AdminCreateTaxRateZipCodeRangeTest"
+      title: "Create tax rate, zip code range"
+      description: "Test log in to Create Tax Rate and Create Zip Code Range"
+- filename: "Update1299TaxRateEntityTest.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/Tax/Test/Mftf/Test/Update1299TaxRateEntityTest.xml"
+  module: "Tax"
+  tests:
+    - testname: "Update1299TaxRateEntityTest"
+      title: "Update tax rate, 12.99 rate"
+      description: "Test log in to Tax Rate and Update 12.99 Rate"
+- filename: "AdminCreateTaxRuleWithNewTaxClassesAndTaxRateTest.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/Tax/Test/Mftf/Test/AdminCreateTaxRuleWithNewTaxClassesAndTaxRateTest.xml"
+  module: "Tax"
+  tests:
+    - testname: "AdminCreateTaxRuleWithNewTaxClassesAndTaxRateTest"
+      title: "Creating tax rule with new tax classes and tax rate"
+      description: "Test log in to Create Tax Rule and Create tax rule with New Tax Classes and Tax Rate"
+- filename: "AdminDeleteTaxRuleTest.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/Tax/Test/Mftf/Test/AdminDeleteTaxRuleTest.xml"
+  module: "Tax"
+  tests:
+    - testname: "AdminDeleteTaxRuleTest"
+      title: "Delete tax rule"
+      description: "Test log in to tax rule and Delete tax rule"
+- filename: "AdminCheckCreditMemoTotalsTest.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/Tax/Test/Mftf/Test/AdminCheckCreditMemoTotalsTest.xml"
+  module: "Tax"
+  tests:
+    - testname: "AdminCheckCreditMemoTotalsTest"
+      title: "Checking Credit memo Totals"
+      description: "Checking Credit memo Totals"
+- filename: "AdminTaxReportGridTest.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/Tax/Test/Mftf/Test/AdminTaxReportGridTest.xml"
+  module: "Tax"
+  tests:
+    - testname: "AdminTaxReportGridTest"
+      title: "Checking Tax Report grid"
+      description: "Tax Report Grid displays Tax amount in rows 'Total' and 'Subtotal' is a sum of all tax amounts"
+- filename: "StorefrontTaxInformationInShoppingCartForCustomerPhysicalQuoteTest.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/Tax/Test/Mftf/Test/StorefrontTaxInformationInShoppingCartForCustomerPhysicalQuoteTest.xml"
+  module: "Tax"
+  tests:
+    - testname: "StorefrontTaxInformationInShoppingCartForCustomerPhysicalQuoteTest"
+      title: "DEPRECATED. Tax information are updating/recalculating on fly in shopping cart for Customer with default addresses (physical quote)"
+      description: "Tax information are updating/recalculating on fly in shopping cart for Customer with default addresses (physical quote)"
+- filename: "AdminStoresTaxZonesAndRatesNavigateMenuTest.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/Tax/Test/Mftf/Test/AdminStoresTaxZonesAndRatesNavigateMenuTest.xml"
+  module: "Tax"
+  tests:
+    - testname: "AdminStoresTaxZonesAndRatesNavigateMenuTest"
+      title: "Admin stores tax  zones and rates navigate menu test"
+      description: "Admin should be able to navigate to Stores &gt; Tax Zones and Rates"
+- filename: "AdminCreateDefaultsTaxRuleTest.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/Tax/Test/Mftf/Test/AdminCreateDefaultsTaxRuleTest.xml"
+  module: "Tax"
+  tests:
+    - testname: "AdminCreateDefaultsTaxRuleTest"
+      title: "Create tax rule, defaults"
+      description: "Test log in to Create Tax Rule and Create Defaults Tax Rule"
+- filename: "AdminCreateTaxRateSpecificPostcodeTest.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/Tax/Test/Mftf/Test/AdminCreateTaxRateSpecificPostcodeTest.xml"
+  module: "Tax"
+  tests:
+    - testname: "AdminCreateTaxRateSpecificPostcodeTest"
+      title: "Create tax rate, specific postcode"
+      description: "Test log in to Create Tax Rate and Create specific Postcode"
+- filename: "AdminCreateTaxRateAllPostCodesTest.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/Tax/Test/Mftf/Test/AdminCreateTaxRateAllPostCodesTest.xml"
+  module: "Tax"
+  tests:
+    - testname: "AdminCreateTaxRateAllPostCodesTest"
+      title: "Create tax rate, all postcodes"
+      description: "Tests log into Create tax rate and create all postcodes"
+- filename: "AdminCreateTaxRateLargeRateTest.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/Tax/Test/Mftf/Test/AdminCreateTaxRateLargeRateTest.xml"
+  module: "Tax"
+  tests:
+    - testname: "AdminCreateTaxRateLargeRateTest"
+      title: "Create tax rate, large rate"
+      description: "Test log in to Create Tax Rate and Create Large Rate"
+- filename: "StorefrontTaxInformationInShoppingCartForCustomerVirtualQuoteTest.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/Tax/Test/Mftf/Test/StorefrontTaxInformationInShoppingCartForCustomerVirtualQuoteTest.xml"
+  module: "Tax"
+  tests:
+    - testname: "StorefrontTaxInformationInShoppingCartForCustomerVirtualQuoteTest"
+      title: "DEPRECATED. Tax information are updating/recalculating on fly in shopping cart for Customer with default addresses (virtual quote)"
+      description: "Tax information are updating/recalculating on fly in shopping cart for Customer with default addresses (virtual quote)"
+- filename: "AdminUpdateTaxRuleWithCustomClassesTest.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/Tax/Test/Mftf/Test/AdminUpdateTaxRuleWithCustomClassesTest.xml"
+  module: "Tax"
+  tests:
+    - testname: "AdminUpdateTaxRuleWithCustomClassesTest"
+      title: "Update tax rule, tax rule with custom classes"
+      description: "Test log in to Update tax rule and Update tax rule with custom classes"
+- filename: "StorefrontTaxInformationInShoppingCartForGuestPhysicalQuoteTest.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/Tax/Test/Mftf/Test/StorefrontTaxInformationInShoppingCartForGuestPhysicalQuoteTest.xml"
+  module: "Tax"
+  tests:
+    - testname: "StorefrontTaxInformationInShoppingCartForGuestPhysicalQuoteTest"
+      title: "DEPRECATED. Tax information are updating/recalculating on fly in shopping cart for Guest (physical quote)"
+      description: "Tax information are updating/recalculating on fly in shopping cart for Guest (physical quote)"
+- filename: "CheckCreditMemoTotalsTest.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/Tax/Test/Mftf/Test/CheckCreditMemoTotalsTest.xml"
+  module: "Tax"
+  tests:
+    - testname: "CheckCreditMemoTotalsTest"
+      title: "DEPRECATED. Checking Credit memo Totals"
+      description: "Checking Credit memo Totals"
+- filename: "AdminCreateTaxRateWiderZipCodeRangeTest.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/Tax/Test/Mftf/Test/AdminCreateTaxRateWiderZipCodeRangeTest.xml"
+  module: "Tax"
+  tests:
+    - testname: "AdminCreateTaxRateWiderZipCodeRangeTest"
+      title: "Create tax rate, wider zip code range"
+      description: "Test log in to Create Tax Rate and Create Wider Zip Code Range"
+- filename: "UpdateLargeTaxRateEntityTest.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/Tax/Test/Mftf/Test/UpdateLargeTaxRateEntityTest.xml"
+  module: "Tax"
+  tests:
+    - testname: "UpdateLargeTaxRateEntityTest"
+      title: "Update tax rate, large rate"
+      description: "Test log in to Tax Rate and Update Large Rate"
+- filename: "DeleteTaxRateEntityTest.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/Tax/Test/Mftf/Test/DeleteTaxRateEntityTest.xml"
+  module: "Tax"
+  tests:
+    - testname: "DeleteTaxRateEntityTest"
+      title: "Delete tax rate"
+      description: "Test log in to Tax Rate and Delete Tax Rate"
+- filename: "Update100TaxRateEntityTest.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/Tax/Test/Mftf/Test/Update100TaxRateEntityTest.xml"
+  module: "Tax"
+  tests:
+    - testname: "Update100TaxRateEntityTest"
+      title: "Update tax rate, 100 rate"
+      description: "Test log in to Tax Rate and Update 100 Rate"
+- filename: "AdminUpdateDefaultTaxRuleTest.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/Tax/Test/Mftf/Test/AdminUpdateDefaultTaxRuleTest.xml"
+  module: "Tax"
+  tests:
+    - testname: "AdminUpdateDefaultTaxRuleTest"
+      title: "Update tax rule, tax rule default"
+      description: "Test log in to Update tax rule and Update default tax rule"
+- filename: "TransactionalEmailsLogoUploadTest.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/Email/Test/Mftf/Test/TransactionalEmailsLogoUploadTest.xml"
+  module: "Email"
+  tests:
+    - testname: "TransactionalEmailsLogoUploadTest"
+      title: "MC-13908: Uploading a Transactional Emails logo"
+      description: "Transactional Emails Logo should be able to be uploaded in the admin and previewed"
+- filename: "AdminMarketingEmailTemplatesNavigateMenuTest.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/Email/Test/Mftf/Test/AdminMarketingEmailTemplatesNavigateMenuTest.xml"
+  module: "Email"
+  tests:
+    - testname: "AdminMarketingEmailTemplatesNavigateMenuTest"
+      title: "Admin marketing email templates navigate menu test"
+      description: "Admin should be able to navigate to Marketing &gt; Email Templates"
+- filename: "AdminEmailTemplatePreviewTest.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/Email/Test/Mftf/Test/AdminEmailTemplatePreviewTest.xml"
+  module: "Email"
+  tests:
+    - testname: "AdminEmailTemplatePreviewTest"
+      title: "Check email template preview"
+      description: "Check if email template preview works correctly"
+
+    - testname: "AdminEmailTemplatePreviewWithDirectivesTest"
+      title: "Check email template preview with directives"
+      description: "Check if email template preview works correctly with directives"
+
+    - testname: "AdminEmailTemplatePreviewAsDraftWithDirectivesTest"
+      title: "Check email template preview with directives and preview as draft"
+      description: "Check if email template preview works correctly with directives in draft mode"
+- filename: "AdminMarketingSiteMapNavigateMenuTest.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/Sitemap/Test/Mftf/Test/AdminMarketingSiteMapNavigateMenuTest.xml"
+  module: "Sitemap"
+  tests:
+    - testname: "AdminMarketingSiteMapNavigateMenuTest"
+      title: "Admin marketing site map navigate menu test"
+      description: "Admin should be able to navigate to Marketing &gt; Site Map"
+- filename: "AdminMarketingSiteMapCreateNewTest.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/Sitemap/Test/Mftf/Test/AdminMarketingSiteMapCreateNewTest.xml"
+  module: "Sitemap"
+  tests:
+    - testname: "AdminMarketingSiteMapCreateNewTest"
+      title: "Create New Site Map with valid data"
+      description: "Create New Site Map with valid data"
+- filename: "AdminCreateDownloadableProductWithoutFillingQuantityAndStockTest.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/Downloadable/Test/Mftf/Test/AdminCreateDownloadableProductWithoutFillingQuantityAndStockTest.xml"
+  module: "Downloadable"
+  tests:
+    - testname: "AdminCreateDownloadableProductWithoutFillingQuantityAndStockTest"
+      title: "Create downloadable product without filling quantity and stock test"
+      description: "Admin should be able to create downloadable product without filling quantity and stock"
+- filename: "AdminCreateDownloadableProductWithSpecialPriceTest.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/Downloadable/Test/Mftf/Test/AdminCreateDownloadableProductWithSpecialPriceTest.xml"
+  module: "Downloadable"
+  tests:
+    - testname: "AdminCreateDownloadableProductWithSpecialPriceTest"
+      title: "Create downloadable product with special price test"
+      description: "Admin should be able to create downloadable product with special price"
+- filename: "AdminCreateDownloadableProductAndAssignItToCustomStoreTest.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/Downloadable/Test/Mftf/Test/AdminCreateDownloadableProductAndAssignItToCustomStoreTest.xml"
+  module: "Downloadable"
+  tests:
+    - testname: "AdminCreateDownloadableProductAndAssignItToCustomStoreTest"
+      title: "Create downloadable product and assign it to custom store test"
+      description: "Admin should be able to create downloadable and assign it to custom website"
+- filename: "AdminRemoveDefaultVideoDownloadableProductTest.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/Downloadable/Test/Mftf/Test/AdminRemoveDefaultVideoDownloadableProductTest.xml"
+  module: "Downloadable"
+  tests:
+    - testname: "AdminRemoveDefaultVideoDownloadableProductTest"
+      title: "Admin should be able to remove default video from a Downloadable Product"
+      description: "Admin should be able to remove default video from a Downloadable Product"
+- filename: "AdminCreateDownloadableProductWithCustomOptionsTest.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/Downloadable/Test/Mftf/Test/AdminCreateDownloadableProductWithCustomOptionsTest.xml"
+  module: "Downloadable"
+  tests:
+    - testname: "AdminCreateDownloadableProductWithCustomOptionsTest"
+      title: "Create downloadable product with custom options test"
+      description: "Admin should be able to create downloadable product with custom options"
+- filename: "NewProductsListWidgetDownloadableProductTest.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/Downloadable/Test/Mftf/Test/NewProductsListWidgetDownloadableProductTest.xml"
+  module: "Downloadable"
+  tests:
+    - testname: "NewProductsListWidgetDownloadableProductTest"
+      title: "Admin should be able to set Downloadable Product as new so that it shows up in the Catalog New Products List Widget"
+      description: "Admin should be able to set Downloadable Product as new so that it shows up in the Catalog New Products List Widget"
+- filename: "AdminCreateDownloadableProductWithoutTaxClassIdTest.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/Downloadable/Test/Mftf/Test/AdminCreateDownloadableProductWithoutTaxClassIdTest.xml"
+  module: "Downloadable"
+  tests:
+    - testname: "AdminCreateDownloadableProductWithoutTaxClassIdTest"
+      title: "Create downloadable product without tax class id test"
+      description: "Admin should be able to create downloadable product without tax class id"
+- filename: "VerifyDisableDownloadableProductSamplesAreNotAccessibleTest.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/Downloadable/Test/Mftf/Test/VerifyDisableDownloadableProductSamplesAreNotAccessibleTest.xml"
+  module: "Downloadable"
+  tests:
+    - testname: "VerifyDisableDownloadableProductSamplesAreNotAccessibleTest"
+      title: "Samples of Downloadable Products are not accessible, if product is disabled"
+      description: "Samples of Downloadable Products are not accessible, if product is disabled"
+- filename: "AdminCreateDownloadableProductWithGroupPriceTest.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/Downloadable/Test/Mftf/Test/AdminCreateDownloadableProductWithGroupPriceTest.xml"
+  module: "Downloadable"
+  tests:
+    - testname: "AdminCreateDownloadableProductWithGroupPriceTest"
+      title: "Create downloadable product with group price test"
+      description: "Admin should be able to create downloadable product with group price"
+- filename: "AdminCreateDownloadableProductWithDefaultSetLinksTest.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/Downloadable/Test/Mftf/Test/AdminCreateDownloadableProductWithDefaultSetLinksTest.xml"
+  module: "Downloadable"
+  tests:
+    - testname: "AdminCreateDownloadableProductWithDefaultSetLinksTest"
+      title: "Create downloadable product with default set links"
+      description: "Admin should be able to create downloadable product with default set links"
+- filename: "AdminRemoveDefaultImageDownloadableProductTest.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/Downloadable/Test/Mftf/Test/AdminRemoveDefaultImageDownloadableProductTest.xml"
+  module: "Downloadable"
+  tests:
+    - testname: "AdminRemoveDefaultImageDownloadableProductTest"
+      title: "Admin should be able to remove default images from a Downloadable Product"
+      description: "Admin should be able to remove default images from a Downloadable Product"
+- filename: "AdminAddDefaultImageDownloadableProductTest.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/Downloadable/Test/Mftf/Test/AdminAddDefaultImageDownloadableProductTest.xml"
+  module: "Downloadable"
+  tests:
+    - testname: "AdminAddDefaultImageDownloadableProductTest"
+      title: "Admin should be able to add default images for a Downloadable Product"
+      description: "Admin should be able to add default images for a Downloadable Product"
+- filename: "AdminProductTypeSwitchingOnEditingTest.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/Downloadable/Test/Mftf/Test/AdminProductTypeSwitchingOnEditingTest.xml"
+  module: "Downloadable"
+  tests:
+    - testname: "AdminDownloadableProductTypeSwitchingToConfigurableProductTest"
+      title: "Downloadable product type switching on editing to configurable product"
+      description: "Downloadable product type switching on editing to configurable product"
+
+    - testname: "AdminSimpleProductTypeSwitchingToDownloadableProductTest"
+      title: "Simple product type switching on editing to downloadable product"
+      description: "Simple product type switching on editing to downloadable product"
+- filename: "StorefrontAdvanceCatalogSearchDownloadableBySkuWithHyphenTest.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/Downloadable/Test/Mftf/Test/StorefrontAdvanceCatalogSearchDownloadableBySkuWithHyphenTest.xml"
+  module: "Downloadable"
+  tests:
+    - testname: "StorefrontAdvanceCatalogSearchDownloadableBySkuWithHyphenTest"
+      title: "Guest customer should be able to advance search Downloadable product with product sku that contains hyphen"
+      description: "Guest customer should be able to advance search Downloadable product with product that contains hyphen"
+- filename: "AdvanceCatalogSearchDownloadableProductTest.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/Downloadable/Test/Mftf/Test/AdvanceCatalogSearchDownloadableProductTest.xml"
+  module: "Downloadable"
+  tests:
+    - testname: "AdvanceCatalogSearchDownloadableByNameTest"
+      title: "Guest customer should be able to advance search Downloadable product with product name"
+      description: "Guest customer should be able to advance search Downloadable product with product name"
+
+    - testname: "AdvanceCatalogSearchDownloadableBySkuTest"
+      title: "Guest customer should be able to advance search Downloadable product with product sku"
+      description: "Guest customer should be able to advance search Downloadable product with product sku"
+
+    - testname: "AdvanceCatalogSearchDownloadableByDescriptionTest"
+      title: "Guest customer should be able to advance search Downloadable product with product description"
+      description: "Guest customer should be able to advance search Downloadable product with product description"
+
+    - testname: "AdvanceCatalogSearchDownloadableByShortDescriptionTest"
+      title: "Guest customer should be able to advance search Downloadable product with product short description"
+      description: "Guest customer should be able to advance search Downloadable product with product short description"
+
+    - testname: "AdvanceCatalogSearchDownloadableByPriceTest"
+      title: "Guest customer should be able to advance search Downloadable product with product price"
+      description: "Guest customer should be able to advance search Downloadable product with product price"
+- filename: "EndToEndB2CAdminTest.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/Downloadable/Test/Mftf/Test/EndToEndB2CAdminTest.xml"
+  module: "Downloadable"
+  tests:
+    - testname: "EndToEndB2CAdminTest"
+      title: ""
+      description: ""
+- filename: "AdminDownloadableSetEditRelatedProductsTest.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/Downloadable/Test/Mftf/Test/AdminDownloadableSetEditRelatedProductsTest.xml"
+  module: "Downloadable"
+  tests:
+    - testname: "AdminDownloadableSetEditRelatedProductsTest"
+      title: "Admin should be able to set/edit Related Products information when editing a downloadable product"
+      description: "Admin should be able to set/edit Related Products information when editing a downloadable product"
+- filename: "LinkDownloadableProductFromGuestToCustomerTest.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/Downloadable/Test/Mftf/Test/LinkDownloadableProductFromGuestToCustomerTest.xml"
+  module: "Downloadable"
+  tests:
+    - testname: "LinkDownloadableProductFromGuestToCustomerTest"
+      title: "Customer should see downloadable products after place order as guest and registering after that"
+      description: "Verify that in 'My Downloadable Products' section in customer account user can see products."
+- filename: "AdminCreateDownloadableProductWithOutOfStockStatusTest.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/Downloadable/Test/Mftf/Test/AdminCreateDownloadableProductWithOutOfStockStatusTest.xml"
+  module: "Downloadable"
+  tests:
+    - testname: "AdminCreateDownloadableProductWithOutOfStockStatusTest"
+      title: "Create downloadable product with out of stock status test"
+      description: "Admin should be able to create downloadable product with out of stock status"
+- filename: "AdminCreateDownloadableProductWithInvalidDomainLinkUrlTest.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/Downloadable/Test/Mftf/Test/AdminCreateDownloadableProductWithInvalidDomainLinkUrlTest.xml"
+  module: "Downloadable"
+  tests:
+    - testname: "AdminCreateDownloadableProductWithInvalidDomainLinkUrlTest"
+      title: "Create Downloadable Product with invalid domain link url"
+      description: "Admin should not be able to create downloadable product with invalid domain link url"
+- filename: "StorefrontVerifySecureURLRedirectDownloadableTest.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/Downloadable/Test/Mftf/Test/StorefrontVerifySecureURLRedirectDownloadableTest.xml"
+  module: "Downloadable"
+  tests:
+    - testname: "StorefrontVerifySecureURLRedirectDownloadable"
+      title: "Verify Secure URLs For Storefront Downloadable Pages"
+      description: "Verify that the Secure URL configuration applies to the Downloadable pages on the Storefront"
+- filename: "ManualSelectAllDownloadableLinksDownloadableProductTest.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/Downloadable/Test/Mftf/Test/ManualSelectAllDownloadableLinksDownloadableProductTest.xml"
+  module: "Downloadable"
+  tests:
+    - testname: "ManualSelectAllDownloadableLinksDownloadableProductTest"
+      title: "Manual select all downloadable links downloadable product test"
+      description: "Manually selecting all downloadable links must change 'Select/Unselect all' button label to 'Unselect all', and 'Select all' otherwise"
+- filename: "EditDownloadableProductWithSeparateLinksFromCartTest.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/Downloadable/Test/Mftf/Test/EditDownloadableProductWithSeparateLinksFromCartTest.xml"
+  module: "Downloadable"
+  tests:
+    - testname: "EditDownloadableProductWithSeparateLinksFromCartTest"
+      title: "Edit downloadable product with separate links from cart test"
+      description: "Product price should remain correct when editing downloadable product with separate links from cart."
+- filename: "AdminCreateDownloadableProductWithManageStockTest.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/Downloadable/Test/Mftf/Test/AdminCreateDownloadableProductWithManageStockTest.xml"
+  module: "Downloadable"
+  tests:
+    - testname: "AdminCreateDownloadableProductWithManageStockTest"
+      title: "Create downloadable product with manage stock test"
+      description: "Admin should be able to create downloadable product with manage stock"
+- filename: "AdminAddDefaultVideoDownloadableProductTest.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/Downloadable/Test/Mftf/Test/AdminAddDefaultVideoDownloadableProductTest.xml"
+  module: "Downloadable"
+  tests:
+    - testname: "AdminAddDefaultVideoDownloadableProductTest"
+      title: "Admin should be able to add default video for a Downloadable Product"
+      description: "Admin should be able to add default video for a Downloadable Product"
+- filename: "AdminDeleteDownloadableProductTest.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/Downloadable/Test/Mftf/Test/AdminDeleteDownloadableProductTest.xml"
+  module: "Downloadable"
+  tests:
+    - testname: "AdminDeleteDownloadableProductTest"
+      title: "Delete Downloadable Product"
+      description: "Admin should be able to delete a downloadable product"
+- filename: "AdminDownloadableProductSetEditContentTest.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/Downloadable/Test/Mftf/Test/AdminDownloadableProductSetEditContentTest.xml"
+  module: "Downloadable"
+  tests:
+    - testname: "AdminDownloadableProductSetEditContentTest"
+      title: "Admin should be able to set/edit product Content when editing a downloadable product"
+      description: "Admin should be able to set/edit product Content when editing a downloadable product"
+- filename: "AdminCreateDownloadableProductWithLinkTest.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/Downloadable/Test/Mftf/Test/AdminCreateDownloadableProductWithLinkTest.xml"
+  module: "Downloadable"
+  tests:
+    - testname: "AdminCreateDownloadableProductWithLinkTest"
+      title: "Create Downloadable Product with link"
+      description: "Admin should be able to create downloadable product with one simple link"
+- filename: "AdminCreateAndEditDownloadableProductSettingsTest.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/Downloadable/Test/Mftf/Test/AdminCreateAndEditDownloadableProductSettingsTest.xml"
+  module: "Downloadable"
+  tests:
+    - testname: "AdminCreateAndEditDownloadableProductSettingsTest"
+      title: "Admin should be able to set/edit other product information when creating/editing a downloadable product"
+      description: "Admin should be able to set/edit other product information when creating/editing a downloadable product"
+- filename: "SelectAllDownloadableLinksDownloadableProductTest.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/Downloadable/Test/Mftf/Test/SelectAllDownloadableLinksDownloadableProductTest.xml"
+  module: "Downloadable"
+  tests:
+    - testname: "SelectAllDownloadableLinksDownloadableProductTest"
+      title: "Select all downloadable links downloadable product test"
+      description: "All the downloadable links must be selected or unselected when anyone click on select all or unselect all checkbox respectively."
+- filename: "AdminGridFilterDeleteAndVerifyErrorMessageTest.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/Ui/Test/Mftf/Test/AdminGridFilterDeleteAndVerifyErrorMessageTest.xml"
+  module: "Ui"
+  tests:
+    - testname: "AdminGridFilterDeleteAndVerifyErrorMessageTest"
+      title: "Grid Filter Delete and Verify Error Message"
+      description: "Test log in to uI and Delete Grid Filter Test"
+- filename: "AdminExportSimpleProductAssignedToMainWebsiteAndConfigurableProductAssignedToCustomWebsiteTest.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/CatalogImportExport/Test/Mftf/Test/AdminExportSimpleProductAssignedToMainWebsiteAndConfigurableProductAssignedToCustomWebsiteTest.xml"
+  module: "CatalogImportExport"
+  tests:
+    - testname: "AdminExportSimpleProductAssignedToMainWebsiteAndConfigurableProductAssignedToCustomWebsiteTest"
+      title: "Export Simple Product assigned to Main Website and Configurable Product assigned to Custom Website"
+      description: "Admin should be able to export Simple Product assigned to Main Website and Configurable Product assigned to Custom Website"
+- filename: "AdminExportSimpleProductAndConfigurableProductsWithAssignedImagesTest.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/CatalogImportExport/Test/Mftf/Test/AdminExportSimpleProductAndConfigurableProductsWithAssignedImagesTest.xml"
+  module: "CatalogImportExport"
+  tests:
+    - testname: "AdminExportSimpleProductAndConfigurableProductsWithAssignedImagesTest"
+      title: "Export Simple product and Configurable products with assigned images"
+      description: "Admin should be able to export Simple and Configurable products with assigned images"
+- filename: "AdminExportSimpleAndConfigurableProductsWithCustomOptionsTest.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/CatalogImportExport/Test/Mftf/Test/AdminExportSimpleAndConfigurableProductsWithCustomOptionsTest.xml"
+  module: "CatalogImportExport"
+  tests:
+    - testname: "AdminExportSimpleAndConfigurableProductsWithCustomOptionsTest"
+      title: "Export Simple and Configurable products with custom options"
+      description: "Admin should be able to export Simple and Configurable products with custom options"
+- filename: "AdminExportGroupedProductWithSpecialPriceTest.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/CatalogImportExport/Test/Mftf/Test/AdminExportGroupedProductWithSpecialPriceTest.xml"
+  module: "CatalogImportExport"
+  tests:
+    - testname: "AdminExportGroupedProductWithSpecialPriceTest"
+      title: "Export grouped product with special price"
+      description: "Admin should be able to export grouped product with special price"
+- filename: "AdminExportBundleProductTest.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/CatalogImportExport/Test/Mftf/Test/AdminExportBundleProductTest.xml"
+  module: "CatalogImportExport"
+  tests:
+    - testname: "AdminExportBundleProductTest"
+      title: "Export Bundle Product"
+      description: "Admin should be able to export Bundle Product"
+- filename: "AdminExportImportConfigurableProductWithImagesTest.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/CatalogImportExport/Test/Mftf/Test/AdminExportImportConfigurableProductWithImagesTest.xml"
+  module: "CatalogImportExport"
+  tests:
+    - testname: "AdminExportImportConfigurableProductWithImagesTest"
+      title: "Check importing of configurable products with images present in filesystem"
+      description: "Check importing of configurable products with images present in filesystem"
+- filename: "AdminExportSimpleProductWithCustomAttributeTest.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/CatalogImportExport/Test/Mftf/Test/AdminExportSimpleProductWithCustomAttributeTest.xml"
+  module: "CatalogImportExport"
+  tests:
+    - testname: "AdminExportSimpleProductWithCustomAttributeTest"
+      title: "Export Simple Product with custom attribute"
+      description: "Admin should be able to export Simple Product with custom attribute"
+- filename: "AdminAdvancedReportingButtonTest.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/Analytics/Test/Mftf/Test/AdminAdvancedReportingButtonTest.xml"
+  module: "Analytics"
+  tests:
+    - testname: "AdminAdvancedReportingButtonTest"
+      title: "AdvancedReportingButtonTest"
+      description: "Test log in to AdvancedReporting and tests AdvancedReportingButtonTest"
+- filename: "AdminConfigurationTimeToSendDataTest.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/Analytics/Test/Mftf/Test/AdminConfigurationTimeToSendDataTest.xml"
+  module: "Analytics"
+  tests:
+    - testname: "AdminConfigurationTimeToSendDataTest"
+      title: "Time of the day to collect data"
+      description: "An admin user can change the time of the day to collect data setting on the Advanced Reporting configuration page."
+- filename: "AdminAdvancedReportingNavigateMenuTest.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/Analytics/Test/Mftf/Test/AdminAdvancedReportingNavigateMenuTest.xml"
+  module: "Analytics"
+  tests:
+    - testname: "AdminAdvancedReportingNavigateMenuTest"
+      title: "Admin advanced reporting navigate menu test"
+      description: "Admin should be able to navigate through advanced reporting admin menu to BI reports page"
+- filename: "AdminConfigurationEnableDisableAnalyticsTest.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/Analytics/Test/Mftf/Test/AdminConfigurationEnableDisableAnalyticsTest.xml"
+  module: "Analytics"
+  tests:
+    - testname: "AdminConfigurationEnableDisableAnalyticsTest"
+      title: "Enable Disable Advanced Reporting"
+      description: "An admin user can enable/disable Advanced Reporting."
+- filename: "AdminConfigurationIndustryTest.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/Analytics/Test/Mftf/Test/AdminConfigurationIndustryTest.xml"
+  module: "Analytics"
+  tests:
+    - testname: "AdminConfigurationIndustryTest"
+      title: "Set Magento Advanced reporting industry"
+      description: "An admin user can change the industry setting on the Advanced Reporting configuration page."
+- filename: "AdminConfigurationPermissionTest.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/Analytics/Test/Mftf/Test/AdminConfigurationPermissionTest.xml"
+  module: "Analytics"
+  tests:
+    - testname: "AdminConfigurationPermissionTest"
+      title: "Advanced Reporting configuration permission"
+      description: "An admin user without Analytics permissions should not be able to see the Advanced Reporting configuration page."
+- filename: "AdminConfigurationBlankIndustryTest.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/Analytics/Test/Mftf/Test/AdminConfigurationBlankIndustryTest.xml"
+  module: "Analytics"
+  tests:
+    - testname: "AdminConfigurationBlankIndustryTest"
+      title: "Try to save empty Magento Advanced Reporting vertical"
+      description: "An admin user cannot save a blank industry setting on the Advanced Reporting configuration page."
+- filename: "AdminCreateCustomCMSPageUrlRewriteAndAddTemporaryRedirectTest.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/UrlRewrite/Test/Mftf/Test/AdminCreateCustomCMSPageUrlRewriteAndAddTemporaryRedirectTest.xml"
+  module: "UrlRewrite"
+  tests:
+    - testname: "AdminCreateCustomCMSPageUrlRewriteAndAddTemporaryRedirectTest"
+      title: "Create custom URL rewrite, CMS temporary"
+      description: "Login as Admin and create custom CMS page UrlRewrite and add Temporary redirect type "
+- filename: "AdminCreateProductURLRewriteWithCategoryAndAddTemporaryRedirectTest.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/UrlRewrite/Test/Mftf/Test/AdminCreateProductURLRewriteWithCategoryAndAddTemporaryRedirectTest.xml"
+  module: "UrlRewrite"
+  tests:
+    - testname: "AdminCreateProductURLRewriteWithCategoryAndAddTemporaryRedirectTest"
+      title: "Create product URL rewrite, add temporary redirect for product"
+      description: "Login as admin, create product with category and UrlRewrite and add temporary redirect  "
+- filename: "AdminCheckUrlRewritesCorrectlyGeneratedForMultipleStoreviewsDuringProductImportTest.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/UrlRewrite/Test/Mftf/Test/AdminCheckUrlRewritesCorrectlyGeneratedForMultipleStoreviewsDuringProductImportTest.xml"
+  module: "UrlRewrite"
+  tests:
+    - testname: "AdminCheckUrlRewritesCorrectlyGeneratedForMultipleStoreviewsDuringProductImportTest"
+      title: "Url Rewrites Correctly Generated for Multiple Storeviews During Product Import"
+      description: "Check Url Rewrites Correctly Generated for Multiple Storeviews During Product Import."
+
+    - testname: "AdminCheckUrlRewritesCorrectlyGeneratedForMultipleStoreviewsDuringProductImportTestWithConfigurationTurnedOff"
+      title: "Url Rewrites Correctly Generated for Multiple Storeviews During Product Import With Configuration Turned Off"
+      description: "Check Url Rewrites Correctly Generated for Multiple Storeviews During Product Import."
+- filename: "AdminUpdateCategoryUrlRewriteAndAddTemporaryRedirectTest.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/UrlRewrite/Test/Mftf/Test/AdminUpdateCategoryUrlRewriteAndAddTemporaryRedirectTest.xml"
+  module: "UrlRewrite"
+  tests:
+    - testname: "AdminUpdateCategoryUrlRewriteAndAddTemporaryRedirectTest"
+      title: "Update Category URL Rewrites, Temporary redirect type"
+      description: "Login as Admin and update category UrlRewrite and add Temporary redirect type"
+- filename: "AdminCheckUrlRewritesInCatalogCategoriesAfterChangingUrlKeyForStoreViewAndMovingCategoryTest.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/UrlRewrite/Test/Mftf/Test/AdminCheckUrlRewritesInCatalogCategoriesAfterChangingUrlKeyForStoreViewAndMovingCategoryTest.xml"
+  module: "UrlRewrite"
+  tests:
+    - testname: "AdminCheckUrlRewritesInCatalogCategoriesAfterChangingUrlKeyForStoreViewAndMovingCategoryTest"
+      title: "DEPRECATED. Check url rewrites in catalog categories after changing url key"
+      description: "DEPRECATED. Check url rewrites in catalog categories after changing url key for store view and moving category"
+- filename: "AdminUpdateCategoryUrlRewriteAndAddPermanentRedirectTest.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/UrlRewrite/Test/Mftf/Test/AdminUpdateCategoryUrlRewriteAndAddPermanentRedirectTest.xml"
+  module: "UrlRewrite"
+  tests:
+    - testname: "AdminUpdateCategoryUrlRewriteAndAddPermanentRedirectTest"
+      title: "Update Category URL Rewrites, permanent"
+      description: "Login as Admin and update category UrlRewrite and add Permanent redirect type"
+- filename: "AdminCreateProductUrLRewriteAndAddPermanentRedirectTest.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/UrlRewrite/Test/Mftf/Test/AdminCreateProductUrLRewriteAndAddPermanentRedirectTest.xml"
+  module: "UrlRewrite"
+  tests:
+    - testname: "AdminCreateProductUrLRewriteAndAddPermanentRedirectTest"
+      title: "Create product URL rewrite, with permanent redirect"
+      description: "Login as admin, create product UrlRewrite and add Permanent redirect"
+- filename: "AdminUrlRewritesForProductAfterImportTest.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/UrlRewrite/Test/Mftf/Test/AdminUrlRewritesForProductAfterImportTest.xml"
+  module: "UrlRewrite"
+  tests:
+    - testname: "AdminUrlRewritesForProductAfterImportTest"
+      title: "Verify the number of URL rewrites when edit or import product"
+      description: "After importing products to admin verify the number of URL including categories matches"
+- filename: "AdminUpdateCmsPageRewriteEntityWithNoRedirectTest.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/UrlRewrite/Test/Mftf/Test/AdminUpdateCmsPageRewriteEntityWithNoRedirectTest.xml"
+  module: "UrlRewrite"
+  tests:
+    - testname: "AdminUpdateCmsPageRewriteEntityWithNoRedirectTest"
+      title: "Update CMS Page URL Redirect With No Redirect"
+      description: "Login as Admin and tried to update the created URL Rewrite for CMS page"
+- filename: "AdminCreateCustomCategoryUrlRewriteAndAddPermanentRedirectTest.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/UrlRewrite/Test/Mftf/Test/AdminCreateCustomCategoryUrlRewriteAndAddPermanentRedirectTest.xml"
+  module: "UrlRewrite"
+  tests:
+    - testname: "AdminCreateCustomCategoryUrlRewriteAndAddPermanentRedirectTest"
+      title: "Create custom URL rewrite, permanent"
+      description: "Login as Admin and create custom UrlRewrite and add redirect type permenent"
+- filename: "AdminUpdateCategoryUrlRewriteAndAddAspxRequestPathTest.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/UrlRewrite/Test/Mftf/Test/AdminUpdateCategoryUrlRewriteAndAddAspxRequestPathTest.xml"
+  module: "UrlRewrite"
+  tests:
+    - testname: "AdminUpdateCategoryUrlRewriteAndAddAspxRequestPathTest"
+      title: "Update Category URL Rewrites, aspx request path"
+      description: "Login as Admin, update category UrlRewrite, add aspx request path and Temporary redirect type "
+- filename: "AdminCreateProductUrLRewriteAndAddTemporaryRedirectTest.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/UrlRewrite/Test/Mftf/Test/AdminCreateProductUrLRewriteAndAddTemporaryRedirectTest.xml"
+  module: "UrlRewrite"
+  tests:
+    - testname: "AdminCreateProductUrLRewriteAndAddTemporaryRedirectTest"
+      title: "Create product URL rewrite, with temporary redirect"
+      description: "Login as admin, create product UrlRewrite and add Temporary redirect"
+- filename: "AdminUpdateCmsPageRewriteEntityWithTemporaryRedirectTest.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/UrlRewrite/Test/Mftf/Test/AdminUpdateCmsPageRewriteEntityWithTemporaryRedirectTest.xml"
+  module: "UrlRewrite"
+  tests:
+    - testname: "AdminUpdateCmsPageRewriteEntityWithTemporaryRedirectTest"
+      title: "Update CMS Page URL Redirect With Temporary Redirect"
+      description: "Login as Admin and tried to update the created URL Rewrite for CMS page"
+- filename: "AdminCreateCategoryUrlRewriteAndAddTemporaryRedirectTest.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/UrlRewrite/Test/Mftf/Test/AdminCreateCategoryUrlRewriteAndAddTemporaryRedirectTest.xml"
+  module: "UrlRewrite"
+  tests:
+    - testname: "AdminCreateCategoryUrlRewriteAndAddTemporaryRedirectTest"
+      title: "Create category URL rewrite, with temporary redirect"
+      description: "Login as admin and create category UrlRewrite with Temporary redirect"
+- filename: "AdminProductCreateUrlRewriteForCustomStoreViewTest.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/UrlRewrite/Test/Mftf/Test/AdminProductCreateUrlRewriteForCustomStoreViewTest.xml"
+  module: "UrlRewrite"
+  tests:
+    - testname: "AdminProductCreateUrlRewriteForCustomStoreViewTest"
+      title: "Product custom URL Key is preserved when assigned to a Category"
+      description: "Verify Product custom URL Key (for custom Store View) is preserved when assigned to a Category (with custom URL Key) alongside with another Product without custom URL Key"
+- filename: "AdminCreateProductURLRewriteAndAddNoRedirectTest.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/UrlRewrite/Test/Mftf/Test/AdminCreateProductURLRewriteAndAddNoRedirectTest.xml"
+  module: "UrlRewrite"
+  tests:
+    - testname: "AdminCreateProductUrLRewriteAndAddNoRedirectTest"
+      title: "Create product URL rewrite, with no redirect"
+      description: "Login as admin, create product UrlRewrite and add No redirect  "
+- filename: "AdminCreateCategoryUrlRewriteAndAddNoRedirectTest.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/UrlRewrite/Test/Mftf/Test/AdminCreateCategoryUrlRewriteAndAddNoRedirectTest.xml"
+  module: "UrlRewrite"
+  tests:
+    - testname: "AdminCreateCategoryUrlRewriteAndAddNoRedirectTest"
+      title: "Create category URL rewrite, with no redirect"
+      description: "Login as admin and create category UrlRewrite with No redirect"
+- filename: "AdminMarketingUrlRewritesNavigateMenuTest.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/UrlRewrite/Test/Mftf/Test/AdminMarketingUrlRewritesNavigateMenuTest.xml"
+  module: "UrlRewrite"
+  tests:
+    - testname: "AdminMarketingUrlRewritesNavigateMenuTest"
+      title: "Admin marketing url rewrites navigate menu test"
+      description: "Admin should be able to navigate to Marketing &gt; URL Rewrites"
+- filename: "AdminUpdateCategoryUrlRewriteAndAddNoRedirectTest.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/UrlRewrite/Test/Mftf/Test/AdminUpdateCategoryUrlRewriteAndAddNoRedirectTest.xml"
+  module: "UrlRewrite"
+  tests:
+    - testname: "AdminUpdateCategoryUrlRewriteAndAddNoRedirectTest"
+      title: "Update Category URL Rewrites, no redirect type"
+      description: "Login as Admin and update category Url Rewrite and add redirect type No"
+- filename: "AdminCreateCustomProductUrlRewriteAndAddTemporaryRedirectTest.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/UrlRewrite/Test/Mftf/Test/AdminCreateCustomProductUrlRewriteAndAddTemporaryRedirectTest.xml"
+  module: "UrlRewrite"
+  tests:
+    - testname: "AdminCreateCustomProductUrlRewriteAndAddTemporaryRedirectTest"
+      title: "Create custom URL rewrite, temporary"
+      description: "Login as Admin and create custom product UrlRewrite and add Temporary redirect type "
+- filename: "AdminUpdateCmsPageRewriteEntityWithPermanentReirectTest.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/UrlRewrite/Test/Mftf/Test/AdminUpdateCmsPageRewriteEntityWithPermanentReirectTest.xml"
+  module: "UrlRewrite"
+  tests:
+    - testname: "AdminUpdateCmsPageRewriteEntityWithPermanentRedirectTest"
+      title: "Update CMS Page URL Redirect With Permanent Redirect"
+      description: "Login as Admin and tried to update the created URL Rewrite for CMS page"
+- filename: "AdminCreateCategoryUrlRewriteAndAddPermanentRedirectTest.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/UrlRewrite/Test/Mftf/Test/AdminCreateCategoryUrlRewriteAndAddPermanentRedirectTest.xml"
+  module: "UrlRewrite"
+  tests:
+    - testname: "AdminCreateCategoryUrlRewriteAndAddPermanentRedirectTest"
+      title: "Create category URL rewrite, add permanent redirect for category"
+      description: "Login as admin and create category UrlRewrite with Permanent redirect"
+- filename: "AdminCheckUrlRewritesInCatalogCategoriesAfterChangingUrlKeyForStoreViewAndMovingCategory2Test.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/UrlRewrite/Test/Mftf/Test/AdminCheckUrlRewritesInCatalogCategoriesAfterChangingUrlKeyForStoreViewAndMovingCategory2Test.xml"
+  module: "UrlRewrite"
+  tests:
+    - testname: "AdminCheckUrlRewritesInCatalogCategoriesAfterChangingUrlKeyForStoreViewAndMovingCategory2Test"
+      title: "Check url rewrites in catalog categories after changing url key"
+      description: "Check url rewrites in catalog categories after changing url key for store view and moving category"
+- filename: "AdminGenerateUrlRewritesForProductInCategoriesSwitchOffTest.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/UrlRewrite/Test/Mftf/Test/AdminGenerateUrlRewritesForProductInCategoriesSwitchOffTest.xml"
+  module: "UrlRewrite"
+  tests:
+    - testname: "AdminGenerateUrlRewritesForProductInCategoriesSwitchOffTest"
+      title: "Clear Url Rewrites after configuration turned off"
+      description: "Check Url Rewrites for product in categories is correctly cleared after configuration turned off"
+- filename: "AdminUpdateProductUrlRewriteAndAddTemporaryRedirectTest.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/UrlRewrite/Test/Mftf/Test/AdminUpdateProductUrlRewriteAndAddTemporaryRedirectTest.xml"
+  module: "UrlRewrite"
+  tests:
+    - testname: "AdminUpdateProductUrlRewriteAndAddTemporaryRedirectTest"
+      title: "Update Product URL Rewrites"
+      description: "Login as Admin and update product UrlRewrite and add Temporary redirect type "
+- filename: "AdminDeleteCustomUrlRewriteTest.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/UrlRewrite/Test/Mftf/Test/AdminDeleteCustomUrlRewriteTest.xml"
+  module: "UrlRewrite"
+  tests:
+    - testname: "AdminDeleteCustomUrlRewriteTest"
+      title: "Delete custom URL rewrite"
+      description: "Test log in to URL rewrite and Delete custom URL rewrite"
+- filename: "AdminAutoUpdateURLRewriteWhenCategoryIsDeletedTest.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/UrlRewrite/Test/Mftf/Test/AdminAutoUpdateURLRewriteWhenCategoryIsDeletedTest.xml"
+  module: "UrlRewrite"
+  tests:
+    - testname: "AdminAutoUpdateURLRewriteWhenCategoryIsDeletedTest"
+      title: "Create product URL rewrite, autoupdate if subcategory deleted"
+      description: "Login as admin,verify UrlRewrite auto update when subcategory is deleted  "
+- filename: "AdminUpdateCustomURLRewritesTemporaryTest.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/UrlRewrite/Test/Mftf/Test/AdminUpdateCustomURLRewritesTemporaryTest.xml"
+  module: "UrlRewrite"
+  tests:
+    - testname: "AdminUpdateCustomURLRewritesTemporaryTest"
+      title: "Update Custom URL Rewrites, temporary"
+      description: "Test log in to URL Rewrites and Update Custom URL Rewrites, temporary"
+- filename: "AdminCreateProductWithSeveralWebsitesAndCheckURLRewritesTest.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/UrlRewrite/Test/Mftf/Test/AdminCreateProductWithSeveralWebsitesAndCheckURLRewritesTest.xml"
+  module: "UrlRewrite"
+  tests:
+    - testname: "AdminCreateProductWithSeveralWebsitesAndCheckURLRewritesTest"
+      title: "Create product with several websites and check URL Rewrites"
+      description: "Test log in to Create product and Create product with several websites and check URL Rewrites"
+- filename: "AdminCreateCustomCMSPageUrlRewriteAndAddPermanentRedirectTest.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/UrlRewrite/Test/Mftf/Test/AdminCreateCustomCMSPageUrlRewriteAndAddPermanentRedirectTest.xml"
+  module: "UrlRewrite"
+  tests:
+    - testname: "AdminCreateCustomCMSPageUrlRewriteAndAddPermanentRedirectTest"
+      title: "Create custom URL rewrite, CMS permanent"
+      description: "Login as Admin and create custom CMS page UrlRewrite and add Permanent redirect type "
+- filename: "AdminUpdateCustomURLRewritesPermanentTest.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/UrlRewrite/Test/Mftf/Test/AdminUpdateCustomURLRewritesPermanentTest.xml"
+  module: "UrlRewrite"
+  tests:
+    - testname: "AdminUpdateCustomURLRewritesPermanentTest"
+      title: "Update Custom URL Rewrites, permanent"
+      description: "Test log in to URL Rewrites and Update Custom URL Rewrites, permanent"
+- filename: "AdminUrlRewritesForProductInAnchorCategoriesTest.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/UrlRewrite/Test/Mftf/Test/AdminUrlRewritesForProductInAnchorCategoriesTest.xml"
+  module: "UrlRewrite"
+  tests:
+    - testname: "AdminUrlRewritesForProductInAnchorCategoriesTest"
+      title: "Url-rewrites for product in anchor categories"
+      description: "For a product with category that has parent anchor categories, the rewrites is created when the category/product is saved."
+
+    - testname: "AdminUrlRewritesForProductInAnchorCategoriesTestWithConfigurationTurnedOff"
+      title: "Url-rewrites for product in anchor categories with configuration turned off"
+      description: "For a product with category that has parent anchor categories, the rewrites is created when the category/product is saved."
+
+    - testname: "AdminUrlRewritesForProductInAnchorCategoriesTestAllStoreView"
+      title: "Url-rewrites for product in anchor categories for all store views"
+      description: "Verify that Saving category do not delete UrlRewrites for subcategories and all products in them."
+
+    - testname: "AdminUrlRewritesForProductInAnchorCategoriesTestAllStoreViewWithConfigurationTurnedOff"
+      title: "Url-rewrites for product in anchor categories for all store views with configuration turned off"
+      description: "Url-rewrites for product in anchor categories for all store views with configuration turned off"
+
+    - testname: "AdminUrlRewritesForProductsWithConfigurationTurnedOff"
+      title: "No auto generated of request path for simple product when assigned to subCategory"
+      description: "No auto generated of request path when SEO configuration to Generate url rewrite for Generate 'category/product' URL Rewrites is set to No"
+- filename: "StorefrontCheckAdvancedSearchOnElasticSearchTest.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/Elasticsearch/Test/Mftf/Test/StorefrontCheckAdvancedSearchOnElasticSearchTest.xml"
+  module: "Elasticsearch"
+  tests:
+    - testname: "StorefrontCheckAdvancedSearchOnElasticSearchTest"
+      title: "Check Advanced Search on ElasticSearch"
+      description: "Check Advanced Search on ElasticSearch"
+- filename: "StorefrontProductQuickSearchUsingElasticSearch6Test.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/Elasticsearch/Test/Mftf/Test/StorefrontProductQuickSearchUsingElasticSearch6Test.xml"
+  module: "Elasticsearch"
+  tests:
+    - testname: "StorefrontProductQuickSearchUsingElasticSearch6Test"
+      title: "Product quick search doesn't throw exception after ES is chosen as search engine with different amount per page"
+      description: "Verify no elastic search exception is thrown when searching for products, when displayed products per page are greater or equal the size of available products."
+
+    - testname: "StorefrontProductQuickSearchUsingElasticSearch6WithNotAvailablePageTest"
+      title: "Product quick search doesn't throw exception after ES is chosen as search engine with selected page out of range"
+      description: "Verify no elastic search exception is thrown when try to get page with selected page out of range."
+- filename: "ProductQuickSearchUsingElasticSearchTest.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/Elasticsearch/Test/Mftf/Test/ProductQuickSearchUsingElasticSearchTest.xml"
+  module: "Elasticsearch"
+  tests:
+    - testname: "ProductQuickSearchUsingElasticSearchTest"
+      title: "Product quick search doesn't throw exception after ES is chosen as search engine"
+      description: "Verify no elastic search exception is thrown when searching for product before catalogsearch reindexing"
+- filename: "StorefrontProductQuickSearchWithDecimalAttributeUsingElasticSearchTest.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/Elasticsearch/Test/Mftf/Test/StorefrontProductQuickSearchWithDecimalAttributeUsingElasticSearchTest.xml"
+  module: "Elasticsearch"
+  tests:
+    - testname: "StorefrontProductQuickSearchWithDecimalAttributeUsingElasticSearchTest"
+      title: "Search decimal attribute with ElasticSearch"
+      description: "User should be able to search decimal attribute using ElasticSearch"
+- filename: "AdminCheckInputFieldsDisabledAfterAppConfigDumpTest.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/Ups/Test/Mftf/Test/AdminCheckInputFieldsDisabledAfterAppConfigDumpTest.xml"
+  module: "Ups"
+  tests:
+    - testname: "AdminCheckInputFieldsDisabledAfterAppConfigDumpTest"
+      title: ""
+      description: ""
+- filename: "DefaultConfigForUPSTypeTest.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/Ups/Test/Mftf/Test/DefaultConfigForUPSTypeTest.xml"
+  module: "Ups"
+  tests:
+    - testname: "DefaultConfigForUPSTypeTest"
+      title: "Default Configuration for UPS Type"
+      description: "Default Configuration for UPS Type"
+- filename: "AdminCreateAndDeleteBackupsTest.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/Backup/Test/Mftf/Test/AdminCreateAndDeleteBackupsTest.xml"
+  module: "Backup"
+  tests:
+    - testname: "AdminCreateAndDeleteBackupsTest"
+      title: "Create and delete backups"
+      description: "An admin user can create a backup of each type and delete each backup."
+- filename: "StorefrontVerifySecureURLRedirectContactTest.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/Contact/Test/Mftf/Test/StorefrontVerifySecureURLRedirectContactTest.xml"
+  module: "Contact"
+  tests:
+    - testname: "StorefrontVerifySecureURLRedirectContact"
+      title: "Verify Secure URLs For Storefront Contact Pages"
+      description: "Verify that the Secure URL configuration applies to the Contact pages on the Storefront"
+- filename: "AdminCheckInputFieldsDisabledAfterAppConfigDumpTest.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/Usps/Test/Mftf/Test/AdminCheckInputFieldsDisabledAfterAppConfigDumpTest.xml"
+  module: "Usps"
+  tests:
+    - testname: "AdminCheckInputFieldsDisabledAfterAppConfigDumpTest"
+      title: ""
+      description: ""
+- filename: "AdminDeleteConfigurableProductTest.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/ConfigurableProduct/Test/Mftf/Test/AdminDeleteConfigurableProductTest.xml"
+  module: "ConfigurableProduct"
+  tests:
+    - testname: "AdminDeleteConfigurableProductTest"
+      title: "Delete configurable product test"
+      description: "Admin should be able to delete a configurable product"
+- filename: "NewProductsListWidgetConfigurableProductTest.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/ConfigurableProduct/Test/Mftf/Test/NewProductsListWidgetConfigurableProductTest.xml"
+  module: "ConfigurableProduct"
+  tests:
+    - testname: "NewProductsListWidgetConfigurableProductTest"
+      title: "Admin should be able to set Configurable Product as new so that it shows up in the Catalog New Products List Widget"
+      description: "Admin should be able to set Configurable Product as new so that it shows up in the Catalog New Products List Widget"
+- filename: "StorefrontSortingByPriceForConfigurableWithCatalogRuleAppliedTest.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/ConfigurableProduct/Test/Mftf/Test/StorefrontSortingByPriceForConfigurableWithCatalogRuleAppliedTest.xml"
+  module: "ConfigurableProduct"
+  tests:
+    - testname: "StorefrontSortingByPriceForConfigurableProductWithCatalogRuleAppliedTest"
+      title: "DEPRECATED. Sorting by price for Configurable with Catalog Rule applied"
+      description: "Sort by price should be correct if the apply Catalog Rule to child product of configurable product"
+- filename: "AdminCheckConfigurableProductAttributeValueUniquenessTest.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/ConfigurableProduct/Test/Mftf/Test/AdminCheckConfigurableProductAttributeValueUniquenessTest.xml"
+  module: "ConfigurableProduct"
+  tests:
+    - testname: "AdminCheckConfigurableProductAttributeValueUniquenessTest"
+      title: "Attribute value validation (check for uniqueness) in configurable products"
+      description: "Attribute value validation (check for uniqueness) in configurable products"
+- filename: "ConfigurableProductAttributeNameDesignTest.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/ConfigurableProduct/Test/Mftf/Test/ConfigurableProductAttributeNameDesignTest.xml"
+  module: "ConfigurableProduct"
+  tests:
+    - testname: "ConfigurableProductAttributeNameDesignTest"
+      title: "Generation of configurable products with an attribute named 'design'"
+      description: "Generation of configurable products with an attribute named 'design'"
+- filename: "StorefrontVerifyConfigurableProductLayeredNavigationTest.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/ConfigurableProduct/Test/Mftf/Test/StorefrontVerifyConfigurableProductLayeredNavigationTest.xml"
+  module: "ConfigurableProduct"
+  tests:
+    - testname: "StorefrontVerifyConfigurableProductLayeredNavigationTest"
+      title: "Out of stock configurable attribute option doesn't show in Layered Navigation"
+      description: " Login as admin and verify out of stock configurable attribute option doesn't show in Layered Navigation"
+- filename: "AdminConfigurableProductUpdateTest.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/ConfigurableProduct/Test/Mftf/Test/AdminConfigurableProductUpdateTest.xml"
+  module: "ConfigurableProduct"
+  tests:
+    - testname: "AdminConfigurableProductBulkUpdateTest"
+      title: "admin should be able to bulk update attributes of configurable products"
+      description: "admin should be able to bulk update attributes of configurable products"
+
+    - testname: "AdminConfigurableProductRemoveAnOptionTest"
+      title: "Admin should be able to remove a product configuration"
+      description: "Admin should be able to remove a product configuration"
+
+    - testname: "AdminConfigurableProductDisableAnOptionTest"
+      title: "Admin should be able to disable a product configuration"
+      description: "Admin should be able to disable a product configuration"
+
+    - testname: "AdminConfigurableProductRemoveConfigurationTest"
+      title: "Admin should be able to remove a configuration from a Configurable Product"
+      description: "Admin should be able to remove a configuration from a Configurable Product"
+
+    - testname: "AdminConfigurableProductAddConfigurationTest"
+      title: "Admin should be able to edit configuration to add a value to an existing attribute"
+      description: "Admin should be able to edit configuration to add a value to an existing attribute"
+- filename: "AdminCreateConfigurableProductWithTwoOptionsAssignedToCategoryTest.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/ConfigurableProduct/Test/Mftf/Test/AdminCreateConfigurableProductWithTwoOptionsAssignedToCategoryTest.xml"
+  module: "ConfigurableProduct"
+  tests:
+    - testname: "AdminCreateConfigurableProductWithTwoOptionsAssignedToCategoryTest"
+      title: "Create configurable product with two new options assigned to category with not visible child products"
+      description: "Admin should be able to create configurable product with two new options, assigned to category, child products are not visible individually"
+- filename: "NoErrorForMiniCartItemEditTest.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/ConfigurableProduct/Test/Mftf/Test/NoErrorForMiniCartItemEditTest.xml"
+  module: "ConfigurableProduct"
+  tests:
+    - testname: "NoErrorForMiniCartItemEditTest"
+      title: "No error for minicart item edit test"
+      description: "Already selected configurable option should be selected when configurable product is edited from minicart"
+- filename: "AdminCreateAndEditConfigurableProductSettingsTest.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/ConfigurableProduct/Test/Mftf/Test/AdminCreateAndEditConfigurableProductSettingsTest.xml"
+  module: "ConfigurableProduct"
+  tests:
+    - testname: "AdminCreateAndEditConfigurableProductSettingsTest"
+      title: "Admin should be able to set/edit other product information when creating/editing a configurable product"
+      description: "Admin should be able to set/edit other product information when creating/editing a configurable product"
+- filename: "AdminAddDefaultImageConfigurableTest.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/ConfigurableProduct/Test/Mftf/Test/AdminAddDefaultImageConfigurableTest.xml"
+  module: "ConfigurableProduct"
+  tests:
+    - testname: "AdminAddDefaultImageConfigurableTest"
+      title: "Admin should be able to add default images for a Configurable Product"
+      description: "Admin should be able to add default images for a Configurable Product"
+- filename: "AdminCreateConfigurableProductWithTwoOptionsWithoutAssignedToCategoryTest.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/ConfigurableProduct/Test/Mftf/Test/AdminCreateConfigurableProductWithTwoOptionsWithoutAssignedToCategoryTest.xml"
+  module: "ConfigurableProduct"
+  tests:
+    - testname: "AdminCreateConfigurableProductWithTwoOptionsWithoutAssignedToCategoryTest"
+      title: "Create configurable product with two new options without assigned to category with not visible child products"
+      description: "Admin should be able to create configurable product with two options without assigned to category, child products are not visible individually"
+- filename: "AdminCreateConfigurableProductWithTierPriceForOneItemTest.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/ConfigurableProduct/Test/Mftf/Test/AdminCreateConfigurableProductWithTierPriceForOneItemTest.xml"
+  module: "ConfigurableProduct"
+  tests:
+    - testname: "AdminCreateConfigurableProductWithTierPriceForOneItemTest"
+      title: "Create configurable product with tier price for one item"
+      description: "Admin should be able to create configurable product with tier price for one item"
+- filename: "AdminCreateConfigurableProductWithDisabledChildrenProductsTest.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/ConfigurableProduct/Test/Mftf/Test/AdminCreateConfigurableProductWithDisabledChildrenProductsTest.xml"
+  module: "ConfigurableProduct"
+  tests:
+    - testname: "AdminCreateConfigurableProductWithDisabledChildrenProductsTest"
+      title: "Create configurable product with disabled children products"
+      description: "Admin should be able to create configurable product with disabled children products, assigned to category"
+- filename: "AdminCheckValidatorConfigurableProductTest.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/ConfigurableProduct/Test/Mftf/Test/AdminCheckValidatorConfigurableProductTest.xml"
+  module: "ConfigurableProduct"
+  tests:
+    - testname: "AdminCheckValidatorConfigurableProductTest"
+      title: "Check that validator works correctly when creating Configurations for Configurable Products"
+      description: "Verify validator works correctly for Configurable Products"
+- filename: "EndToEndB2CGuestUserTest.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/ConfigurableProduct/Test/Mftf/Test/EndToEndB2CGuestUserTest.xml"
+  module: "ConfigurableProduct"
+  tests:
+    - testname: "EndToEndB2CGuestUserTest"
+      title: ""
+      description: ""
+
+    - testname: "EndToEndB2CGuestUserMysqlTest"
+      title: ""
+      description: ""
+- filename: "StorefrontShouldSeeOnlyConfigurableProductChildAssignedToSeparateCategoryTest.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/ConfigurableProduct/Test/Mftf/Test/StorefrontShouldSeeOnlyConfigurableProductChildAssignedToSeparateCategoryTest.xml"
+  module: "ConfigurableProduct"
+  tests:
+    - testname: "StorefrontShouldSeeOnlyConfigurableProductChildAssignedToSeparateCategoryTest"
+      title: "It should be possible to only view the child product of a configurable product"
+      description: "Create configurable product, add to category such that only child variation is visible in category"
+- filename: "AdminConfigurableProductLongSkuTest.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/ConfigurableProduct/Test/Mftf/Test/AdminConfigurableProductLongSkuTest.xml"
+  module: "ConfigurableProduct"
+  tests:
+    - testname: "AdminConfigurableProductLongSkuTest"
+      title: "Admin is able to create an product with a long sku below that is below the character limit"
+      description: "Try to create a product with sku slightly less than char limit. Get client side SKU length error for child products. Correct SKUs and save product succeeds."
+- filename: "AdminRemoveDefaultImageConfigurableTest.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/ConfigurableProduct/Test/Mftf/Test/AdminRemoveDefaultImageConfigurableTest.xml"
+  module: "ConfigurableProduct"
+  tests:
+    - testname: "AdminRemoveDefaultImageConfigurableTest"
+      title: "Admin should be able to remove default images from a Configurable Product"
+      description: "Admin should be able to remove default images from a Configurable Product"
+- filename: "StorefrontConfigurableProductChildSearchTest.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/ConfigurableProduct/Test/Mftf/Test/StorefrontConfigurableProductChildSearchTest.xml"
+  module: "ConfigurableProduct"
+  tests:
+    - testname: "StorefrontConfigurableProductChildSearchTest"
+      title: "Guest customer should be able to search configurable product by attributes of child products"
+      description: "Guest customer should be able to search configurable product by attributes of child products"
+- filename: "AdminConfigurableProductOutOfStockTest.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/ConfigurableProduct/Test/Mftf/Test/AdminConfigurableProductOutOfStockTest.xml"
+  module: "ConfigurableProduct"
+  tests:
+    - testname: "AdminConfigurableProductChildrenOutOfStockTest"
+      title: "Configurable Product goes 'Out of Stock' if all associated Simple Products are 'Out of Stock'"
+      description: "Configurable Product goes 'Out of Stock' if all associated Simple Products are 'Out of Stock'"
+
+    - testname: "AdminConfigurableProductOutOfStockTestDeleteChildren"
+      title: "Configurable Product goes 'Out of Stock' if all associated Simple Products are deleted"
+      description: "Configurable Product goes 'Out of Stock' if all associated Simple Products are deleted"
+
+    - testname: "AdminConfigurableProductOutOfStockAndDeleteCombinationTest"
+      title: "Configurable Product goes 'Out of Stock' if all associated Simple Products are a combination of 'Out of Stock' and deleted"
+      description: "Configurable Product goes 'Out of Stock' if all associated Simple Products are a combination of 'Out of Stock' and deleted"
+- filename: "AdminRelatedProductsTest.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/ConfigurableProduct/Test/Mftf/Test/AdminRelatedProductsTest.xml"
+  module: "ConfigurableProduct"
+  tests:
+    - testname: "AdminRelatedProductsTest"
+      title: "Admin should be able to promote products as related"
+      description: "Admin should be able to promote products as related"
+- filename: "StorefrontVisibilityOfDuplicateProductTest.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/ConfigurableProduct/Test/Mftf/Test/StorefrontVisibilityOfDuplicateProductTest.xml"
+  module: "ConfigurableProduct"
+  tests:
+    - testname: "StorefrontVisibilityOfDuplicateProductTest"
+      title: "Visibility of duplicate product on the Storefront"
+      description: "Check visibility of duplicate product on the Storefront"
+- filename: "ConfigurableProductPriceAdditionalStoreViewTest.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/ConfigurableProduct/Test/Mftf/Test/ConfigurableProductPriceAdditionalStoreViewTest.xml"
+  module: "ConfigurableProduct"
+  tests:
+    - testname: "ConfigurableProductPriceAdditionalStoreViewTest"
+      title: "Configurable product prices should not disappear on storefront for additional store"
+      description: "Configurable product price should not disappear for additional stores on frontEnd if disabled for default store"
+- filename: "AdminAssertNoticeThatExistingSkuAutomaticallyChangedWhenSavingProductWithSameSkuTest.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/ConfigurableProduct/Test/Mftf/Test/AdminAssertNoticeThatExistingSkuAutomaticallyChangedWhenSavingProductWithSameSkuTest.xml"
+  module: "ConfigurableProduct"
+  tests:
+    - testname: "AdminAssertNoticeThatExistingSkuAutomaticallyChangedWhenSavingProductWithSameSkuTest"
+      title: "Assert notice that existing sku automatically changed when saving product with same sku"
+      description: "Admin should not be able to create configurable product and two new options with the same sku"
+- filename: "StorefrontConfigurableProductWithFileCustomOptionTest.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/ConfigurableProduct/Test/Mftf/Test/StorefrontConfigurableProductWithFileCustomOptionTest.xml"
+  module: "ConfigurableProduct"
+  tests:
+    - testname: "StorefrontConfigurableProductWithFileCustomOptionTest"
+      title: "Correct error message and redirect with invalid file option"
+      description: "Configurable product has file custom option. When adding to cart with an invalid filetype, the correct error message is shown, and options remain selected."
+- filename: "AdminCreateConfigurableProductWithImagesTest.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/ConfigurableProduct/Test/Mftf/Test/AdminCreateConfigurableProductWithImagesTest.xml"
+  module: "ConfigurableProduct"
+  tests:
+    - testname: "AdminCreateConfigurableProductWithImagesTest"
+      title: "Create configurable product with images"
+      description: "Admin should be able to create configurable product with images"
+- filename: "AdvanceCatalogSearchConfigurableTest.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/ConfigurableProduct/Test/Mftf/Test/AdvanceCatalogSearchConfigurableTest.xml"
+  module: "ConfigurableProduct"
+  tests:
+    - testname: "AdvanceCatalogSearchConfigurableByNameTest"
+      title: "Guest customer should be able to advance search configurable product with product name"
+      description: "Guest customer should be able to advance search configurable product with product name"
+
+    - testname: "AdvanceCatalogSearchConfigurableBySkuTest"
+      title: "Guest customer should be able to advance search configurable product with product sku"
+      description: "Guest customer should be able to advance search configurable product with product sku"
+
+    - testname: "AdvanceCatalogSearchConfigurableByDescriptionTest"
+      title: "Guest customer should be able to advance search configurable product with product description"
+      description: "Guest customer should be able to advance search configurable product with product description"
+
+    - testname: "AdvanceCatalogSearchConfigurableByShortDescriptionTest"
+      title: "Guest customer should be able to advance search configurable product with product short description"
+      description: "Guest customer should be able to advance search configurable product with product short description"
+- filename: "AdminCreateConfigurableProductWithThreeProductDisplayOutOfStockProductsTest.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/ConfigurableProduct/Test/Mftf/Test/AdminCreateConfigurableProductWithThreeProductDisplayOutOfStockProductsTest.xml"
+  module: "ConfigurableProduct"
+  tests:
+    - testname: "AdminCreateConfigurableProductWithThreeProductDisplayOutOfStockProductsTest"
+      title: "Create Configurable Product with three product, display out of stock products"
+      description: "Admin should be able to create Configurable Product with one out of stock and several in stock options, display out of stock products"
+- filename: "AdminProductTypeSwitchingOnEditingTest.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/ConfigurableProduct/Test/Mftf/Test/AdminProductTypeSwitchingOnEditingTest.xml"
+  module: "ConfigurableProduct"
+  tests:
+    - testname: "AdminSimpleProductTypeSwitchingToConfigurableProductTest"
+      title: "Simple product type switching on editing to configurable product"
+      description: "Simple product type switching on editing to configurable product"
+
+    - testname: "AdminConfigurableProductTypeSwitchingToVirtualProductTest"
+      title: "Configurable product type switching on editing to virtual product"
+      description: "Configurable product type switching on editing to virtual product"
+
+    - testname: "AdminVirtualProductTypeSwitchingToConfigurableProductTest"
+      title: "Virtual product type switching on editing to configurable product"
+      description: "Virtual product type switching on editing to configurable product"
+- filename: "NoOptionAvailableToConfigureDisabledProductTest.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/ConfigurableProduct/Test/Mftf/Test/NoOptionAvailableToConfigureDisabledProductTest.xml"
+  module: "ConfigurableProduct"
+  tests:
+    - testname: "NoOptionAvailableToConfigureDisabledProductTest"
+      title: "Disabled variation of configurable product can't be added to shopping cart via admin"
+      description: "Disabled variation of configurable product can't be added to shopping cart via admin"
+- filename: "AdminConfigurableProductDeleteTest.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/ConfigurableProduct/Test/Mftf/Test/AdminConfigurableProductDeleteTest.xml"
+  module: "ConfigurableProduct"
+  tests:
+    - testname: "AdminConfigurableProductDeleteTest"
+      title: "admin should be able to delete a configurable product"
+      description: "admin should be able to delete a configurable product"
+
+    - testname: "AdminConfigurableProductBulkDeleteTest"
+      title: "admin should be able to mass delete configurable products"
+      description: "admin should be able to mass delete configurable products"
+- filename: "EndToEndB2CAdminTest.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/ConfigurableProduct/Test/Mftf/Test/EndToEndB2CAdminTest.xml"
+  module: "ConfigurableProduct"
+  tests:
+    - testname: "EndToEndB2CAdminTest"
+      title: ""
+      description: ""
+- filename: "StorefrontCheckSortingByPriceForConfigurableWithCatalogRuleAppliedTest.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/ConfigurableProduct/Test/Mftf/Test/StorefrontCheckSortingByPriceForConfigurableWithCatalogRuleAppliedTest.xml"
+  module: "ConfigurableProduct"
+  tests:
+    - testname: "StorefrontCheckSortingByPriceForConfigurableWithCatalogRuleAppliedTest"
+      title: "Check sorting by price for Configurable product with Catalog Rule applied"
+      description: "Sort by price should be correct if the apply Catalog Rule to child product of configurable product"
+- filename: "AdminConfigurableProductUpdateAttributeTest.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/ConfigurableProduct/Test/Mftf/Test/AdminConfigurableProductUpdateAttributeTest.xml"
+  module: "ConfigurableProduct"
+  tests:
+    - testname: "AdminConfigurableProductUpdateAttributeTest"
+      title: "Admin should be able to update existing attributes of a configurable product"
+      description: "Admin should be able to update existing attributes of a configurable product"
+
+    - testname: "AdminConfigurableProductUpdateChildAttributeTest"
+      title: "Admin should be able to update existing attributes of child products of a configurable product"
+      description: "Admin should be able to update existing attributes of child products of a configurable product"
+- filename: "AdminConfigurableSetEditRelatedProductsTest.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/ConfigurableProduct/Test/Mftf/Test/AdminConfigurableSetEditRelatedProductsTest.xml"
+  module: "ConfigurableProduct"
+  tests:
+    - testname: "AdminConfigurableSetEditRelatedProductsTest"
+      title: "Admin should be able to set/edit Related Products information when editing a configurable product"
+      description: "Admin should be able to set/edit Related Products information when editing a configurable product"
+- filename: "AdminCreateConfigurableProductWithThreeProductDontDisplayOutOfStockProductsTest.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/ConfigurableProduct/Test/Mftf/Test/AdminCreateConfigurableProductWithThreeProductDontDisplayOutOfStockProductsTest.xml"
+  module: "ConfigurableProduct"
+  tests:
+    - testname: "AdminCreateConfigurableProductWithThreeProductDontDisplayOutOfStockProductsTest"
+      title: "Create Configurable Product with three product, don't display out of stock products"
+      description: "Admin should be able to create Configurable Product with one out of stock and several in stock options, don't display out of stock products"
+- filename: "AdminCreateConfigurableProductWithCreatingCategoryAndAttributeTest.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/ConfigurableProduct/Test/Mftf/Test/AdminCreateConfigurableProductWithCreatingCategoryAndAttributeTest.xml"
+  module: "ConfigurableProduct"
+  tests:
+    - testname: "AdminCreateConfigurableProductWithCreatingCategoryAndAttributeTest"
+      title: "Create configurable product with creating new category and new attribute (required fields only)"
+      description: "Admin should be able to create configurable product with creating new category and new attribute (required fields only)"
+- filename: "AdminCheckResultsOfColorAndOtherFiltersTest.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/ConfigurableProduct/Test/Mftf/Test/AdminCheckResultsOfColorAndOtherFiltersTest.xml"
+  module: "ConfigurableProduct"
+  tests:
+    - testname: "AdminCheckResultsOfColorAndOtherFiltersTest"
+      title: "Checking results of color and other filters"
+      description: "Checking results of filters: color and other filters"
+- filename: "ProductsQtyReturnAfterOrderCancelTest.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/ConfigurableProduct/Test/Mftf/Test/ProductsQtyReturnAfterOrderCancelTest.xml"
+  module: "ConfigurableProduct"
+  tests:
+    - testname: "ProductsQtyReturnAfterOrderCancel"
+      title: "Product qunatity return after order cancel"
+      description: "Check Product qunatity return after order cancel"
+- filename: "AdminConfigurableProductSearchTest.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/ConfigurableProduct/Test/Mftf/Test/AdminConfigurableProductSearchTest.xml"
+  module: "ConfigurableProduct"
+  tests:
+    - testname: "AdminConfigurableProductSearchTest"
+      title: "admin should be able to search for a configurable product"
+      description: "admin should be able to search for a configurable product"
+
+    - testname: "AdminConfigurableProductFilterByTypeTest"
+      title: "admin should be able to filter by type configurable product"
+      description: "admin should be able to filter by type configurable product"
+- filename: "EndToEndB2CLoggedInUserTest.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/ConfigurableProduct/Test/Mftf/Test/EndToEndB2CLoggedInUserTest.xml"
+  module: "ConfigurableProduct"
+  tests:
+    - testname: "EndToEndB2CLoggedInUserTest"
+      title: ""
+      description: ""
+- filename: "AdminAddingNewOptionsWithImagesAndPricesToConfigurableProductTest.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/ConfigurableProduct/Test/Mftf/Test/AdminAddingNewOptionsWithImagesAndPricesToConfigurableProductTest.xml"
+  module: "ConfigurableProduct"
+  tests:
+    - testname: "AdminAddingNewOptionsWithImagesAndPricesToConfigurableProductTest"
+      title: "Adding new options with images and prices to Configurable Product"
+      description: "Test case verifies possibility to add new options for configurable attribute for existing configurable product."
+- filename: "StorefrontAdvanceCatalogSearchConfigurableBySkuWithHyphenTest.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/ConfigurableProduct/Test/Mftf/Test/StorefrontAdvanceCatalogSearchConfigurableBySkuWithHyphenTest.xml"
+  module: "ConfigurableProduct"
+  tests:
+    - testname: "StorefrontAdvanceCatalogSearchConfigurableBySkuWithHyphenTest"
+      title: "Guest customer should be able to advance search configurable product with product sku that contains hyphen"
+      description: "Guest customer should be able to advance search configurable product with product sku that contains hyphen"
+- filename: "AdminCreateConfigurableProductBasedOnParentSkuTest.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/ConfigurableProduct/Test/Mftf/Test/AdminCreateConfigurableProductBasedOnParentSkuTest.xml"
+  module: "ConfigurableProduct"
+  tests:
+    - testname: "AdminCreateConfigurableProductBasedOnParentSkuTest"
+      title: "Configurable product variation's sku should be based on parent SKU"
+      description: "Admin should be able to create configurable product with two new options based on parent SKU, without assigned to category and attribute set"
+- filename: "AdminConfigurableProductCreateTest.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/ConfigurableProduct/Test/Mftf/Test/AdminConfigurableProductCreateTest.xml"
+  module: "ConfigurableProduct"
+  tests:
+    - testname: "AdminConfigurableProductCreateTest"
+      title: "admin should be able to create a configurable product with attributes"
+      description: "admin should be able to create a configurable product with attributes"
+
+    - testname: "AdminCreateConfigurableProductAfterGettingIncorrectSKUMessageTest"
+      title: "admin should be able to create a configurable product after incorrect sku"
+      description: "admin should be able to create a configurable product after incorrect sku"
+- filename: "StorefrontConfigurableProductDetailsTest.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/ConfigurableProduct/Test/Mftf/Test/StorefrontConfigurableProductDetailsTest.xml"
+  module: "ConfigurableProduct"
+  tests:
+    - testname: "StorefrontConfigurableProductBasicInfoTest"
+      title: "Guest customer should see basic Configurable Product details"
+      description: "Guest customer should see basic Configurable Product details"
+
+    - testname: "StorefrontConfigurableProductOptionsTest"
+      title: "Guest customer should be able to see product configuration options"
+      description: "Guest customer should be able to see product configuration options"
+
+    - testname: "StorefrontConfigurableProductCanAddToCartTest"
+      title: "Guest customer should be able to successfully add the product to the cart"
+      description: "Guest customer should be able to successfully add the product to the cart"
+
+    - testname: "StorefrontConfigurableProductCantAddToCartTest"
+      title: "Guest customer should not be able to add the product to the cart if options are not selected"
+      description: "Guest customer should not be able to add the product to the cart if options are not selected"
+
+    - testname: "StorefrontConfigurableProductVariationsTest"
+      title: "Customer should get the right options list"
+      description: "Customer should get the right options list for each variation of configurable product"
+- filename: "StorefrontConfigurableProductViewTest.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/ConfigurableProduct/Test/Mftf/Test/StorefrontConfigurableProductViewTest.xml"
+  module: "ConfigurableProduct"
+  tests:
+    - testname: "StorefrontConfigurableProductGridViewTest"
+      title: "customer should see the configurable product in the category grid"
+      description: "customer should see the configurable product in the category grid"
+
+    - testname: "StorefrontConfigurableProductListViewTest"
+      title: "customer should see the configurable product in the category list"
+      description: "customer should see the configurable product in the category list"
+
+    - testname: "StorefrontConfigurableProductAddToCartTest"
+      title: "customer should be taken to the product details page when clicking add to cart"
+      description: "customer should be taken to the product details page when clicking add to cart"
+- filename: "AdminConfigurableProductSetEditContentTest.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/ConfigurableProduct/Test/Mftf/Test/AdminConfigurableProductSetEditContentTest.xml"
+  module: "ConfigurableProduct"
+  tests:
+    - testname: "AdminConfigurableProductSetEditContentTest"
+      title: "Admin should be able to set/edit product Content when editing a configurable product"
+      description: "Admin should be able to set/edit product Content when editing a configurable product"
+- filename: "StorefrontConfigurableProductCategoryViewChildOnlyTest.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/ConfigurableProduct/Test/Mftf/Test/StorefrontConfigurableProductCategoryViewChildOnlyTest.xml"
+  module: "ConfigurableProduct"
+  tests:
+    - testname: "StorefrontConfigurableProductCategoryViewChildOnlyTest"
+      title: "DEPRECATED It should be possible to only view the child product of a configurable product"
+      description: "Create configurable product, add to category such that only child variation is visible in category"
+- filename: "AdminShouldBeAbleToMassUpdateAttributesForBundleProductsTest.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/Bundle/Test/Mftf/Test/AdminShouldBeAbleToMassUpdateAttributesForBundleProductsTest.xml"
+  module: "Bundle"
+  tests:
+    - testname: "AdminShouldBeAbleToMassUpdateAttributesForBundleProductsTest"
+      title: "Admin should be able to mass update attributes for bundle products"
+      description: "Admin should be able to mass update attributes for bundle products"
+- filename: "EnableDisableBundleProductStatusTest.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/Bundle/Test/Mftf/Test/EnableDisableBundleProductStatusTest.xml"
+  module: "Bundle"
+  tests:
+    - testname: "EnableDisableBundleProductStatusTest"
+      title: "Admin should be able to change a bundle product status to Enabled/Disabled"
+      description: "Admin should be able to change a bundle product status to Enabled/Disabled"
+- filename: "AdminCreateAndEditBundleProductSettingsTest.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/Bundle/Test/Mftf/Test/AdminCreateAndEditBundleProductSettingsTest.xml"
+  module: "Bundle"
+  tests:
+    - testname: "AdminCreateAndEditBundleProductSettingsTest"
+      title: "Admin should be able to set/edit other product information when creating/editing a bundle product"
+      description: "Admin should be able to set/edit other product information when creating/editing a bundle product"
+
+    - testname: "AdminCreateAndEditBundleProductOptionsNegativeTest"
+      title: "Admin should be able to remove any bundle option a bundle product"
+      description: "Admin should be able to set/edit other product information when creating/editing a bundle product"
+- filename: "AdminEditRelatedBundleProductTest.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/Bundle/Test/Mftf/Test/AdminEditRelatedBundleProductTest.xml"
+  module: "Bundle"
+  tests:
+    - testname: "AdminEditRelatedBundleProductTest"
+      title: "Admin should be able to set/edit Related Products information when editing a bundle product"
+      description: "Admin should be able to set/edit Related Products information when editing a bundle product"
+- filename: "AdminAddBundleItemsTest.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/Bundle/Test/Mftf/Test/AdminAddBundleItemsTest.xml"
+  module: "Bundle"
+  tests:
+    - testname: "AdminAddBundleItemsTest"
+      title: "Admin should be able to add/edit bundle items when creating/editing a bundle product"
+      description: "Admin should be able to add/edit bundle items when creating/editing a bundle product"
+- filename: "StorefrontSpecialPriceBundleProductInCartTest.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/Bundle/Test/Mftf/Test/StorefrontSpecialPriceBundleProductInCartTest.xml"
+  module: "Bundle"
+  tests:
+    - testname: "StorefrontSpecialPriceBundleProductInCartTest"
+      title: "Customer should not be able to add a Bundle Product to the cart when added a special price for associated products"
+      description: "Customer should not be able to add a Bundle Product to the cart when added a special price for associated products"
+- filename: "StorefrontAdminEditDataTest.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/Bundle/Test/Mftf/Test/StorefrontAdminEditDataTest.xml"
+  module: "Bundle"
+  tests:
+    - testname: "StorefrontAdminEditDataTest"
+      title: "Customer should be able to see chosen options for Bundle Product in Shopping Cart when Option Title is edited in Admin"
+      description: "Customer should be able to see chosen options for Bundle Product in Shopping Cart when Option Title is edited in Admin"
+- filename: "StorefrontAddBundleOptionsToCartTest.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/Bundle/Test/Mftf/Test/StorefrontAddBundleOptionsToCartTest.xml"
+  module: "Bundle"
+  tests:
+    - testname: "StorefrontAddBundleOptionsToCartTest"
+      title: "Checking adding of bundle options to the cart"
+      description: "Verifying adding of bundle options to the cart"
+- filename: "StorefrontBundleProductDetailsTest.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/Bundle/Test/Mftf/Test/StorefrontBundleProductDetailsTest.xml"
+  module: "Bundle"
+  tests:
+    - testname: "StorefrontBundleProductDetailsTest"
+      title: "Customer should be able to see basic bundle product details"
+      description: "Customer should be able to see basic bundle product details"
+- filename: "BundleProductWithTierPriceInCartTest.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/Bundle/Test/Mftf/Test/BundleProductWithTierPriceInCartTest.xml"
+  module: "Bundle"
+  tests:
+    - testname: "BundleProductWithTierPriceInCartTest"
+      title: "Customer should get the right subtotal in cart when the bundle product added to the cart twice"
+      description: "Customer should be able to add one more bundle product to the cart and get the right price"
+- filename: "StorefrontEditBundleProductTest.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/Bundle/Test/Mftf/Test/StorefrontEditBundleProductTest.xml"
+  module: "Bundle"
+  tests:
+    - testname: "StorefrontEditBundleProductTest"
+      title: "Customer should be able to change chosen options for Bundle Product when clicking Edit button in Shopping Cart page"
+      description: "Customer should be able to change chosen options for Bundle Product when clicking Edit button in Shopping Cart page"
+- filename: "AdminProductBundleCreationTest.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/Bundle/Test/Mftf/Test/AdminProductBundleCreationTest.xml"
+  module: "Bundle"
+  tests:
+    - testname: "AdminProductBundleCreationTest"
+      title: "Admin should be able to save and publish a bundle product"
+      description: "Admin should be able to save and publish a bundle product"
+- filename: "AdminDeleteBundleDynamicProductTest.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/Bundle/Test/Mftf/Test/AdminDeleteBundleDynamicProductTest.xml"
+  module: "Bundle"
+  tests:
+    - testname: "AdminDeleteBundleDynamicProductTest"
+      title: "Delete Bundle Dynamic Product"
+      description: "Admin should be able to delete a bundle dynamic product"
+- filename: "AdminRemoveDefaultImageBundleProductTest.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/Bundle/Test/Mftf/Test/AdminRemoveDefaultImageBundleProductTest.xml"
+  module: "Bundle"
+  tests:
+    - testname: "AdminRemoveDefaultImageBundleProductTest"
+      title: "Admin should be able to remove default images from a Bundle Product"
+      description: "Admin should be able to remove default images from a Bundle Product"
+- filename: "StorefrontAdvanceCatalogSearchBundleBySkuWithHyphenTest.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/Bundle/Test/Mftf/Test/StorefrontAdvanceCatalogSearchBundleBySkuWithHyphenTest.xml"
+  module: "Bundle"
+  tests:
+    - testname: "StorefrontAdvanceCatalogSearchBundleBySkuWithHyphenTest"
+      title: "Guest customer should be able to advance search Bundle product with product sku that contains hyphen"
+      description: "Guest customer should be able to advance search Bundle product with product sku that contains hyphen"
+- filename: "AdminAddDefaultVideoBundleProductTest.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/Bundle/Test/Mftf/Test/AdminAddDefaultVideoBundleProductTest.xml"
+  module: "Bundle"
+  tests:
+    - testname: "AdminAddDefaultVideoBundleProductTest"
+      title: "Admin should be able to add default video for a Bundle Product"
+      description: "Admin should be able to add default video for a Bundle Product"
+- filename: "NewBundleProductSelectionTest.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/Bundle/Test/Mftf/Test/NewBundleProductSelectionTest.xml"
+  module: "Bundle"
+  tests:
+    - testname: "NewBundleProductSelectionTest"
+      title: "Admin should be able to select a “Bundle Product” product type when adding a new product"
+      description: "Admin should be able to select a “Bundle Product” product type when adding a new product"
+- filename: "StorefrontCustomerSearchBundleProductsByKeywordsTest.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/Bundle/Test/Mftf/Test/StorefrontCustomerSearchBundleProductsByKeywordsTest.xml"
+  module: "Bundle"
+  tests:
+    - testname: "StorefrontCustomerSearchBundleProductsByKeywordsTest"
+      title: "Customer should be able to see search results when searching for bundle products by keyword"
+      description: "Customer should be able to see search results when searching for bundle products by keyword"
+- filename: "AdminAttributeSetSelectionTest.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/Bundle/Test/Mftf/Test/AdminAttributeSetSelectionTest.xml"
+  module: "Bundle"
+  tests:
+    - testname: "AdminAttributeSetSelectionTest"
+      title: "Admin should be able to select/edit the “Attributes Set” when creating/editing a bundle product"
+      description: "Admin should be able to select/edit the “Attributes Set” when creating/editing a bundle product"
+- filename: "StorefrontBundleCartTest.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/Bundle/Test/Mftf/Test/StorefrontBundleCartTest.xml"
+  module: "Bundle"
+  tests:
+    - testname: "StorefrontBundleCartTest"
+      title: "Customer should not be able to add a Bundle Product to the cart without selecting options"
+      description: "Customer should not be able to add a Bundle Product to the cart without selecting options"
+
+    - testname: "StorefrontBundleAddToCartSuccessTest"
+      title: "Customer should be able to add the bundle product to the cart"
+      description: "Customer should be able to add the bundle product to the cart"
+- filename: "StorefrontCustomerSelectAndSetBundleOptionsTest.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/Bundle/Test/Mftf/Test/StorefrontCustomerSelectAndSetBundleOptionsTest.xml"
+  module: "Bundle"
+  tests:
+    - testname: "StorefrontCustomerSelectAndSetBundleOptionsTest"
+      title: "Customer should be able to select customisable bundle product options and set quantity for them"
+      description: "Customer should be able to select customisable bundle product options and set quantity for them"
+- filename: "EndToEndB2CAdminTest.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/Bundle/Test/Mftf/Test/EndToEndB2CAdminTest.xml"
+  module: "Bundle"
+  tests:
+    - testname: "EndToEndB2CAdminTest"
+      title: ""
+      description: ""
+- filename: "CurrencyChangingBundleProductInCartTest.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/Bundle/Test/Mftf/Test/CurrencyChangingBundleProductInCartTest.xml"
+  module: "Bundle"
+  tests:
+    - testname: "CurrencyChangingBundleProductInCartTest"
+      title: "User should be able change the currency and get right price in cart when the bundle product added to the cart"
+      description: "User should be able change the currency and add one more product in cart and get right price in previous currency"
+- filename: "AdminBasicBundleProductAttributesTest.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/Bundle/Test/Mftf/Test/AdminBasicBundleProductAttributesTest.xml"
+  module: "Bundle"
+  tests:
+    - testname: "AdminBasicBundleProductAttributesTest"
+      title: "Admin should be able to set/edit all the basic product attributes when creating/editing a bundle product"
+      description: "Admin should be able to set/edit all the basic product attributes when creating/editing a bundle product"
+- filename: "NewProductsListWidgetBundleProductTest.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/Bundle/Test/Mftf/Test/NewProductsListWidgetBundleProductTest.xml"
+  module: "Bundle"
+  tests:
+    - testname: "NewProductsListWidgetBundleProductTest"
+      title: "Admin should be able to set Bundle Product as new so that it shows up in the Catalog New Products List Widget"
+      description: "Admin should be able to set Bundle Product as new so that it shows up in the Catalog New Products List Widget"
+- filename: "AdminAddBundleProductToCartFromWishListPageTest.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/Bundle/Test/Mftf/Test/AdminAddBundleProductToCartFromWishListPageTest.xml"
+  module: "Bundle"
+  tests:
+    - testname: "AdminAddBundleProductToCartFromWishListPageTest"
+      title: "Add bundle product to Cart from Wish list page"
+      description: "Add bundle product to Cart from Wish list page"
+- filename: "StorefrontVerifyDynamicBundleProductPricesForCombinationOfOptionsTest.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/Bundle/Test/Mftf/Test/StorefrontVerifyDynamicBundleProductPricesForCombinationOfOptionsTest.xml"
+  module: "Bundle"
+  tests:
+    - testname: "StorefrontVerifyDynamicBundleProductPricesForCombinationOfOptionsTest"
+      title: "Verify dynamic bundle product prices for combination of options"
+      description: "Verify prices for various configurations of Dynamic Bundle product"
+- filename: "StorefrontAddBundleProductWithZeroPriceToShoppingCartTest.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/Bundle/Test/Mftf/Test/StorefrontAddBundleProductWithZeroPriceToShoppingCartTest.xml"
+  module: "Bundle"
+  tests:
+    - testname: "StorefrontAddBundleProductWithZeroPriceToShoppingCartTest"
+      title: "Add Bundle product with zero price to shopping cart"
+      description: "Add Bundle product with zero price to shopping cart"
+- filename: "AdminAddDefaultImageBundleProductTest.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/Bundle/Test/Mftf/Test/AdminAddDefaultImageBundleProductTest.xml"
+  module: "Bundle"
+  tests:
+    - testname: "AdminAddDefaultImageBundleProductTest"
+      title: "Admin should be able to add default images for a Bundle Product"
+      description: "Admin should be able to add default images for a Bundle Product"
+- filename: "BundleProductFixedPricingTest.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/Bundle/Test/Mftf/Test/BundleProductFixedPricingTest.xml"
+  module: "Bundle"
+  tests:
+    - testname: "BundleProductFixedPricingTest"
+      title: "Admin should be able to apply fixed pricing for Bundled Product"
+      description: "Admin should be able to apply fixed pricing for Bundled Product"
+- filename: "StorefrontSortBundleProductsByPriceTest.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/Bundle/Test/Mftf/Test/StorefrontSortBundleProductsByPriceTest.xml"
+  module: "Bundle"
+  tests:
+    - testname: "StorefrontSortBundleProductsByPriceTest"
+      title: "Customer should be able to sort bundle products by price when viewing products list"
+      description: "Customer should be able to sort bundle products by price when viewing products list"
+- filename: "AdminRemoveDefaultVideoBundleProductTest.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/Bundle/Test/Mftf/Test/AdminRemoveDefaultVideoBundleProductTest.xml"
+  module: "Bundle"
+  tests:
+    - testname: "AdminRemoveDefaultVideoBundleProductTest"
+      title: "Admin should be able to remove default video from a Bundle Product"
+      description: "Admin should be able to remove default video from a Bundle Product"
+- filename: "AdminAssociateBundleProductToWebsitesTest.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/Bundle/Test/Mftf/Test/AdminAssociateBundleProductToWebsitesTest.xml"
+  module: "Bundle"
+  tests:
+    - testname: "AdminAssociateBundleProductToWebsitesTest"
+      title: "Admin should be able to associate bundle product to websites"
+      description: "Admin should be able to associate bundle product to websites"
+- filename: "MassEnableDisableBundleProductsTest.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/Bundle/Test/Mftf/Test/MassEnableDisableBundleProductsTest.xml"
+  module: "Bundle"
+  tests:
+    - testname: "MassEnableDisableBundleProductsTest"
+      title: "Admin should be able to mass change bundle products status to Enabled/Disabled"
+      description: "Admin should be able to mass change bundle products status to Enabled/Disabled"
+- filename: "StorefrontGoToDetailsPageWhenAddingToCartTest.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/Bundle/Test/Mftf/Test/StorefrontGoToDetailsPageWhenAddingToCartTest.xml"
+  module: "Bundle"
+  tests:
+    - testname: "StorefrontGoToDetailsPageWhenAddingToCart"
+      title: "Customer should be taken to bundle product details page when clicking “Add to Cart” button"
+      description: "Customer should be taken to bundle product details page when clicking “Add to Cart” button"
+- filename: "AdminDeleteBundleFixedProductTest.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/Bundle/Test/Mftf/Test/AdminDeleteBundleFixedProductTest.xml"
+  module: "Bundle"
+  tests:
+    - testname: "AdminDeleteBundleFixedProductTest"
+      title: "Delete Bundle Fixed Product"
+      description: "Admin should be able to delete a bundle fixed product"
+- filename: "AdvanceCatalogSearchBundleProductTest.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/Bundle/Test/Mftf/Test/AdvanceCatalogSearchBundleProductTest.xml"
+  module: "Bundle"
+  tests:
+    - testname: "AdvanceCatalogSearchBundleByNameTest"
+      title: "Guest customer should be able to advance search Bundle product with product name"
+      description: "Guest customer should be able to advance search Bundle product with product name"
+
+    - testname: "AdvanceCatalogSearchBundleByNameMysqlTest"
+      title: "Guest customer should be able to advance search Bundle product with product name using the MySQL search engine"
+      description: "Guest customer should be able to advance search Bundle product with product name using the MySQL search engine"
+
+    - testname: "AdvanceCatalogSearchBundleBySkuTest"
+      title: "Guest customer should be able to advance search Bundle product with product sku"
+      description: "Guest customer should be able to advance search Bundle product with product sku"
+
+    - testname: "AdvanceCatalogSearchBundleByDescriptionTest"
+      title: "Guest customer should be able to advance search Bundle product with product description"
+      description: "Guest customer should be able to advance search Bundle product with product description"
+
+    - testname: "AdvanceCatalogSearchBundleByDescriptionMysqlTest"
+      title: "Guest customer should be able to advance search Bundle product with product description using the MySQL search engine"
+      description: "Guest customer should be able to advance search Bundle product with product description using the MySQL search engine"
+
+    - testname: "AdvanceCatalogSearchBundleByShortDescriptionTest"
+      title: "Guest customer should be able to advance search Bundle product with product short description"
+      description: "Guest customer should be able to advance search Bundle product with product short description"
+
+    - testname: "AdvanceCatalogSearchBundleByShortDescriptionMysqlTest"
+      title: "Guest customer should be able to advance search Bundle product with product short description using the MySQL search engine"
+      description: "Guest customer should be able to advance search Bundle product with product short description using the MySQL search engine"
+
+    - testname: "AdvanceCatalogSearchBundleByPriceTest"
+      title: "Guest customer should be able to advance search Bundle product with product price"
+      description: "Guest customer should be able to advance search Bundle product with product price"
+
+    - testname: "AdvanceCatalogSearchBundleByPriceMysqlTest"
+      title: "Guest customer should be able to advance search Bundle product with product price using the MySQL search engine"
+      description: "Guest customer should be able to advance search Bundle product with product price the MySQL search engine"
+- filename: "AdminBundleProductSetEditContentTest.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/Bundle/Test/Mftf/Test/AdminBundleProductSetEditContentTest.xml"
+  module: "Bundle"
+  tests:
+    - testname: "AdminBundleProductSetEditContentTest"
+      title: "Admin should be able to set/edit product Content when editing a bundle product"
+      description: "Admin should be able to set/edit product Content when editing a bundle product"
+- filename: "StorefrontDisplayTableRatesShippingMethodForAETest.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/Shipping/Test/Mftf/Test/StorefrontDisplayTableRatesShippingMethodForAETest.xml"
+  module: "Shipping"
+  tests:
+    - testname: "StorefrontDisplayTableRatesShippingMethodForAETest"
+      title: "Displaying of Table Rates for Armed Forces Europe (AE)"
+      description: "Displaying of Table Rates for Armed Forces Europe (AE)"
+- filename: "AdminCheckInputFieldsDisabledAfterAppConfigDumpTest.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/Shipping/Test/Mftf/Test/AdminCheckInputFieldsDisabledAfterAppConfigDumpTest.xml"
+  module: "Shipping"
+  tests:
+    - testname: "AdminCheckInputFieldsDisabledAfterAppConfigDumpTest"
+      title: "Check that all input fields disabled after executing CLI app:config:dump"
+      description: "Check that all input fields disabled after executing CLI app:config:dump"
+- filename: "AdminCreatePartialShipmentEntityTest.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/Shipping/Test/Mftf/Test/AdminCreatePartialShipmentEntityTest.xml"
+  module: "Shipping"
+  tests:
+    - testname: "AdminCreatePartialShipmentEntityTest"
+      title: "Create Partial Shipment for Offline Payment Methods"
+      description: "Admin Should be Able to Create Partial Shipments"
+- filename: "AdminValidateShippingTrackingNumberTest.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/Shipping/Test/Mftf/Test/AdminValidateShippingTrackingNumberTest.xml"
+  module: "Shipping"
+  tests:
+    - testname: "AdminValidateShippingTrackingNumberTest"
+      title: "Admin validate the shipping tracking number for an order"
+      description: "Testing for a required tracking number when adding new shipping information"
+- filename: "AdminCreateShipmentEntityTest.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/Shipping/Test/Mftf/Test/AdminCreateShipmentEntityTest.xml"
+  module: "Shipping"
+  tests:
+    - testname: "AdminCreateShipmentEntityWithTrackingNumberTest"
+      title: "Create Shipment for Offline Payment Methods"
+      description: "Admin Should be Able to Create Shipments"
+- filename: "TableRatesShippingMethodForDifferentStatesTest.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/Shipping/Test/Mftf/Test/TableRatesShippingMethodForDifferentStatesTest.xml"
+  module: "Shipping"
+  tests:
+    - testname: "TableRatesShippingMethodForDifferentStatesTest"
+      title: "Table rates shipping method for different states test"
+      description: "Checkout with Table Rates for different states of the USA"
+- filename: "AdminCreateOrderCustomStoreShippingMethodTableRatesTest.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/Shipping/Test/Mftf/Test/AdminCreateOrderCustomStoreShippingMethodTableRatesTest.xml"
+  module: "Shipping"
+  tests:
+    - testname: "AdminCreateOrderCustomStoreShippingMethodTableRatesTest"
+      title: "Create order on second store with shipping method Table Rates"
+      description: "Create order on second store with shipping method Table Rates"
+- filename: "EndToEndB2CAdminTest.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/Shipping/Test/Mftf/Test/EndToEndB2CAdminTest.xml"
+  module: "Shipping"
+  tests:
+    - testname: "EndToEndB2CAdminTest"
+      title: ""
+      description: ""
+- filename: "AdminCheckTheConfirmationPopupTest.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/Shipping/Test/Mftf/Test/AdminCheckTheConfirmationPopupTest.xml"
+  module: "Shipping"
+  tests:
+    - testname: "AdminCheckTheConfirmationPopupTest"
+      title: "Admin confirmation modal should be in Magento style"
+      description: "Testing the confirmation modal for removing the tracking number"
+- filename: "StorefrontProductGridUIUpdatesOnDesktopTest.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/CatalogWidget/Test/Mftf/Test/StorefrontProductGridUIUpdatesOnDesktopTest.xml"
+  module: "CatalogWidget"
+  tests:
+    - testname: "StorefrontProductGridUIUpdatesOnDesktopTest"
+      title: "Storefront product grid UI updates on Desktop"
+      description: "Storefront product grid UI updates on Desktop"
+- filename: "CatalogProductListWidgetOrderTest.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/CatalogWidget/Test/Mftf/Test/CatalogProductListWidgetOrderTest.xml"
+  module: "CatalogWidget"
+  tests:
+    - testname: "CatalogProductListWidgetOrderTest"
+      title: "Checking order of products in the 'catalog Products List' widget"
+      description: "Check that products are ordered with recently added products first"
+- filename: "CatalogProductListWidgetOperatorsTest.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/CatalogWidget/Test/Mftf/Test/CatalogProductListWidgetOperatorsTest.xml"
+  module: "CatalogWidget"
+  tests:
+    - testname: "CatalogProductListWidgetOperatorsTest"
+      title: "Checking operator more/less in the 'catalog Products List' widget"
+      description: "Check 'less than', 'equals or greater than', 'equals or less than' operators"
+- filename: "StorefrontVerifySecureURLRedirectVaultTest.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/Vault/Test/Mftf/Test/StorefrontVerifySecureURLRedirectVaultTest.xml"
+  module: "Vault"
+  tests:
+    - testname: "StorefrontVerifySecureURLRedirectVault"
+      title: "Verify Secure URLs For Storefront Vault Pages"
+      description: "Verify that the Secure URL configuration applies to the Vault pages on the Storefront"
+- filename: "BraintreeCreditCardOnCheckoutTest.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/Braintree/Test/Mftf/Test/BraintreeCreditCardOnCheckoutTest.xml"
+  module: "Braintree"
+  tests:
+    - testname: "BraintreeCreditCardOnCheckoutTest"
+      title: "Use saved for Braintree credit card on checkout with selecting billing address"
+      description: "Use saved for Braintree credit card on checkout with selecting billing address"
+- filename: "StoreFrontMyAccountWithMultishipmentTest.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/Multishipping/Test/Mftf/Test/StoreFrontMyAccountWithMultishipmentTest.xml"
+  module: "Multishipping"
+  tests:
+    - testname: "StorefrontMyAccountWithMultishipmentTest"
+      title: "Verify Shipping price for Storefront after multiple address checkout"
+      description: "Verify that shipping price on My account matches with shipping method prices after multiple addresses checkout (Order view page)"
+- filename: "StoreFrontMinicartWithMultishipmentTest.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/Multishipping/Test/Mftf/Test/StoreFrontMinicartWithMultishipmentTest.xml"
+  module: "Multishipping"
+  tests:
+    - testname: "StoreFrontMinicartWithMultishipmentTest"
+      title: "Checking multi shipment with multiple shipment at minicart from checkout"
+      description: "Shipping price shows 0 when you return from multiple checkout to cart"
+- filename: "StoreFrontCheckingWithMultishipmentTest.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/Multishipping/Test/Mftf/Test/StoreFrontCheckingWithMultishipmentTest.xml"
+  module: "Multishipping"
+  tests:
+    - testname: "StoreFrontCheckingWithMultishipmentTest"
+      title: "Checking multi shipment with multiple shipment adresses on front end order page"
+      description: "Shipping price shows 0 when you return from multiple checkout to cart"
+- filename: "StorefrontCheckoutWithMultipleAddressesTest.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/Multishipping/Test/Mftf/Test/StorefrontCheckoutWithMultipleAddressesTest.xml"
+  module: "Multishipping"
+  tests:
+    - testname: "StorefrontCheckoutWithMultipleAddressesTest"
+      title: "Place an order with three different addresses"
+      description: "Place an order with three different addresses"
+- filename: "StorefrontProcessMultishippingCheckoutWhenCartPageIsOpenedInAnotherTabTest.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/Multishipping/Test/Mftf/Test/StorefrontProcessMultishippingCheckoutWhenCartPageIsOpenedInAnotherTabTest.xml"
+  module: "Multishipping"
+  tests:
+    - testname: "StorefrontProcessMultishippingCheckoutWhenCartPageIsOpenedInAnotherTabTest"
+      title: "Process multishipping checkout when Cart page is opened in another tab"
+      description: "Process multishipping checkout when Cart page is opened in another tab"
+- filename: "StorefrontVerifySecureURLRedirectMultishippingTest.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/Multishipping/Test/Mftf/Test/StorefrontVerifySecureURLRedirectMultishippingTest.xml"
+  module: "Multishipping"
+  tests:
+    - testname: "StorefrontVerifySecureURLRedirectMultishipping"
+      title: "Verify Secure URLs For Storefront Multishipping Pages"
+      description: "Verify that the Secure URL configuration applies to the Multishipping pages on the Storefront"
+- filename: "StorefrontCheckingWithCartPriceRuleMatchingSubtotalForMultiShipmentTest.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/Multishipping/Test/Mftf/Test/StorefrontCheckingWithCartPriceRuleMatchingSubtotalForMultiShipmentTest.xml"
+  module: "Multishipping"
+  tests:
+    - testname: "StorefrontCheckingWithCartPriceRuleMatchingSubtotalForMultiShipmentTest"
+      title: "Checking sub total amount and free shipping is applied with multiple shipment addresses on front end order page"
+      description: "Cart Price Rules not working and free shipping not applied for Multi shipping "
+- filename: "StoreFrontCheckingWithSingleShipmentTest.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/Multishipping/Test/Mftf/Test/StoreFrontCheckingWithSingleShipmentTest.xml"
+  module: "Multishipping"
+  tests:
+    - testname: "StoreFrontCheckingWithSingleShipmentTest"
+      title: "Checking multi shipment with single shipment adresses on front end order page"
+      description: "Shipping price shows 0 when you return from multiple checkout to cart"
 - filename: "AdminSystemIntegrationsNavigateMenuTest.xml"
-  repo: "https://github.com/magento/magento2/blob/2.3/app/code/Magento/Integration/Test/Mftf/Test/AdminSystemIntegrationsNavigateMenuTest.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/Integration/Test/Mftf/Test/AdminSystemIntegrationsNavigateMenuTest.xml"
   module: "Integration"
   tests:
     - testname: "AdminSystemIntegrationsNavigateMenuTest"
       title: "Admin system integrations navigate menu test"
       description: "Admin should be able to navigate to System &gt; Integrations"
- 
-- filename: "AdminStoresCurrencySymbolsNavigateMenuTest.xml"
-  repo: "https://github.com/magento/magento2/blob/2.3/app/code/Magento/CurrencySymbol/Test/Mftf/Test/AdminStoresCurrencySymbolsNavigateMenuTest.xml"
-  module: "CurrencySymbol"
+- filename: "AdminDeleteIntegrationEntityTest.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/Integration/Test/Mftf/Test/AdminDeleteIntegrationEntityTest.xml"
+  module: "Integration"
   tests:
-    - testname: "AdminStoresCurrencySymbolsNavigateMenuTest"
-      title: "Admin stores currency symbols navigate menu test"
-      description: "Admin should be able to navigate to Stores &gt; Currency Symbols"
- 
-- filename: "AdminStoresCurrencyRatesNavigateMenuTest.xml"
-  repo: "https://github.com/magento/magento2/blob/2.3/app/code/Magento/CurrencySymbol/Test/Mftf/Test/AdminStoresCurrencyRatesNavigateMenuTest.xml"
-  module: "CurrencySymbol"
+    - testname: "AdminDeleteIntegrationEntityTest"
+      title: "Admin system integration"
+      description: "Admin Deletes Created Integration"
+- filename: "StorefrontProductWithMapAssignedConfigProductIsCorrectTest.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/Msrp/Test/Mftf/Test/StorefrontProductWithMapAssignedConfigProductIsCorrectTest.xml"
+  module: "Msrp"
   tests:
-    - testname: "AdminStoresCurrencyRatesNavigateMenuTest"
-      title: "Admin stores currency rates navigate menu test"
-      description: "Admin should be able to navigate to Stores &gt; Currency Rates"
- 
+    - testname: "StorefrontProductWithMapAssignedConfigProductIsCorrectTest"
+      title: "Check that simple products with MAP assigned to configurable product displayed correctly"
+      description: "Check that simple products with MAP assigned to configurable product displayed correctly"
+- filename: "AdminAddVariableToWYSIWYGBlockTest.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/Cms/Test/Mftf/Test/AdminAddVariableToWYSIWYGBlockTest.xml"
+  module: "Cms"
+  tests:
+    - testname: "AdminAddVariableToWYSIWYGBlockTest"
+      title: "Admin should be able to add variable to WYSIWYG content of Block"
+      description: "You should be able to add variable to WYSIWYG content Block"
+- filename: "AdminAddVariableToWYSIWYGCMSTest.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/Cms/Test/Mftf/Test/AdminAddVariableToWYSIWYGCMSTest.xml"
+  module: "Cms"
+  tests:
+    - testname: "AdminAddVariableToWYSIWYGCMSTest"
+      title: "Admin should be able to insert the default Magento variable into content of WYSIWYG on CMS Pages"
+      description: "Admin should be able to insert the default Magento variable into content of WYSIWYG on CMS Pages"
+- filename: "AdminAddWidgetToWYSIWYGWithCMSPageLinkTypeTest.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/Cms/Test/Mftf/Test/AdminAddWidgetToWYSIWYGWithCMSPageLinkTypeTest.xml"
+  module: "Cms"
+  tests:
+    - testname: "AdminAddWidgetToWYSIWYGWithCMSPageLinkTypeTest"
+      title: "Admin should be able to create a CMS page with widget type: CMS page link"
+      description: "Admin should be able to create a CMS page with widget type: CMS page link"
+- filename: "AdminAddWidgetToWYSIWYGWithCatalogProductLinkTypeTest.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/Cms/Test/Mftf/Test/AdminAddWidgetToWYSIWYGWithCatalogProductLinkTypeTest.xml"
+  module: "Cms"
+  tests:
+    - testname: "AdminAddWidgetToWYSIWYGWithCatalogProductLinkTypeTest"
+      title: "Admin should be able to create a CMS page with widget type: Catalog product link"
+      description: "Admin should be able to create a CMS page with widget type: Catalog product link"
+- filename: "VerifyTinyMCEv4IsNativeWYSIWYGOnBlockTest.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/Cms/Test/Mftf/Test/VerifyTinyMCEv4IsNativeWYSIWYGOnBlockTest.xml"
+  module: "Cms"
+  tests:
+    - testname: "VerifyTinyMCEv4IsNativeWYSIWYGOnBlockTest"
+      title: "Admin should see TinyMCEv4.6 is the native WYSIWYG on Block"
+      description: "Admin should see TinyMCEv4.6 is the native WYSIWYG on Block"
+- filename: "AdminAddWidgetToWYSIWYGWithCatalogCategoryLinkTypeTest.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/Cms/Test/Mftf/Test/AdminAddWidgetToWYSIWYGWithCatalogCategoryLinkTypeTest.xml"
+  module: "Cms"
+  tests:
+    - testname: "AdminAddWidgetToWYSIWYGWithCatalogCategoryLinkTypeTest"
+      title: "Admin should be able to create a CMS page with widget type: Catalog category link"
+      description: "Admin should be able to create a CMS page with widget type: Catalog category link"
+- filename: "AdminCmsPageMassActionTest.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/Cms/Test/Mftf/Test/AdminCmsPageMassActionTest.xml"
+  module: "Cms"
+  tests:
+    - testname: "AdminCmsPageMassActionTest"
+      title: "Create two CMS Pages and perform mass disable action"
+      description: "Admin should be able to perform mass actions to CMS pages"
+- filename: "AdminAddWidgetToWYSIWYGWithRecentlyComparedProductsTypeTest.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/Cms/Test/Mftf/Test/AdminAddWidgetToWYSIWYGWithRecentlyComparedProductsTypeTest.xml"
+  module: "Cms"
+  tests:
+    - testname: "AdminAddWidgetToWYSIWYGWithRecentlyComparedProductsTypeTest"
+      title: "Admin should be able to create a CMS page with widget type: Recently Compared Products"
+      description: "Admin should be able to create a CMS page with widget type: Recently Compared Products"
+- filename: "VerifyTinyMCEv4IsNativeWYSIWYGOnCMSPageTest.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/Cms/Test/Mftf/Test/VerifyTinyMCEv4IsNativeWYSIWYGOnCMSPageTest.xml"
+  module: "Cms"
+  tests:
+    - testname: "VerifyTinyMCEv4IsNativeWYSIWYGOnCMSPageTest"
+      title: "Admin should see TinyMCEv4.6 is the native WYSIWYG on CMS Page"
+      description: "Admin should see TinyMCEv4.6 is the native WYSIWYG on CMS Page"
+- filename: "StoreViewLanguageCorrectSwitchTest.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/Cms/Test/Mftf/Test/StoreViewLanguageCorrectSwitchTest.xml"
+  module: "Cms"
+  tests:
+    - testname: "StoreViewLanguageCorrectSwitchTest"
+      title: "Check that Store View(language) switches correct"
+      description: "Check that Store View(language) switches correct"
+- filename: "AdminAddWidgetToWYSIWYGWithRecentlyViewedProductsTypeTest.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/Cms/Test/Mftf/Test/AdminAddWidgetToWYSIWYGWithRecentlyViewedProductsTypeTest.xml"
+  module: "Cms"
+  tests:
+    - testname: "AdminAddWidgetToWYSIWYGWithRecentlyViewedProductsTypeTest"
+      title: "Admin should be able to create a CMS page with widget type: Recently Viewed Products"
+      description: "Admin should be able to create a CMS page with widget type: Recently Viewed Products"
+- filename: "AdminMediaGalleryPopupUploadImagesWithoutErrorTest.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/Cms/Test/Mftf/Test/AdminMediaGalleryPopupUploadImagesWithoutErrorTest.xml"
+  module: "Cms"
+  tests:
+    - testname: "AdminMediaGalleryPopupUploadImagesWithoutErrorTest"
+      title: "Media Gallery popup upload images without error"
+      description: "Media Gallery popup upload images without error"
+- filename: "AdminAddImageToCMSPageTinyMCE3Test.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/Cms/Test/Mftf/Test/AdminAddImageToCMSPageTinyMCE3Test.xml"
+  module: "Cms"
+  tests:
+    - testname: "AdminAddImageToCMSPageTinyMCE3Test"
+      title: "Verify that admin is able to upload image to a CMS Page with TinyMCE3 enabled"
+      description: "Verify that admin is able to upload image to CMS Page with TinyMCE3 enabled"
+- filename: "AdminContentPagesNavigateMenuTest.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/Cms/Test/Mftf/Test/AdminContentPagesNavigateMenuTest.xml"
+  module: "Cms"
+  tests:
+    - testname: "AdminContentPagesNavigateMenuTest"
+      title: "Admin content pages navigate menu test"
+      description: "Admin should be able to navigate to Content &gt; Pages"
+- filename: "AdminAddWidgetToWYSIWYGBlockTest.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/Cms/Test/Mftf/Test/AdminAddWidgetToWYSIWYGBlockTest.xml"
+  module: "Cms"
+  tests:
+    - testname: "AdminAddWidgetToWYSIWYGBlockTest"
+      title: "Admin should be able to add widget to WYSIWYG content of Block"
+      description: "Admin should be able to add widget to WYSIWYG content Block"
+- filename: "AdminAddWidgetToWYSIWYGWithCMSStaticBlockTypeTest.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/Cms/Test/Mftf/Test/AdminAddWidgetToWYSIWYGWithCMSStaticBlockTypeTest.xml"
+  module: "Cms"
+  tests:
+    - testname: "AdminAddWidgetToWYSIWYGWithCMSStaticBlockTypeTest"
+      title: "Admin should be able to create a CMS page with widget type: CMS Static Block"
+      description: "Admin should be able to create a CMS page with widget type: CMS Static Block"
+- filename: "AdminAddWidgetToWYSIWYGWithCatalogProductListTypeTest.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/Cms/Test/Mftf/Test/AdminAddWidgetToWYSIWYGWithCatalogProductListTypeTest.xml"
+  module: "Cms"
+  tests:
+    - testname: "AdminAddWidgetToWYSIWYGWithCatalogProductListTypeTest"
+      title: "Admin should be able to create a CMS page with widget type: Catalog product list"
+      description: "Admin should be able to create a CMS page with widget type: Catalog product list"
+- filename: "AdminCreateCmsPageTest.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/Cms/Test/Mftf/Test/AdminCreateCmsPageTest.xml"
+  module: "Cms"
+  tests:
+    - testname: "AdminCreateCmsPageTest"
+      title: "Admin should be able to create a CMS Page"
+      description: "Admin should be able to create a CMS Page"
+
+    - testname: "AdminConfigDefaultCMSPageLayoutFromConfigurationSettingTest"
+      title: "Admin should be able to configure the default layout for CMS Page from System Configuration"
+      description: "Admin should be able to configure the default layout for CMS Page from System Configuration"
+
+    - testname: "AdminCreateDuplicatedCmsPageTest"
+      title: "Admin should be able to duplicate a CMS Page"
+      description: "Admin should be able to duplicate a CMS Page"
+- filename: "CheckOrderOfProdsInWidgetOnCMSPageTest.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/Cms/Test/Mftf/Test/CheckOrderOfProdsInWidgetOnCMSPageTest.xml"
+  module: "Cms"
+  tests:
+    - testname: "CheckOrderOfProdsInWidgetOnCMSPageTest"
+      title: "Checking order of products in a widget on a CMS page - SKU condition"
+      description: "Checking order of products in a widget on a CMS page - SKU condition"
+- filename: "AdminAddImageToWYSIWYGBlockTest.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/Cms/Test/Mftf/Test/AdminAddImageToWYSIWYGBlockTest.xml"
+  module: "Cms"
+  tests:
+    - testname: "AdminAddImageToWYSIWYGBlockTest"
+      title: "Admin should be able to add image to WYSIWYG content of Block"
+      description: "Admin should be able to add image to WYSIWYG content of Block"
+- filename: "AdminAddImageToWYSIWYGCMSTest.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/Cms/Test/Mftf/Test/AdminAddImageToWYSIWYGCMSTest.xml"
+  module: "Cms"
+  tests:
+    - testname: "AdminAddImageToWYSIWYGCMSTest"
+      title: "Admin should be able to add image to WYSIWYG content of CMS Page"
+      description: "Admin should be able to add image to WYSIWYG content of CMS Page"
+- filename: "AdminCreateCmsBlockTest.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/Cms/Test/Mftf/Test/AdminCreateCmsBlockTest.xml"
+  module: "Cms"
+  tests:
+    - testname: "AdminCreateDuplicatedCmsBlockTest"
+      title: "Admin should be able to duplicate a CMS block"
+      description: "Admin should be able to duplicate a CMS block"
+- filename: "CheckStaticBlocksTest.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/Cms/Test/Mftf/Test/CheckStaticBlocksTest.xml"
+  module: "Cms"
+  tests:
+    - testname: "CheckStaticBlocksTest"
+      title: "Check static blocks: ID should be unique per Store View"
+      description: "Check static blocks: ID should be unique per Store View"
+- filename: "AdminContentBlocksNavigateMenuTest.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/Cms/Test/Mftf/Test/AdminContentBlocksNavigateMenuTest.xml"
+  module: "Cms"
+  tests:
+    - testname: "AdminContentBlocksNavigateMenuTest"
+      title: "Admin content blocks navigate menu test"
+      description: "Admin should be able to navigate to Content &gt; Blocks"
+- filename: "AdminDisablingSwatchTooltipsTest.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/Swatches/Test/Mftf/Test/AdminDisablingSwatchTooltipsTest.xml"
+  module: "Swatches"
+  tests:
+    - testname: "AdminDisablingSwatchTooltipsTest"
+      title: "Admin disabling swatch tooltips test."
+      description: "Verify possibility to disable/enable swatch tooltips."
+- filename: "AdminCreateVisualSwatchTest.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/Swatches/Test/Mftf/Test/AdminCreateVisualSwatchTest.xml"
+  module: "Swatches"
+  tests:
+    - testname: "AdminCreateVisualSwatchTest"
+      title: "Admin can create product attribute with picked color swatch"
+      description: "Admin can create product attribute with picked color swatch"
+- filename: "StorefrontSwatchProductWithFileCustomOptionTest.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/Swatches/Test/Mftf/Test/StorefrontSwatchProductWithFileCustomOptionTest.xml"
+  module: "Swatches"
+  tests:
+    - testname: "StorefrontSwatchProductWithFileCustomOptionTest"
+      title: "Configurable product with swatch option and file custom option"
+      description: "Configurable product with swatch option and file custom option. When adding to cart with an invalid filetype, the correct error message is shown, and options remain selected."
+- filename: "AdminSaveConfigurableProductWithAttributesImagesAndSwatchesTest.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/Swatches/Test/Mftf/Test/AdminSaveConfigurableProductWithAttributesImagesAndSwatchesTest.xml"
+  module: "Swatches"
+  tests:
+    - testname: "AdminSaveConfigurableProductWithAttributesImagesAndSwatchesTest"
+      title: "Saving configurable product with custom product attribute (images as swatches)"
+      description: "Saving configurable product with custom product attribute (images as swatches)"
+- filename: "AdminCreateVisualSwatchWithNonValidOptionsTest.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/Swatches/Test/Mftf/Test/AdminCreateVisualSwatchWithNonValidOptionsTest.xml"
+  module: "Swatches"
+  tests:
+    - testname: "AdminCreateVisualSwatchWithNonValidOptionsTest"
+      title: "Admin should be able to create swatch product attribute"
+      description: "Admin should be able to create swatch product attribute"
+- filename: "StorefrontSwatchAttributesDisplayInWidgetCMSTest.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/Swatches/Test/Mftf/Test/StorefrontSwatchAttributesDisplayInWidgetCMSTest.xml"
+  module: "Swatches"
+  tests:
+    - testname: "StorefrontSwatchAttributesDisplayInWidgetCMSTest"
+      title: "Swatch Attribute is not displayed in the Widget CMS"
+      description: "Swatch Attribute is not displayed in the Widget CMS"
+- filename: "StorefrontFilterByTextSwatchTest.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/Swatches/Test/Mftf/Test/StorefrontFilterByTextSwatchTest.xml"
+  module: "Swatches"
+  tests:
+    - testname: "StorefrontFilterByTextSwatchTest"
+      title: "Customers can filter products using text swatches"
+      description: "Customers can filter products using text swatches"
+- filename: "StorefrontSeeProductImagesMatchingProductSwatchesTest.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/Swatches/Test/Mftf/Test/StorefrontSeeProductImagesMatchingProductSwatchesTest.xml"
+  module: "Swatches"
+  tests:
+    - testname: "StorefrontSeeProductImagesMatchingProductSwatchesTest"
+      title: "Customer can see product images matching product swatches"
+      description: "Customer can see product images matching product swatches"
+- filename: "StorefrontCustomerCanChangeProductOptionsUsingSwatchesTest.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/Swatches/Test/Mftf/Test/StorefrontCustomerCanChangeProductOptionsUsingSwatchesTest.xml"
+  module: "Swatches"
+  tests:
+    - testname: "StorefrontCustomerCanChangeProductOptionsUsingSwatchesTest"
+      title: "Customer can change product options using swatches"
+      description: "Customer can change product options using swatches"
+- filename: "StorefrontFilterByImageSwatchTest.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/Swatches/Test/Mftf/Test/StorefrontFilterByImageSwatchTest.xml"
+  module: "Swatches"
+  tests:
+    - testname: "StorefrontFilterByImageSwatchTest"
+      title: "Customers can filter products using image swatches"
+      description: "Customers can filter products using image swatches"
+- filename: "AdminCreateTextSwatchTest.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/Swatches/Test/Mftf/Test/AdminCreateTextSwatchTest.xml"
+  module: "Swatches"
+  tests:
+    - testname: "AdminCreateTextSwatchTest"
+      title: "Admin can create product attribute with text swatch"
+      description: "Admin can create product attribute with text swatch"
+- filename: "StorefrontFilterByVisualSwatchTest.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/Swatches/Test/Mftf/Test/StorefrontFilterByVisualSwatchTest.xml"
+  module: "Swatches"
+  tests:
+    - testname: "StorefrontFilterByVisualSwatchTest"
+      title: "Customers can filter products using visual swatches"
+      description: "Customers can filter products using visual swatches "
+- filename: "AdminSetUpWatermarkForSwatchImageTest.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/Swatches/Test/Mftf/Test/AdminSetUpWatermarkForSwatchImageTest.xml"
+  module: "Swatches"
+  tests:
+    - testname: "AdminSetUpWatermarkForSwatchImageTest"
+      title: "Possibility to set up watermark for a swatch image type"
+      description: "Possibility to set up watermark for a swatch image type"
+- filename: "StorefrontConfigurableProductSwatchMinimumPriceTest.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/Swatches/Test/Mftf/Test/StorefrontConfigurableProductSwatchMinimumPriceTest.xml"
+  module: "Swatches"
+  tests:
+    - testname: "StorefrontConfigurableProductSwatchMinimumPriceProductPageTest"
+      title: "Swatch option should show the lowest price possible on product page"
+      description: "Swatch option should show the lowest price possible on product page"
+
+    - testname: "StorefrontConfigurableProductSwatchMinimumPriceCategoryPageTest"
+      title: "Swatch option should show the lowest price possible on category page"
+      description: "Swatch option should show the lowest price possible on category page"
+- filename: "StorefrontDisplayAllCharactersOnTextSwatchTest.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/Swatches/Test/Mftf/Test/StorefrontDisplayAllCharactersOnTextSwatchTest.xml"
+  module: "Swatches"
+  tests:
+    - testname: "StorefrontDisplayAllCharactersOnTextSwatchTest"
+      title: "Admin can create product attribute with text swatch and view the display characters  in full"
+      description: "Admin can create product attribute with text swatch and check the display characters in full"
+- filename: "AdminCreateImageSwatchTest.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/Swatches/Test/Mftf/Test/AdminCreateImageSwatchTest.xml"
+  module: "Swatches"
+  tests:
+    - testname: "AdminCreateImageSwatchTest"
+      title: "Admin can create product attribute with image swatch"
+      description: "Admin can create product attribute with image swatch"
+- filename: "StorefrontImageColorWhenFilterByColorFilterTest.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/Swatches/Test/Mftf/Test/StorefrontImageColorWhenFilterByColorFilterTest.xml"
+  module: "Swatches"
+  tests:
+    - testname: "StorefrontImageColorWhenFilterByColorFilterTest"
+      title: "Image color when filtering by color filter on the Storefront"
+      description: "Image color when filtering by color filter on the Storefront"
+- filename: "StorefrontGuestCheckoutDisabledProductTest.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/Quote/Test/Mftf/Test/StorefrontGuestCheckoutDisabledProductTest.xml"
+  module: "Quote"
+  tests:
+    - testname: "StorefrontGuestCheckoutDisabledProductTest"
+      title: "Remove item from cart if product disabled"
+      description: "Remove item from cart if simple or configurable product is disabled"
+- filename: "AssociatedProductToConfigurableOutOfStockTest.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/CatalogInventory/Test/Mftf/Test/AssociatedProductToConfigurableOutOfStockTest.xml"
+  module: "CatalogInventory"
+  tests:
+    - testname: "AssociatedProductToConfigurableOutOfStockTest"
+      title: "Out of stock associated products to configurable are not full page cache cleaned "
+      description: "After last configurable product was ordered it becomes out of stock"
+- filename: "AdminCreateProductWithZeroMaximumQtyAllowedInShoppingCartTest.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/CatalogInventory/Test/Mftf/Test/AdminCreateProductWithZeroMaximumQtyAllowedInShoppingCartTest.xml"
+  module: "CatalogInventory"
+  tests:
+    - testname: "AdminCreateProductWithZeroMaximumQtyAllowedInShoppingCartTest"
+      title: "Verify that product maximum qty allowed in shopping cart can't be set to zero or less"
+      description: "Verify that product maximum qty allowed in shopping cart can't be set to zero or less"
+- filename: "CreateOrderFromEditCustomerPageTest.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/Sales/Test/Mftf/Test/CreateOrderFromEditCustomerPageTest.xml"
+  module: "Sales"
+  tests:
+    - testname: "CreateOrderFromEditCustomerPageTest"
+      title: "Create order from edit customer page and add products to wish list and shopping cart"
+      description: "Create an order from edit customer page and add products to the wish list and shopping cart "
+- filename: "AdminProductInTheShoppingCartCouldBeReachedByAdminDuringOrderCreationWithMultiWebsiteConfigTest.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/Sales/Test/Mftf/Test/AdminProductInTheShoppingCartCouldBeReachedByAdminDuringOrderCreationWithMultiWebsiteConfigTest.xml"
+  module: "Sales"
+  tests:
+    - testname: "AdminProductInTheShoppingCartCouldBeReachedByAdminDuringOrderCreationWithMultiWebsiteConfigTest"
+      title: "Product in the shopping cart could be reached by admin during order creation with multi website config"
+      description: "Product in the shopping cart could be reached by admin during order creation with multi website config"
+- filename: "AdminSubmitConfigurableProductOrderTest.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/Sales/Test/Mftf/Test/AdminSubmitConfigurableProductOrderTest.xml"
+  module: "Sales"
+  tests:
+    - testname: "AdminSubmitConfigurableProductOrderTest"
+      title: "Create Order in Admin and update product configuration"
+      description: "Create Order in Admin and update product configuration"
+- filename: "AdminAddSelectedProductToOrderTest.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/Sales/Test/Mftf/Test/AdminAddSelectedProductToOrderTest.xml"
+  module: "Sales"
+  tests:
+    - testname: "AdminAddSelectedProductToOrderTest"
+      title: "Add selected products to order in Admin when requested qty more than available"
+      description: "Trying to add selected products to order in Admin when requested qty more than available"
+- filename: "AdminCreateOrderWithSimpleProductTest.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/Sales/Test/Mftf/Test/AdminCreateOrderWithSimpleProductTest.xml"
+  module: "Sales"
+  tests:
+    - testname: "AdminCreateOrderWithSimpleProductTest"
+      title: "Create Order in Admin with simple product"
+      description: "Create order with simple product and assert if it gets out of stock after ordering it."
+- filename: "AdminStoresOrderStatusNavigateMenuTest.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/Sales/Test/Mftf/Test/AdminStoresOrderStatusNavigateMenuTest.xml"
+  module: "Sales"
+  tests:
+    - testname: "AdminStoresOrderStatusNavigateMenuTest"
+      title: "Admin stores order status navigate menu test"
+      description: "Admin should be able to navigate to Stores &gt; Order Status"
+- filename: "AdminSubmitsOrderWithAndWithoutFieldsValidationTest.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/Sales/Test/Mftf/Test/AdminSubmitsOrderWithAndWithoutFieldsValidationTest.xml"
+  module: "Sales"
+  tests:
+    - testname: "AdminSubmitsOrderWithAndWithoutFieldsValidationTest"
+      title: "Fields validation is required to create an order from Admin Panel"
+      description: "Admin should not be able to submit orders without invalid address fields"
+- filename: "AdminCreateOrderWithSelectedShoppingCartItemsTest.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/Sales/Test/Mftf/Test/AdminCreateOrderWithSelectedShoppingCartItemsTest.xml"
+  module: "Sales"
+  tests:
+    - testname: "AdminCreateOrderWithSelectedShoppingCartItemsTest"
+      title: "Shopping cart items must not be added to the order unless they were moved manually"
+      description: "Shopping cart items must not be added to the order unless they were moved manually"
+- filename: "AddConfigurableProductToOrderFromShoppingCartTest.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/Sales/Test/Mftf/Test/AddConfigurableProductToOrderFromShoppingCartTest.xml"
+  module: "Sales"
+  tests:
+    - testname: "AddConfigurableProductToOrderFromShoppingCartTest"
+      title: "Add configurable product to order from shopping cart test"
+      description: "Add configurable product to order from shopping cart"
+- filename: "AssignCustomOrderStatusNotVisibleOnStorefrontTest.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/Sales/Test/Mftf/Test/AssignCustomOrderStatusNotVisibleOnStorefrontTest.xml"
+  module: "Sales"
+  tests:
+    - testname: "AssignCustomOrderStatusNotVisibleOnStorefrontTest"
+      title: "Assign custom order status not visible on storefront test"
+      description: "Assign custom order status not visible on storefront"
+- filename: "AdminCreateCreditMemoBankTransferPaymentTest.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/Sales/Test/Mftf/Test/AdminCreateCreditMemoBankTransferPaymentTest.xml"
+  module: "Sales"
+  tests:
+    - testname: "AdminCreateCreditMemoBankTransferPaymentTest"
+      title: "Create Credit Memo with Bank Transfer Payment"
+      description: "Create Credit Memo with Bank Transfer Payment and assert 0 shipping refund"
+- filename: "AdminSalesShipmentsNavigateMenuTest.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/Sales/Test/Mftf/Test/AdminSalesShipmentsNavigateMenuTest.xml"
+  module: "Sales"
+  tests:
+    - testname: "AdminSalesShipmentsNavigateMenuTest"
+      title: "Admin sales shipments navigate menu test"
+      description: "Admin should be able to navigate to Sales &gt; Shipments"
+- filename: "AdminCancelTheCreatedOrderWithProductQtyWithoutStockDecreaseTest.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/Sales/Test/Mftf/Test/AdminCancelTheCreatedOrderWithProductQtyWithoutStockDecreaseTest.xml"
+  module: "Sales"
+  tests:
+    - testname: "AdminCancelTheCreatedOrderWithProductQtyWithoutStockDecreaseTest"
+      title: "Cancel the created order with product quantity without stock decrease"
+      description: "Create an order with product quantity without stock decrease, cancel the order and verify product quantity in backend"
+- filename: "StorefrontPrintOrderGuestTest.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/Sales/Test/Mftf/Test/StorefrontPrintOrderGuestTest.xml"
+  module: "Sales"
+  tests:
+    - testname: "StorefrontPrintOrderGuestTest"
+      title: "Print Order from Guest on Frontend"
+      description: "Print Order from Guest on Frontend"
+- filename: "MoveRecentlyViewedConfigurableProductOnOrderPageTest.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/Sales/Test/Mftf/Test/MoveRecentlyViewedConfigurableProductOnOrderPageTest.xml"
+  module: "Sales"
+  tests:
+    - testname: "MoveRecentlyViewedConfigurableProductOnOrderPageTest"
+      title: "Move recently viewed configurable product on order page test"
+      description: "Move recently viewed configurable product on order page"
+- filename: "AdminCreateInvoiceTest.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/Sales/Test/Mftf/Test/AdminCreateInvoiceTest.xml"
+  module: "Sales"
+  tests:
+    - testname: "AdminCreateInvoiceTest"
+      title: "Admin should be able to create an invoice"
+      description: "Admin should be able to create an invoice"
+- filename: "AdminCreateCreditMemoWithCashOnDeliveryTest.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/Sales/Test/Mftf/Test/AdminCreateCreditMemoWithCashOnDeliveryTest.xml"
+  module: "Sales"
+  tests:
+    - testname: "AdminCreateCreditMemoWithCashOnDeliveryTest"
+      title: "Create Credit Memo with cash on delivery payment method"
+      description: "Create Credit Memo with cash on delivery payment and assert 0 shipping refund"
+- filename: "AssignCustomOrderStatusVisibleOnStorefrontTest.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/Sales/Test/Mftf/Test/AssignCustomOrderStatusVisibleOnStorefrontTest.xml"
+  module: "Sales"
+  tests:
+    - testname: "AssignCustomOrderStatusVisibleOnStorefrontTest"
+      title: "Assign custom order status visible on storefront test"
+      description: "Assign custom order status visible on storefront"
+- filename: "AdminOrdersReleaseInUnholdStatusTest.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/Sales/Test/Mftf/Test/AdminOrdersReleaseInUnholdStatusTest.xml"
+  module: "Sales"
+  tests:
+    - testname: "AdminOrdersReleaseInUnholdStatusTest"
+      title: "Release order in status On Hold"
+      description: "Release order in status On Hold"
+- filename: "CreditMemoTotalAfterShippingDiscountTest.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/Sales/Test/Mftf/Test/CreditMemoTotalAfterShippingDiscountTest.xml"
+  module: "Sales"
+  tests:
+    - testname: "CreditMemoTotalAfterShippingDiscountTest"
+      title: "Verify credit memo grand total after shipping discount is applied via Cart Price Rule"
+      description: "Verify credit memo grand total after shipping discount is applied via Cart Price Rule"
+- filename: "AdminSalesCreditMemosNavigateMenuTest.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/Sales/Test/Mftf/Test/AdminSalesCreditMemosNavigateMenuTest.xml"
+  module: "Sales"
+  tests:
+    - testname: "AdminSalesCreditMemosNavigateMenuTest"
+      title: "Admin sales credit memos navigate menu test"
+      description: "Admin should be able to navigate to Sales &gt; Credit Memos"
+- filename: "AdminCorrectnessInvoicedItemInBundleProductTest.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/Sales/Test/Mftf/Test/AdminCorrectnessInvoicedItemInBundleProductTest.xml"
+  module: "Sales"
+  tests:
+    - testname: "AdminCorrectnessInvoicedItemInBundleProductTest"
+      title: "Check correctness of invoiced items in a Bundle Product"
+      description: "Check correctness of invoiced items in a Bundle Product"
+- filename: "AdminCancelTheCreatedOrderWithCheckMoneyOrderPaymentMethodTest.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/Sales/Test/Mftf/Test/AdminCancelTheCreatedOrderWithCheckMoneyOrderPaymentMethodTest.xml"
+  module: "Sales"
+  tests:
+    - testname: "AdminCancelTheCreatedOrderWithCheckMoneyOrderPaymentMethodTest"
+      title: "Cancel the created order with check/money order payment method"
+      description: " Create an order with check/money order payment method and cancel the order"
+- filename: "AdminCancelTheCreatedOrderWithZeroSubtotalCheckoutTest.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/Sales/Test/Mftf/Test/AdminCancelTheCreatedOrderWithZeroSubtotalCheckoutTest.xml"
+  module: "Sales"
+  tests:
+    - testname: "AdminCancelTheCreatedOrderWithZeroSubtotalCheckoutTest"
+      title: "Cancel the created order with zero subtotal checkout"
+      description: "Create an order with Zero Subtotal checkout and cancel the order"
+- filename: "CreateInvoiceWithShipmentAndCheckInvoicedOrderTest.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/Sales/Test/Mftf/Test/CreateInvoiceWithShipmentAndCheckInvoicedOrderTest.xml"
+  module: "Sales"
+  tests:
+    - testname: "CreateInvoiceWithShipmentAndCheckInvoicedOrderTest"
+      title: "Create invoice with shipment and check invoiced order test"
+      description: "Create invoice with shipment for offline payment methods and check invoiced order on admin dashboard"
+- filename: "CreateInvoiceWithPurchaseOrderPaymentMethodTest.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/Sales/Test/Mftf/Test/CreateInvoiceWithPurchaseOrderPaymentMethodTest.xml"
+  module: "Sales"
+  tests:
+    - testname: "CreateInvoiceWithPurchaseOrderPaymentMethodTest"
+      title: "Create invoice with purchase order payment method test"
+      description: "Create invoice with purchase order payment method"
+- filename: "AdminCreateCreditMemoWithPurchaseOrderTest.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/Sales/Test/Mftf/Test/AdminCreateCreditMemoWithPurchaseOrderTest.xml"
+  module: "Sales"
+  tests:
+    - testname: "AdminCreateCreditMemoWithPurchaseOrderTest"
+      title: "Create Credit Memo with purchase order payment method"
+      description: "Create Credit Memo with purchase order payment payment and assert 0 shipping refund"
+- filename: "MoveLastOrderedSimpleProductOnOrderPageTest.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/Sales/Test/Mftf/Test/MoveLastOrderedSimpleProductOnOrderPageTest.xml"
+  module: "Sales"
+  tests:
+    - testname: "MoveLastOrderedSimpleProductOnOrderPageTest"
+      title: "Move last ordered simple product on order page test"
+      description: "Move last ordered simple product on order page"
+- filename: "AdminMassOrdersReleasePendingOrderTest.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/Sales/Test/Mftf/Test/AdminMassOrdersReleasePendingOrderTest.xml"
+  module: "Sales"
+  tests:
+    - testname: "AdminMassOrdersReleasePendingOrderTest"
+      title: "Try to Release order in status Pending"
+      description: "Try to Release order in status Pending"
+- filename: "StorefrontOrderPagerDisplayedTest.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/Sales/Test/Mftf/Test/StorefrontOrderPagerDisplayedTest.xml"
+  module: "Sales"
+  tests:
+    - testname: "StorefrontOrderPagerDisplayedTest"
+      title: "Pager is displayed for 21 order items"
+      description: "Pager is displayed for 21 order items"
+- filename: "AdminMassOrdersHoldOnPendingAndProcessingTest.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/Sales/Test/Mftf/Test/AdminMassOrdersHoldOnPendingAndProcessingTest.xml"
+  module: "Sales"
+  tests:
+    - testname: "AdminMassOrdersHoldOnPendingAndProcessingTest"
+      title: "Mass put orders in statuses Pending, Processing on Hold"
+      description: "Put orders in statuses Pending, Processing on Hold"
+- filename: "AdminSubmitsOrderPaymentMethodValidationTest.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/Sales/Test/Mftf/Test/AdminSubmitsOrderPaymentMethodValidationTest.xml"
+  module: "Sales"
+  tests:
+    - testname: "AdminSubmitsOrderPaymentMethodValidationTest"
+      title: "UI validation for Payment methods when creating an order from admin"
+      description: "Admin should not be able to submit orders without selecting a payment method when there is more than one"
+- filename: "AdminSaveInAddressBookCheckboxStateTest.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/Sales/Test/Mftf/Test/AdminSaveInAddressBookCheckboxStateTest.xml"
+  module: "Sales"
+  tests:
+    - testname: "AdminSaveInAddressBookCheckboxStateTest"
+      title: "The state of 'Save in address book' check-box inside 'Shipping Address' section on 'create Order' Admin page"
+      description: "The state of 'Save in address book' check-box inside 'Shipping Address' section on 'create Order' Admin page"
+- filename: "AdminReorderWithCatalogPriceTest.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/Sales/Test/Mftf/Test/AdminReorderWithCatalogPriceTest.xml"
+  module: "Sales"
+  tests:
+    - testname: "AdminReorderWithCatalogPriceTest"
+      title: "DEPRECATED. Reorder doesn't show discount price in Order Totals block"
+      description: "Reorder doesn't show discount price in Order Totals block"
+- filename: "StorefrontVerifySecureURLRedirectSalesTest.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/Sales/Test/Mftf/Test/StorefrontVerifySecureURLRedirectSalesTest.xml"
+  module: "Sales"
+  tests:
+    - testname: "StorefrontVerifySecureURLRedirectSales"
+      title: "Verify Secure URLs For Storefront Sales Pages"
+      description: "Verify that the Secure URL configuration applies to the Sales pages on the Storefront"
+- filename: "AdminHoldCreatedOrderTest.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/Sales/Test/Mftf/Test/AdminHoldCreatedOrderTest.xml"
+  module: "Sales"
+  tests:
+    - testname: "AdminHoldCreatedOrderTest"
+      title: "Hold the created order"
+      description: "Create an order and hold the order"
+- filename: "AdminSubmitsOrderWithAndWithoutEmailTest.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/Sales/Test/Mftf/Test/AdminSubmitsOrderWithAndWithoutEmailTest.xml"
+  module: "Sales"
+  tests:
+    - testname: "AdminSubmitsOrderWithAndWithoutEmailTest"
+      title: "Email is required to create an order from Admin Panel"
+      description: "Admin should not be able to submit orders without an email address"
+- filename: "AdminSalesTransactionsNavigateMenuTest.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/Sales/Test/Mftf/Test/AdminSalesTransactionsNavigateMenuTest.xml"
+  module: "Sales"
+  tests:
+    - testname: "AdminSalesTransactionsNavigateMenuTest"
+      title: "Admin sales transactions navigate menu test"
+      description: "Admin should be able to navigate to Sales &gt; Transactions"
+- filename: "AdminCreateCreditMemoConfigurableProductTest.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/Sales/Test/Mftf/Test/AdminCreateCreditMemoConfigurableProductTest.xml"
+  module: "Sales"
+  tests:
+    - testname: "AdminCreateCreditMemoConfigurableProductTest"
+      title: "Create Credit Memo for Offline Payment Methods"
+      description: "Create CreditMemo return to stock only one unit of configurable product"
+- filename: "AdminFreeShippingNotAvailableIfMinimumOrderAmountNotMatchOrderTotalTest.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/Sales/Test/Mftf/Test/AdminFreeShippingNotAvailableIfMinimumOrderAmountNotMatchOrderTotalTest.xml"
+  module: "Sales"
+  tests:
+    - testname: "AdminFreeShippingNotAvailableIfMinimumOrderAmountNotMatchOrderTotalTest"
+      title: "Free Shipping is not available in Admin if Minimum Order Amount does not match Order total"
+      description: "Admin should not be able place order with Free Shipping method if Minimum Order Amount does not match Order total"
+- filename: "EndToEndB2CAdminTest.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/Sales/Test/Mftf/Test/EndToEndB2CAdminTest.xml"
+  module: "Sales"
+  tests:
+    - testname: "EndToEndB2CAdminTest"
+      title: ""
+      description: ""
+- filename: "AdminCheckingDateAfterChangeInterfaceLocaleTest.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/Sales/Test/Mftf/Test/AdminCheckingDateAfterChangeInterfaceLocaleTest.xml"
+  module: "Sales"
+  tests:
+    - testname: "AdminCheckingDateAfterChangeInterfaceLocaleTest"
+      title: "Checking date format in orders grid column after changing admin interface locale"
+      description: "Checking date format in orders grid column after changing admin interface locale"
+- filename: "CreateInvoiceWithCashOnDeliveryPaymentMethodTest.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/Sales/Test/Mftf/Test/CreateInvoiceWithCashOnDeliveryPaymentMethodTest.xml"
+  module: "Sales"
+  tests:
+    - testname: "CreateInvoiceWithCashOnDeliveryPaymentMethodTest"
+      title: "Create invoice with cash on delivery payment method test"
+      description: "Create invoice with cash on delivery payment method"
+- filename: "AdminCreateOrderStatusDuplicatingLabelTest.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/Sales/Test/Mftf/Test/AdminCreateOrderStatusDuplicatingLabelTest.xml"
+  module: "Sales"
+  tests:
+    - testname: "AdminCreateOrderStatusDuplicatingLabelTest"
+      title: "Create order status with duplicating label"
+      description: "Create an order status and get success message"
+- filename: "AdminMassOrdersUpdateCancelPendingOrderTest.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/Sales/Test/Mftf/Test/AdminMassOrdersUpdateCancelPendingOrderTest.xml"
+  module: "Sales"
+  tests:
+    - testname: "AdminMassOrdersUpdateCancelPendingOrderTest"
+      title: "Mass cancel orders in status Pending"
+      description: "Mass cancel orders in status Pending"
+- filename: "AdminCreateOrderWithBundleProductTest.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/Sales/Test/Mftf/Test/AdminCreateOrderWithBundleProductTest.xml"
+  module: "Sales"
+  tests:
+    - testname: "AdminCreateOrderWithBundleProductTest"
+      title: "Create Order in Admin and update bundle product configuration"
+      description: "Add bundle product with bundle option items with default quantity 2 to order in Admin and check price in product grid"
+- filename: "MoveLastOrderedConfigurableProductOnOrderPageTest.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/Sales/Test/Mftf/Test/MoveLastOrderedConfigurableProductOnOrderPageTest.xml"
+  module: "Sales"
+  tests:
+    - testname: "MoveLastOrderedConfigurableProductOnOrderPageTest"
+      title: "Move last ordered configurable product on order page test"
+      description: "Move last ordered configurable product on order page"
+- filename: "MoveSimpleProductsInComparedOnOrderPageTest.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/Sales/Test/Mftf/Test/MoveSimpleProductsInComparedOnOrderPageTest.xml"
+  module: "Sales"
+  tests:
+    - testname: "MoveSimpleProductsInComparedOnOrderPageTest"
+      title: "Move simple products in compared on order page test"
+      description: "Move simple products in compared on order page test"
+- filename: "AdminCreateOrderAddProductCheckboxTest.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/Sales/Test/Mftf/Test/AdminCreateOrderAddProductCheckboxTest.xml"
+  module: "Sales"
+  tests:
+    - testname: "AdminCreateOrderAddProductCheckboxTest"
+      title: "Create Order in Admin and Add Product"
+      description: "Create order in Admin panel, add product by clicking checkbox, and verify it is checked"
+- filename: "AdminCreateOrderForCustomerWithTwoAddressesTaxableAndNonTaxableTest.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/Sales/Test/Mftf/Test/AdminCreateOrderForCustomerWithTwoAddressesTaxableAndNonTaxableTest.xml"
+  module: "Sales"
+  tests:
+    - testname: "AdminCreateOrderForCustomerWithTwoAddressesTaxableAndNonTaxableTest"
+      title: "Tax should not be displayed for non taxable address"
+      description: "Tax should not be displayed for non taxable address when switching from taxable address"
+- filename: "AdminAvailabilityCreditMemoWithNoPaymentTest.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/Sales/Test/Mftf/Test/AdminAvailabilityCreditMemoWithNoPaymentTest.xml"
+  module: "Sales"
+  tests:
+    - testname: "AdminAvailabilityCreditMemoWithNoPaymentTest"
+      title: "Checking availability of 'Credit memo' button for order with no payment required"
+      description: "*Credit Memo* button should be displayed"
+- filename: "AdminMassOrdersCancelProcessingAndClosedTest.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/Sales/Test/Mftf/Test/AdminMassOrdersCancelProcessingAndClosedTest.xml"
+  module: "Sales"
+  tests:
+    - testname: "AdminMassOrdersCancelProcessingAndClosedTest"
+      title: "Mass cancel orders in status  Processing, Closed"
+      description: "Try to cancel orders in status Processing, Closed"
+- filename: "MoveConfigurableProductsInComparedOnOrderPageTest.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/Sales/Test/Mftf/Test/MoveConfigurableProductsInComparedOnOrderPageTest.xml"
+  module: "Sales"
+  tests:
+    - testname: "MoveConfigurableProductsInComparedOnOrderPageTest"
+      title: "Move configurable products in compared on order page test"
+      description: "Move configurable products in compared on order page test"
+- filename: "AdminCreateCreditMemoPartialRefundTest.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/Sales/Test/Mftf/Test/AdminCreateCreditMemoPartialRefundTest.xml"
+  module: "Sales"
+  tests:
+    - testname: "AdminCreateCreditMemoPartialRefundTest"
+      title: "Create Credit Memo for Offline Payment Methods"
+      description: "Assert items return to stock (partial refund)"
+- filename: "MoveRecentlyViewedBundleFixedProductOnOrderPageTest.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/Sales/Test/Mftf/Test/MoveRecentlyViewedBundleFixedProductOnOrderPageTest.xml"
+  module: "Sales"
+  tests:
+    - testname: "MoveRecentlyViewedBundleFixedProductOnOrderPageTest"
+      title: "Move recently viewed bundle fixed product on order page test"
+      description: "Move recently viewed bundle fixed product on order page"
+- filename: "AdminMassOrdersCancelCompleteAndClosedTest.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/Sales/Test/Mftf/Test/AdminMassOrdersCancelCompleteAndClosedTest.xml"
+  module: "Sales"
+  tests:
+    - testname: "AdminMassOrdersCancelCompleteAndClosedTest"
+      title: "Mass cancel orders in status  Complete, Closed"
+      description: "Try to cancel orders in status Complete, Closed"
+- filename: "AdminCreateOrderStatusTest.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/Sales/Test/Mftf/Test/AdminCreateOrderStatusTest.xml"
+  module: "Sales"
+  tests:
+    - testname: "AdminCreateOrderStatusTest"
+      title: "Create custom order status"
+      description: "Tests opening admin order status page, create a new order status with success message"
+- filename: "AdminCheckingCreditMemoUpdateTotalsTest.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/Sales/Test/Mftf/Test/AdminCheckingCreditMemoUpdateTotalsTest.xml"
+  module: "Sales"
+  tests:
+    - testname: "AdminCheckingCreditMemoTotalsTest"
+      title: "Checking Credit Memo Update Totals button"
+      description: "Checking Credit Memo Update Totals button"
+- filename: "AddSimpleProductToOrderFromShoppingCartTest.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/Sales/Test/Mftf/Test/AddSimpleProductToOrderFromShoppingCartTest.xml"
+  module: "Sales"
+  tests:
+    - testname: "AddSimpleProductToOrderFromShoppingCartTest"
+      title: "Add simple product to order from shopping cart test"
+      description: "Add simple product to order from shopping cart"
+- filename: "CreateInvoiceAndCheckInvoiceOrderTest.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/Sales/Test/Mftf/Test/CreateInvoiceAndCheckInvoiceOrderTest.xml"
+  module: "Sales"
+  tests:
+    - testname: "CreateInvoiceAndCheckInvoiceOrderTest"
+      title: "Create invoice and check invoice order test"
+      description: "Create invoice for offline payment methods and check invoice order on admin dashboard"
+- filename: "AdminCreateOrderWithMinimumAmountEnabledTest.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/Sales/Test/Mftf/Test/AdminCreateOrderWithMinimumAmountEnabledTest.xml"
+  module: "Sales"
+  tests:
+    - testname: "AdminCreateOrderWithMinimumAmountEnabledTest"
+      title: "Admin order is not restricted by 'Minimum Order Amount' configuration."
+      description: "Admin should be able to create an order regardless of the minimum order amount."
+- filename: "AdminCancelTheCreatedOrderWithPurchaseOrderPaymentMethodTest.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/Sales/Test/Mftf/Test/AdminCancelTheCreatedOrderWithPurchaseOrderPaymentMethodTest.xml"
+  module: "Sales"
+  tests:
+    - testname: "AdminCancelTheCreatedOrderWithPurchaseOrderPaymentMethodTest"
+      title: "Cancel the created order with purchase order payment method"
+      description: "Create an order using Purchase Order payment method and cancel the order"
+- filename: "AdminCreateOrderAndCheckTheReorderTest.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/Sales/Test/Mftf/Test/AdminCreateOrderAndCheckTheReorderTest.xml"
+  module: "Sales"
+  tests:
+    - testname: "AdminCreateOrderAndCheckTheReorderTest"
+      title: "'Reorder' button is not visible for customer if ordered item is out of stock"
+      description: "'Reorder' button is not visible for customer if ordered item is out of stock"
+- filename: "StorefrontOrderPagerIsAbsentTest.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/Sales/Test/Mftf/Test/StorefrontOrderPagerIsAbsentTest.xml"
+  module: "Sales"
+  tests:
+    - testname: "StorefrontOrderPagerIsAbsentTest"
+      title: "Pager is absent for 20 order items"
+      description: "Pager is disabled for orders with less than 20 items"
+- filename: "AdminReorderWithCatalogPriceRuleDiscountTest.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/Sales/Test/Mftf/Test/AdminReorderWithCatalogPriceRuleDiscountTest.xml"
+  module: "Sales"
+  tests:
+    - testname: "AdminReorderWithCatalogPriceRuleDiscountTest"
+      title: "Reorder doesn't show discount price in Order Totals block"
+      description: "Reorder doesn't show discount price in Order Totals block"
+- filename: "AdminSalesInvoicesNavigateMenuTest.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/Sales/Test/Mftf/Test/AdminSalesInvoicesNavigateMenuTest.xml"
+  module: "Sales"
+  tests:
+    - testname: "AdminSalesInvoicesNavigateMenuTest"
+      title: "Admin sales invoices navigate menu test"
+      description: "Admin should be able to navigate to Sales &gt; Invoices"
+- filename: "AdminSalesOrdersNavigateMenuTest.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/Sales/Test/Mftf/Test/AdminSalesOrdersNavigateMenuTest.xml"
+  module: "Sales"
+  tests:
+    - testname: "AdminSalesOrdersNavigateMenuTest"
+      title: "Admin sales orders navigate menu test"
+      description: "Admin should be able to navigate to Sales &gt; Orders"
+- filename: "CheckXSSVulnerabilityDuringOrderCreationTest.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/Sales/Test/Mftf/Test/CheckXSSVulnerabilityDuringOrderCreationTest.xml"
+  module: "Sales"
+  tests:
+    - testname: "CheckXSSVulnerabilityDuringOrderCreationTest"
+      title: "Check XSS vulnerability during order creation test"
+      description: "Order should not be created with XSS vulnerability in email address"
+- filename: "AdminCreateOrderStatusDuplicatingCodeTest.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/Sales/Test/Mftf/Test/AdminCreateOrderStatusDuplicatingCodeTest.xml"
+  module: "Sales"
+  tests:
+    - testname: "AdminCreateOrderStatusDuplicatingCodeTest"
+      title: "Create order status with duplicating code"
+      description: "Receive error when creating order status with the code which is already exist"
+- filename: "AdminUnassignCustomOrderStatusTest.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/Sales/Test/Mftf/Test/AdminUnassignCustomOrderStatusTest.xml"
+  module: "Sales"
+  tests:
+    - testname: "AdminUnassignCustomOrderStatusTest"
+      title: "Admin Unassign Custom Order Status Test"
+      description: "Test log in to Sales and Unassign Custom Order Status Test"
+- filename: "AdminMassOrdersHoldOnCompleteTest.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/Sales/Test/Mftf/Test/AdminMassOrdersHoldOnCompleteTest.xml"
+  module: "Sales"
+  tests:
+    - testname: "AdminMassOrdersHoldOnCompleteTest"
+      title: "Try to put order in status Complete on Hold"
+      description: "Try to put order in status Complete on Hold"
+- filename: "CreateInvoiceWithZeroSubtotalCheckoutTest.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/Sales/Test/Mftf/Test/CreateInvoiceWithZeroSubtotalCheckoutTest.xml"
+  module: "Sales"
+  tests:
+    - testname: "CreateInvoiceWithZeroSubtotalCheckoutTest"
+      title: "Create invoice with zero subtotal checkout test"
+      description: "Create invoice with with zero subtotal checkout"
+- filename: "AdminCancelTheCreatedOrderWithCashOnDeliveryPaymentMethodTest.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/Sales/Test/Mftf/Test/AdminCancelTheCreatedOrderWithCashOnDeliveryPaymentMethodTest.xml"
+  module: "Sales"
+  tests:
+    - testname: "AdminCancelTheCreatedOrderWithCashOnDeliveryPaymentMethodTest"
+      title: "Cancel the created order with cash on delivery payment method"
+      description: "Create an order with cash on delivery payment method and cancel the order"
+- filename: "AdminCancelTheCreatedOrderWithBankTransferPaymentMethodTest.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/Sales/Test/Mftf/Test/AdminCancelTheCreatedOrderWithBankTransferPaymentMethodTest.xml"
+  module: "Sales"
+  tests:
+    - testname: "AdminCancelTheCreatedOrderWithBankTransferPaymentMethodTest"
+      title: "Cancel the created order with bank transfer payment method"
+      description: "Created an order with bank transfer payment method and cancel the order"
+- filename: "AdminUpdateWebsiteTest.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/Store/Test/Mftf/Test/AdminUpdateWebsiteTest.xml"
+  module: "Store"
+  tests:
+    - testname: "AdminUpdateWebsiteTest"
+      title: "Update Website and Verify Store Form"
+      description: "Test log in to Stores and Update Website Test"
+- filename: "StorefrontAddStoreCodeInUrlTest.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/Store/Test/Mftf/Test/StorefrontAddStoreCodeInUrlTest.xml"
+  module: "Store"
+  tests:
+    - testname: "StorefrontAddStoreCodeInUrlTest"
+      title: "Store code should be added to storefront URL if the corresponding configuration is enabled"
+      description: "Store code should be added to storefront URL if the corresponding configuration is enabled"
+- filename: "AdminCreateStoreGroupWithDefaultWebsiteAndDefaultCategoryTest.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/Store/Test/Mftf/Test/AdminCreateStoreGroupWithDefaultWebsiteAndDefaultCategoryTest.xml"
+  module: "Store"
+  tests:
+    - testname: "AdminCreateStoreGroupWithDefaultWebsiteAndDefaultCategoryTest"
+      title: "Create Store Group with Default Website and Default Category"
+      description: "Test log in to Stores and Create Store Group with Default Website and Default Category Test"
+- filename: "AdminCreateNewLocalizedStoreViewStatusEnabledTest.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/Store/Test/Mftf/Test/AdminCreateNewLocalizedStoreViewStatusEnabledTest.xml"
+  module: "Store"
+  tests:
+    - testname: "AdminCreateNewLocalizedStoreViewStatusEnabledTest"
+      title: "Create New Localized Store View Status Enabled and Verify Save Message"
+      description: "Test log in to Stores and Create New Localized Store View Status Enabled Test"
+- filename: "AdminCreateStoreViewStatusDisabledVerifyBackendAndFrontendTest.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/Store/Test/Mftf/Test/AdminCreateStoreViewStatusDisabledVerifyBackendAndFrontendTest.xml"
+  module: "Store"
+  tests:
+    - testname: "AdminCreateStoreViewStatusDisabledVerifyBackendAndFrontendTest"
+      title: "Create Store View Status Disabled and Verify Backend and Frontend"
+      description: "Test log in to Stores and Create Store View Status Disabled Test"
+- filename: "AdminUpdateStoreGroupAndVerifyStoreViewFormTest.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/Store/Test/Mftf/Test/AdminUpdateStoreGroupAndVerifyStoreViewFormTest.xml"
+  module: "Store"
+  tests:
+    - testname: "AdminUpdateStoreGroupAndVerifyStoreViewFormTest"
+      title: "Update Store Group and Verify Store View Form"
+      description: "Test log in to Stores and Update Store Group Test"
+- filename: "AdminCreateCustomStoreViewStatusDisabledVerifyErrorSaveMessageTest.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/Store/Test/Mftf/Test/AdminCreateCustomStoreViewStatusDisabledVerifyErrorSaveMessageTest.xml"
+  module: "Store"
+  tests:
+    - testname: "AdminCreateCustomStoreViewStatusDisabledVerifyErrorSaveMessageTest"
+      title: "Create Custom Store View Status Disabled and Verify Error Save Message"
+      description: "Test log in to Stores and Create Custom Store View Status Enabled and Verify Error Save Message Test"
+- filename: "AdminCreateWebsiteTest.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/Store/Test/Mftf/Test/AdminCreateWebsiteTest.xml"
+  module: "Store"
+  tests:
+    - testname: "AdminCreateWebsiteTest"
+      title: "Create Website and Verify Store Form"
+      description: "Test log in to Stores and Create Website Test"
+- filename: "AdminCreateStoreGroupWithCustomWebsiteAndDefaultCategoryTest.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/Store/Test/Mftf/Test/AdminCreateStoreGroupWithCustomWebsiteAndDefaultCategoryTest.xml"
+  module: "Store"
+  tests:
+    - testname: "AdminCreateStoreGroupWithCustomWebsiteAndDefaultCategoryTest"
+      title: "Create Store Group with Custom Website and Default Category"
+      description: "Test log in to Stores and Create Store Group with Custom Website and Default Category Test"
+- filename: "AdminMoveStoreToOtherGroupSameWebsiteTest.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/Store/Test/Mftf/Test/AdminMoveStoreToOtherGroupSameWebsiteTest.xml"
+  module: "Store"
+  tests:
+    - testname: "AdminMoveStoreToOtherGroupSameWebsiteTest"
+      title: "Move Store To Other Group Same Website and Verify Backend and Frontend"
+      description: "Test log in to Stores and Move Store To Other Group Same Website Test"
+- filename: "AdminDeleteStoreGroupTest.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/Store/Test/Mftf/Test/AdminDeleteStoreGroupTest.xml"
+  module: "Store"
+  tests:
+    - testname: "AdminDeleteStoreGroupTest"
+      title: "Delete store group and save backup"
+      description: "Test log in to Stores and Delete Store Group Test"
+- filename: "AdminDeleteDefaultStoreViewTest.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/Store/Test/Mftf/Test/AdminDeleteDefaultStoreViewTest.xml"
+  module: "Store"
+  tests:
+    - testname: "AdminDeleteDefaultStoreViewTest"
+      title: "Delete Default Store View"
+      description: "Test another store view should be set as default when default store view is deleted"
+- filename: "AdminCreateStoreViewTest.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/Store/Test/Mftf/Test/AdminCreateStoreViewTest.xml"
+  module: "Store"
+  tests:
+    - testname: "AdminCreateStoreViewTest"
+      title: "Admin shouldn't be able to create a Store View with the same code"
+      description: "Admin shouldn't be able to create a Store View with the same code"
+- filename: "AdminCreateCustomStoreViewStatusEnabledVerifyBackendAndFrontendTest.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/Store/Test/Mftf/Test/AdminCreateCustomStoreViewStatusEnabledVerifyBackendAndFrontendTest.xml"
+  module: "Store"
+  tests:
+    - testname: "AdminCreateCustomStoreViewStatusEnabledVerifyBackendAndFrontendTest"
+      title: "Create Custom Store View Status Enabled and Verify Backend and Frontend"
+      description: "Test log in to Stores and Create Custom Store View Status Enabled and Verify Backend and Frontend Test"
+- filename: "AdminCreateStoreViewStatusEnabledVerifyBackendAndFrontendTest.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/Store/Test/Mftf/Test/AdminCreateStoreViewStatusEnabledVerifyBackendAndFrontendTest.xml"
+  module: "Store"
+  tests:
+    - testname: "AdminCreateStoreViewStatusEnabledVerifyBackendAndFrontendTest"
+      title: "Create Store View Status Enabled and Verify Backend and Frontend"
+      description: "Test log in to Stores and Create Store View Status Enabled Test"
+- filename: "AdminUpdateStoreGroupAcceptAlertAndVerifyStoreViewFormTest.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/Store/Test/Mftf/Test/AdminUpdateStoreGroupAcceptAlertAndVerifyStoreViewFormTest.xml"
+  module: "Store"
+  tests:
+    - testname: "AdminUpdateStoreGroupAcceptAlertAndVerifyStoreViewFormTest"
+      title: "Update Store Group, Accept Alert and Verify Store View Form"
+      description: "Test log in to Stores and Update Store Group Test"
+- filename: "AdminUpdateStoreViewTest.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/Store/Test/Mftf/Test/AdminUpdateStoreViewTest.xml"
+  module: "Store"
+  tests:
+    - testname: "AdminUpdateStoreViewTest"
+      title: "Update Store View and Verify Backend and Frontend"
+      description: "Test log in to Stores and Update Store View Test"
+- filename: "AdminDeleteStoreViewTest.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/Store/Test/Mftf/Test/AdminDeleteStoreViewTest.xml"
+  module: "Store"
+  tests:
+    - testname: "AdminDeleteStoreViewTest"
+      title: "Delete Store View and Save Backup"
+      description: "Test log in to Stores and Delete Store View"
+- filename: "AdminCreateStoreGroupWithCustomWebsiteAndRootCategoryTest.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/Store/Test/Mftf/Test/AdminCreateStoreGroupWithCustomWebsiteAndRootCategoryTest.xml"
+  module: "Store"
+  tests:
+    - testname: "AdminCreateStoreGroupWithCustomWebsiteAndRootCategoryTest"
+      title: "Create Store Group with Custom Website and Root Category"
+      description: "Test log in to Stores and Create Store Group with Custom Website and Root Category Test"
+- filename: "AdminCreateCustomStoreViewStatusEnabledVerifyAbsenceOfDeleteButtonTest.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/Store/Test/Mftf/Test/AdminCreateCustomStoreViewStatusEnabledVerifyAbsenceOfDeleteButtonTest.xml"
+  module: "Store"
+  tests:
+    - testname: "AdminCreateCustomStoreViewStatusEnabledVerifyAbsenceOfDeleteButtonTest"
+      title: "Create Custom Store View Status Enabled and Verify Absence Of Delete Button"
+      description: "Test log in to Stores and Create Custom Store View Status Enabled and Verify Absence Of Delete Button Test"
+- filename: "StorefrontCheckNecessaryLogicToActionClassForCookieMessagesTest.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/Security/Test/Mftf/Test/StorefrontCheckNecessaryLogicToActionClassForCookieMessagesTest.xml"
+  module: "Security"
+  tests:
+    - testname: "StorefrontCheckNecessaryLogicToActionClassForCookieMessagesTest"
+      title: "Storefront check necessary logic to action class for cookie messages test"
+      description: "Check necessary logic to action class for cookie messages"
+- filename: "AdminUserLockWhenEditingUserTest.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/Security/Test/Mftf/Test/AdminUserLockWhenEditingUserTest.xml"
+  module: "Security"
+  tests:
+    - testname: "AdminUserLockWhenEditingUserTest"
+      title: "Lock admin user when creating new user."
+      description: "Runs Lock admin user when editing existing user test."
+- filename: "AdminLockAdminUserWhenCreatingNewIntegrationTest.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/Security/Test/Mftf/Test/AdminLockAdminUserWhenCreatingNewIntegrationTest.xml"
+  module: "Security"
+  tests:
+    - testname: "AdminLockAdminUserWhenCreatingNewIntegrationTest"
+      title: "Lock admin user when creating new integration"
+      description: "Runs Lock admin user when creating new integration test."
+- filename: "AdminLockAdminUserWhenCreatingNewRoleTest.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/Security/Test/Mftf/Test/AdminLockAdminUserWhenCreatingNewRoleTest.xml"
+  module: "Security"
+  tests:
+    - testname: "AdminLockAdminUserWhenCreatingNewRoleTest"
+      title: "Lock admin user when creating new admin role"
+      description: "Runs Lock admin user when creating new admin role test."
+- filename: "AdminUserLockWhenCreatingNewUserTest.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/Security/Test/Mftf/Test/AdminUserLockWhenCreatingNewUserTest.xml"
+  module: "Security"
+  tests:
+    - testname: "AdminUserLockWhenCreatingNewUserTest"
+      title: "Lock admin user when creating new user"
+      description: "Runs Lock admin user when creating new user test."
+- filename: "AdminCategoryWithRestrictedUrlKeyNotCreatedTest.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/CatalogUrlRewrite/Test/Mftf/Test/AdminCategoryWithRestrictedUrlKeyNotCreatedTest.xml"
+  module: "CatalogUrlRewrite"
+  tests:
+    - testname: "AdminCategoryWithRestrictedUrlKeyNotCreatedTest"
+      title: "Category with restricted Url Key cannot be created"
+      description: "Category with restricted Url Key cannot be created"
+- filename: "RewriteStoreLevelUrlKeyOfChildCategoryTest.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/CatalogUrlRewrite/Test/Mftf/Test/RewriteStoreLevelUrlKeyOfChildCategoryTest.xml"
+  module: "CatalogUrlRewrite"
+  tests:
+    - testname: "RewriteStoreLevelUrlKeyOfChildCategoryTest"
+      title: "Rewriting Store-level URL key of child category"
+      description: "Rewriting Store-level URL key of child category"
+- filename: "AdminUrlForProductRewrittenCorrectlyTest.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/CatalogUrlRewrite/Test/Mftf/Test/AdminUrlForProductRewrittenCorrectlyTest.xml"
+  module: "CatalogUrlRewrite"
+  tests:
+    - testname: "AdminUrlForProductRewrittenCorrectlyTest"
+      title: "Check that URL for product rewritten correctly"
+      description: "Check that URL for product rewritten correctly"
+- filename: "AdminCheckInputFieldsDisabledAfterAppConfigDumpTest.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/Fedex/Test/Mftf/Test/AdminCheckInputFieldsDisabledAfterAppConfigDumpTest.xml"
+  module: "Fedex"
+  tests:
+    - testname: "AdminCheckInputFieldsDisabledAfterAppConfigDumpTest"
+      title: ""
+      description: ""
+- filename: "AdminCreatingShippingLabelTest.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/Fedex/Test/Mftf/Test/AdminCreatingShippingLabelTest.xml"
+  module: "Fedex"
+  tests:
+    - testname: "AdminCreatingShippingLabelTest"
+      title: "Creating shipping label"
+      description: "Creating shipping label"
+- filename: "StorefrontUsingElasticSearchWithWeightAttributeTest.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/Search/Test/Mftf/Test/StorefrontUsingElasticSearchWithWeightAttributeTest.xml"
+  module: "Search"
+  tests:
+    - testname: "StorefrontUsingElasticSearchWithWeightAttributeTest"
+      title: "Using ElasticSearch with weight attribute"
+      description: "Use ElasticSearch for products with weight attributes"
+- filename: "StorefrontVerifySearchSuggestionByProductShortDescriptionTest.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/Search/Test/Mftf/Test/StorefrontVerifySearchSuggestionByProductShortDescriptionTest.xml"
+  module: "Search"
+  tests:
+    - testname: "StorefrontVerifySearchSuggestionByProductShortDescriptionTest"
+      title: "Create search query using product short description and verify search suggestions"
+      description: "Storefront search by product short description, generate search query and verify dropdown product search suggestions"
+- filename: "AdminMassDeleteSearchTermEntityTest.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/Search/Test/Mftf/Test/AdminMassDeleteSearchTermEntityTest.xml"
+  module: "Search"
+  tests:
+    - testname: "AdminMassDeleteSearchTermEntityTest"
+      title: "Admin mass delete search term entity test"
+      description: "Admin should be able to Mass Delete Search Term Entity Test"
+- filename: "StorefrontVerifySearchSuggestionByProductDescriptionTest.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/Search/Test/Mftf/Test/StorefrontVerifySearchSuggestionByProductDescriptionTest.xml"
+  module: "Search"
+  tests:
+    - testname: "StorefrontVerifySearchSuggestionByProductDescriptionTest"
+      title: "Create search query using product description and verify search suggestions"
+      description: "Storefront search by product description, generate search query and verify dropdown product search suggestions"
+- filename: "AdminGlobalSearchOnProductPageTest.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/Search/Test/Mftf/Test/AdminGlobalSearchOnProductPageTest.xml"
+  module: "Search"
+  tests:
+    - testname: "AdminGlobalSearchOnProductPageTest"
+      title: "Admin global search on product page test"
+      description: "Admin search displays settings and content items"
+- filename: "StorefrontVerifySearchSuggestionByProductNameTest.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/Search/Test/Mftf/Test/StorefrontVerifySearchSuggestionByProductNameTest.xml"
+  module: "Search"
+  tests:
+    - testname: "StorefrontVerifySearchSuggestionByProductNameTest"
+      title: "Create search query using product name and verify search suggestions"
+      description: "Storefront search by product name and verify dropdown product search suggestions"
+- filename: "StorefrontVerifySearchSuggestionByProductSkuTest.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/Search/Test/Mftf/Test/StorefrontVerifySearchSuggestionByProductSkuTest.xml"
+  module: "Search"
+  tests:
+    - testname: "StorefrontVerifySearchSuggestionByProductSkuTest"
+      title: "Create search query using product sku and verify search suggestions"
+      description: "Storefront search by product sku, generate search query and verify dropdown product search suggestions"
+- filename: "AdminReportsDownloadsNavigateMenuTest.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/Reports/Test/Mftf/Test/AdminReportsDownloadsNavigateMenuTest.xml"
+  module: "Reports"
+  tests:
+    - testname: "AdminReportsDownloadsNavigateMenuTest"
+      title: "Admin reports downloads navigate menu test"
+      description: "Admin should be able to navigate to Reports &gt; Downloads"
+- filename: "AdminReportsBestsellersNavigateMenuTest.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/Reports/Test/Mftf/Test/AdminReportsBestsellersNavigateMenuTest.xml"
+  module: "Reports"
+  tests:
+    - testname: "AdminReportsBestsellersNavigateMenuTest"
+      title: "Admin reports bestsellers navigate menu test"
+      description: "Admin should be able to navigate to Reports &gt; Bestsellers"
+- filename: "AdminReportsOrderCountNavigateMenuTest.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/Reports/Test/Mftf/Test/AdminReportsOrderCountNavigateMenuTest.xml"
+  module: "Reports"
+  tests:
+    - testname: "AdminReportsOrderCountNavigateMenuTest"
+      title: "Admin reports order count navigate menu test"
+      description: "Admin should be able to navigate to Reports &gt; Order Count"
+- filename: "AdminReportsNewNavigateMenuTest.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/Reports/Test/Mftf/Test/AdminReportsNewNavigateMenuTest.xml"
+  module: "Reports"
+  tests:
+    - testname: "AdminReportsNewNavigateMenuTest"
+      title: "Admin reports new navigate menu test"
+      description: "Admin should be able to navigate to Reports &gt; New"
+- filename: "AdminReportsAbandonedCartsNavigateMenuTest.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/Reports/Test/Mftf/Test/AdminReportsAbandonedCartsNavigateMenuTest.xml"
+  module: "Reports"
+  tests:
+    - testname: "AdminReportsAbandonedCartsNavigateMenuTest"
+      title: "Admin reports abandoned carts navigate menu test"
+      description: "Admin should be able to navigate to Reports &gt; Abandoned Carts"
+- filename: "AdminReportsViewsNavigateMenuTest.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/Reports/Test/Mftf/Test/AdminReportsViewsNavigateMenuTest.xml"
+  module: "Reports"
+  tests:
+    - testname: "AdminReportsViewsNavigateMenuTest"
+      title: "Admin reports views navigate menu test"
+      description: "Admin should be able to navigate to Reports &gt; Views"
+- filename: "AdminReportsLowStockNavigateMenuTest.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/Reports/Test/Mftf/Test/AdminReportsLowStockNavigateMenuTest.xml"
+  module: "Reports"
+  tests:
+    - testname: "AdminReportsLowStockNavigateMenuTest"
+      title: "Admin reports low stock navigate menu test"
+      description: "Admin should be able to navigate to Reports &gt; Low Stock"
+- filename: "AdminReportsRefreshStatisticsNavigateMenuTest.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/Reports/Test/Mftf/Test/AdminReportsRefreshStatisticsNavigateMenuTest.xml"
+  module: "Reports"
+  tests:
+    - testname: "AdminReportsRefreshStatisticsNavigateMenuTest"
+      title: "Admin reports refresh statistics navigate menu test"
+      description: "Admin should be able to navigate to Reports &gt; Refresh Statistics"
+- filename: "AdminReportsInvoicedNavigateMenuTest.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/Reports/Test/Mftf/Test/AdminReportsInvoicedNavigateMenuTest.xml"
+  module: "Reports"
+  tests:
+    - testname: "AdminReportsInvoicedNavigateMenuTest"
+      title: "Admin reports invoiced navigate menu test"
+      description: "Admin should be able to navigate to Reports &gt; Invoiced"
+- filename: "AdminReportsCouponsNavigateMenuTest.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/Reports/Test/Mftf/Test/AdminReportsCouponsNavigateMenuTest.xml"
+  module: "Reports"
+  tests:
+    - testname: "AdminReportsCouponsNavigateMenuTest"
+      title: "Admin reports coupons navigate menu test"
+      description: "Admin should be able to navigate to Reports &gt; Coupons"
+- filename: "AdminReportsOrdersNavigateMenuTest.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/Reports/Test/Mftf/Test/AdminReportsOrdersNavigateMenuTest.xml"
+  module: "Reports"
+  tests:
+    - testname: "AdminReportsOrdersNavigateMenuTest"
+      title: "Admin reports orders navigate menu test"
+      description: "Admin should be able to navigate to Reports &gt; Orders"
+- filename: "CancelOrdersInOrderSalesReportTest.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/Reports/Test/Mftf/Test/CancelOrdersInOrderSalesReportTest.xml"
+  module: "Reports"
+  tests:
+    - testname: "CancelOrdersInOrderSalesReportTest"
+      title: "Canceled orders in order sales report"
+      description: "Verify canceling of orders in order sales report"
+- filename: "AdminReportsProductsInCartNavigateMenuTest.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/Reports/Test/Mftf/Test/AdminReportsProductsInCartNavigateMenuTest.xml"
+  module: "Reports"
+  tests:
+    - testname: "AdminReportsProductsInCartNavigateMenuTest"
+      title: "Admin reports products in cart navigate menu test"
+      description: "Admin should be able to navigate to Reports &gt; Products in Cart"
+- filename: "AdminReportsOrderTotalNavigateMenuTest.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/Reports/Test/Mftf/Test/AdminReportsOrderTotalNavigateMenuTest.xml"
+  module: "Reports"
+  tests:
+    - testname: "AdminReportsOrderTotalNavigateMenuTest"
+      title: "Admin reports order total navigate menu test"
+      description: "Admin should be able to navigate to Reports &gt; Order Total"
+- filename: "AdminReportsTaxNavigateMenuTest.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/Reports/Test/Mftf/Test/AdminReportsTaxNavigateMenuTest.xml"
+  module: "Reports"
+  tests:
+    - testname: "AdminReportsTaxNavigateMenuTest"
+      title: "Admin reports tax navigate menu test"
+      description: "Admin should be able to navigate to Reports &gt; Tax"
+- filename: "AdminReportsOrderedNavigateMenuTest.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/Reports/Test/Mftf/Test/AdminReportsOrderedNavigateMenuTest.xml"
+  module: "Reports"
+  tests:
+    - testname: "AdminReportsOrderedNavigateMenuTest"
+      title: "Admin reports ordered navigate menu test"
+      description: "Admin should be able to navigate to Reports &gt; Ordered"
+- filename: "StorefrontRemoveProductsFromWishlistUsingSidebarTest.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/Wishlist/Test/Mftf/Test/StorefrontRemoveProductsFromWishlistUsingSidebarTest.xml"
+  module: "Wishlist"
+  tests:
+    - testname: "StorefrontRemoveProductsFromWishlistUsingSidebarTest"
+      title: "Remove products from the wishlist using the sidebar."
+      description: "Products removed from wishlist and a customer remains on the same page."
+- filename: "AdminCustomerWishListShareOptionsInputValidationTest.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/Wishlist/Test/Mftf/Test/AdminCustomerWishListShareOptionsInputValidationTest.xml"
+  module: "Wishlist"
+  tests:
+    - testname: "AdminCustomerWishListShareOptionsInputValidationTest"
+      title: "When user tries to set the Email Text Length Limit higher then 10,000 then validation message occurs"
+      description: "When user tries to set the Email Text Length Limit higher then 10,000 then validation message occurs"
+- filename: "StorefrontDeleteBundleFixedProductFromWishlistTest.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/Wishlist/Test/Mftf/Test/StorefrontDeleteBundleFixedProductFromWishlistTest.xml"
+  module: "Wishlist"
+  tests:
+    - testname: "StorefrontDeleteBundleFixedProductFromWishlistTest"
+      title: "Delete Fixed Bundle Product from Wishlist on Frontend"
+      description: "Delete Fixed Bundle Product from Wishlist on Frontend"
+- filename: "StorefrontShareWishlistEntityTest.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/Wishlist/Test/Mftf/Test/StorefrontShareWishlistEntityTest.xml"
+  module: "Wishlist"
+  tests:
+    - testname: "StorefrontShareWishlistEntityTest"
+      title: "Customer should be able to share a persistent wishlist"
+      description: "Customer should be able to share a persistent wishlist"
+- filename: "StorefrontVerifySecureURLRedirectWishlistTest.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/Wishlist/Test/Mftf/Test/StorefrontVerifySecureURLRedirectWishlistTest.xml"
+  module: "Wishlist"
+  tests:
+    - testname: "StorefrontVerifySecureURLRedirectWishlist"
+      title: "Verify Secure URLs For Storefront Wishlist Pages"
+      description: "Verify that the Secure URL configuration applies to the Wishlist pages on the Storefront"
+- filename: "WishListWithDisabledProductTest.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/Wishlist/Test/Mftf/Test/WishListWithDisabledProductTest.xml"
+  module: "Wishlist"
+  tests:
+    - testname: "WishListWithDisabledProductTest"
+      title: "Wish List should not include disabled products"
+      description: "Wish List should not include disabled products and pager should be absent"
+- filename: "StorefrontDeleteConfigurableProductFromWishlistTest.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/Wishlist/Test/Mftf/Test/StorefrontDeleteConfigurableProductFromWishlistTest.xml"
+  module: "Wishlist"
+  tests:
+    - testname: "StorefrontDeleteConfigurableProductFromWishlistTest"
+      title: "Delete Configurable Product from Wishlist on Frontend"
+      description: "Delete Configurable Product from Wishlist on Frontend"
+- filename: "StorefrontAddProductsToCartFromWishlistUsingSidebarTest.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/Wishlist/Test/Mftf/Test/StorefrontAddProductsToCartFromWishlistUsingSidebarTest.xml"
+  module: "Wishlist"
+  tests:
+    - testname: "StorefrontAddProductsToCartFromWishlistUsingSidebarTest"
+      title: "Add products from the wishlist to the cart using the sidebar."
+      description: "Products added to the cart from wishlist and a customer remains on the same page."
+- filename: "ConfigurableProductChildImageShouldBeShownOnWishListTest.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/Wishlist/Test/Mftf/Test/ConfigurableProductChildImageShouldBeShownOnWishListTest.xml"
+  module: "Wishlist"
+  tests:
+    - testname: "ConfigurableProductChildImageShouldBeShownOnWishListTest"
+      title: "When user add Configurable child product to WIshlist then child product image should be shown in Wishlist"
+      description: "When user add Configurable child product to WIshlist then child product image should be shown in Wishlist"
+- filename: "ConfProdAddToCartWishListWithUnselectedAttrTest.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/Wishlist/Test/Mftf/Test/ConfProdAddToCartWishListWithUnselectedAttrTest.xml"
+  module: "Wishlist"
+  tests:
+    - testname: "ConfProdAddToCartWishListWithUnselectedAttrTest"
+      title: "Adding configurable product to Cart from Wish List with unselected attributes"
+      description: "Verify adding configurable product to Cart from Wish List when attributes is unselected"
+- filename: "StorefrontUpdateWishlistTest.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/Wishlist/Test/Mftf/Test/StorefrontUpdateWishlistTest.xml"
+  module: "Wishlist"
+  tests:
+    - testname: "StorefrontUpdateWishlistTest"
+      title: "Displaying of message after Wish List update"
+      description: "Displaying of message after Wish List update"
+- filename: "StorefrontDeleteBundleDynamicProductFromWishlistTest.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/Wishlist/Test/Mftf/Test/StorefrontDeleteBundleDynamicProductFromWishlistTest.xml"
+  module: "Wishlist"
+  tests:
+    - testname: "StorefrontDeleteBundleDynamicProductFromWishlistTest"
+      title: "Delete Dynamic Bundle Product from Wishlist on Frontend"
+      description: "Delete Dynamic Bundle Product from Wishlist on Frontend"
+- filename: "StorefrontDeletePersistedWishlistTest.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/Wishlist/Test/Mftf/Test/StorefrontDeletePersistedWishlistTest.xml"
+  module: "Wishlist"
+  tests:
+    - testname: "StorefrontDeletePersistedWishlistTest"
+      title: "Customer should be able to delete a persistent wishlist"
+      description: "Customer should be able to delete a persistent wishlist"
+- filename: "EndToEndB2CLoggedInUserTest.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/Wishlist/Test/Mftf/Test/EndToEndB2CLoggedInUserTest.xml"
+  module: "Wishlist"
+  tests:
+    - testname: "EndToEndB2CLoggedInUserTest"
+      title: ""
+      description: ""
+- filename: "StorefrontAddMultipleStoreProductsToWishlistTest.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/Wishlist/Test/Mftf/Test/StorefrontAddMultipleStoreProductsToWishlistTest.xml"
+  module: "Wishlist"
+  tests:
+    - testname: "StorefrontAddMultipleStoreProductsToWishlistTest"
+      title: "Customer should be able to add products to wishlist from different stores"
+      description: "All products added to wishlist should be visible on any store. Even if product visibility was set to 'Not Visible Individually' for this store"
+- filename: "AdminResetUserPasswordFailedTest.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/Captcha/Test/Mftf/Test/AdminResetUserPasswordFailedTest.xml"
+  module: "Captcha"
+  tests:
+    - testname: "AdminResetUserPasswordFailedTest"
+      title: ""
+      description: ""
+- filename: "StorefrontCaptchaOnContactUsTest.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/Captcha/Test/Mftf/Test/StorefrontCaptchaOnContactUsTest.xml"
+  module: "Captcha"
+  tests:
+    - testname: "StorefrontCaptchaOnContactUsTest"
+      title: "Captcha on contact us form test"
+      description: "Test creation for send comment using the contact us form with captcha."
+- filename: "StorefrontCaptchaOnCustomerLoginTest.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/Captcha/Test/Mftf/Test/StorefrontCaptchaOnCustomerLoginTest.xml"
+  module: "Captcha"
+  tests:
+    - testname: "StorefrontCaptchaOnCustomerLoginTest"
+      title: "Captcha customer login page test"
+      description: "Check CAPTCHA on Storefront Login Page."
+- filename: "AdminLoginWithCaptchaTest.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/Captcha/Test/Mftf/Test/AdminLoginWithCaptchaTest.xml"
+  module: "Captcha"
+  tests:
+    - testname: "AdminLoginWithCaptchaTest"
+      title: "Captcha on Admin login form"
+      description: "Test creation for admin login with captcha."
+- filename: "CaptchaFormsDisplayingTest.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/Captcha/Test/Mftf/Test/CaptchaFormsDisplayingTest.xml"
+  module: "Captcha"
+  tests:
+    - testname: "CaptchaFormsDisplayingTest"
+      title: "Captcha forms displaying"
+      description: "Captcha forms displaying"
+
+    - testname: "CaptchaWithDisabledGuestCheckout"
+      title: "Captcha is displaying on login form with disabled guest checkout"
+      description: "Captcha is displaying on login form with disabled guest checkout"
+- filename: "StorefrontCaptchaRegisterNewCustomerTest.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/Captcha/Test/Mftf/Test/StorefrontCaptchaRegisterNewCustomerTest.xml"
+  module: "Captcha"
+  tests:
+    - testname: "StorefrontCaptchaRegisterNewCustomerTest"
+      title: "Test creation for customer register with captcha on storefront."
+      description: "Test creation for customer register with captcha on storefront."
+- filename: "StorefrontResetCustomerPasswordFailedTest.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/Captcha/Test/Mftf/Test/StorefrontResetCustomerPasswordFailedTest.xml"
+  module: "Captcha"
+  tests:
+    - testname: "StorefrontResetCustomerPasswordFailedTest"
+      title: ""
+      description: ""
+- filename: "StorefrontCaptchaEditCustomerEmailTest.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/Captcha/Test/Mftf/Test/StorefrontCaptchaEditCustomerEmailTest.xml"
+  module: "Captcha"
+  tests:
+    - testname: "StorefrontCaptchaEditCustomerEmailTest"
+      title: "Test for checking captcha on the customer account edit page."
+      description: "Test for checking captcha on the customer account edit page and customer is locked."
+- filename: "AdminImportProductsWithReplaceBehaviorTest.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/ImportExport/Test/Mftf/Test/AdminImportProductsWithReplaceBehaviorTest.xml"
+  module: "ImportExport"
+  tests:
+    - testname: "AdminImportProductsWithReplaceBehaviorTest"
+      title: "Verify Magento native import products with replace behavior."
+      description: "Verify Magento native import products with replace behavior."
+- filename: "AdminProductVisibilityDifferentStoreViewsAfterImportTest.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/ImportExport/Test/Mftf/Test/AdminProductVisibilityDifferentStoreViewsAfterImportTest.xml"
+  module: "ImportExport"
+  tests:
+    - testname: "AdminProductVisibilityDifferentStoreViewsAfterImportTest"
+      title: "Checking product visibility in different store views after product importing"
+      description: "Checking product visibility in different store views after product importing"
+- filename: "AdminImportProductsWithErrorEntriesTest.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/ImportExport/Test/Mftf/Test/AdminImportProductsWithErrorEntriesTest.xml"
+  module: "ImportExport"
+  tests:
+    - testname: "AdminImportProductsWithErrorEntriesTest"
+      title: "Import products with error entries"
+      description: "Verify import status during import products with error entries"
+- filename: "AdminImportCSVWithSpecialCharactersTest.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/ImportExport/Test/Mftf/Test/AdminImportCSVWithSpecialCharactersTest.xml"
+  module: "ImportExport"
+  tests:
+    - testname: "AdminImportCSVWithSpecialCharactersTest"
+      title: "Import CSV with special characters"
+      description: "Import CSV with special characters"
+- filename: "AdminExportPagerGridTest.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/ImportExport/Test/Mftf/Test/AdminExportPagerGridTest.xml"
+  module: "ImportExport"
+  tests:
+    - testname: "AdminExportPagerGridTest"
+      title: "Testing if the grid is present on export page"
+      description: "Admin should be able to see the grid onn export page"
+- filename: "AdminProductImportCSVFileCorrectDifferentFilesTest.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/ImportExport/Test/Mftf/Test/AdminProductImportCSVFileCorrectDifferentFilesTest.xml"
+  module: "ImportExport"
+  tests:
+    - testname: "AdminProductImportCSVFileCorrectDifferentFilesTest"
+      title: "Product import from CSV file correct from different files."
+      description: "Product import from CSV file correct from different files."
+- filename: "AdminImportProductsWithAddUpdateBehaviorTest.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/ImportExport/Test/Mftf/Test/AdminImportProductsWithAddUpdateBehaviorTest.xml"
+  module: "ImportExport"
+  tests:
+    - testname: "AdminImportProductsWithAddUpdateBehaviorTest"
+      title: "Verify Magento native import products with add/update behavior."
+      description: "Verify Magento native import products with add/update behavior."
+- filename: "AdminURLKeyWorksWhenUpdatingProductThroughImportingCSVTest.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/ImportExport/Test/Mftf/Test/AdminURLKeyWorksWhenUpdatingProductThroughImportingCSVTest.xml"
+  module: "ImportExport"
+  tests:
+    - testname: "AdminURLKeyWorksWhenUpdatingProductThroughImportingCSVTest"
+      title: "Check that new URL Key works after updating a product through importing CSV file"
+      description: "Check that new URL Key works after updating a product through importing CSV file"
+- filename: "AdminCheckThatSomeAttributesChangedValueToEmptyAfterImportTest.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/ImportExport/Test/Mftf/Test/AdminCheckThatSomeAttributesChangedValueToEmptyAfterImportTest.xml"
+  module: "ImportExport"
+  tests:
+    - testname: "AdminCheckThatSomeAttributesChangedValueToEmptyAfterImportTest"
+      title: "Check that some attributes changed the value to an empty after import CSV"
+      description: "Check that some attributes changed the value to an empty after import CSV"
+- filename: "AdminExportPageNavigateMenuTest.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/ImportExport/Test/Mftf/Test/AdminExportPageNavigateMenuTest.xml"
+  module: "ImportExport"
+  tests:
+    - testname: "AdminExportPageNavigateMenuTest"
+      title: "Admin export page navigate menu test"
+      description: "Admin should be able to navigate to System &gt; Export"
+- filename: "AdminSystemImportNavigateMenuTest.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/ImportExport/Test/Mftf/Test/AdminSystemImportNavigateMenuTest.xml"
+  module: "ImportExport"
+  tests:
+    - testname: "AdminSystemImportNavigateMenuTest"
+      title: "Admin system import navigate menu test"
+      description: "Admin should be able to navigate to System &gt; Import"
+- filename: "AdminImportProductsWithDeleteBehaviorTest.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/ImportExport/Test/Mftf/Test/AdminImportProductsWithDeleteBehaviorTest.xml"
+  module: "ImportExport"
+  tests:
+    - testname: "AdminImportProductsWithDeleteBehaviorTest"
+      title: "Verify Magento native import products with delete behavior."
+      description: "Verify Magento native import products with delete behavior."
+- filename: "AdminApplyCatalogRuleForConfigurableProductWithAssignedSimpleProducts2Test.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/CatalogRuleConfigurable/Test/Mftf/Test/AdminApplyCatalogRuleForConfigurableProductWithAssignedSimpleProducts2Test.xml"
+  module: "CatalogRuleConfigurable"
+  tests:
+    - testname: "AdminApplyCatalogRuleForConfigurableProductWithAssignedSimpleProducts2Test"
+      title: "Apply catalog rule for configurable product with assigned simple products"
+      description: "Admin should be able to apply catalog rule for configurable product with assigned simple products"
+- filename: "AdminApplyCatalogRuleForConfigurableProductWithAssignedSimpleProductsTest.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/CatalogRuleConfigurable/Test/Mftf/Test/AdminApplyCatalogRuleForConfigurableProductWithAssignedSimpleProductsTest.xml"
+  module: "CatalogRuleConfigurable"
+  tests:
+    - testname: "AdminApplyCatalogRuleForConfigurableProductWithAssignedSimpleProductsTest"
+      title: "DEPRECATED. Apply catalog rule for configurable product with assigned simple products"
+      description: "DEPRECATED. Admin should be able to apply catalog rule for configurable product with assigned simple products"
+- filename: "AdminApplyCatalogRuleForConfigurableProductWithOptionsTest.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/CatalogRuleConfigurable/Test/Mftf/Test/AdminApplyCatalogRuleForConfigurableProductWithOptionsTest.xml"
+  module: "CatalogRuleConfigurable"
+  tests:
+    - testname: "AdminApplyCatalogRuleForConfigurableProductWithOptionsTest"
+      title: "DEPRECATED. Apply catalog price rule for configurable product with options"
+      description: "DEPRECATED. Admin should be able to apply the catalog rule for configurable product with options"
+- filename: "AdminApplyCatalogRuleForConfigurableProductWithOptions2Test.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/CatalogRuleConfigurable/Test/Mftf/Test/AdminApplyCatalogRuleForConfigurableProductWithOptions2Test.xml"
+  module: "CatalogRuleConfigurable"
+  tests:
+    - testname: "AdminApplyCatalogRuleForConfigurableProductWithOptions2Test"
+      title: "Apply catalog price rule for configurable product with options"
+      description: "Admin should be able to apply the catalog rule for configurable product with options"
+- filename: "AdminSystemIndexManagementNavigateMenuTest.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/Indexer/Test/Mftf/Test/AdminSystemIndexManagementNavigateMenuTest.xml"
+  module: "Indexer"
+  tests:
+    - testname: "AdminSystemIndexManagementNavigateMenuTest"
+      title: "Admin system index management navigate menu test"
+      description: "Admin should be able to navigate to System &gt; Index Management"
 - filename: "AdminOrderRateDisplayWhenChooseThreeAllowedCurrenciesTest.xml"
-  repo: "https://github.com/magento/magento2/blob/2.3/app/code/Magento/CurrencySymbol/Test/Mftf/Test/AdminOrderRateDisplayWhenChooseThreeAllowedCurrenciesTest.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/CurrencySymbol/Test/Mftf/Test/AdminOrderRateDisplayWhenChooseThreeAllowedCurrenciesTest.xml"
   module: "CurrencySymbol"
   tests:
     - testname: "AdminOrderRateDisplayWhenChooseThreeAllowedCurrenciesTest"
       title: "Order rate converting currency for 'Base Currency' and 'Default Display Currency' displayed correct"
       description: "Order rate converting currency for 'Base Currency' and 'Default Display Currency' displayed correct"
- 
-- filename: "AdminOrderRateDisplayedInOneLineTest.xml"
-  repo: "https://github.com/magento/magento2/blob/2.3/app/code/Magento/CurrencySymbol/Test/Mftf/Test/AdminOrderRateDisplayedInOneLineTest.xml"
-  module: "CurrencySymbol"
-  tests:
-    - testname: "AdminOrderRateDisplayedInOneLineTest"
-      title: "Order rate converting currency for 'Base Currency' and 'Default Display Currency' displayed correct once"
-      description: "Order rate converting currency for 'Base Currency' and 'Default Display Currency' displayed correct once"
- 
 - filename: "AdminCurrencyConverterAPIConfigurationTest.xml"
-  repo: "https://github.com/magento/magento2/blob/2.3/app/code/Magento/CurrencySymbol/Test/Mftf/Test/AdminCurrencyConverterAPIConfigurationTest.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/CurrencySymbol/Test/Mftf/Test/AdminCurrencyConverterAPIConfigurationTest.xml"
   module: "CurrencySymbol"
   tests:
     - testname: "AdminCurrencyConverterAPIConfigurationTest"
       title: "Currency Converter API configuration"
       description: "Currency Converter API configuration"
- 
+- filename: "AdminStoresCurrencyRatesNavigateMenuTest.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/CurrencySymbol/Test/Mftf/Test/AdminStoresCurrencyRatesNavigateMenuTest.xml"
+  module: "CurrencySymbol"
+  tests:
+    - testname: "AdminStoresCurrencyRatesNavigateMenuTest"
+      title: "Admin stores currency rates navigate menu test"
+      description: "Admin should be able to navigate to Stores &gt; Currency Rates"
+- filename: "AdminOrderRateDisplayedInOneLineTest.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/CurrencySymbol/Test/Mftf/Test/AdminOrderRateDisplayedInOneLineTest.xml"
+  module: "CurrencySymbol"
+  tests:
+    - testname: "AdminOrderRateDisplayedInOneLineTest"
+      title: "Order rate converting currency for 'Base Currency' and 'Default Display Currency' displayed correct once"
+      description: "Order rate converting currency for 'Base Currency' and 'Default Display Currency' displayed correct once"
+- filename: "AdminStoresCurrencySymbolsNavigateMenuTest.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/CurrencySymbol/Test/Mftf/Test/AdminStoresCurrencySymbolsNavigateMenuTest.xml"
+  module: "CurrencySymbol"
+  tests:
+    - testname: "AdminStoresCurrencySymbolsNavigateMenuTest"
+      title: "Admin stores currency symbols navigate menu test"
+      description: "Admin should be able to navigate to Stores &gt; Currency Symbols"
+- filename: "StorefrontPaypalSmartButtonInCheckoutPageTest.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/Paypal/Test/Mftf/Test/StorefrontPaypalSmartButtonInCheckoutPageTest.xml"
+  module: "Paypal"
+  tests:
+    - testname: "StorefrontPaypalSmartButtonInCheckoutPageTest"
+      title: "Mainflow of Paypal Smart Button"
+      description: "Users are able to place order using Paypal Smart Button"
+- filename: "AdminOnePayPalSolutionsEnabledAtTheSameTimeTest.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/Paypal/Test/Mftf/Test/AdminOnePayPalSolutionsEnabledAtTheSameTimeTest.xml"
+  module: "Paypal"
+  tests:
+    - testname: "AdminOnePayPalSolutionsEnabledAtTheSameTimeTest"
+      title: "Only one PayPal solution enabled at the same time"
+      description: "Verify that only one PayPal solution can be enabled"
+- filename: "AdminReportsPayPalSettlementNavigateMenuTest.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/Paypal/Test/Mftf/Test/AdminReportsPayPalSettlementNavigateMenuTest.xml"
+  module: "Paypal"
+  tests:
+    - testname: "AdminReportsPayPalSettlementNavigateMenuTest"
+      title: "Admin reports paypal settlement navigate menu test"
+      description: "Admin should be able to navigate to Reports &gt; PayPal Settlement"
+- filename: "StorefrontCheckCreditButtonConfigurationTest.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/Paypal/Test/Mftf/Test/StorefrontCheckCreditButtonConfigurationTest.xml"
+  module: "Paypal"
+  tests:
+    - testname: "StorefrontCheckCreditButtonConfigurationTest"
+      title: "Check Credit Button Configuration"
+      description: "Admin is able to customize Credit button"
+- filename: "AdminCheckDefaultValueOfPayPalCustomizeButtonTest.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/Paypal/Test/Mftf/Test/AdminCheckDefaultValueOfPayPalCustomizeButtonTest.xml"
+  module: "Paypal"
+  tests:
+    - testname: "AdminCheckDefaultValueOfPayPalCustomizeButtonTest"
+      title: "Check Default Value Of Paypal Customize Button"
+      description: "Default value of Paypal Customize Button should be NO"
+- filename: "StorefrontVerifySecureURLRedirectPaypalTest.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/Paypal/Test/Mftf/Test/StorefrontVerifySecureURLRedirectPaypalTest.xml"
+  module: "Paypal"
+  tests:
+    - testname: "StorefrontVerifySecureURLRedirectPaypal"
+      title: "Verify Secure URLs For Storefront Paypal Pages"
+      description: "Verify that the Secure URL configuration applies to the Paypal pages on the Storefront"
+- filename: "AdminSalesBillingAgreementsNavigateMenuTest.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/Paypal/Test/Mftf/Test/AdminSalesBillingAgreementsNavigateMenuTest.xml"
+  module: "Paypal"
+  tests:
+    - testname: "AdminSalesBillingAgreementsNavigateMenuTest"
+      title: "Admin sales billing agreements navigate menu test"
+      description: "Admin should be able to navigate to Sales &gt; Billing Agreements"
+- filename: "AdminResetUserPasswordFailedTest.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/User/Test/Mftf/Test/AdminResetUserPasswordFailedTest.xml"
+  module: "User"
+  tests:
+    - testname: "AdminResetUserPasswordFailedTest"
+      title: "Admin user should not be able to trigger the password reset procedure twice"
+      description: "Admin user should not be able to trigger the password reset procedure twice"
+- filename: "AdminSystemUserRolesNavigateMenuTest.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/User/Test/Mftf/Test/AdminSystemUserRolesNavigateMenuTest.xml"
+  module: "User"
+  tests:
+    - testname: "AdminSystemUserRolesNavigateMenuTest"
+      title: "Admin system user roles navigate menu test"
+      description: "Admin should be able to navigate to System &gt; User Roles"
+- filename: "AdminSystemLockedUsersNavigateMenuTest.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/User/Test/Mftf/Test/AdminSystemLockedUsersNavigateMenuTest.xml"
+  module: "User"
+  tests:
+    - testname: "AdminSystemLockedUsersNavigateMenuTest"
+      title: "Admin system locked users navigate menu test"
+      description: "Admin should be able to navigate to System &gt; Locked Users"
+- filename: "AdminCreateInactiveUserEntityTest.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/User/Test/Mftf/Test/AdminCreateInactiveUserEntityTest.xml"
+  module: "User"
+  tests:
+    - testname: "AdminCreateInactiveUserEntityTest"
+      title: "Admin user should be able to create inactive admin user"
+      description: "Admin user should be able to create inactive admin user"
+- filename: "AdminLockAdminUserEntityTest.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/User/Test/Mftf/Test/AdminLockAdminUserEntityTest.xml"
+  module: "User"
+  tests:
+    - testname: "AdminLockAdminUserEntityTest"
+      title: "Lock admin  user after entering incorrect password specified number of times"
+      description: "Lock admin  user after entering incorrect password specified number of times"
+- filename: "AdminSystemManageEncryptionKeyNavigateMenuTest.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/User/Test/Mftf/Test/AdminSystemManageEncryptionKeyNavigateMenuTest.xml"
+  module: "User"
+  tests:
+    - testname: "AdminSystemManageEncryptionKeyNavigateMenuTest"
+      title: "Admin system manage encryption key navigate menu test"
+      description: "Admin should be able to navigate to System &gt; Manage Encryption Key"
+- filename: "AdminBulkOperationsLogIsNotAccessibleForAdminUserWithLimitedAccessTest.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/User/Test/Mftf/Test/AdminBulkOperationsLogIsNotAccessibleForAdminUserWithLimitedAccessTest.xml"
+  module: "User"
+  tests:
+    - testname: "AdminBulkOperationsLogIsNotAccessibleForAdminUserWithLimitedAccessTest"
+      title: "'Your Bulk Operations Log' isn't accessible if admin user doesn't have privileges for it"
+      description: "An admin user can view his own bulk operations only in a separate grid if his role has Bulk Operations resource."
+- filename: "AdminSystemAllUsersNavigateMenuTest.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/User/Test/Mftf/Test/AdminSystemAllUsersNavigateMenuTest.xml"
+  module: "User"
+  tests:
+    - testname: "AdminSystemAllUsersNavigateMenuTest"
+      title: "Admin system all users navigate menu test"
+      description: "Admin should be able to navigate to System &gt; All Users"
+- filename: "AdminUpdateUserTest.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/User/Test/Mftf/Test/AdminUpdateUserTest.xml"
+  module: "User"
+  tests:
+    - testname: "AdminUpdateUserTest"
+      title: "Update admin user entity by changing user role"
+      description: "Change full access role for admin user to custom one with restricted permission (Sales)"
+- filename: "AdminCreateActiveUserEntityTest.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/User/Test/Mftf/Test/AdminCreateActiveUserEntityTest.xml"
+  module: "User"
+  tests:
+    - testname: "AdminCreateActiveUserEntityTest"
+      title: "Admin user should be able to create active admin user"
+      description: "Admin user should be able to create active admin user"
+- filename: "AdminInlineTranslationOnCheckoutTest.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/Translation/Test/Mftf/Test/AdminInlineTranslationOnCheckoutTest.xml"
+  module: "Translation"
+  tests:
+    - testname: "AdminInlineTranslationOnCheckoutTest"
+      title: "[Inline Translation] Inline translate on Checkout"
+      description: "As merchant I want to be able to rename text labels on Checkout steps"
+- filename: "StorefrontButtonsInlineTranslationTest.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/Translation/Test/Mftf/Test/StorefrontButtonsInlineTranslationTest.xml"
+  module: "Translation"
+  tests:
+    - testname: "StorefrontButtonsInlineTranslationTest"
+      title: "[Inline Translation] Buttons inline translation"
+      description: "[Inline Translation] Buttons inline translation"
+- filename: "AdminAddWidgetToWYSIWYGNewsletterTest.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/Newsletter/Test/Mftf/Test/AdminAddWidgetToWYSIWYGNewsletterTest.xml"
+  module: "Newsletter"
+  tests:
+    - testname: "AdminAddWidgetToWYSIWYGNewsletterTest"
+      title: "Admin should be able to add widget to WYSIWYG Editor of Newsletter"
+      description: "Admin should be able to add widget to WYSIWYG Editor Newsletter"
+- filename: "AdminMarketingNewsletterTemplateNavigateMenuTest.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/Newsletter/Test/Mftf/Test/AdminMarketingNewsletterTemplateNavigateMenuTest.xml"
+  module: "Newsletter"
+  tests:
+    - testname: "AdminMarketingNewsletterTemplateNavigateMenuTest"
+      title: "Admin marketing newsletter template navigate menu test"
+      description: "Admin should be able to navigate to Marketing &gt; Newsletter Template"
+- filename: "AdminReportsNewsletterProblemReportsNavigateMenuTest.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/Newsletter/Test/Mftf/Test/AdminReportsNewsletterProblemReportsNavigateMenuTest.xml"
+  module: "Newsletter"
+  tests:
+    - testname: "AdminReportsNewsletterProblemReportsNavigateMenuTest"
+      title: "Admin reports newsletter problem reports navigate menu test"
+      description: "Admin should be able to navigate to Reports &gt; Newsletter Problem Reports"
+- filename: "VerifyTinyMCEv4IsNativeWYSIWYGOnNewsletterTest.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/Newsletter/Test/Mftf/Test/VerifyTinyMCEv4IsNativeWYSIWYGOnNewsletterTest.xml"
+  module: "Newsletter"
+  tests:
+    - testname: "VerifyTinyMCEv4IsNativeWYSIWYGOnNewsletterTest"
+      title: "Admin should see TinyMCEv4.6 is the native WYSIWYG on Newsletter"
+      description: "Admin should see TinyMCEv4.6 is the native WYSIWYG on Newsletter"
+- filename: "AdminMarketingNewsletterQueueNavigateMenuTest.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/Newsletter/Test/Mftf/Test/AdminMarketingNewsletterQueueNavigateMenuTest.xml"
+  module: "Newsletter"
+  tests:
+    - testname: "AdminMarketingNewsletterQueueNavigateMenuTest"
+      title: "Admin marketing newsletter queue navigate menu test"
+      description: "Admin should be able to navigate to Marketing &gt; Newsletter Queue"
+- filename: "VerifySubscribedNewsletterDisplayedTest.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/Newsletter/Test/Mftf/Test/VerifySubscribedNewsletterDisplayedTest.xml"
+  module: "Newsletter"
+  tests:
+    - testname: "VerifySubscribedNewsletterDisplayedTest"
+      title: "Newsletter subscription when user is registered on 2 stores"
+      description: "Newsletter subscription when user is registered on 2 stores"
+- filename: "AdminMarketingNewsletterSubscribersNavigateMenuTest.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/Newsletter/Test/Mftf/Test/AdminMarketingNewsletterSubscribersNavigateMenuTest.xml"
+  module: "Newsletter"
+  tests:
+    - testname: "AdminMarketingNewsletterSubscribersNavigateMenuTest"
+      title: "Admin marketing newsletter subscribers navigate menu test"
+      description: "Admin should be able to navigate to Marketing &gt; Newsletter Subscribers"
+- filename: "StorefrontVerifySecureURLRedirectNewsletterTest.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/Newsletter/Test/Mftf/Test/StorefrontVerifySecureURLRedirectNewsletterTest.xml"
+  module: "Newsletter"
+  tests:
+    - testname: "StorefrontVerifySecureURLRedirectNewsletter"
+      title: "Verify Secure URLs For Storefront Newsletter Pages"
+      description: "Verify that the Secure URL configuration applies to the Newsletter pages on the Storefront"
+- filename: "AdminAddVariableToWYSIWYGNewsletterTest.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/Newsletter/Test/Mftf/Test/AdminAddVariableToWYSIWYGNewsletterTest.xml"
+  module: "Newsletter"
+  tests:
+    - testname: "AdminAddVariableToWYSIWYGNewsletterTest"
+      title: "Admin should be able to add variable to WYSIWYG Editor of Newsletter"
+      description: "Admin should be able to add variable to WYSIWYG Editor Newsletter"
+- filename: "AdminAddImageToWYSIWYGNewsletterTest.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/Newsletter/Test/Mftf/Test/AdminAddImageToWYSIWYGNewsletterTest.xml"
+  module: "Newsletter"
+  tests:
+    - testname: "AdminAddImageToWYSIWYGNewsletterTest"
+      title: "Admin should be able to add image to WYSIWYG content of Newsletter"
+      description: "Admin should be able to add image to WYSIWYG content Newsletter"
+- filename: "AdminDeleteCatalogPriceRuleEntityTest.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/CatalogRule/Test/Mftf/Test/AdminDeleteCatalogPriceRuleEntityTest.xml"
+  module: "CatalogRule"
+  tests:
+    - testname: "AdminDeleteCatalogPriceRuleEntityFromSimpleProductTest"
+      title: "Delete Catalog Price Rule for Simple Product"
+      description: "Assert that Catalog Price Rule is not applied for simple product."
+
+    - testname: "AdminDeleteCatalogPriceRuleEntityFromConfigurableProductTest"
+      title: "Delete Catalog Price Rule for Configurable Product"
+      description: "Assert that Catalog Price Rule is not applied for configurable product"
+- filename: "ApplyCatalogPriceRuleByProductAttributeTest.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/CatalogRule/Test/Mftf/Test/ApplyCatalogPriceRuleByProductAttributeTest.xml"
+  module: "CatalogRule"
+  tests:
+    - testname: "ApplyCatalogPriceRuleByProductAttributeTest"
+      title: "Admin should be able to apply the catalog price rule by product attribute"
+      description: "Admin should be able to apply the catalog price rule by product attribute"
+- filename: "AdminMarketingCatalogPriceRuleNavigateMenuTest.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/CatalogRule/Test/Mftf/Test/AdminMarketingCatalogPriceRuleNavigateMenuTest.xml"
+  module: "CatalogRule"
+  tests:
+    - testname: "AdminMarketingCatalogPriceRuleNavigateMenuTest"
+      title: "Admin marketing catalog price rule navigate menu test"
+      description: "Admin should be able to navigate to Marketing &gt; Catalog Price Rule"
+- filename: "AdminDeleteCatalogPriceRuleTest.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/CatalogRule/Test/Mftf/Test/AdminDeleteCatalogPriceRuleTest.xml"
+  module: "CatalogRule"
+  tests:
+    - testname: "AdminDeleteCatalogPriceRuleTest"
+      title: "Admin should be able to delete catalog price rule"
+      description: "Admin should be able to delete catalog price rule"
+- filename: "AdminApplyCatalogRuleForConfigurableProductWithSpecialPricesTest.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/CatalogRule/Test/Mftf/Test/AdminApplyCatalogRuleForConfigurableProductWithSpecialPricesTest.xml"
+  module: "CatalogRule"
+  tests:
+    - testname: "AdminApplyCatalogRuleForConfigurableProductWithSpecialPricesTest"
+      title: "Admin should be able to apply the catalog price rule for configurable product with special prices"
+      description: "Admin should be able to apply the catalog price rule for configurable product with special prices"
+- filename: "ApplyCatalogRuleForSimpleAndConfigurableProductTest.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/CatalogRule/Test/Mftf/Test/ApplyCatalogRuleForSimpleAndConfigurableProductTest.xml"
+  module: "CatalogRule"
+  tests:
+    - testname: "ApplyCatalogPriceRuleForSimpleProductAndConfigurableProductTest"
+      title: "Admin should be able to apply the catalog price rule for simple product and configurable product"
+      description: "Admin should be able to apply the catalog price rule for simple product and configurable product"
+- filename: "AdminCreateInactiveCatalogPriceRuleTest.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/CatalogRule/Test/Mftf/Test/AdminCreateInactiveCatalogPriceRuleTest.xml"
+  module: "CatalogRule"
+  tests:
+    - testname: "AdminCreateInactiveCatalogPriceRuleTest"
+      title: "Create Inactive Catalog Price Rule"
+      description: "Login as admin and create inactive catalog price Rule"
+- filename: "StorefrontCatalogPriceRuleAndCustomerGroupMembershipArePersistedUnderLongTermCookieTest.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/CatalogRule/Test/Mftf/Test/StorefrontCatalogPriceRuleAndCustomerGroupMembershipArePersistedUnderLongTermCookieTest.xml"
+  module: "CatalogRule"
+  tests:
+    - testname: "StorefrontCatalogPriceRuleAndCustomerGroupMembershipArePersistedUnderLongTermCookieTest"
+      title: "Verify that Catalog Price Rule and Customer Group Membership are persisted under long-term cookie"
+      description: "Verify that Catalog Price Rule and Customer Group Membership are persisted under long-term cookie"
+- filename: "AdminCreateCatalogPriceRuleTest.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/CatalogRule/Test/Mftf/Test/AdminCreateCatalogPriceRuleTest.xml"
+  module: "CatalogRule"
+  tests:
+    - testname: "AdminCreateCatalogPriceRuleByPercentTest"
+      title: "Admin should be able to create a catalog price rule applied as a percentage of original (for simple product)"
+      description: "Admin should be able to create a catalog price rule applied as a percentage of original (for simple product)"
+
+    - testname: "AdminCreateCatalogPriceRuleByFixedTest"
+      title: "Admin should be able to create a catalog price rule applied as a fixed amount (for simple product)"
+      description: "Admin should be able to create a catalog price rule applied as a fixed amount (for simple product)"
+
+    - testname: "AdminCreateCatalogPriceRuleToPercentTest"
+      title: "Admin should be able to create a catalog price rule adjust final price to this percentage (for simple product)"
+      description: "Admin should be able to create a catalog price rule adjust final price to this percentage (for simple product)"
+
+    - testname: "AdminCreateCatalogPriceRuleToFixedTest"
+      title: "Admin should be able to create a catalog price rule adjust final price to discount value (for simple product)"
+      description: "Admin should be able to create a catalog price rule adjust final price to discount value (for simple product)"
+
+    - testname: "AdminCreateCatalogPriceRuleForCustomerGroupTest"
+      title: "Admin should be able to apply the catalog rule by customer group"
+      description: "Admin should be able to apply the catalog rule by customer group"
+
+    - testname: "AdminCreateCatalogPriceRuleWithInvalidDataTest"
+      title: "Admin can not create catalog price rule with the invalid data"
+      description: "Admin can not create catalog price rule with the invalid data"
+- filename: "AdminEnableAttributeIsUndefinedCatalogPriceRuleTest.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/CatalogRule/Test/Mftf/Test/AdminEnableAttributeIsUndefinedCatalogPriceRuleTest.xml"
+  module: "CatalogRule"
+  tests:
+    - testname: "AdminEnableAttributeIsUndefinedCatalogPriceRuleTest"
+      title: "Enable 'is undefined' condition to Scope Catalog Price rules by custom product attribute"
+      description: "Enable 'is undefined' condition to Scope Catalog Price rules by custom product attribute"
+- filename: "AdminApplyCatalogRuleByCategoryTest.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/CatalogRule/Test/Mftf/Test/AdminApplyCatalogRuleByCategoryTest.xml"
+  module: "CatalogRule"
+  tests:
+    - testname: "AdminApplyCatalogRuleByCategoryTest"
+      title: "Admin should be able to apply the catalog rule by category"
+      description: "Admin should be able to apply the catalog rule by category"
+- filename: "ApplyCatalogRuleForSimpleProductAndFixedMethodTest.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/CatalogRule/Test/Mftf/Test/ApplyCatalogRuleForSimpleProductAndFixedMethodTest.xml"
+  module: "CatalogRule"
+  tests:
+    - testname: "ApplyCatalogRuleForSimpleProductAndFixedMethodTest"
+      title: "Admin should be able to apply the catalog price rule for simple product with custom options"
+      description: "Admin should be able to apply the catalog price rule for simple product with custom options"
+- filename: "StorefrontInactiveCatalogRule2Test.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/CatalogRule/Test/Mftf/Test/StorefrontInactiveCatalogRule2Test.xml"
+  module: "CatalogRule"
+  tests:
+    - testname: "StorefrontInactiveCatalogRule2Test"
+      title: "Customer should not see the catalog price rule promotion if status is inactive"
+      description: "Customer should not see the catalog price rule promotion if status is inactive"
+- filename: "StorefrontInactiveCatalogRuleTest.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/CatalogRule/Test/Mftf/Test/StorefrontInactiveCatalogRuleTest.xml"
+  module: "CatalogRule"
+  tests:
+    - testname: "StorefrontInactiveCatalogRuleTest"
+      title: "DEPRECATED. Customer should not see the catalog price rule promotion if status is inactive"
+      description: "Customer should not see the catalog price rule promotion if status is inactive"
+- filename: "DeleteCustomerGroupTest.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/CatalogRule/Test/Mftf/Test/DeleteCustomerGroupTest.xml"
+  module: "CatalogRule"
+  tests:
+    - testname: "DeleteCustomerGroupTest"
+      title: ""
+      description: ""
+- filename: "ApplyCatalogRuleForSimpleProductWithCustomOptionsTest.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/CatalogRule/Test/Mftf/Test/ApplyCatalogRuleForSimpleProductWithCustomOptionsTest.xml"
+  module: "CatalogRule"
+  tests:
+    - testname: "ApplyCatalogRuleForSimpleProductWithCustomOptionsTest"
+      title: "Admin should be able to apply the catalog price rule for simple product with custom options"
+      description: "Admin should be able to apply the catalog price rule for simple product with custom options"
+- filename: "CatalogPriceRuleAndCustomerGroupMembershipArePersistedUnderLongTermCookieTest.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/CatalogRule/Test/Mftf/Test/CatalogPriceRuleAndCustomerGroupMembershipArePersistedUnderLongTermCookieTest.xml"
+  module: "CatalogRule"
+  tests:
+    - testname: "CatalogPriceRuleAndCustomerGroupMembershipArePersistedUnderLongTermCookieTest"
+      title: "DEPRECATED. Verify that Catalog Price Rule and Customer Group Membership are persisted under long-term cookie"
+      description: "Verify that Catalog Price Rule and Customer Group Membership are persisted under long-term cookie"
+- filename: "ApplyCatalogRuleForSimpleProductForNewCustomerGroupTest.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/CatalogRule/Test/Mftf/Test/ApplyCatalogRuleForSimpleProductForNewCustomerGroupTest.xml"
+  module: "CatalogRule"
+  tests:
+    - testname: "ApplyCatalogRuleForSimpleProductForNewCustomerGroupTest"
+      title: "Admin should be able to apply the catalog price rule for simple product for new customer group"
+      description: "Admin should be able to apply the catalog price rule for simple product for new customer group"
+- filename: "ThemeTest.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/Theme/Test/Mftf/Test/ThemeTest.xml"
+  module: "Theme"
+  tests:
+    - testname: "ThemeTest"
+      title: "Magento Rush theme should not be available in Themes grid"
+      description: "Magento Rush theme should not be available in Themes grid"
+- filename: "AdminDesignConfigMediaGalleryImageUploadTest.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/Theme/Test/Mftf/Test/AdminDesignConfigMediaGalleryImageUploadTest.xml"
+  module: "Theme"
+  tests:
+    - testname: "AdminDesignConfigMediaGalleryImageUploadTest"
+      title: "MC-5784: Image fields using imageUploader UIComponent cannot use gallery image"
+      description: "Admin should be able to use Image Uploader to add Gallery Images"
+- filename: "AdminWatermarkUploadTest.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/Theme/Test/Mftf/Test/AdminWatermarkUploadTest.xml"
+  module: "Theme"
+  tests:
+    - testname: "AdminWatermarkUploadTest"
+      title: "MAGETWO-95934: Can't upload Watermark Image"
+      description: "Watermark images should be able to be uploaded in the admin"
+- filename: "AdminContentThemesNavigateMenuTest.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/Theme/Test/Mftf/Test/AdminContentThemesNavigateMenuTest.xml"
+  module: "Theme"
+  tests:
+    - testname: "AdminContentThemesNavigateMenuTest"
+      title: "Admin content themes navigate menu test"
+      description: "Admin should be able to navigate to Content &gt; Themes"
+- filename: "AdminScheduledImportSettingsHiddenTest.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/Directory/Test/Mftf/Test/AdminScheduledImportSettingsHiddenTest.xml"
+  module: "Directory"
+  tests:
+    - testname: "AdminScheduledImportSettingsHiddenTest"
+      title: "Scheduled import settings hidden"
+      description: "Scheduled Import Settings' should hide fields when 'Enabled' is 'No'"
+- filename: "AdminContentScheduleNavigateMenuTest.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/Backend/Test/Mftf/Test/AdminContentScheduleNavigateMenuTest.xml"
+  module: "Backend"
+  tests:
+    - testname: "AdminContentScheduleNavigateMenuTest"
+      title: "Admin content schedule navigate menu test"
+      description: "Admin should be able to navigate to Content &gt; Schedule"
+- filename: "AdminExpireAdminSessionTest.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/Backend/Test/Mftf/Test/AdminExpireAdminSessionTest.xml"
+  module: "Backend"
+  tests:
+    - testname: "AdminExpireAdminSessionTest"
+      title: "Admin Session Expire"
+      description: "Admin Session Expire"
+- filename: "AdminAttributeTextSwatchesCanBeFiledTest.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/Backend/Test/Mftf/Test/AdminAttributeTextSwatchesCanBeFiledTest.xml"
+  module: "Backend"
+  tests:
+    - testname: "AdminAttributeTextSwatchesCanBeFiledTest"
+      title: "Check that attribute text swatches can be filed"
+      description: "Check that attribute text swatches can be filed"
+- filename: "AdminSystemCacheManagementNavigateMenuTest.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/Backend/Test/Mftf/Test/AdminSystemCacheManagementNavigateMenuTest.xml"
+  module: "Backend"
+  tests:
+    - testname: "AdminSystemCacheManagementNavigateMenuTest"
+      title: "Admin system cache management navigate menu test"
+      description: "Admin should be able to navigate to System &gt; Cache Management"
+- filename: "AdminLoginTest.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/Backend/Test/Mftf/Test/AdminLoginTest.xml"
+  module: "Backend"
+  tests:
+    - testname: "AdminLoginTest"
+      title: "Admin should be able to log into the Magento Admin backend"
+      description: "Admin should be able to log into the Magento Admin backend"
+- filename: "AdminDashboardNavigateMenuTest.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/Backend/Test/Mftf/Test/AdminDashboardNavigateMenuTest.xml"
+  module: "Backend"
+  tests:
+    - testname: "AdminDashboardNavigateMenuTest"
+      title: "Admin dashboard navigate menu test"
+      description: "Admin should be able to navigate to Dashboard"
+- filename: "AdminMenuNavigationWithSecretKeysTest.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/Backend/Test/Mftf/Test/AdminMenuNavigationWithSecretKeysTest.xml"
+  module: "Backend"
+  tests:
+    - testname: "AdminMenuNavigationWithSecretKeysTest"
+      title: "Admin should be able to navigate between menu options with secret url keys enabled"
+      description: "Admin should be able to navigate between menu options with secret url keys enabled"
+- filename: "AdminLoginAfterJSMinificationTest.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/Backend/Test/Mftf/Test/AdminLoginAfterJSMinificationTest.xml"
+  module: "Backend"
+  tests:
+    - testname: "AdminLoginAfterJSMinificationTest"
+      title: "Admin panel should be accessible with JS minification enabled"
+      description: "Admin panel should be accessible with JS minification enabled"
+- filename: "AdminUserLoginWithStoreCodeInUrlTest.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/Backend/Test/Mftf/Test/AdminUserLoginWithStoreCodeInUrlTest.xml"
+  module: "Backend"
+  tests:
+    - testname: "AdminUserLoginWithStoreCodeInUrlTest"
+      title: "Admin panel should be accessible with Add Store Code to URL setting enabled"
+      description: "Admin panel should be accessible with Add Store Code to URL setting enabled"
+- filename: "AdminCheckLocaleAndDeveloperConfigInProductionModeTest.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/Backend/Test/Mftf/Test/AdminCheckLocaleAndDeveloperConfigInProductionModeTest.xml"
+  module: "Backend"
+  tests:
+    - testname: "AdminCheckLocaleAndDeveloperConfigInProductionModeTest"
+      title: "Check locale dropdown and developer configuration page are not available in production mode"
+      description: "Check locale dropdown and developer configuration page are not available in production mode"
+- filename: "AdminLoginAfterChangeCookieDomainTest.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/Backend/Test/Mftf/Test/AdminLoginAfterChangeCookieDomainTest.xml"
+  module: "Backend"
+  tests:
+    - testname: "AdminLoginAfterChangeCookieDomainTest"
+      title: "Admin user can login after changing cookie domain on main website scope without changing cookie domain on default scope"
+      description: "Admin user can login after changing cookie domain on main website scope without changing cookie domain on default scope"
+- filename: "AdminStoresConfigurationNavigateMenuTest.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/Backend/Test/Mftf/Test/AdminStoresConfigurationNavigateMenuTest.xml"
+  module: "Backend"
+  tests:
+    - testname: "AdminStoresConfigurationNavigateMenuTest"
+      title: "Admin stores configuration navigate menu test"
+      description: "Admin should be able to navigate to Stores &gt; Configuration"
+- filename: "AdminPrivacyPolicyTest.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/Backend/Test/Mftf/Test/AdminPrivacyPolicyTest.xml"
+  module: "Backend"
+  tests:
+    - testname: "AdminPrivacyPolicyTest"
+      title: "There should be a privacy policy url in the admin page and every sub page"
+      description: "There should be a privacy policy url in the admin page and every sub page"
+- filename: "AdminCheckLocaleAndDeveloperConfigInDeveloperModeTest.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/Backend/Test/Mftf/Test/AdminCheckLocaleAndDeveloperConfigInDeveloperModeTest.xml"
+  module: "Backend"
+  tests:
+    - testname: "AdminCheckLocaleAndDeveloperConfigInDeveloperModeTest"
+      title: "Check locale dropdown and developer configuration page are available in developer mode"
+      description: "Check locale dropdown and developer configuration page are available in developer mode"
+- filename: "AdminExpireCustomerSessionTest.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/Backend/Test/Mftf/Test/AdminExpireCustomerSessionTest.xml"
+  module: "Backend"
+  tests:
+    - testname: "AdminExpireCustomerSessionTest"
+      title: "Customer Session Expireon"
+      description: "Customer Session Expire"
+- filename: "AdminStoresAllStoresNavigateMenuTest.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/Backend/Test/Mftf/Test/AdminStoresAllStoresNavigateMenuTest.xml"
+  module: "Backend"
+  tests:
+    - testname: "AdminStoresAllStoresNavigateMenuTest"
+      title: "Admin stores all stores navigate menu test"
+      description: "Admin should be able to navigate to Stores &gt; All Stores"
+- filename: "NewProductsListWidgetTest.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/Widget/Test/Mftf/Test/NewProductsListWidgetTest.xml"
+  module: "Widget"
+  tests:
+    - testname: "NewProductsListWidgetTest"
+      title: "Admin should be able to set products as new so that they show up in the Catalog New Products List Widget"
+      description: "Admin should be able to set products as new so that they show up in the Catalog New Products List Widget"
+- filename: "ProductsListWidgetTest.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/Widget/Test/Mftf/Test/ProductsListWidgetTest.xml"
+  module: "Widget"
+  tests:
+    - testname: "ProductsListWidgetTest"
+      title: "Admin should be able to set Products List Widget"
+      description: "Admin should be able to set Products List Widget"
+- filename: "AdminContentWidgetsNavigateMenuTest.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/Widget/Test/Mftf/Test/AdminContentWidgetsNavigateMenuTest.xml"
+  module: "Widget"
+  tests:
+    - testname: "AdminContentWidgetsNavigateMenuTest"
+      title: "Admin content widgets navigate menu test"
+      description: "Admin should be able to navigate to Content &gt; Widgets"
+- filename: "AdminCardinalCommerceSettingsHiddenTest.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/CardinalCommerce/Test/Mftf/Test/AdminCardinalCommerceSettingsHiddenTest.xml"
+  module: "CardinalCommerce"
+  tests:
+    - testname: "AdminCardinalCommerceSettingsHiddenTest"
+      title: "CardinalCommerce settings hidden"
+      description: "CardinalCommerce config shouldn't be visible if the 3D secure is disabled for Authorize.Net."
+- filename: "AdminSystemNotificationNavigateMenuTest.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/AdminNotification/Test/Mftf/Test/AdminSystemNotificationNavigateMenuTest.xml"
+  module: "AdminNotification"
+  tests:
+    - testname: "AdminSystemNotificationNavigateMenuTest"
+      title: "Admin system notification navigate menu test"
+      description: "Admin should be able to navigate to System &gt; Notifications"
+- filename: "AdminSystemCustomVariablesNavigateMenuTest.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/Variable/Test/Mftf/Test/AdminSystemCustomVariablesNavigateMenuTest.xml"
+  module: "Variable"
+  tests:
+    - testname: "AdminSystemCustomVariablesNavigateMenuTest"
+      title: "Admin system custom variables navigate menu test"
+      description: "Admin should be able to navigate to System &gt; Custom Variables"
+- filename: "AdminCreateCustomVariableEntityTest.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/Variable/Test/Mftf/Test/AdminCreateCustomVariableEntityTest.xml"
+  module: "Variable"
+  tests:
+    - testname: "AdminCreateCustomVariableEntityTest"
+      title: "Admin Create Custom Variable"
+      description: "Test for creating a custom variable."
+- filename: "StorefrontVerifyThatInformationAboutViewingComparisonWishlistIsPersistedUnderLongTermCookieTest.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/Persistent/Test/Mftf/Test/StorefrontVerifyThatInformationAboutViewingComparisonWishlistIsPersistedUnderLongTermCookieTest.xml"
+  module: "Persistent"
+  tests:
+    - testname: "StorefrontVerifyThatInformationAboutViewingComparisonWishlistIsPersistedUnderLongTermCookieTest"
+      title: "Verify that information about viewing, comparison, wishlist and last ordered items is persisted under long-term cookie"
+      description: "Verify that information about viewing, comparison, wishlist and last ordered items is persisted under long-term cookie"
+- filename: "StorefrontVerifyShoppingCartPersistenceUnderLongTermCookieTest.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/Persistent/Test/Mftf/Test/StorefrontVerifyShoppingCartPersistenceUnderLongTermCookieTest.xml"
+  module: "Persistent"
+  tests:
+    - testname: "StorefrontVerifyShoppingCartPersistenceUnderLongTermCookieTest"
+      title: "Verify Shopping Cart Persistence under long-term cookie"
+      description: "Verify Shopping Cart Persistence under long-term cookie"
+- filename: "CheckShoppingCartBehaviorAfterSessionExpiredTest.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/Persistent/Test/Mftf/Test/CheckShoppingCartBehaviorAfterSessionExpiredTest.xml"
+  module: "Persistent"
+  tests:
+    - testname: "CheckShoppingCartBehaviorAfterSessionExpiredTest"
+      title: "Checking behavior with the persistent shopping cart after the session is expired"
+      description: "Checking behavior with the persistent shopping cart after the session is expired"
+- filename: "ShippingQuotePersistedForGuestTest.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/Persistent/Test/Mftf/Test/ShippingQuotePersistedForGuestTest.xml"
+  module: "Persistent"
+  tests:
+    - testname: "ShippingQuotePersistedForGuestTest"
+      title: "Estimate Shipping and Tax block sections on shipping cart saving correctly for Guest."
+      description: "Verify that 'Estimate Shipping and Tax' block sections on shipping cart saving correctly for Guest after switching to another page. And check that the shopping cart is cleared after reset persistent cookie."
+- filename: "StorefrontCorrectWelcomeMessageAfterCustomerIsLoggedOutTest.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/Persistent/Test/Mftf/Test/StorefrontCorrectWelcomeMessageAfterCustomerIsLoggedOutTest.xml"
+  module: "Persistent"
+  tests:
+    - testname: "StorefrontCorrectWelcomeMessageAfterCustomerIsLoggedOutTest"
+      title: "Checking welcome message for persistent customer after logout"
+      description: "Checking welcome message for persistent customer after logout"
+- filename: "GuestCheckoutWithEnabledPersistentTest.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/Persistent/Test/Mftf/Test/GuestCheckoutWithEnabledPersistentTest.xml"
+  module: "Persistent"
+  tests:
+    - testname: "GuestCheckoutWithEnabledPersistentTest"
+      title: "Guest Checkout with Enabled Persistent"
+      description: "Checkout data must be restored after page checkout reload."
+- filename: "AdminSortingAssociatedProductsTest.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/GroupedProduct/Test/Mftf/Test/AdminSortingAssociatedProductsTest.xml"
+  module: "GroupedProduct"
+  tests:
+    - testname: "AdminSortingAssociatedProductsTest"
+      title: "Grouped Products: Sorting Associated Products Between Pages"
+      description: "Make sure that products in grid were recalculated when sorting associated products between pages"
+- filename: "AdminCreateAndEditGroupedProductSettingsTest.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/GroupedProduct/Test/Mftf/Test/AdminCreateAndEditGroupedProductSettingsTest.xml"
+  module: "GroupedProduct"
+  tests:
+    - testname: "AdminCreateAndEditGroupedProductSettingsTest"
+      title: "Admin should be able to set/edit other product information when creating/editing a grouped product"
+      description: "Admin should be able to set/edit other product information when creating/editing a grouped product"
+- filename: "AdminRemoveDefaultVideoGroupedProductTest.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/GroupedProduct/Test/Mftf/Test/AdminRemoveDefaultVideoGroupedProductTest.xml"
+  module: "GroupedProduct"
+  tests:
+    - testname: "AdminRemoveDefaultVideoGroupedProductTest"
+      title: "Admin should be able to remove default video from a Grouped Product"
+      description: "Admin should be able to remove default video from a Grouped Product"
+- filename: "AdminRemoveDefaultImageGroupedProductTest.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/GroupedProduct/Test/Mftf/Test/AdminRemoveDefaultImageGroupedProductTest.xml"
+  module: "GroupedProduct"
+  tests:
+    - testname: "AdminRemoveDefaultImageGroupedProductTest"
+      title: "Admin should be able to remove default images from a Grouped Product"
+      description: "Admin should be able to remove default images from a Grouped Product"
+- filename: "NewProductsListWidgetGroupedProductTest.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/GroupedProduct/Test/Mftf/Test/NewProductsListWidgetGroupedProductTest.xml"
+  module: "GroupedProduct"
+  tests:
+    - testname: "NewProductsListWidgetGroupedProductTest"
+      title: "Admin should be able to set Grouped Product as new so that it shows up in the Catalog New Products List Widget"
+      description: "Admin should be able to set Grouped Product as new so that it shows up in the Catalog New Products List Widget"
+- filename: "AdminGroupedSetEditRelatedProductsTest.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/GroupedProduct/Test/Mftf/Test/AdminGroupedSetEditRelatedProductsTest.xml"
+  module: "GroupedProduct"
+  tests:
+    - testname: "AdminGroupedSetEditRelatedProductsTest"
+      title: "Admin should be able to set/edit Related Products information when editing a grouped product"
+      description: "Admin should be able to set/edit Related Products information when editing a grouped product"
+- filename: "AdminGroupedProductSetEditContentTest.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/GroupedProduct/Test/Mftf/Test/AdminGroupedProductSetEditContentTest.xml"
+  module: "GroupedProduct"
+  tests:
+    - testname: "AdminGroupedProductSetEditContentTest"
+      title: "Admin should be able to set/edit product Content when editing a grouped product"
+      description: "Admin should be able to set/edit product Content when editing a grouped product"
+- filename: "AdminGroupedProductsListTest.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/GroupedProduct/Test/Mftf/Test/AdminGroupedProductsListTest.xml"
+  module: "GroupedProduct"
+  tests:
+    - testname: "AdminGroupedProductsAreListedWhenOutOfStock"
+      title: "Products in group should show in admin list even when they are out of stock"
+      description: "Products in group should show in admin list even when they are out of stock"
+- filename: "EndToEndB2CAdminTest.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/GroupedProduct/Test/Mftf/Test/EndToEndB2CAdminTest.xml"
+  module: "GroupedProduct"
+  tests:
+    - testname: "EndToEndB2CAdminTest"
+      title: ""
+      description: ""
+- filename: "AdminAssociateGroupedProductToWebsitesTest.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/GroupedProduct/Test/Mftf/Test/AdminAssociateGroupedProductToWebsitesTest.xml"
+  module: "GroupedProduct"
+  tests:
+    - testname: "AdminAssociateGroupedProductToWebsitesTest"
+      title: "Admin should be able to associate grouped product to websites"
+      description: "Admin should be able to associate grouped product to websites"
+- filename: "AdminAddDefaultImageGroupedProductTest.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/GroupedProduct/Test/Mftf/Test/AdminAddDefaultImageGroupedProductTest.xml"
+  module: "GroupedProduct"
+  tests:
+    - testname: "AdminAddDefaultImageGroupedProductTest"
+      title: "Admin should be able to add default images for a Grouped Product"
+      description: "Admin should be able to add default images for a Grouped Product"
+- filename: "AdminAddDefaultVideoGroupedProductTest.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/GroupedProduct/Test/Mftf/Test/AdminAddDefaultVideoGroupedProductTest.xml"
+  module: "GroupedProduct"
+  tests:
+    - testname: "AdminAddDefaultVideoGroupedProductTest"
+      title: "Admin should be able to add default video for a Grouped Product"
+      description: "Admin should be able to add default video for a Grouped Product"
+- filename: "AdminDeleteGroupedProductTest.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/GroupedProduct/Test/Mftf/Test/AdminDeleteGroupedProductTest.xml"
+  module: "GroupedProduct"
+  tests:
+    - testname: "AdminDeleteGroupedProductTest"
+      title: "Delete Grouped Product"
+      description: "Admin should be able to delete a grouped product"
+- filename: "AdvanceCatalogSearchGroupedProductTest.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/GroupedProduct/Test/Mftf/Test/AdvanceCatalogSearchGroupedProductTest.xml"
+  module: "GroupedProduct"
+  tests:
+    - testname: "AdvanceCatalogSearchGroupedProductByNameTest"
+      title: "Guest customer should be able to advance search Grouped product with product name"
+      description: "Guest customer should be able to advance search Grouped product with product name"
+
+    - testname: "AdvanceCatalogSearchGroupedProductByNameMysqlTest"
+      title: "Guest customer should be able to advance search Grouped product with product name using the MySQL search engine"
+      description: "Guest customer should be able to advance search Grouped product with product name using the MySQL search engine"
+
+    - testname: "AdvanceCatalogSearchGroupedProductBySkuTest"
+      title: "Guest customer should be able to advance search Grouped product with product sku"
+      description: "Guest customer should be able to advance search Grouped product with product sku"
+
+    - testname: "AdvanceCatalogSearchGroupedProductByDescriptionTest"
+      title: "Guest customer should be able to advance search Grouped product with product description"
+      description: "Guest customer should be able to advance search Grouped product with product description"
+
+    - testname: "AdvanceCatalogSearchGroupedProductByDescriptionMysqlTest"
+      title: "Guest customer should be able to advance search Grouped product with product description using the MySQL search engine"
+      description: "Guest customer should be able to advance search Grouped product with product description using the MYSQL search engine"
+
+    - testname: "AdvanceCatalogSearchGroupedProductByShortDescriptionTest"
+      title: "Guest customer should be able to advance search Grouped product with product short description"
+      description: "Guest customer should be able to advance search Grouped product with product short description"
+
+    - testname: "AdvanceCatalogSearchGroupedProductByShortDescriptionMysqlTest"
+      title: "Guest customer should be able to advance search Grouped product with product short description using the MySQL search engine"
+      description: "Guest customer should be able to advance search Grouped product with product short description using the MySQL search engine"
+
+    - testname: "AdvanceCatalogSearchGroupedProductByPriceTest"
+      title: "Guest customer should be able to advance search Grouped product with product price"
+      description: "Guest customer should be able to advance search Grouped product with product price"
+
+    - testname: "AdvanceCatalogSearchGroupedProductByPriceMysqlTest"
+      title: "Guest customer should be able to advance search Grouped product with product price using the MySQL search engine"
+      description: "Guest customer should be able to advance search Grouped product with product price using the MySQL search engine"
+- filename: "AdminSwitchWYSIWYGOptionsTest.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/Tinymce3/Test/Mftf/Test/AdminSwitchWYSIWYGOptionsTest.xml"
+  module: "Tinymce3"
+  tests:
+    - testname: "AdminSwitchWYSIWYGOptionsTest"
+      title: "Admin should able to switch between versions of TinyMCE"
+      description: "Admin should able to switch between versions of TinyMCE"
+- filename: "StorefrontElasticsearch6SearchInvalidValueTest.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/Elasticsearch6/Test/Mftf/Test/StorefrontElasticsearch6SearchInvalidValueTest.xml"
+  module: "Elasticsearch6"
+  tests:
+    - testname: "StorefrontElasticsearch6SearchInvalidValueTest"
+      title: "Elasticsearch: try to search by invalid value of 'Searchable' attribute"
+      description: "Elasticsearch: try to search by invalid value of 'Searchable' attribute"
+- filename: "StorefrontElasticSearchForChineseLocaleTest.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/Elasticsearch6/Test/Mftf/Test/StorefrontElasticSearchForChineseLocaleTest.xml"
+  module: "Elasticsearch6"
+  tests:
+    - testname: "StorefrontElasticSearch6ForChineseLocaleTest"
+      title: "Elastic search for Chinese locale"
+      description: "Elastic search for Chinese locale"
+- filename: "AdminStoresTermsAndConditionsNavigateMenuTest.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/CheckoutAgreements/Test/Mftf/Test/AdminStoresTermsAndConditionsNavigateMenuTest.xml"
+  module: "CheckoutAgreements"
+  tests:
+    - testname: "AdminStoresTermsAndConditionsNavigateMenuTest"
+      title: "Admin stores terms and conditions navigate menu test"
+      description: "Admin should be able to navigate to Stores &gt; Terms and Conditions"
+- filename: "AdvanceCatalogSearchSimpleProductTest.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/CatalogSearch/Test/Mftf/Test/AdvanceCatalogSearchSimpleProductTest.xml"
+  module: "CatalogSearch"
+  tests:
+    - testname: "AdvanceCatalogSearchSimpleProductByNameTest"
+      title: ""
+      description: ""
+
+    - testname: "AdvanceCatalogSearchSimpleProductBySkuTest"
+      title: ""
+      description: ""
+
+    - testname: "AdvanceCatalogSearchSimpleProductByDescriptionTest"
+      title: ""
+      description: ""
+
+    - testname: "AdvanceCatalogSearchSimpleProductByShortDescriptionTest"
+      title: ""
+      description: ""
+
+    - testname: "AdvanceCatalogSearchSimpleProductByPriceTest"
+      title: ""
+      description: ""
+- filename: "StorefrontAdvancedSearchNegativeProductSearchTest.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/CatalogSearch/Test/Mftf/Test/StorefrontAdvancedSearchNegativeProductSearchTest.xml"
+  module: "CatalogSearch"
+  tests:
+    - testname: "StorefrontAdvancedSearchNegativeProductSearchTest"
+      title: "Negative product search"
+      description: "Negative product search"
 - filename: "StorefrontAdvancedSearchByPartialNameTest.xml"
-  repo: "https://github.com/magento/magento2/blob/2.3/app/code/Magento/CatalogSearch/Test/Mftf/Test/StorefrontAdvancedSearchByPartialNameTest.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/CatalogSearch/Test/Mftf/Test/StorefrontAdvancedSearchByPartialNameTest.xml"
   module: "CatalogSearch"
   tests:
     - testname: "StorefrontAdvancedSearchByPartialNameTest"
       title: "Search product in advanced search by partial name"
       description: "Search product in advanced search by partial name"
- 
+- filename: "StorefrontAdvancedSearchByShortDescriptionTest.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/CatalogSearch/Test/Mftf/Test/StorefrontAdvancedSearchByShortDescriptionTest.xml"
+  module: "CatalogSearch"
+  tests:
+    - testname: "StorefrontAdvancedSearchByShortDescriptionTest"
+      title: "Search product in advanced search by short description"
+      description: "Search product in advanced search by short description"
+- filename: "StorefrontAdvancedSearchByPartialSkuAndDescriptionTest.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/CatalogSearch/Test/Mftf/Test/StorefrontAdvancedSearchByPartialSkuAndDescriptionTest.xml"
+  module: "CatalogSearch"
+  tests:
+    - testname: "StorefrontAdvancedSearchByPartialSkuAndDescriptionTest"
+      title: "Search product in advanced search by partial sku and description"
+      description: "Search product in advanced search by partial sku and description"
 - filename: "EndToEndB2CGuestUserTest.xml"
-  repo: "https://github.com/magento/magento2/blob/2.3/app/code/Magento/CatalogSearch/Test/Mftf/Test/EndToEndB2CGuestUserTest.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/CatalogSearch/Test/Mftf/Test/EndToEndB2CGuestUserTest.xml"
   module: "CatalogSearch"
   tests:
     - testname: "EndToEndB2CGuestUserTest"
@@ -1030,9 +7263,29 @@
     - testname: "EndToEndB2CGuestUserMysqlTest"
       title: ""
       description: ""
- 
+- filename: "AdminMarketingSearchTermsNavigateMenuTest.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/CatalogSearch/Test/Mftf/Test/AdminMarketingSearchTermsNavigateMenuTest.xml"
+  module: "CatalogSearch"
+  tests:
+    - testname: "AdminMarketingSearchTermsNavigateMenuTest"
+      title: "Admin marketing search terms navigate menu test"
+      description: "Admin should be able to navigate to Marketing &gt; Search Terms"
+- filename: "StorefrontAdvancedSearchByNameSkuDescriptionPriceTest.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/CatalogSearch/Test/Mftf/Test/StorefrontAdvancedSearchByNameSkuDescriptionPriceTest.xml"
+  module: "CatalogSearch"
+  tests:
+    - testname: "StorefrontAdvancedSearchByNameSkuDescriptionPriceTest"
+      title: "Search product in advanced search by name, sku, description, short description, price from 49 and price to 50"
+      description: "Search product in advanced search by name, sku, description, short description, price from 49 and price to 50"
+- filename: "StorefrontAdvancedSearchEntitySimpleProductTest.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/CatalogSearch/Test/Mftf/Test/StorefrontAdvancedSearchEntitySimpleProductTest.xml"
+  module: "CatalogSearch"
+  tests:
+    - testname: "StorefrontAdvancedSearchEntitySimpleProductTest"
+      title: "Use Advanced Search to Find the Product"
+      description: "Use Advanced Search to Find the Product"
 - filename: "SearchEntityResultsTest.xml"
-  repo: "https://github.com/magento/magento2/blob/2.3/app/code/Magento/CatalogSearch/Test/Mftf/Test/SearchEntityResultsTest.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/CatalogSearch/Test/Mftf/Test/SearchEntityResultsTest.xml"
   module: "CatalogSearch"
   tests:
     - testname: "QuickSearchProductBySku"
@@ -1100,7017 +7353,117 @@
       description: "Use Quick Search to find Bundle Fixed Product and Add to Cart"
 
     - testname: "QuickSearchConfigurableChildren"
-      title: "User should be able to use Quick Search to a configurable product's child products"
+      title: "Deprecated. User should be able to use Quick Search to a configurable product's child products"
       description: "Use Quick Search to find a configurable product with enabled/disable children"
- 
-- filename: "StorefrontAdvancedSearchByPartialShortDescriptionTest.xml"
-  repo: "https://github.com/magento/magento2/blob/2.3/app/code/Magento/CatalogSearch/Test/Mftf/Test/StorefrontAdvancedSearchByPartialShortDescriptionTest.xml"
-  module: "CatalogSearch"
-  tests:
-    - testname: "StorefrontAdvancedSearchByPartialShortDescriptionTest"
-      title: "Search product in advanced search by partial short description"
-      description: "Search product in advanced search by partial short description"
- 
-- filename: "StorefrontAdvancedSearchByShortDescriptionTest.xml"
-  repo: "https://github.com/magento/magento2/blob/2.3/app/code/Magento/CatalogSearch/Test/Mftf/Test/StorefrontAdvancedSearchByShortDescriptionTest.xml"
-  module: "CatalogSearch"
-  tests:
-    - testname: "StorefrontAdvancedSearchByShortDescriptionTest"
-      title: "Search product in advanced search by short description"
-      description: "Search product in advanced search by short description"
- 
-- filename: "StorefrontAdvancedSearchByPartialSkuAndDescriptionTest.xml"
-  repo: "https://github.com/magento/magento2/blob/2.3/app/code/Magento/CatalogSearch/Test/Mftf/Test/StorefrontAdvancedSearchByPartialSkuAndDescriptionTest.xml"
-  module: "CatalogSearch"
-  tests:
-    - testname: "StorefrontAdvancedSearchByPartialSkuAndDescriptionTest"
-      title: "Search product in advanced search by partial sku and description"
-      description: "Search product in advanced search by partial sku and description"
- 
-- filename: "StorefrontAdvancedSearchByAllParametersTest.xml"
-  repo: "https://github.com/magento/magento2/blob/2.3/app/code/Magento/CatalogSearch/Test/Mftf/Test/StorefrontAdvancedSearchByAllParametersTest.xml"
-  module: "CatalogSearch"
-  tests:
-    - testname: "StorefrontAdvancedSearchByAllParametersTest"
-      title: "Search product in advanced search by name, sku, description, short description, price from and price to"
-      description: "Search product in advanced search by name, sku, description, short description, price from and price to"
- 
-- filename: "StorefrontAdvancedSearchByPartialSkuTest.xml"
-  repo: "https://github.com/magento/magento2/blob/2.3/app/code/Magento/CatalogSearch/Test/Mftf/Test/StorefrontAdvancedSearchByPartialSkuTest.xml"
-  module: "CatalogSearch"
-  tests:
-    - testname: "StorefrontAdvancedSearchByPartialSkuTest"
-      title: "Search product in advanced search by partial sku"
-      description: "Search product in advanced search by partial sku"
- 
 - filename: "StorefrontAdvancedSearchWithoutEnteringDataTest.xml"
-  repo: "https://github.com/magento/magento2/blob/2.3/app/code/Magento/CatalogSearch/Test/Mftf/Test/StorefrontAdvancedSearchWithoutEnteringDataTest.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/CatalogSearch/Test/Mftf/Test/StorefrontAdvancedSearchWithoutEnteringDataTest.xml"
   module: "CatalogSearch"
   tests:
     - testname: "StorefrontAdvancedSearchWithoutEnteringDataTest"
       title: "Do Advanced Search without entering data"
       description: "'Enter a search term and try again.' error message is missed in Advanced Search"
- 
-- filename: "StorefrontAdvancedSearchByDescriptionTest.xml"
-  repo: "https://github.com/magento/magento2/blob/2.3/app/code/Magento/CatalogSearch/Test/Mftf/Test/StorefrontAdvancedSearchByDescriptionTest.xml"
-  module: "CatalogSearch"
-  tests:
-    - testname: "StorefrontAdvancedSearchByDescriptionTest"
-      title: "Search product in advanced search by description"
-      description: "Search product in advanced search by description"
- 
-- filename: "StorefrontAdvancedSearchByNameSkuDescriptionPriceTest.xml"
-  repo: "https://github.com/magento/magento2/blob/2.3/app/code/Magento/CatalogSearch/Test/Mftf/Test/StorefrontAdvancedSearchByNameSkuDescriptionPriceTest.xml"
-  module: "CatalogSearch"
-  tests:
-    - testname: "StorefrontAdvancedSearchByNameSkuDescriptionPriceTest"
-      title: "Search product in advanced search by name, sku, description, short description, price from 49 and price to 50"
-      description: "Search product in advanced search by name, sku, description, short description, price from 49 and price to 50"
- 
-- filename: "AdminDeleteSearchTermTest.xml"
-  repo: "https://github.com/magento/magento2/blob/2.3/app/code/Magento/CatalogSearch/Test/Mftf/Test/AdminDeleteSearchTermTest.xml"
-  module: "CatalogSearch"
-  tests:
-    - testname: "AdminDeleteSearchTermTest"
-      title: "Delete Search Term and Verify Storefront"
-      description: "Test log in to SearchTerm and DeleteSearchTerm"
- 
 - filename: "StorefrontUpdateSearchTermEntityTest.xml"
-  repo: "https://github.com/magento/magento2/blob/2.3/app/code/Magento/CatalogSearch/Test/Mftf/Test/StorefrontUpdateSearchTermEntityTest.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/CatalogSearch/Test/Mftf/Test/StorefrontUpdateSearchTermEntityTest.xml"
   module: "CatalogSearch"
   tests:
     - testname: "StorefrontUpdateSearchTermEntityTest"
       title: "Update Storefront Search Results"
       description: "You should see the updated Search Term on the Storefront via the Admin."
- 
-- filename: "StorefrontAdvancedSearchByPriceFromAndPriceToTest.xml"
-  repo: "https://github.com/magento/magento2/blob/2.3/app/code/Magento/CatalogSearch/Test/Mftf/Test/StorefrontAdvancedSearchByPriceFromAndPriceToTest.xml"
+- filename: "StorefrontAdvancedSearchByAllParametersTest.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/CatalogSearch/Test/Mftf/Test/StorefrontAdvancedSearchByAllParametersTest.xml"
   module: "CatalogSearch"
   tests:
-    - testname: "StorefrontAdvancedSearchByPriceFromAndPriceToTest"
-      title: "Search product in advanced search by price from and price to"
-      description: "Search product in advanced search by price from and price to"
- 
+    - testname: "StorefrontAdvancedSearchByAllParametersTest"
+      title: "Search product in advanced search by name, sku, description, short description, price from and price to"
+      description: "Search product in advanced search by name, sku, description, short description, price from and price to"
 - filename: "StorefrontAdvancedSearchByNameTest.xml"
-  repo: "https://github.com/magento/magento2/blob/2.3/app/code/Magento/CatalogSearch/Test/Mftf/Test/StorefrontAdvancedSearchByNameTest.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/CatalogSearch/Test/Mftf/Test/StorefrontAdvancedSearchByNameTest.xml"
   module: "CatalogSearch"
   tests:
     - testname: "StorefrontAdvancedSearchByNameTest"
       title: "Search product in advanced search by name"
       description: "Search product in advanced search by name"
- 
-- filename: "AdvanceCatalogSearchSimpleProductTest.xml"
-  repo: "https://github.com/magento/magento2/blob/2.3/app/code/Magento/CatalogSearch/Test/Mftf/Test/AdvanceCatalogSearchSimpleProductTest.xml"
+- filename: "StorefrontAdvancedSearchByDescriptionTest.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/CatalogSearch/Test/Mftf/Test/StorefrontAdvancedSearchByDescriptionTest.xml"
   module: "CatalogSearch"
   tests:
-    - testname: "AdvanceCatalogSearchSimpleProductByNameTest"
-      title: ""
-      description: ""
-
-    - testname: "AdvanceCatalogSearchSimpleProductBySkuTest"
-      title: ""
-      description: ""
-
-    - testname: "AdvanceCatalogSearchSimpleProductByDescriptionTest"
-      title: ""
-      description: ""
-
-    - testname: "AdvanceCatalogSearchSimpleProductByShortDescriptionTest"
-      title: ""
-      description: ""
-
-    - testname: "AdvanceCatalogSearchSimpleProductByPriceTest"
-      title: ""
-      description: ""
- 
-- filename: "MinimalQueryLengthForCatalogSearchTest.xml"
-  repo: "https://github.com/magento/magento2/blob/2.3/app/code/Magento/CatalogSearch/Test/Mftf/Test/MinimalQueryLengthForCatalogSearchTest.xml"
-  module: "CatalogSearch"
-  tests:
-    - testname: "MinimalQueryLengthForCatalogSearchTest"
-      title: "Minimal query length for catalog search"
-      description: "Minimal query length for catalog search"
- 
-- filename: "AdminMarketingSearchTermsNavigateMenuTest.xml"
-  repo: "https://github.com/magento/magento2/blob/2.3/app/code/Magento/CatalogSearch/Test/Mftf/Test/AdminMarketingSearchTermsNavigateMenuTest.xml"
-  module: "CatalogSearch"
-  tests:
-    - testname: "AdminMarketingSearchTermsNavigateMenuTest"
-      title: "Admin marketing search terms navigate menu test"
-      description: "Admin should be able to navigate to Marketing &gt; Search Terms"
- 
-- filename: "AdminCreateSearchTermEntityTest.xml"
-  repo: "https://github.com/magento/magento2/blob/2.3/app/code/Magento/CatalogSearch/Test/Mftf/Test/AdminCreateSearchTermEntityTest.xml"
-  module: "CatalogSearch"
-  tests:
-    - testname: "AdminCreateSearchTermEntityTest"
-      title: "Create search term test"
-      description: "Admin should be able to create search term"
- 
-- filename: "AdminReportsSearchTermsNavigateMenuTest.xml"
-  repo: "https://github.com/magento/magento2/blob/2.3/app/code/Magento/CatalogSearch/Test/Mftf/Test/AdminReportsSearchTermsNavigateMenuTest.xml"
-  module: "CatalogSearch"
-  tests:
-    - testname: "AdminReportsSearchTermsNavigateMenuTest"
-      title: "Admin reports search terms navigate menu test"
-      description: "Admin should be able to navigate to Reports &gt; Search Terms"
- 
-- filename: "StorefrontAdvancedSearchNegativeProductSearchTest.xml"
-  repo: "https://github.com/magento/magento2/blob/2.3/app/code/Magento/CatalogSearch/Test/Mftf/Test/StorefrontAdvancedSearchNegativeProductSearchTest.xml"
-  module: "CatalogSearch"
-  tests:
-    - testname: "StorefrontAdvancedSearchNegativeProductSearchTest"
-      title: "Negative product search"
-      description: "Negative product search"
- 
-- filename: "LayerNavigationOfCatalogSearchTest.xml"
-  repo: "https://github.com/magento/magento2/blob/2.3/app/code/Magento/CatalogSearch/Test/Mftf/Test/LayerNavigationOfCatalogSearchTest.xml"
-  module: "CatalogSearch"
-  tests:
-    - testname: "LayerNavigationOfCatalogSearchTest"
-      title: "Layer Navigation of Catalog Search Should Equalize Price Range As Default Configuration"
-      description: "Make sure filter of custom attribute with type of price displays on storefront Catalog page and price range should respect the configuration in Admin site"
- 
-- filename: "StorefrontAdvancedSearchByPriceToTest.xml"
-  repo: "https://github.com/magento/magento2/blob/2.3/app/code/Magento/CatalogSearch/Test/Mftf/Test/StorefrontAdvancedSearchByPriceToTest.xml"
-  module: "CatalogSearch"
-  tests:
-    - testname: "StorefrontAdvancedSearchByPriceToTest"
-      title: "Search product in advanced search by price to"
-      description: "Search product in advanced search by price to"
- 
+    - testname: "StorefrontAdvancedSearchByDescriptionTest"
+      title: "Search product in advanced search by description"
+      description: "Search product in advanced search by description"
 - filename: "StorefrontAdvancedSearchBySkuTest.xml"
-  repo: "https://github.com/magento/magento2/blob/2.3/app/code/Magento/CatalogSearch/Test/Mftf/Test/StorefrontAdvancedSearchBySkuTest.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/CatalogSearch/Test/Mftf/Test/StorefrontAdvancedSearchBySkuTest.xml"
   module: "CatalogSearch"
   tests:
     - testname: "StorefrontAdvancedSearchBySkuTest"
       title: "Search product in advanced search by sku"
       description: "Search product in advanced search by sku"
- 
+- filename: "AdminDeleteSearchTermTest.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/CatalogSearch/Test/Mftf/Test/AdminDeleteSearchTermTest.xml"
+  module: "CatalogSearch"
+  tests:
+    - testname: "AdminDeleteSearchTermTest"
+      title: "Delete Search Term and Verify Storefront"
+      description: "Test log in to SearchTerm and DeleteSearchTerm"
+- filename: "AdminCreateSearchTermEntityTest.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/CatalogSearch/Test/Mftf/Test/AdminCreateSearchTermEntityTest.xml"
+  module: "CatalogSearch"
+  tests:
+    - testname: "AdminCreateSearchTermEntityTest"
+      title: "Create search term test"
+      description: "Admin should be able to create search term"
+- filename: "StorefrontQuickSearchConfigurableChildrenTest.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/CatalogSearch/Test/Mftf/Test/StorefrontQuickSearchConfigurableChildrenTest.xml"
+  module: "CatalogSearch"
+  tests:
+    - testname: "StorefrontQuickSearchConfigurableChildrenTest"
+      title: "User should be able to use Quick Search to a configurable product's child products"
+      description: "Use Quick Search to find a configurable product with enabled/disable children"
+- filename: "StorefrontAdvancedSearchByPriceFromAndPriceToTest.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/CatalogSearch/Test/Mftf/Test/StorefrontAdvancedSearchByPriceFromAndPriceToTest.xml"
+  module: "CatalogSearch"
+  tests:
+    - testname: "StorefrontAdvancedSearchByPriceFromAndPriceToTest"
+      title: "Search product in advanced search by price from and price to"
+      description: "Search product in advanced search by price from and price to"
+- filename: "MinimalQueryLengthForCatalogSearchTest.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/CatalogSearch/Test/Mftf/Test/MinimalQueryLengthForCatalogSearchTest.xml"
+  module: "CatalogSearch"
+  tests:
+    - testname: "MinimalQueryLengthForCatalogSearchTest"
+      title: "Minimal query length for catalog search"
+      description: "Minimal query length for catalog search"
 - filename: "EndToEndB2CLoggedInUserTest.xml"
-  repo: "https://github.com/magento/magento2/blob/2.3/app/code/Magento/CatalogSearch/Test/Mftf/Test/EndToEndB2CLoggedInUserTest.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/CatalogSearch/Test/Mftf/Test/EndToEndB2CLoggedInUserTest.xml"
   module: "CatalogSearch"
   tests:
     - testname: "EndToEndB2CLoggedInUserTest"
       title: ""
       description: ""
- 
-- filename: "StorefrontAdvancedSearchEntitySimpleProductTest.xml"
-  repo: "https://github.com/magento/magento2/blob/2.3/app/code/Magento/CatalogSearch/Test/Mftf/Test/StorefrontAdvancedSearchEntitySimpleProductTest.xml"
+- filename: "StorefrontAdvancedSearchByPartialSkuTest.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/CatalogSearch/Test/Mftf/Test/StorefrontAdvancedSearchByPartialSkuTest.xml"
   module: "CatalogSearch"
   tests:
-    - testname: "StorefrontAdvancedSearchEntitySimpleProductTest"
-      title: "Use Advanced Search to Find the Product"
-      description: "Use Advanced Search to Find the Product"
- 
-- filename: "AdminProductGridFilteringByCustomAttributeTest.xml"
-  repo: "https://github.com/magento/magento2/blob/2.3/app/code/Magento/Catalog/Test/Mftf/Test/AdminProductGridFilteringByCustomAttributeTest.xml"
-  module: "Catalog"
-  tests:
-    - testname: "AdminProductGridFilteringByCustomAttributeTest"
-      title: "Sorting the product grid by custom product attribute"
-      description: "Sorting the product grid by custom product attribute should sort Alphabetically instead of value id"
- 
-- filename: "StorefrontAdvanceCatalogSearchSimpleProductBySkuWithHyphenTest.xml"
-  repo: "https://github.com/magento/magento2/blob/2.3/app/code/Magento/Catalog/Test/Mftf/Test/StorefrontAdvanceCatalogSearchSimpleProductBySkuWithHyphenTest.xml"
-  module: "Catalog"
-  tests:
-    - testname: "StorefrontAdvanceCatalogSearchSimpleProductBySkuWithHyphenTest"
-      title: "Guest customer should be able to advance search simple product with product sku that contains hyphen"
-      description: "Guest customer should be able to advance search simple product with product sku that contains hyphen"
- 
-- filename: "StorefrontPurchaseProductWithCustomOptionsTest.xml"
-  repo: "https://github.com/magento/magento2/blob/2.3/app/code/Magento/Catalog/Test/Mftf/Test/StorefrontPurchaseProductWithCustomOptionsTest.xml"
-  module: "Catalog"
-  tests:
-    - testname: "StorefrontPurchaseProductWithCustomOptionsTest"
-      title: "Admin should be able to sell products with custom options of different types"
-      description: "Admin should be able to sell products with custom options of different types"
- 
-- filename: "AdminRemoveDefaultImageSimpleProductTest.xml"
-  repo: "https://github.com/magento/magento2/blob/2.3/app/code/Magento/Catalog/Test/Mftf/Test/AdminRemoveDefaultImageSimpleProductTest.xml"
-  module: "Catalog"
-  tests:
-    - testname: "AdminRemoveDefaultImageSimpleProductTest"
-      title: "Admin should be able to remove default images from a Simple Product"
-      description: "Admin should be able to remove default images from a Simple Product"
- 
-- filename: "AdminCreateNewGroupForAttributeSetTest.xml"
-  repo: "https://github.com/magento/magento2/blob/2.3/app/code/Magento/Catalog/Test/Mftf/Test/AdminCreateNewGroupForAttributeSetTest.xml"
-  module: "Catalog"
-  tests:
-    - testname: "AdminCreateNewGroupForAttributeSetTest"
-      title: "Admin should be able to create new group in an Attribute Set"
-      description: "The test verifies creating a new group in an attribute set and a validation message in case of empty group name"
- 
-- filename: "AdminCreateInactiveFlatCategoryAndUpdateAsInactiveTest.xml"
-  repo: "https://github.com/magento/magento2/blob/2.3/app/code/Magento/Catalog/Test/Mftf/Test/AdminCreateInactiveFlatCategoryAndUpdateAsInactiveTest.xml"
-  module: "Catalog"
-  tests:
-    - testname: "AdminCreateInactiveFlatCategoryAndUpdateAsInactiveTest"
-      title: "Flat Catalog - Update Inactive Category as Inactive, Should Not be Visible on Storefront"
-      description: "Login as admin and create inactive flat category and update category as inactive and verify category is not visible in store front"
- 
-- filename: "StorefrontRememberCategoryPaginationTest.xml"
-  repo: "https://github.com/magento/magento2/blob/2.3/app/code/Magento/Catalog/Test/Mftf/Test/StorefrontRememberCategoryPaginationTest.xml"
-  module: "Catalog"
-  tests:
-    - testname: "StorefrontRememberCategoryPaginationTest"
-      title: "Verify that Number of Products per page retained when visiting a different category"
-      description: "Verify that Number of Products per page retained when visiting a different category"
- 
-- filename: "AdminDeleteSystemProductAttributeTest.xml"
-  repo: "https://github.com/magento/magento2/blob/2.3/app/code/Magento/Catalog/Test/Mftf/Test/AdminDeleteSystemProductAttributeTest.xml"
-  module: "Catalog"
-  tests:
-    - testname: "AdminDeleteSystemProductAttributeTest"
-      title: "Delete System Product Attribute"
-      description: "Admin should not be able to see Delete Attribute button"
- 
-- filename: "AdminUpdateVirtualProductWithRegularPriceInStockVisibleInCategoryOnlyTest.xml"
-  repo: "https://github.com/magento/magento2/blob/2.3/app/code/Magento/Catalog/Test/Mftf/Test/AdminUpdateVirtualProductWithRegularPriceInStockVisibleInCategoryOnlyTest.xml"
-  module: "Catalog"
-  tests:
-    - testname: "AdminUpdateVirtualProductWithRegularPriceInStockVisibleInCategoryOnlyTest"
-      title: "Update Virtual Product with Regular Price (In Stock) Visible in Category Only"
-      description: "Test log in to Update Virtual Product and Update Virtual Product with Regular Price (In Stock) Visible in Category Only"
- 
-- filename: "AdminMultipleWebsitesUseDefaultValuesTest.xml"
-  repo: "https://github.com/magento/magento2/blob/2.3/app/code/Magento/Catalog/Test/Mftf/Test/AdminMultipleWebsitesUseDefaultValuesTest.xml"
-  module: "Catalog"
-  tests:
-    - testname: "AdminMultipleWebsitesUseDefaultValuesTest"
-      title: "Use Default Value checkboxes should be checked for new website scope"
-      description: "Use Default Value checkboxes for product attribute should be checked for new website scope"
- 
-- filename: "AdminDeleteVirtualProductTest.xml"
-  repo: "https://github.com/magento/magento2/blob/2.3/app/code/Magento/Catalog/Test/Mftf/Test/AdminDeleteVirtualProductTest.xml"
-  module: "Catalog"
-  tests:
-    - testname: "AdminDeleteVirtualProductTest"
-      title: "Delete Virtual Product"
-      description: "Admin should be able to delete a virtual product"
- 
-- filename: "AdminDeleteProductsImageInCaseOfMultipleStoresTest.xml"
-  repo: "https://github.com/magento/magento2/blob/2.3/app/code/Magento/Catalog/Test/Mftf/Test/AdminDeleteProductsImageInCaseOfMultipleStoresTest.xml"
-  module: "Catalog"
-  tests:
-    - testname: "AdminDeleteProductsImageInCaseOfMultipleStoresTest"
-      title: "Delete products image in case of multiple stores"
-      description: "Delete products image in case of multiple stores"
- 
-- filename: "AdminUnassignProductAttributeFromAttributeSetTest.xml"
-  repo: "https://github.com/magento/magento2/blob/2.3/app/code/Magento/Catalog/Test/Mftf/Test/AdminUnassignProductAttributeFromAttributeSetTest.xml"
-  module: "Catalog"
-  tests:
-    - testname: "AdminUnassignProductAttributeFromAttributeSetTest"
-      title: "Admin should be able to unassign attributes from an attribute set"
-      description: "Admin should be able to unassign attributes from an attribute set"
- 
-- filename: "AdminCreateInactiveInMenuFlatCategoryTest.xml"
-  repo: "https://github.com/magento/magento2/blob/2.3/app/code/Magento/Catalog/Test/Mftf/Test/AdminCreateInactiveInMenuFlatCategoryTest.xml"
-  module: "Catalog"
-  tests:
-    - testname: "AdminCreateInactiveInMenuFlatCategoryTest"
-      title: "Flat Catalog - Exclude Category from Navigation Menu"
-      description: "Login as admin and create inactive Include In Menu flat category and verify category is not displayed in Navigation Menu"
- 
-- filename: "AdminProductTypeSwitchingOnEditingTest.xml"
-  repo: "https://github.com/magento/magento2/blob/2.3/app/code/Magento/Catalog/Test/Mftf/Test/AdminProductTypeSwitchingOnEditingTest.xml"
-  module: "Catalog"
-  tests:
-    - testname: "AdminVirtualProductTypeSwitchingToDownloadableProductTest"
-      title: "Virtual product type switching on editing to Downloadable product"
-      description: "Virtual product type switching on editing to Downloadable product"
-
-    - testname: "AdminDownloadableProductTypeSwitchingToSimpleProductTest"
-      title: "Downloadable product type switching on editing to Simple product"
-      description: "Downloadable product type switching on editing to Simple product"
- 
-- filename: "AdminUpdateSimpleProductWithRegularPriceInStockUnassignFromCategoryTest.xml"
-  repo: "https://github.com/magento/magento2/blob/2.3/app/code/Magento/Catalog/Test/Mftf/Test/AdminUpdateSimpleProductWithRegularPriceInStockUnassignFromCategoryTest.xml"
-  module: "Catalog"
-  tests:
-    - testname: "AdminUpdateSimpleProductWithRegularPriceInStockUnassignFromCategoryTest"
-      title: "Update Simple Product with Regular Price (In Stock) Unassign from Category"
-      description: "Test log in to Update Simple Product and Update Simple Product with Regular Price (In Stock) Unassign from Category"
- 
-- filename: "AdminProductCategoryIndexerInUpdateOnScheduleModeTest.xml"
-  repo: "https://github.com/magento/magento2/blob/2.3/app/code/Magento/Catalog/Test/Mftf/Test/AdminProductCategoryIndexerInUpdateOnScheduleModeTest.xml"
-  module: "Catalog"
-  tests:
-    - testname: "AdminProductCategoryIndexerInUpdateOnScheduleModeTest"
-      title: "Product Categories Indexer in Update on Schedule mode"
-      description: "The test verifies that in Update on Schedule mode if displaying of category products on Storefront changes due to product properties change,             the changes are NOT applied immediately, but applied only after cron runs (twice)."
- 
-- filename: "ProductAvailableAfterEnablingSubCategoriesTest.xml"
-  repo: "https://github.com/magento/magento2/blob/2.3/app/code/Magento/Catalog/Test/Mftf/Test/ProductAvailableAfterEnablingSubCategoriesTest.xml"
-  module: "Catalog"
-  tests:
-    - testname: "ProductAvailableAfterEnablingSubCategoriesTest"
-      title: "Check that parent categories are showing products after enabling subcategories after fully reindex"
-      description: "Check that parent categories are showing products after enabling subcategories after fully reindex"
- 
-- filename: "TieredPricingAndQuantityIncrementsWorkWithDecimalinventoryTest.xml"
-  repo: "https://github.com/magento/magento2/blob/2.3/app/code/Magento/Catalog/Test/Mftf/Test/TieredPricingAndQuantityIncrementsWorkWithDecimalinventoryTest.xml"
-  module: "Catalog"
-  tests:
-    - testname: "TieredPricingAndQuantityIncrementsWorkWithDecimalinventoryTest"
-      title: "Tiered pricing and quantity increments work with decimal inventory"
-      description: "Tiered pricing and quantity increments work with decimal inventory"
- 
-- filename: "StorefrontAdvanceCatalogSearchVirtualProductBySkuWithHyphenTest.xml"
-  repo: "https://github.com/magento/magento2/blob/2.3/app/code/Magento/Catalog/Test/Mftf/Test/StorefrontAdvanceCatalogSearchVirtualProductBySkuWithHyphenTest.xml"
-  module: "Catalog"
-  tests:
-    - testname: "StorefrontAdvanceCatalogSearchVirtualProductBySkuWithHyphenTest"
-      title: "Guest customer should be able to advance search virtual product with product sku that contains hyphen"
-      description: "Guest customer should be able to advance search virtual product with product sku that contains hyphen"
- 
-- filename: "AdminRemoveDefaultVideoVirtualProductTest.xml"
-  repo: "https://github.com/magento/magento2/blob/2.3/app/code/Magento/Catalog/Test/Mftf/Test/AdminRemoveDefaultVideoVirtualProductTest.xml"
-  module: "Catalog"
-  tests:
-    - testname: "AdminRemoveDefaultVideoVirtualProductTest"
-      title: "Admin should be able to remove default product video from a Virtual Product"
-      description: "Admin should be able to remove default product video from a Virtual Product"
- 
-- filename: "StorefrontEnsureThatAccordionAnchorIsVisibleOnViewportOnceClickedTest.xml"
-  repo: "https://github.com/magento/magento2/blob/2.3/app/code/Magento/Catalog/Test/Mftf/Test/StorefrontEnsureThatAccordionAnchorIsVisibleOnViewportOnceClickedTest.xml"
-  module: "Catalog"
-  tests:
-    - testname: "StorefrontEnsureThatAccordionAnchorIsVisibleOnViewportOnceClickedTest"
-      title: "Ensure that accordion anchor is visible on viewport once clicked"
-      description: "Ensure that accordion anchor is visible on viewport once clicked"
- 
-- filename: "StorefrontProductWithEmptyAttributeTest.xml"
-  repo: "https://github.com/magento/magento2/blob/2.3/app/code/Magento/Catalog/Test/Mftf/Test/StorefrontProductWithEmptyAttributeTest.xml"
-  module: "Catalog"
-  tests:
-    - testname: "StorefrontProductWithEmptyAttributeTest"
-      title: "Product attribute is not visible on storefront if it is empty"
-      description: "Product attribute should not be visible on storefront if it is empty"
- 
-- filename: "AdminTierPriceNotAvailableForProductOptionsWithoutTierPriceTest.xml"
-  repo: "https://github.com/magento/magento2/blob/2.3/app/code/Magento/Catalog/Test/Mftf/Test/AdminTierPriceNotAvailableForProductOptionsWithoutTierPriceTest.xml"
-  module: "Catalog"
-  tests:
-    - testname: "AdminTierPriceNotAvailableForProductOptionsWithoutTierPriceTest"
-      title: "Check that 'tier price' block not available for simple product from options without 'tier price'"
-      description: "Check that 'tier price' block not available for simple product from options without 'tier price'"
- 
-- filename: "AdminCreateVirtualProductWithoutManageStockTest.xml"
-  repo: "https://github.com/magento/magento2/blob/2.3/app/code/Magento/Catalog/Test/Mftf/Test/AdminCreateVirtualProductWithoutManageStockTest.xml"
-  module: "Catalog"
-  tests:
-    - testname: "AdminCreateVirtualProductWithoutManageStockTest"
-      title: "Create virtual product without manage stock"
-      description: "Test log in to Create virtual product and Create virtual product without manage stock"
- 
-- filename: "AdminFilteringCategoryProductsUsingScopeSelectorTest.xml"
-  repo: "https://github.com/magento/magento2/blob/2.3/app/code/Magento/Catalog/Test/Mftf/Test/AdminFilteringCategoryProductsUsingScopeSelectorTest.xml"
-  module: "Catalog"
-  tests:
-    - testname: "AdminFilteringCategoryProductsUsingScopeSelectorTest"
-      title: "Filtering Category Products using scope selector"
-      description: "Filtering Category Products using scope selector"
- 
-- filename: "AdminFilterByNameByStoreViewOnProductGridTest.xml"
-  repo: "https://github.com/magento/magento2/blob/2.3/app/code/Magento/Catalog/Test/Mftf/Test/AdminFilterByNameByStoreViewOnProductGridTest.xml"
-  module: "Catalog"
-  tests:
-    - testname: "AdminFilterByNameByStoreViewOnProductGridTest"
-      title: "Product grid filtering by store view level attribute"
-      description: "Verify that products grid can be filtered on all store view level by attribute"
- 
-- filename: "StorefrontCheckDefaultNumberProductsToDisplayTest.xml"
-  repo: "https://github.com/magento/magento2/blob/2.3/app/code/Magento/Catalog/Test/Mftf/Test/StorefrontCheckDefaultNumberProductsToDisplayTest.xml"
-  module: "Catalog"
-  tests:
-    - testname: "StorefrontCheckDefaultNumbersProductsToDisplayTest"
-      title: "Check default numbers: products to display"
-      description: "Check default numbers: products to display"
- 
-- filename: "EndToEndB2CGuestUserTest.xml"
-  repo: "https://github.com/magento/magento2/blob/2.3/app/code/Magento/Catalog/Test/Mftf/Test/EndToEndB2CGuestUserTest.xml"
-  module: "Catalog"
-  tests:
-    - testname: "EndToEndB2CGuestUserTest"
-      title: "You should be able to pass End to End B2C Guest User scenario"
-      description: "User browses catalog, searches for product, adds product to cart, adds product to wishlist, compares products, uses coupon code and checks out."
-
-    - testname: "EndToEndB2CGuestUserMysqlTest"
-      title: "You should be able to pass End to End B2C Guest User scenario using the Mysql search engine"
-      description: "User browses catalog, searches for product, adds product to cart, adds product to wishlist, compares products, uses coupon code and checks out using the Mysql search engine."
- 
-- filename: "DisplayRefreshCacheAfterChangingCategoryPageLayoutTest.xml"
-  repo: "https://github.com/magento/magento2/blob/2.3/app/code/Magento/Catalog/Test/Mftf/Test/DisplayRefreshCacheAfterChangingCategoryPageLayoutTest.xml"
-  module: "Catalog"
-  tests:
-    - testname: "DisplayRefreshCacheAfterChangingCategoryPageLayoutTest"
-      title: "'Refresh cache' admin notification is displayed when changing category page layout"
-      description: "'Refresh cache' message is not displayed when changing category page layout"
- 
-- filename: "VerifyChildCategoriesShouldNotIncludeInMenuTest.xml"
-  repo: "https://github.com/magento/magento2/blob/2.3/app/code/Magento/Catalog/Test/Mftf/Test/VerifyChildCategoriesShouldNotIncludeInMenuTest.xml"
-  module: "Catalog"
-  tests:
-    - testname: "VerifyChildCategoriesShouldNotIncludeInMenuTest"
-      title: "Customer should not see categories that are not included in the menu"
-      description: "Customer should not see categories that are not included in the menu"
- 
-- filename: "AdminCreateNewAttributeFromProductTest.xml"
-  repo: "https://github.com/magento/magento2/blob/2.3/app/code/Magento/Catalog/Test/Mftf/Test/AdminCreateNewAttributeFromProductTest.xml"
-  module: "Catalog"
-  tests:
-    - testname: "AdminCreateNewAttributeFromProductTest"
-      title: "Check that New Attribute from Product is create"
-      description: "Check that New Attribute from Product is create"
- 
-- filename: "AdminCreateSimpleProductTest.xml"
-  repo: "https://github.com/magento/magento2/blob/2.3/app/code/Magento/Catalog/Test/Mftf/Test/AdminCreateSimpleProductTest.xml"
-  module: "Catalog"
-  tests:
-    - testname: "AdminCreateSimpleProductTest"
-      title: "Admin should be able to create a Simple Product"
-      description: "Admin should be able to create a Simple Product"
-
-    - testname: "AdminConfigDefaultProductLayoutFromConfigurationSettingTest"
-      title: "Admin should be able to configure a default layout for Product Page from System Configuration"
-      description: "Admin should be able to configure a default layout for Product Page from System Configuration"
-
-    - testname: "AdminCreateSimpleProductZeroPriceTest"
-      title: "Admin should be able to create a product with zero price"
-      description: "Admin should be able to create a product with zero price"
-
-    - testname: "AdminCreateSimpleProductNegativePriceTest"
-      title: "Admin should not be able to create a product with a negative price"
-      description: "Admin should not be able to create a product with a negative price"
- 
-- filename: "AdminCreateNewAttributeFromProductPageTest.xml"
-  repo: "https://github.com/magento/magento2/blob/2.3/app/code/Magento/Catalog/Test/Mftf/Test/AdminCreateNewAttributeFromProductPageTest.xml"
-  module: "Catalog"
-  tests:
-    - testname: "AdminCreateNewAttributeFromProductPageTest"
-      title: "We should validate the form when the user click Save in New Attribute Set"
-      description: "Admin should be able to create product attribute and validate the form when the user click Save in New Attribute Set"
- 
-- filename: "AdminUpdateCategoryAndCheckDefaultUrlKeyOnStoreViewTest.xml"
-  repo: "https://github.com/magento/magento2/blob/2.3/app/code/Magento/Catalog/Test/Mftf/Test/AdminUpdateCategoryAndCheckDefaultUrlKeyOnStoreViewTest.xml"
-  module: "Catalog"
-  tests:
-    - testname: "AdminUpdateCategoryAndCheckDefaultUrlKeyOnStoreViewTest"
-      title: "Update category, check default URL key on the custom store view"
-      description: "Login as admin and update category and check default URL Key on custom store view"
- 
-- filename: "SaveProductWithCustomOptionsSecondWebsiteTest.xml"
-  repo: "https://github.com/magento/magento2/blob/2.3/app/code/Magento/Catalog/Test/Mftf/Test/SaveProductWithCustomOptionsSecondWebsiteTest.xml"
-  module: "Catalog"
-  tests:
-    - testname: "SaveProductWithCustomOptionsAdditionalWebsiteTest"
-      title: "You should be able to save a product with custom options assigned to a different website"
-      description: "Custom Options should not be split when saving the product after assigning to a different website"
- 
-- filename: "AdminNavigateMultipleUpSellProductsTest.xml"
-  repo: "https://github.com/magento/magento2/blob/2.3/app/code/Magento/Catalog/Test/Mftf/Test/AdminNavigateMultipleUpSellProductsTest.xml"
-  module: "Catalog"
-  tests:
-    - testname: "AdminNavigateMultipleUpSellProductsTest"
-      title: "Promote Multiple Products (Simple, Configurable) as Up-Sell Products"
-      description: "Login as admin and add simple and configurable Products as Up-Sell products"
- 
-- filename: "SimpleProductTwoCustomOptionsTest.xml"
-  repo: "https://github.com/magento/magento2/blob/2.3/app/code/Magento/Catalog/Test/Mftf/Test/SimpleProductTwoCustomOptionsTest.xml"
-  module: "Catalog"
-  tests:
-    - testname: "SimpleProductTwoCustomOptionsTest"
-      title: "Admin should be able to create simple product with two custom options"
-      description: "Admin should be able to create simple product with two custom options"
- 
-- filename: "AdminCreateCategoryWithRequiredFieldsTest.xml"
-  repo: "https://github.com/magento/magento2/blob/2.3/app/code/Magento/Catalog/Test/Mftf/Test/AdminCreateCategoryWithRequiredFieldsTest.xml"
-  module: "Catalog"
-  tests:
-    - testname: "AdminCreateCategoryWithRequiredFieldsTest"
-      title: "Create Category from Category page with Required Fields Only"
-      description: "Login as an admin and create a category with required fields."
- 
-- filename: "AdminCreateDropdownProductAttributeTest.xml"
-  repo: "https://github.com/magento/magento2/blob/2.3/app/code/Magento/Catalog/Test/Mftf/Test/AdminCreateDropdownProductAttributeTest.xml"
-  module: "Catalog"
-  tests:
-    - testname: "AdminCreateDropdownProductAttributeTest"
-      title: "Admin should be able to create dropdown product attribute"
-      description: "Admin should be able to create dropdown product attribute"
- 
-- filename: "AdminUpdateSimpleProductNameToVerifyDataOverridingOnStoreViewLevelTest.xml"
-  repo: "https://github.com/magento/magento2/blob/2.3/app/code/Magento/Catalog/Test/Mftf/Test/AdminUpdateSimpleProductNameToVerifyDataOverridingOnStoreViewLevelTest.xml"
-  module: "Catalog"
-  tests:
-    - testname: "AdminUpdateSimpleProductNameToVerifyDataOverridingOnStoreViewLevelTest"
-      title: "Update Simple Product Name to Verify Data Overriding on Store View Level"
-      description: "Test log in to Update Simple Product and Update Simple Product Name to Verify Data Overriding on Store View Level"
- 
-- filename: "AdminDeleteConfigurableChildProductsTest.xml"
-  repo: "https://github.com/magento/magento2/blob/2.3/app/code/Magento/Catalog/Test/Mftf/Test/AdminDeleteConfigurableChildProductsTest.xml"
-  module: "Catalog"
-  tests:
-    - testname: "AdminDeleteConfigurableChildProductsTest"
-      title: "Configurable Product should not be visible on storefront after child products are deleted"
-      description: "Login as admin, delete configurable child product and verify product displays out of stock in store front"
- 
-- filename: "AdminCreateAndEditVirtualProductSettingsTest.xml"
-  repo: "https://github.com/magento/magento2/blob/2.3/app/code/Magento/Catalog/Test/Mftf/Test/AdminCreateAndEditVirtualProductSettingsTest.xml"
-  module: "Catalog"
-  tests:
-    - testname: "AdminCreateAndEditVirtualProductSettingsTest"
-      title: "Admin should be able to set/edit other product information when creating/editing a virtual product"
-      description: "Admin should be able to set/edit other product information when creating/editing a virtual product"
- 
-- filename: "AdminCreateProductAttributeRequiredTextFieldTest.xml"
-  repo: "https://github.com/magento/magento2/blob/2.3/app/code/Magento/Catalog/Test/Mftf/Test/AdminCreateProductAttributeRequiredTextFieldTest.xml"
-  module: "Catalog"
-  tests:
-    - testname: "AdminCreateProductAttributeRequiredTextFieldTest"
-      title: "Create Custom Product Attribute Text Field (Required) from Product Page"
-      description: "Login as admin and create product attribute with Text Field and Required option"
- 
-- filename: "AdminCreateDuplicateProductTest.xml"
-  repo: "https://github.com/magento/magento2/blob/2.3/app/code/Magento/Catalog/Test/Mftf/Test/AdminCreateDuplicateProductTest.xml"
-  module: "Catalog"
-  tests:
-    - testname: "AdminCreateDuplicateProductTest"
-      title: "Create Duplicate Product With Existed Subcategory Name And UrlKey"
-      description: "Login as admin and create duplicate Product"
- 
-- filename: "VerifyDefaultWYSIWYGToolbarOnProductTest.xml"
-  repo: "https://github.com/magento/magento2/blob/2.3/app/code/Magento/Catalog/Test/Mftf/Test/VerifyDefaultWYSIWYGToolbarOnProductTest.xml"
-  module: "Catalog"
-  tests:
-    - testname: "VerifyDefaultWYSIWYGToolbarOnProductTest"
-      title: "Admin should be able to see default toolbar display on Description content area"
-      description: "Admin should be able to see default toolbar display on Description content area"
-
-    - testname: "Verifydefaultcontrolsonproductshortdescription"
-      title: "Admin should be able to see default toolbar display on Short Description content area"
-      description: "Admin should be able to see default toolbar display on Short Description content area"
- 
-- filename: "AdminMoveCategoryFromParentAnchoredCategoryTest.xml"
-  repo: "https://github.com/magento/magento2/blob/2.3/app/code/Magento/Catalog/Test/Mftf/Test/AdminMoveCategoryFromParentAnchoredCategoryTest.xml"
-  module: "Catalog"
-  tests:
-    - testname: "AdminMoveCategoryFromParentAnchoredCategoryTest"
-      title: "Move default subcategory with anchored parent to default subcategory"
-      description: "Login as admin,move subcategory with anchored parent to default subcategory"
- 
-- filename: "AdminCheckInactiveAndNotIncludeInMenuCategoryAndSubcategoryIsNotVisibleInNavigationTest.xml"
-  repo: "https://github.com/magento/magento2/blob/2.3/app/code/Magento/Catalog/Test/Mftf/Test/AdminCheckInactiveAndNotIncludeInMenuCategoryAndSubcategoryIsNotVisibleInNavigationTest.xml"
-  module: "Catalog"
-  tests:
-    - testname: "AdminCheckInactiveAndNotIncludeInMenuCategoryAndSubcategoryIsNotVisibleInNavigationTest"
-      title: "Inactive Category and subcategory are not visible on navigation menu, Include in Menu = No"
-      description: "Login as admin and verify inactive and inactive include in menu category and subcategory is not visible in navigation menu"
- 
-- filename: "AdminVerifyProductOrderTest.xml"
-  repo: "https://github.com/magento/magento2/blob/2.3/app/code/Magento/Catalog/Test/Mftf/Test/AdminVerifyProductOrderTest.xml"
-  module: "Catalog"
-  tests:
-    - testname: "AdminVerifyProductOrder"
-      title: "Admin should see product types in specified order"
-      description: "Product Type Order should be Simple -&gt; Configurable -&gt; Grouped -&gt; Virtual -&gt; Bundle -&gt; Downloadable -&gt; EE"
- 
-- filename: "AdminMoveProductBetweenCategoriesTest.xml"
-  repo: "https://github.com/magento/magento2/blob/2.3/app/code/Magento/Catalog/Test/Mftf/Test/AdminMoveProductBetweenCategoriesTest.xml"
-  module: "Catalog"
-  tests:
-    - testname: "AdminMoveProductBetweenCategoriesTest"
-      title: "Move Product between Categories (Cron is ON, 'Update by Schedule' Mode)"
-      description: "Verifies correctness of showing data (products, categories) on Storefront after moving an anchored category in terms of products/categories association"
- 
-- filename: "AdminCreateCategoryWithInactiveIncludeInMenuTest.xml"
-  repo: "https://github.com/magento/magento2/blob/2.3/app/code/Magento/Catalog/Test/Mftf/Test/AdminCreateCategoryWithInactiveIncludeInMenuTest.xml"
-  module: "Catalog"
-  tests:
-    - testname: "AdminCreateCategoryWithInactiveIncludeInMenuTest"
-      title: "Create not included in menu subcategory"
-      description: "Login as admin and create category with inactivated include in menu option"
- 
-- filename: "AdminBackorderAllowedAddProductToCartTest.xml"
-  repo: "https://github.com/magento/magento2/blob/2.3/app/code/Magento/Catalog/Test/Mftf/Test/AdminBackorderAllowedAddProductToCartTest.xml"
-  module: "Catalog"
-  tests:
-    - testname: "AdminBackorderAllowedAddProductToCartTest"
-      title: "Add Product to Cart, Backorder Allowed"
-      description: "Customer should be able to add products to cart when that products quantity is zero"
- 
-- filename: "AdminProductGridFilteringByDateAttributeTest.xml"
-  repo: "https://github.com/magento/magento2/blob/2.3/app/code/Magento/Catalog/Test/Mftf/Test/AdminProductGridFilteringByDateAttributeTest.xml"
-  module: "Catalog"
-  tests:
-    - testname: "AdminProductGridFilteringByDateAttributeTest"
-      title: "Verify Set Product as new Filter input on Product Grid doesn't getreset to currentDate"
-      description: "Data input in the new from date filter field should not change"
- 
-- filename: "DeleteCategoriesTest.xml"
-  repo: "https://github.com/magento/magento2/blob/2.3/app/code/Magento/Catalog/Test/Mftf/Test/DeleteCategoriesTest.xml"
-  module: "Catalog"
-  tests:
-    - testname: "DeleteCategoriesTest"
-      title: "Admin should be able to delete the default root category and subcategories and still see products in the storefront"
-      description: "Admin should be able to delete the default root category and subcategories and still see products in the storefront"
- 
-- filename: "AdminRestrictedUserAddCategoryFromProductPageTest.xml"
-  repo: "https://github.com/magento/magento2/blob/2.3/app/code/Magento/Catalog/Test/Mftf/Test/AdminRestrictedUserAddCategoryFromProductPageTest.xml"
-  module: "Catalog"
-  tests:
-    - testname: "AdminRestrictedUserAddCategoryFromProductPageTest"
-      title: "Adding new category from product page by restricted user"
-      description: "Adding new category from product page by restricted user"
- 
-- filename: "AdminMoveAnchoredCategoryToDefaultCategoryTest.xml"
-  repo: "https://github.com/magento/magento2/blob/2.3/app/code/Magento/Catalog/Test/Mftf/Test/AdminMoveAnchoredCategoryToDefaultCategoryTest.xml"
-  module: "Catalog"
-  tests:
-    - testname: "AdminMoveAnchoredCategoryToDefaultCategoryTest"
-      title: "Move default anchored subcategory with anchored parent to default subcategory"
-      description: "Login as admin,move anchored subcategory with anchored parent to default subcategory"
- 
-- filename: "AdminUpdateSimpleProductWithRegularPriceInStockWithCustomOptionsTest.xml"
-  repo: "https://github.com/magento/magento2/blob/2.3/app/code/Magento/Catalog/Test/Mftf/Test/AdminUpdateSimpleProductWithRegularPriceInStockWithCustomOptionsTest.xml"
-  module: "Catalog"
-  tests:
-    - testname: "AdminUpdateSimpleProductWithRegularPriceInStockWithCustomOptionsTest"
-      title: "Update Simple Product with Regular Price (In Stock) with Custom Options"
-      description: "Test log in to Update Simple Product and Update Simple Product with Regular Price (In Stock) with Custom Options"
- 
-- filename: "AdminUpdateCategoryUrlKeyWithStoreViewTest.xml"
-  repo: "https://github.com/magento/magento2/blob/2.3/app/code/Magento/Catalog/Test/Mftf/Test/AdminUpdateCategoryUrlKeyWithStoreViewTest.xml"
-  module: "Catalog"
-  tests:
-    - testname: "AdminUpdateCategoryUrlKeyWithStoreViewTest"
-      title: "Update category, URL key with custom store view"
-      description: "Login as admin and update category URL Key with store view"
- 
-- filename: "AdminAddDefaultImageSimpleProductTest.xml"
-  repo: "https://github.com/magento/magento2/blob/2.3/app/code/Magento/Catalog/Test/Mftf/Test/AdminAddDefaultImageSimpleProductTest.xml"
-  module: "Catalog"
-  tests:
-    - testname: "AdminAddDefaultImageSimpleProductTest"
-      title: "Admin should be able to add default image for a Simple Product"
-      description: "Admin should be able to add default images for a Simple Product"
- 
-- filename: "AdminUpdateVirtualProductWithTierPriceInStockVisibleInCategoryOnlyTest.xml"
-  repo: "https://github.com/magento/magento2/blob/2.3/app/code/Magento/Catalog/Test/Mftf/Test/AdminUpdateVirtualProductWithTierPriceInStockVisibleInCategoryOnlyTest.xml"
-  module: "Catalog"
-  tests:
-    - testname: "AdminUpdateVirtualProductWithTierPriceInStockVisibleInCategoryOnlyTest"
-      title: "Update Virtual Product with Tier Price (In Stock) Visible in Category Only"
-      description: "Test log in to Update Virtual Product and Update Virtual Product with Tier Price (In Stock) Visible in Category Only"
- 
-- filename: "VerifyTinyMCEv4IsNativeWYSIWYGOnCatalogTest.xml"
-  repo: "https://github.com/magento/magento2/blob/2.3/app/code/Magento/Catalog/Test/Mftf/Test/VerifyTinyMCEv4IsNativeWYSIWYGOnCatalogTest.xml"
-  module: "Catalog"
-  tests:
-    - testname: "VerifyTinyMCEv4IsNativeWYSIWYGOnCatalogTest"
-      title: "Admin should see TinyMCEv4.6 is the native WYSIWYG on Catalog Page"
-      description: "Admin should see TinyMCEv4.6 is the native WYSIWYG on Catalog Page"
- 
-- filename: "AdminSimpleProductSetEditContentTest.xml"
-  repo: "https://github.com/magento/magento2/blob/2.3/app/code/Magento/Catalog/Test/Mftf/Test/AdminSimpleProductSetEditContentTest.xml"
-  module: "Catalog"
-  tests:
-    - testname: "AdminSimpleProductSetEditContentTest"
-      title: "Admin should be able to set/edit product Content when editing a simple product"
-      description: "Admin should be able to set/edit product Content when editing a simple product"
- 
-- filename: "AdminGridPageNumberAfterSaveAndCloseActionTest.xml"
-  repo: "https://github.com/magento/magento2/blob/2.3/app/code/Magento/Catalog/Test/Mftf/Test/AdminGridPageNumberAfterSaveAndCloseActionTest.xml"
-  module: "Catalog"
-  tests:
-    - testname: "AdminGridPageNumberAfterSaveAndCloseActionTest"
-      title: "Checking Catalog grid page number after Save and Close action"
-      description: "Checking Catalog grid page number after Save and Close action"
- 
-- filename: "AdminCreateAndEditSimpleProductSettingsTest.xml"
-  repo: "https://github.com/magento/magento2/blob/2.3/app/code/Magento/Catalog/Test/Mftf/Test/AdminCreateAndEditSimpleProductSettingsTest.xml"
-  module: "Catalog"
-  tests:
-    - testname: "AdminCreateAndEditSimpleProductSettingsTest"
-      title: "Admin should be able to set/edit other product information when creating/editing a simple product"
-      description: "Admin should be able to set/edit product information when creating/editing a simple product"
- 
-- filename: "AdminCatalogProductsNavigateMenuTest.xml"
-  repo: "https://github.com/magento/magento2/blob/2.3/app/code/Magento/Catalog/Test/Mftf/Test/AdminCatalogProductsNavigateMenuTest.xml"
-  module: "Catalog"
-  tests:
-    - testname: "AdminCatalogProductsNavigateMenuTest"
-      title: "Admin catalog products navigate menu test"
-      description: "Admin should be able to navigate to Catalog &gt; Products"
- 
-- filename: "AdminCreateTextEditorProductAttributeTest.xml"
-  repo: "https://github.com/magento/magento2/blob/2.3/app/code/Magento/Catalog/Test/Mftf/Test/AdminCreateTextEditorProductAttributeTest.xml"
-  module: "Catalog"
-  tests:
-    - testname: "AdminCreateTextEditorProductAttributeTest"
-      title: "Admin create text editor product attribute test"
-      description: "Create text editor product attribute with TinyMCE4 enabled"
- 
-- filename: "AdminUpdateCategoryStoreUrlKeyTest.xml"
-  repo: "https://github.com/magento/magento2/blob/2.3/app/code/Magento/Catalog/Test/Mftf/Test/AdminUpdateCategoryStoreUrlKeyTest.xml"
-  module: "Catalog"
-  tests:
-    - testname: "AdminUpdateCategoryStoreUrlKeyTest"
-      title: "SEO-friendly URL should update regardless of scope or redirect change."
-      description: "SEO-friendly URL should update regardless of scope or redirect change."
- 
-- filename: "AdminRemoveDefaultImageVirtualProductTest.xml"
-  repo: "https://github.com/magento/magento2/blob/2.3/app/code/Magento/Catalog/Test/Mftf/Test/AdminRemoveDefaultImageVirtualProductTest.xml"
-  module: "Catalog"
-  tests:
-    - testname: "AdminRemoveDefaultImageVirtualProductTest"
-      title: "Admin should be able to remove default images from a Virtual Product"
-      description: "Admin should be able to remove default images from a Virtual Product"
- 
-- filename: "AdminRequiredFieldsHaveRequiredFieldIndicatorTest.xml"
-  repo: "https://github.com/magento/magento2/blob/2.3/app/code/Magento/Catalog/Test/Mftf/Test/AdminRequiredFieldsHaveRequiredFieldIndicatorTest.xml"
-  module: "Catalog"
-  tests:
-    - testname: "AdminRequiredFieldsHaveRequiredFieldIndicatorTest"
-      title: "Required fields should have the required asterisk indicator "
-      description: "Verify that Required fields should have the required indicator icon next to the field name"
- 
-- filename: "AdminUpdateCategoryWithProductsTest.xml"
-  repo: "https://github.com/magento/magento2/blob/2.3/app/code/Magento/Catalog/Test/Mftf/Test/AdminUpdateCategoryWithProductsTest.xml"
-  module: "Catalog"
-  tests:
-    - testname: "AdminUpdateCategoryWithProductsTest"
-      title: "Update category, sort products by default sorting"
-      description: "Login as admin, update category and sort products"
- 
-- filename: "AdvanceCatalogSearchVirtualProductTest.xml"
-  repo: "https://github.com/magento/magento2/blob/2.3/app/code/Magento/Catalog/Test/Mftf/Test/AdvanceCatalogSearchVirtualProductTest.xml"
-  module: "Catalog"
-  tests:
-    - testname: "AdvanceCatalogSearchVirtualProductByNameTest"
-      title: "Guest customer should be able to advance search virtual product with product name"
-      description: "Guest customer should be able to advance search virtual product with product name"
-
-    - testname: "AdvanceCatalogSearchVirtualProductBySkuTest"
-      title: "Guest customer should be able to advance search virtual product with product sku"
-      description: "Guest customer should be able to advance search virtual product with product sku"
-
-    - testname: "AdvanceCatalogSearchVirtualProductByDescriptionTest"
-      title: "Guest customer should be able to advance search virtual product with product description"
-      description: "Guest customer should be able to advance search virtual product with product description"
-
-    - testname: "AdvanceCatalogSearchVirtualProductByShortDescriptionTest"
-      title: "Guest customer should be able to advance search virtual product with product short description"
-      description: "Guest customer should be able to advance search virtual product with product short description"
-
-    - testname: "AdvanceCatalogSearchVirtualProductByPriceTest"
-      title: "Guest customer should be able to advance search virtual product with product price"
-      description: "Guest customer should be able to advance search virtual product with product price"
- 
-- filename: "AdminDeleteSimpleProductTest.xml"
-  repo: "https://github.com/magento/magento2/blob/2.3/app/code/Magento/Catalog/Test/Mftf/Test/AdminDeleteSimpleProductTest.xml"
-  module: "Catalog"
-  tests:
-    - testname: "AdminDeleteSimpleProductTest"
-      title: "Delete Simple Product"
-      description: "Admin should be able to delete a simple product"
- 
-- filename: "AdminUpdateVirtualProductWithRegularPriceInStockWithCustomOptionsVisibleInSearchOnlyTest.xml"
-  repo: "https://github.com/magento/magento2/blob/2.3/app/code/Magento/Catalog/Test/Mftf/Test/AdminUpdateVirtualProductWithRegularPriceInStockWithCustomOptionsVisibleInSearchOnlyTest.xml"
-  module: "Catalog"
-  tests:
-    - testname: "AdminUpdateVirtualProductWithRegularPriceInStockWithCustomOptionsVisibleInSearchOnlyTest"
-      title: "Update Virtual Product with Regular Price (In Stock) with Custom Options Visible in Search Only"
-      description: "Test log in to Update Virtual Product and Update Virtual Product with Regular Price (In Stock) with Custom Options Visible in Search Only"
- 
-- filename: "AdminUpdateSimpleProductWithRegularPriceInStockVisibleInCatalogAndSearchTest.xml"
-  repo: "https://github.com/magento/magento2/blob/2.3/app/code/Magento/Catalog/Test/Mftf/Test/AdminUpdateSimpleProductWithRegularPriceInStockVisibleInCatalogAndSearchTest.xml"
-  module: "Catalog"
-  tests:
-    - testname: "AdminUpdateSimpleProductWithRegularPriceInStockVisibleInCatalogAndSearchTest"
-      title: "Update Simple Product with Regular Price (In Stock) Visible in Catalog and Search"
-      description: "Test log in to Update Simple Product and Update Simple Product with Regular Price (In Stock) Visible in Catalog and Search"
- 
-- filename: "AdminMoveCategoryToAnotherPositionInCategoryTreeTest.xml"
-  repo: "https://github.com/magento/magento2/blob/2.3/app/code/Magento/Catalog/Test/Mftf/Test/AdminMoveCategoryToAnotherPositionInCategoryTreeTest.xml"
-  module: "Catalog"
-  tests:
-    - testname: "AdminMoveCategoryToAnotherPositionInCategoryTreeTest"
-      title: "Move Category to Another Position in Category Tree"
-      description: "Test log in to Move Category and Move Category to Another Position in Category Tree"
- 
-- filename: "AdminVirtualSetEditRelatedProductsTest.xml"
-  repo: "https://github.com/magento/magento2/blob/2.3/app/code/Magento/Catalog/Test/Mftf/Test/AdminVirtualSetEditRelatedProductsTest.xml"
-  module: "Catalog"
-  tests:
-    - testname: "AdminVirtualSetEditRelatedProductsTest"
-      title: "Admin should be able to set/edit Related Products information when editing a virtual product"
-      description: "Admin should be able to set/edit Related Products information when editing a virtual product"
- 
-- filename: "AdminAssignProductAttributeToAttributeSetTest.xml"
-  repo: "https://github.com/magento/magento2/blob/2.3/app/code/Magento/Catalog/Test/Mftf/Test/AdminAssignProductAttributeToAttributeSetTest.xml"
-  module: "Catalog"
-  tests:
-    - testname: "AdminAssignProductAttributeToAttributeSetTest"
-      title: "Admin should be able to assign attributes to an attribute set"
-      description: "Admin should be able to assign attributes to an attribute set"
- 
-- filename: "StorefrontCategoryHighlightedAndProductDisplayedTest.xml"
-  repo: "https://github.com/magento/magento2/blob/2.3/app/code/Magento/Catalog/Test/Mftf/Test/StorefrontCategoryHighlightedAndProductDisplayedTest.xml"
-  module: "Catalog"
-  tests:
-    - testname: "StorefrontCategoryHighlightedAndProductDisplayedTest"
-      title: "Сheck that current category is highlighted and all products displayed for it"
-      description: "Сheck that current category is highlighted and all products displayed for it"
- 
-- filename: "AdminCreateDropdownProductAttributeVisibleInStorefrontAdvancedSearchFormTest.xml"
-  repo: "https://github.com/magento/magento2/blob/2.3/app/code/Magento/Catalog/Test/Mftf/Test/AdminCreateDropdownProductAttributeVisibleInStorefrontAdvancedSearchFormTest.xml"
-  module: "Catalog"
-  tests:
-    - testname: "AdminCreateDropdownProductAttributeVisibleInStorefrontAdvancedSearchFormTest"
-      title: "AdminCreateDropdownProductAttributeVisibleInStorefrontAdvancedSearchFormTest"
-      description: "Admin should able to create product Dropdown attribute and check its visibility on frontend in Advanced Search form"
- 
-- filename: "AdminCheckPaginationInStorefrontTest.xml"
-  repo: "https://github.com/magento/magento2/blob/2.3/app/code/Magento/Catalog/Test/Mftf/Test/AdminCheckPaginationInStorefrontTest.xml"
-  module: "Catalog"
-  tests:
-    - testname: "AdminCheckPaginationInStorefrontTest"
-      title: "Verify that pagination works when Flat Category is enabled"
-      description: "Login as admin, create flat catalog product and check pagination"
- 
-- filename: "AdminUpdateCategoryNameWithStoreViewTest.xml"
-  repo: "https://github.com/magento/magento2/blob/2.3/app/code/Magento/Catalog/Test/Mftf/Test/AdminUpdateCategoryNameWithStoreViewTest.xml"
-  module: "Catalog"
-  tests:
-    - testname: "AdminUpdateCategoryNameWithStoreViewTest"
-      title: "Update category, with custom store view"
-      description: "Login as admin and update category name with custom Store View"
- 
-- filename: "AdminMoveAnchoredCategoryTest.xml"
-  repo: "https://github.com/magento/magento2/blob/2.3/app/code/Magento/Catalog/Test/Mftf/Test/AdminMoveAnchoredCategoryTest.xml"
-  module: "Catalog"
-  tests:
-    - testname: "AdminMoveAnchoredCategoryTest"
-      title: "Admin should be able to move a category via categories tree and changes should be applied on frontend without a forced cache cleaning"
-      description: "Admin should be able to move a category via categories tree and changes should be applied on frontend without a forced cache cleaning"
- 
-- filename: "AdminCreateRootCategoryRequiredFieldsTest.xml"
-  repo: "https://github.com/magento/magento2/blob/2.3/app/code/Magento/Catalog/Test/Mftf/Test/AdminCreateRootCategoryRequiredFieldsTest.xml"
-  module: "Catalog"
-  tests:
-    - testname: "AdminCreateRootCategoryRequiredFieldsTest"
-      title: "Create Root Category from Category Page"
-      description: "Create Root Category from Category Page"
- 
-- filename: "AdminSortingByWebsitesTest.xml"
-  repo: "https://github.com/magento/magento2/blob/2.3/app/code/Magento/Catalog/Test/Mftf/Test/AdminSortingByWebsitesTest.xml"
-  module: "Catalog"
-  tests:
-    - testname: "AdminSortingByWebsitesTest"
-      title: "Sorting by websites in Admin"
-      description: "Sorting products by websites in Admin"
- 
-- filename: "StorefrontPurchaseProductCustomOptionsDifferentStoreViewsTest.xml"
-  repo: "https://github.com/magento/magento2/blob/2.3/app/code/Magento/Catalog/Test/Mftf/Test/StorefrontPurchaseProductCustomOptionsDifferentStoreViewsTest.xml"
-  module: "Catalog"
-  tests:
-    - testname: "StorefrontPurchaseProductCustomOptionsDifferentStoreViewsTest"
-      title: "Admin should be able to sell products with different variants of their own"
-      description: "Admin should be able to sell products with different variants of their own"
- 
-- filename: "AdminCreateCategoryWithAnchorFieldTest.xml"
-  repo: "https://github.com/magento/magento2/blob/2.3/app/code/Magento/Catalog/Test/Mftf/Test/AdminCreateCategoryWithAnchorFieldTest.xml"
-  module: "Catalog"
-  tests:
-    - testname: "AdminCreateCategoryWithAnchorFieldTest"
-      title: "Create anchor subcategory with all fields"
-      description: "Login as admin and create anchor subcategory with all fields"
- 
-- filename: "AdminUpdateSimpleProductWithRegularPriceInStockNotVisibleIndividuallyTest.xml"
-  repo: "https://github.com/magento/magento2/blob/2.3/app/code/Magento/Catalog/Test/Mftf/Test/AdminUpdateSimpleProductWithRegularPriceInStockNotVisibleIndividuallyTest.xml"
-  module: "Catalog"
-  tests:
-    - testname: "AdminUpdateSimpleProductWithRegularPriceInStockNotVisibleIndividuallyTest"
-      title: "Update Simple Product with Regular Price (In Stock) Not Visible Individually"
-      description: "Test log in to Update Simple Product and Update Simple Product with Regular Price (In Stock) Not Visible Individually"
- 
-- filename: "AdminDeleteAttributeSetTest.xml"
-  repo: "https://github.com/magento/magento2/blob/2.3/app/code/Magento/Catalog/Test/Mftf/Test/AdminDeleteAttributeSetTest.xml"
-  module: "Catalog"
-  tests:
-    - testname: "AdminDeleteAttributeSetTest"
-      title: "Delete Attribute Set"
-      description: "Admin should be able to delete an attribute set"
- 
-- filename: "AdminAddImageToWYSIWYGProductTest.xml"
-  repo: "https://github.com/magento/magento2/blob/2.3/app/code/Magento/Catalog/Test/Mftf/Test/AdminAddImageToWYSIWYGProductTest.xml"
-  module: "Catalog"
-  tests:
-    - testname: "AdminAddImageToWYSIWYGProductTest"
-      title: "Admin should be able to add image to WYSIWYG Editor on Product Page"
-      description: "Admin should be able to add image to WYSIWYG Editor on Product Page"
- 
-- filename: "AdminUpdateFlatCategoryIncludeInNavigationTest.xml"
-  repo: "https://github.com/magento/magento2/blob/2.3/app/code/Magento/Catalog/Test/Mftf/Test/AdminUpdateFlatCategoryIncludeInNavigationTest.xml"
-  module: "Catalog"
-  tests:
-    - testname: "AdminUpdateFlatCategoryAndIncludeInMenuTest"
-      title: "Flat Catalog - Update Category, Include in Navigation Menu"
-      description: "Login as admin and update flat category by enabling Include in Menu"
- 
-- filename: "EndToEndB2CAdminTest.xml"
-  repo: "https://github.com/magento/magento2/blob/2.3/app/code/Magento/Catalog/Test/Mftf/Test/EndToEndB2CAdminTest.xml"
-  module: "Catalog"
-  tests:
-    - testname: "EndToEndB2CAdminTest"
-      title: "Pass End to End B2C Admin scenario"
-      description: "Admin creates products, creates and manages categories, creates promotions, creates an order, processes an order, processes a return, uses admin grids"
- 
-- filename: "NewProductsListWidgetVirtualProductTest.xml"
-  repo: "https://github.com/magento/magento2/blob/2.3/app/code/Magento/Catalog/Test/Mftf/Test/NewProductsListWidgetVirtualProductTest.xml"
-  module: "Catalog"
-  tests:
-    - testname: "NewProductsListWidgetVirtualProductTest"
-      title: "Admin should be able to set Virtual Product as new so that it shows up in the Catalog New Products List Widget"
-      description: "Admin should be able to set Virtual Product as new so that it shows up in the Catalog New Products List Widget"
- 
-- filename: "AdminCheckInactiveIncludeInMenuCategoryAndSubcategoryIsNotVisibleInNavigationTest.xml"
-  repo: "https://github.com/magento/magento2/blob/2.3/app/code/Magento/Catalog/Test/Mftf/Test/AdminCheckInactiveIncludeInMenuCategoryAndSubcategoryIsNotVisibleInNavigationTest.xml"
-  module: "Catalog"
-  tests:
-    - testname: "AdminCheckInactiveIncludeInMenuCategoryAndSubcategoryIsNotVisibleInNavigationTest"
-      title: "Active Category and subcategory are not visible on navigation menu, Include in Menu = No"
-      description: "Login as admin and verify inactive include in menu category and subcategory is not visible in navigation menu"
- 
-- filename: "AdminCreateSimpleProductWithUnicodeTest.xml"
-  repo: "https://github.com/magento/magento2/blob/2.3/app/code/Magento/Catalog/Test/Mftf/Test/AdminCreateSimpleProductWithUnicodeTest.xml"
-  module: "Catalog"
-  tests:
-    - testname: "AdminCreateSimpleProductWithUnicodeTest"
-      title: "Admin should be able to create a unicode named simple product"
-      description: "Admin should be able to create a unicode named simple product"
- 
-- filename: "AdminDisableProductOnChangingAttributeSetTest.xml"
-  repo: "https://github.com/magento/magento2/blob/2.3/app/code/Magento/Catalog/Test/Mftf/Test/AdminDisableProductOnChangingAttributeSetTest.xml"
-  module: "Catalog"
-  tests:
-    - testname: "AdminDisableProductOnChangingAttributeSetTest"
-      title: "Verify product status while changing attribute set"
-      description: "Value set for enabled product has to be shown when attribute set is changed"
- 
-- filename: "AdminConfigureProductImagePlaceholderTest.xml"
-  repo: "https://github.com/magento/magento2/blob/2.3/app/code/Magento/Catalog/Test/Mftf/Test/AdminConfigureProductImagePlaceholderTest.xml"
-  module: "Catalog"
-  tests:
-    - testname: "AdminConfigureProductImagePlaceholderTest"
-      title: "Admin is able to configure product placeholder images"
-      description: "Admin should be able to configure the images used for product image placeholders. The configured placeholders should be seen on the frontend when an image has no image."
- 
-- filename: "AdminUpdateVirtualProductWithRegularPriceOutOfStockVisibleInCategoryAndSearchTest.xml"
-  repo: "https://github.com/magento/magento2/blob/2.3/app/code/Magento/Catalog/Test/Mftf/Test/AdminUpdateVirtualProductWithRegularPriceOutOfStockVisibleInCategoryAndSearchTest.xml"
-  module: "Catalog"
-  tests:
-    - testname: "AdminUpdateVirtualProductWithRegularPriceOutOfStockVisibleInCategoryAndSearchTest"
-      title: "Update Virtual Product with Regular Price (Out of Stock) Visible in Category and Search"
-      description: "Test log in to Update Virtual Product and Update Virtual Product with Regular Price (Out of Stock) Visible in Category and Search"
- 
-- filename: "AdminMoveCategoryAndCheckUrlRewritesTest.xml"
-  repo: "https://github.com/magento/magento2/blob/2.3/app/code/Magento/Catalog/Test/Mftf/Test/AdminMoveCategoryAndCheckUrlRewritesTest.xml"
-  module: "Catalog"
-  tests:
-    - testname: "AdminMoveCategoryAndCheckUrlRewritesTest"
-      title: "URL Rewrites for subcategories during creation and move"
-      description: "Login as admin, move category from one to another and check category url rewrites"
- 
-- filename: "AdminCreateVirtualProductWithCustomOptionsSuiteAndImportOptionsTest.xml"
-  repo: "https://github.com/magento/magento2/blob/2.3/app/code/Magento/Catalog/Test/Mftf/Test/AdminCreateVirtualProductWithCustomOptionsSuiteAndImportOptionsTest.xml"
-  module: "Catalog"
-  tests:
-    - testname: "AdminCreateVirtualProductWithCustomOptionsSuiteAndImportOptionsTest"
-      title: "Create virtual product with custom options suite and import options"
-      description: "Test log in to Create virtual product and Create virtual product with custom options suite and import options"
- 
-- filename: "AdminRemoveImageFromCategoryTest.xml"
-  repo: "https://github.com/magento/magento2/blob/2.3/app/code/Magento/Catalog/Test/Mftf/Test/AdminRemoveImageFromCategoryTest.xml"
-  module: "Catalog"
-  tests:
-    - testname: "AdminRemoveImageFromCategoryTest"
-      title: "Admin should be able to remove image from a Category"
-      description: "Admin should be able to remove image from a Category"
- 
-- filename: "AdminAddDefaultVideoSimpleProductTest.xml"
-  repo: "https://github.com/magento/magento2/blob/2.3/app/code/Magento/Catalog/Test/Mftf/Test/AdminAddDefaultVideoSimpleProductTest.xml"
-  module: "Catalog"
-  tests:
-    - testname: "AdminAddDefaultVideoSimpleProductTest"
-      title: "Admin should be able to add default product video for a Simple Product"
-      description: "Admin should be able to add default product video for a Simple Product"
- 
-- filename: "CreateProductAttributeEntityTest.xml"
-  repo: "https://github.com/magento/magento2/blob/2.3/app/code/Magento/Catalog/Test/Mftf/Test/CreateProductAttributeEntityTest.xml"
-  module: "Catalog"
-  tests:
-    - testname: "CreateProductAttributeEntityTextFieldTest"
-      title: "Admin should be able to create a TextField product attribute"
-      description: "Admin should be able to create a TextField product attribute"
-
-    - testname: "CreateProductAttributeEntityDateTest"
-      title: "Admin should be able to create a Date product attribute"
-      description: "Admin should be able to create a Date product attribute"
-
-    - testname: "CreateProductAttributeEntityPriceTest"
-      title: "Admin should be able to create a Price product attribute"
-      description: "Admin should be able to create a Price product attribute"
-
-    - testname: "CreateProductAttributeEntityDropdownTest"
-      title: "Admin should be able to create a Dropdown product attribute"
-      description: "Admin should be able to create a Dropdown product attribute"
-
-    - testname: "CreateProductAttributeEntityDropdownWithSingleQuoteTest"
-      title: "Admin should be able to create a Dropdown product attribute containing a single quote"
-      description: "Admin should be able to create a Dropdown product attribute containing a single quote"
-
-    - testname: "CreateProductAttributeEntityMultiSelectTest"
-      title: "Admin should be able to create a MultiSelect product attribute"
-      description: "Admin should be able to create a MultiSelect product attribute"
- 
-- filename: "AdminDeleteRootCategoryTest.xml"
-  repo: "https://github.com/magento/magento2/blob/2.3/app/code/Magento/Catalog/Test/Mftf/Test/AdminDeleteRootCategoryTest.xml"
-  module: "Catalog"
-  tests:
-    - testname: "AdminDeleteRootCategoryTest"
-      title: "Can delete a root category not assigned to any store"
-      description: "Login as admin and delete a root category not assigned to any store"
- 
-- filename: "AdminUpdateVirtualProductWithTierPriceInStockVisibleInCategoryAndSearchTest.xml"
-  repo: "https://github.com/magento/magento2/blob/2.3/app/code/Magento/Catalog/Test/Mftf/Test/AdminUpdateVirtualProductWithTierPriceInStockVisibleInCategoryAndSearchTest.xml"
-  module: "Catalog"
-  tests:
-    - testname: "UpdateVirtualProductWithTierPriceInStockVisibleInCategoryAndSearchTest"
-      title: "Update Virtual Product with Tier Price (In Stock) Visible in Category and Search"
-      description: "Test log in to Update Virtual Product and Update Virtual Product with Tier Price (In Stock) Visible in Category and Search"
- 
-- filename: "AdvanceCatalogSearchSimpleProductTest.xml"
-  repo: "https://github.com/magento/magento2/blob/2.3/app/code/Magento/Catalog/Test/Mftf/Test/AdvanceCatalogSearchSimpleProductTest.xml"
-  module: "Catalog"
-  tests:
-    - testname: "AdvanceCatalogSearchSimpleProductByNameTest"
-      title: "Guest customer should be able to advance search simple product with product name"
-      description: "Guest customer should be able to advance search simple product with product name"
-
-    - testname: "AdvanceCatalogSearchSimpleProductBySkuTest"
-      title: "Guest customer should be able to advance search simple product with product sku"
-      description: "Guest customer should be able to advance search simple product with product sku"
-
-    - testname: "AdvanceCatalogSearchSimpleProductByDescriptionTest"
-      title: "Guest customer should be able to advance search simple product with product description"
-      description: "Guest customer should be able to advance search simple product with product description"
-
-    - testname: "AdvanceCatalogSearchSimpleProductByShortDescriptionTest"
-      title: "Guest customer should be able to advance search simple product with product short description"
-      description: "Guest customer should be able to advance search simple product with product short description"
-
-    - testname: "AdvanceCatalogSearchSimpleProductByPriceTest"
-      title: "Guest customer should be able to advance search simple product with product price"
-      description: "Guest customer should be able to advance search simple product with product price"
- 
-- filename: "AdminUpdateSimpleProductWithRegularPriceInStockVisibleInCatalogOnlyTest.xml"
-  repo: "https://github.com/magento/magento2/blob/2.3/app/code/Magento/Catalog/Test/Mftf/Test/AdminUpdateSimpleProductWithRegularPriceInStockVisibleInCatalogOnlyTest.xml"
-  module: "Catalog"
-  tests:
-    - testname: "AdminUpdateSimpleProductWithRegularPriceInStockVisibleInCatalogOnlyTest"
-      title: "Update Simple Product with Regular Price (In Stock) Visible in Catalog Only"
-      description: "Test log in to Update Simple Product and Update Simple Product with Regular Price (In Stock) Visible in Catalog Only"
- 
-- filename: "AdminUpdateSimpleProductPriceToVerifyDataOverridingOnStoreViewLevelTest.xml"
-  repo: "https://github.com/magento/magento2/blob/2.3/app/code/Magento/Catalog/Test/Mftf/Test/AdminUpdateSimpleProductPriceToVerifyDataOverridingOnStoreViewLevelTest.xml"
-  module: "Catalog"
-  tests:
-    - testname: "AdminUpdateSimpleProductPriceToVerifyDataOverridingOnStoreViewLevelTest"
-      title: "Update Simple Product Price to Verify Data Overriding on Store View Level"
-      description: "Test log in to Update Simple Product and Update Simple Product Price to Verify Data Overriding on Store View Level"
- 
-- filename: "StorefrontCatalogNavigationMenuUIDesktopTest.xml"
-  repo: "https://github.com/magento/magento2/blob/2.3/app/code/Magento/Catalog/Test/Mftf/Test/StorefrontCatalogNavigationMenuUIDesktopTest.xml"
-  module: "Catalog"
-  tests:
-    - testname: "StorefrontCatalogNavigationMenuUIDesktopTest"
-      title: "Storefront Catalog Navigation Menu UI, desktop"
-      description: "Verify UI of Navigation Menu functionality on Storefront"
- 
-- filename: "AdminUpdateFlatCategoryNameAndDescriptionTest.xml"
-  repo: "https://github.com/magento/magento2/blob/2.3/app/code/Magento/Catalog/Test/Mftf/Test/AdminUpdateFlatCategoryNameAndDescriptionTest.xml"
-  module: "Catalog"
-  tests:
-    - testname: "AdminUpdateFlatCategoryNameAndDescriptionTest"
-      title: "Flat Catalog - Update Category Name and Description"
-      description: "Login as admin and update flat category name and description"
- 
-- filename: "AdminCreateAttributeSetEntityTest.xml"
-  repo: "https://github.com/magento/magento2/blob/2.3/app/code/Magento/Catalog/Test/Mftf/Test/AdminCreateAttributeSetEntityTest.xml"
-  module: "Catalog"
-  tests:
-    - testname: "AdminCreateAttributeSetEntityTest"
-      title: "Create attribute set with new product attribute"
-      description: "Admin should be able to create attribute set with new product attribute"
- 
-- filename: "DeleteUsedInConfigurableProductAttributeTest.xml"
-  repo: "https://github.com/magento/magento2/blob/2.3/app/code/Magento/Catalog/Test/Mftf/Test/DeleteUsedInConfigurableProductAttributeTest.xml"
-  module: "Catalog"
-  tests:
-    - testname: "DeleteUsedInConfigurableProductAttributeTest"
-      title: "Admin should not be able to delete product attribute used in configurable product"
-      description: "Admin should not be able to delete product attribute used in configurable product"
- 
-- filename: "AdminUpdateVirtualProductWithSpecialPriceInStockVisibleInCategoryAndSearchTest.xml"
-  repo: "https://github.com/magento/magento2/blob/2.3/app/code/Magento/Catalog/Test/Mftf/Test/AdminUpdateVirtualProductWithSpecialPriceInStockVisibleInCategoryAndSearchTest.xml"
-  module: "Catalog"
-  tests:
-    - testname: "AdminUpdateVirtualProductWithSpecialPriceInStockVisibleInCategoryAndSearchTest"
-      title: "Update Virtual Product with Special Price (In Stock) Visible in Category and Search"
-      description: "Test log in to Update Virtual Product and Update Virtual Product with Special Price (In Stock) Visible in Category and Search"
- 
-- filename: "AdminUpdateSimpleProductTieredPriceTest.xml"
-  repo: "https://github.com/magento/magento2/blob/2.3/app/code/Magento/Catalog/Test/Mftf/Test/AdminUpdateSimpleProductTieredPriceTest.xml"
-  module: "Catalog"
-  tests:
-    - testname: "AdminUpdateSimpleProductTieredPriceTest"
-      title: "Update Simple Product Tiered Price"
-      description: "Test log in to Update Simple Product and Update Simple Product Tiered Price"
- 
-- filename: "AdminEditTextEditorProductAttributeTest.xml"
-  repo: "https://github.com/magento/magento2/blob/2.3/app/code/Magento/Catalog/Test/Mftf/Test/AdminEditTextEditorProductAttributeTest.xml"
-  module: "Catalog"
-  tests:
-    - testname: "AdminEditTextEditorProductAttributeTest"
-      title: "Admin are able to change Input Type of Text Editor product attribute"
-      description: "Admin are able to change Input Type of Text Editor product attribute"
- 
-- filename: "AdminDeleteRootCategoryAssignedToStoreTest.xml"
-  repo: "https://github.com/magento/magento2/blob/2.3/app/code/Magento/Catalog/Test/Mftf/Test/AdminDeleteRootCategoryAssignedToStoreTest.xml"
-  module: "Catalog"
-  tests:
-    - testname: "AdminDeleteRootCategoryAssignedToStoreTest"
-      title: "Cannot delete root category assigned to some store"
-      description: "Login as admin and root category can not be deleted when category is assigned with any store."
- 
-- filename: "AdminVirtualProductSetEditContentTest.xml"
-  repo: "https://github.com/magento/magento2/blob/2.3/app/code/Magento/Catalog/Test/Mftf/Test/AdminVirtualProductSetEditContentTest.xml"
-  module: "Catalog"
-  tests:
-    - testname: "AdminVirtualProductSetEditContentTest"
-      title: "Admin should be able to set/edit product Content when editing a virtual product"
-      description: "Admin should be able to set/edit product Content when editing a virtual product"
- 
-- filename: "AdminMassChangeProductsStatusTest.xml"
-  repo: "https://github.com/magento/magento2/blob/2.3/app/code/Magento/Catalog/Test/Mftf/Test/AdminMassChangeProductsStatusTest.xml"
-  module: "Catalog"
-  tests:
-    - testname: "AdminMassChangeProductsStatusTest"
-      title: "Admin should be able to mass change products status"
-      description: "Admin should be able to mass change products status"
- 
-- filename: "AdminMassUpdateProductAttributesStoreViewScopeTest.xml"
-  repo: "https://github.com/magento/magento2/blob/2.3/app/code/Magento/Catalog/Test/Mftf/Test/AdminMassUpdateProductAttributesStoreViewScopeTest.xml"
-  module: "Catalog"
-  tests:
-    - testname: "AdminMassUpdateProductAttributesStoreViewScopeTest"
-      title: "Admin should be able to mass update product attributes in store view scope"
-      description: "Admin should be able to mass update product attributes in store view scope"
-
-    - testname: "AdminMassUpdateProductAttributesStoreViewScopeMysqlTest"
-      title: "Admin should be able to mass update product attributes in store view scope using the Mysql search engine"
-      description: "Admin should be able to mass update product attributes in store view scope using the Mysql search engine"
- 
-- filename: "AdminAddDefaultImageVirtualProductTest.xml"
-  repo: "https://github.com/magento/magento2/blob/2.3/app/code/Magento/Catalog/Test/Mftf/Test/AdminAddDefaultImageVirtualProductTest.xml"
-  module: "Catalog"
-  tests:
-    - testname: "AdminAddRemoveProductImageVirtualProductTest"
-      title: "Admin should be able to add default images for a Virtual Product"
-      description: "Admin should be able to add default images for a Virtual Product"
- 
-- filename: "AdminCheckConfigurableProductPriceWithOutOfStockChildProductTest.xml"
-  repo: "https://github.com/magento/magento2/blob/2.3/app/code/Magento/Catalog/Test/Mftf/Test/AdminCheckConfigurableProductPriceWithOutOfStockChildProductTest.xml"
-  module: "Catalog"
-  tests:
-    - testname: "AdminCheckConfigurableProductPriceWithOutOfStockChildProductTest"
-      title: "Check Price for Configurable Product when Child is Out of Stock"
-      description: "Login as admin and check the configurable product price when one child product is out of stock "
- 
-- filename: "AdminCreateSimpleProductWithCountryOfManufactureAttributeSKUMaskTest.xml"
-  repo: "https://github.com/magento/magento2/blob/2.3/app/code/Magento/Catalog/Test/Mftf/Test/AdminCreateSimpleProductWithCountryOfManufactureAttributeSKUMaskTest.xml"
-  module: "Catalog"
-  tests:
-    - testname: "AdminCreateSimpleProductWithCountryOfManufactureAttributeSKUMaskTest"
-      title: "Create simple product with (Country of Manufacture) Attribute SKU Mask"
-      description: "Test log in to Create simple product and Create simple product with (Country of Manufacture) Attribute SKU Mask"
- 
-- filename: "AddToCartCrossSellTest.xml"
-  repo: "https://github.com/magento/magento2/blob/2.3/app/code/Magento/Catalog/Test/Mftf/Test/AddToCartCrossSellTest.xml"
-  module: "Catalog"
-  tests:
-    - testname: "AddToCartCrossSellTest"
-      title: "Admin should be able to add cross-sell to products."
-      description: "Create products, add products to cross sells, and check that they appear in the Shopping Cart page."
- 
-- filename: "AdminMassUpdateProductAttributesMissingRequiredFieldTest.xml"
-  repo: "https://github.com/magento/magento2/blob/2.3/app/code/Magento/Catalog/Test/Mftf/Test/AdminMassUpdateProductAttributesMissingRequiredFieldTest.xml"
-  module: "Catalog"
-  tests:
-    - testname: "AdminMassUpdateProductAttributesMissingRequiredFieldTest"
-      title: "Mass update product attributes - missing required field"
-      description: "Mass update product attributes - missing required field"
- 
-- filename: "AdminCheckConfigurableProductPriceWithDisabledChildProductTest.xml"
-  repo: "https://github.com/magento/magento2/blob/2.3/app/code/Magento/Catalog/Test/Mftf/Test/AdminCheckConfigurableProductPriceWithDisabledChildProductTest.xml"
-  module: "Catalog"
-  tests:
-    - testname: "AdminCheckConfigurableProductPriceWithDisabledChildProductTest"
-      title: "Check Price for Configurable Product when One Child is Disabled, Others are Enabled"
-      description: "Login as admin and check the configurable product price when one child product is disabled "
- 
-- filename: "StorefrontProductsCompareWithEmptyAttributeTest.xml"
-  repo: "https://github.com/magento/magento2/blob/2.3/app/code/Magento/Catalog/Test/Mftf/Test/StorefrontProductsCompareWithEmptyAttributeTest.xml"
-  module: "Catalog"
-  tests:
-    - testname: "StorefrontProductsCompareWithEmptyAttributeTest"
-      title: "Product attribute is not visible on product compare page if it is empty"
-      description: "Product attribute should not be visible on the product compare page if it is empty for all products that are being compared, not even displayed as N/A"
- 
-- filename: "AdminUpdateVirtualProductWithTierPriceOutOfStockVisibleInCategoryAndSearchTest.xml"
-  repo: "https://github.com/magento/magento2/blob/2.3/app/code/Magento/Catalog/Test/Mftf/Test/AdminUpdateVirtualProductWithTierPriceOutOfStockVisibleInCategoryAndSearchTest.xml"
-  module: "Catalog"
-  tests:
-    - testname: "AdminUpdateVirtualProductWithTierPriceOutOfStockVisibleInCategoryAndSearchTest"
-      title: "Update Virtual Product with Tier Price (Out of Stock) Visible in Category and Search"
-      description: "Test log in to Update Virtual Product and Update Virtual Product with Tier Price (Out of Stock) Visible in Category and Search"
- 
-- filename: "AdminRemoveImageAffectsAllScopesTest.xml"
-  repo: "https://github.com/magento/magento2/blob/2.3/app/code/Magento/Catalog/Test/Mftf/Test/AdminRemoveImageAffectsAllScopesTest.xml"
-  module: "Catalog"
-  tests:
-    - testname: "AdminRemoveImageAffectsAllScopesTest"
-      title: "Effect of product images changes in default scope to other scopes"
-      description: "Product image should be deleted from all scopes"
- 
-- filename: "AdminMassProductPriceUpdateTest.xml"
-  repo: "https://github.com/magento/magento2/blob/2.3/app/code/Magento/Catalog/Test/Mftf/Test/AdminMassProductPriceUpdateTest.xml"
-  module: "Catalog"
-  tests:
-    - testname: "AdminMassProductPriceUpdateTest"
-      title: "Mass update simple product price"
-      description: "Login as admin and update mass product price"
- 
-- filename: "AdminCreateCategoryFromProductPageTest.xml"
-  repo: "https://github.com/magento/magento2/blob/2.3/app/code/Magento/Catalog/Test/Mftf/Test/AdminCreateCategoryFromProductPageTest.xml"
-  module: "Catalog"
-  tests:
-    - testname: "AdminCreateCategoryFromProductPageTest"
-      title: "Admin should be able to create category from the product page"
-      description: "Admin should be able to create category from the product page"
- 
-- filename: "AdminAddInStockProductToTheCartTest.xml"
-  repo: "https://github.com/magento/magento2/blob/2.3/app/code/Magento/Catalog/Test/Mftf/Test/AdminAddInStockProductToTheCartTest.xml"
-  module: "Catalog"
-  tests:
-    - testname: "AdminAddInStockProductToTheCartTest"
-      title: "Add In Stock Product to Cart"
-      description: "Login as admin and add In Stock product to the cart"
- 
-- filename: "AdminCreateCategoryTest.xml"
-  repo: "https://github.com/magento/magento2/blob/2.3/app/code/Magento/Catalog/Test/Mftf/Test/AdminCreateCategoryTest.xml"
-  module: "Catalog"
-  tests:
-    - testname: "AdminCreateCategoryTest"
-      title: "Admin should be able to create a Category"
-      description: "Admin should be able to create a Category"
-
-    - testname: "AdminConfigDefaultCategoryLayoutFromConfigurationSettingTest"
-      title: "Admin should be able to configure the default layout for Category Page from System Configuration"
-      description: "Admin should be able to configure the default layout for Category Page from System Configuration"
-
-    - testname: "AdminCategoryFormDisplaySettingsUIValidationTest"
-      title: "Category should not be saved once layered navigation price step field is left empty"
-      description: "Once the Config setting is unchecked Category should not be saved with layered navigation price field left empty"
- 
-- filename: "AdminUpdateSimpleProductWithRegularPriceOutOfStockTest.xml"
-  repo: "https://github.com/magento/magento2/blob/2.3/app/code/Magento/Catalog/Test/Mftf/Test/AdminUpdateSimpleProductWithRegularPriceOutOfStockTest.xml"
-  module: "Catalog"
-  tests:
-    - testname: "AdminUpdateSimpleProductWithRegularPriceOutOfStockTest"
-      title: "Update Simple Product with Regular Price (Out of Stock)"
-      description: "Test log in to Update Simple Product and Update Simple Product with Regular Price (Out of Stock)"
- 
-- filename: "AdminCatalogCategoriesNavigateMenuTest.xml"
-  repo: "https://github.com/magento/magento2/blob/2.3/app/code/Magento/Catalog/Test/Mftf/Test/AdminCatalogCategoriesNavigateMenuTest.xml"
-  module: "Catalog"
-  tests:
-    - testname: "AdminCatalogCategoriesNavigateMenuTest"
-      title: "Admin catalog categories navigate menu test"
-      description: "Admin should be able to navigate to Catalog &gt; Categories"
- 
-- filename: "AdminCheckSubCategoryIsNotVisibleInNavigationMenuTest.xml"
-  repo: "https://github.com/magento/magento2/blob/2.3/app/code/Magento/Catalog/Test/Mftf/Test/AdminCheckSubCategoryIsNotVisibleInNavigationMenuTest.xml"
-  module: "Catalog"
-  tests:
-    - testname: "AdminCheckSubCategoryIsNotVisibleInNavigationMenuTest"
-      title: "Active category is visible on navigation menu while subcategory is not visible on navigation menu, Include in Menu = Yes"
-      description: "Login as admin and verify subcategory is not visible in navigation menu"
- 
-- filename: "VerifyCategoryProductAndProductCategoryPartialReindexTest.xml"
-  repo: "https://github.com/magento/magento2/blob/2.3/app/code/Magento/Catalog/Test/Mftf/Test/VerifyCategoryProductAndProductCategoryPartialReindexTest.xml"
-  module: "Catalog"
-  tests:
-    - testname: "VerifyCategoryProductAndProductCategoryPartialReindexTest"
-      title: "Verify Category Product and Product Category partial reindex"
-      description: "Verify that Merchant Developer can use console commands to perform partial reindex for Category Products, Product Categories, and Catalog Search"
- 
-- filename: "AdminCreateProductDuplicateUrlkeyTest.xml"
-  repo: "https://github.com/magento/magento2/blob/2.3/app/code/Magento/Catalog/Test/Mftf/Test/AdminCreateProductDuplicateUrlkeyTest.xml"
-  module: "Catalog"
-  tests:
-    - testname: "AdminCreateProductDuplicateUrlkeyTest"
-      title: "Admin should see an error when trying to save a product with a duplicate URL key"
-      description: "Admin should see an error when trying to save a product with a duplicate URL key"
-
-    - testname: "AdminCreateProductDuplicateProductTest"
-      title: "No validation errors when trying to duplicate product twice"
-      description: "No validation errors when trying to duplicate product twice"
- 
-- filename: "AdminSimpleProductImagesTest.xml"
-  repo: "https://github.com/magento/magento2/blob/2.3/app/code/Magento/Catalog/Test/Mftf/Test/AdminSimpleProductImagesTest.xml"
-  module: "Catalog"
-  tests:
-    - testname: "AdminSimpleProductImagesTest"
-      title: "Admin should be able to add images of different types and sizes to Simple Product"
-      description: "Admin should be able to add images of different types and sizes to Simple Product"
-
-    - testname: "AdminSimpleProductRemoveImagesTest"
-      title: "Admin should be able to remove Product Images assigned as Base, Small and Thumbnail from Simple Product"
-      description: "Admin should be able to remove Product Images assigned as Base, Small and Thumbnail from Simple Product"
- 
-- filename: "AdminSimpleProductEditUiTest.xml"
-  repo: "https://github.com/magento/magento2/blob/2.3/app/code/Magento/Catalog/Test/Mftf/Test/AdminSimpleProductEditUiTest.xml"
-  module: "Catalog"
-  tests:
-    - testname: "AdminSimpleProductUiValidationTest"
-      title: "UI elements on the simple product edit screen should be organized as expected"
-      description: "Admin should be able to use simple product UI in expected manner"
- 
-- filename: "AdminApplyTierPriceToProductTest.xml"
-  repo: "https://github.com/magento/magento2/blob/2.3/app/code/Magento/Catalog/Test/Mftf/Test/AdminApplyTierPriceToProductTest.xml"
-  module: "Catalog"
-  tests:
-    - testname: "AdminApplyTierPriceToProductTest"
-      title: "You should be able to apply tier price to a product."
-      description: "You should be able to apply tier price to a product."
-
-    - testname: "AdminApplyTierPriceToProductWithPercentageDiscountTest"
-      title: "You should be able to apply tier price to a product with float percent discount."
-      description: "You should be able to apply tier price to a product with float percent discount."
- 
-- filename: "AdminCheckOutOfStockProductIsVisibleInCategoryTest.xml"
-  repo: "https://github.com/magento/magento2/blob/2.3/app/code/Magento/Catalog/Test/Mftf/Test/AdminCheckOutOfStockProductIsVisibleInCategoryTest.xml"
-  module: "Catalog"
-  tests:
-    - testname: "AdminCheckOutOfStockProductIsVisibleInCategoryTest"
-      title: "Out of Stock Product is Visible in Category"
-      description: "Login as admin and check out of stock product is visible in category"
- 
-- filename: "AdminProductStatusAttributeDisabledByDefaultTest.xml"
-  repo: "https://github.com/magento/magento2/blob/2.3/app/code/Magento/Catalog/Test/Mftf/Test/AdminProductStatusAttributeDisabledByDefaultTest.xml"
-  module: "Catalog"
-  tests:
-    - testname: "AdminProductStatusAttributeDisabledByDefaultTest"
-      title: "Verify the default option value for product Status attribute is set correctly during product creation"
-      description: "The default option value for product Status attribute is set correctly during product creation"
- 
-- filename: "AdminUpdateCategoryAndMakeInactiveTest.xml"
-  repo: "https://github.com/magento/magento2/blob/2.3/app/code/Magento/Catalog/Test/Mftf/Test/AdminUpdateCategoryAndMakeInactiveTest.xml"
-  module: "Catalog"
-  tests:
-    - testname: "AdminUpdateCategoryAndMakeInactiveTest"
-      title: "Update category, make inactive"
-      description: "Login as admin and update category and  make it Inactive"
- 
-- filename: "AdminCreateProductAttributeFromProductPageTest.xml"
-  repo: "https://github.com/magento/magento2/blob/2.3/app/code/Magento/Catalog/Test/Mftf/Test/AdminCreateProductAttributeFromProductPageTest.xml"
-  module: "Catalog"
-  tests:
-    - testname: "AdminCreateProductAttributeFromProductPageTest"
-      title: "Create Product Attribute from Product Page"
-      description: "Login as admin and create new product attribute from product page with Text Field"
- 
-- filename: "AdminCreateVirtualProductWithTierPriceForGeneralGroupTest.xml"
-  repo: "https://github.com/magento/magento2/blob/2.3/app/code/Magento/Catalog/Test/Mftf/Test/AdminCreateVirtualProductWithTierPriceForGeneralGroupTest.xml"
-  module: "Catalog"
-  tests:
-    - testname: "AdminCreateVirtualProductWithTierPriceForGeneralGroupTest"
-      title: "Create virtual product with tier price for General group"
-      description: "Test log in to Create virtual product and Create virtual product with tier price for General group"
- 
-- filename: "AdminRemoveDefaultVideoSimpleProductTest.xml"
-  repo: "https://github.com/magento/magento2/blob/2.3/app/code/Magento/Catalog/Test/Mftf/Test/AdminRemoveDefaultVideoSimpleProductTest.xml"
-  module: "Catalog"
-  tests:
-    - testname: "AdminRemoveDefaultVideoSimpleProductTest"
-      title: "Admin should be able to remove default product video from a Simple Product"
-      description: "Admin should be able to remove default product video from a Simple Product"
- 
-- filename: "AdminAddImageToWYSIWYGCatalogTest.xml"
-  repo: "https://github.com/magento/magento2/blob/2.3/app/code/Magento/Catalog/Test/Mftf/Test/AdminAddImageToWYSIWYGCatalogTest.xml"
-  module: "Catalog"
-  tests:
-    - testname: "AdminAddImageToWYSIWYGCatalogTest"
-      title: "Admin should be able to add image to WYSIWYG Editor on Catalog Page"
-      description: "Admin should be able to add image to WYSIWYG Editor on Catalog Page"
- 
-- filename: "AddOutOfStockProductToCompareListTest.xml"
-  repo: "https://github.com/magento/magento2/blob/2.3/app/code/Magento/Catalog/Test/Mftf/Test/AddOutOfStockProductToCompareListTest.xml"
-  module: "Catalog"
-  tests:
-    - testname: "AddOutOfStockProductToCompareListTest"
-      title: "Add Product that is Out of Stock product to Product Comparison"
-      description: "Customer should be able to add Product that is Out Of Stock to the Product Comparison"
- 
-- filename: "AdminCreateInactiveFlatCategoryTest.xml"
-  repo: "https://github.com/magento/magento2/blob/2.3/app/code/Magento/Catalog/Test/Mftf/Test/AdminCreateInactiveFlatCategoryTest.xml"
-  module: "Catalog"
-  tests:
-    - testname: "AdminCreateInactiveFlatCategoryTest"
-      title: "Flat Catalog - Create Category as Inactive, Should Not be Visible on Storefront"
-      description: "Login as admin and create flat Inactive category and verify category is not visible in store front"
- 
-- filename: "StorefrontSpecialPriceForDifferentTimezonesForWebsitesTest.xml"
-  repo: "https://github.com/magento/magento2/blob/2.3/app/code/Magento/Catalog/Test/Mftf/Test/StorefrontSpecialPriceForDifferentTimezonesForWebsitesTest.xml"
-  module: "Catalog"
-  tests:
-    - testname: "StorefrontSpecialPriceForDifferentTimezonesForWebsitesTest"
-      title: "Check that special price displayed when 'default config' scope timezone does not match 'website' scope timezone"
-      description: "Check that special price displayed when 'default config' scope timezone does not match 'website' scope timezone"
- 
-- filename: "AdminUpdateCategoryWithInactiveIncludeInMenuTest.xml"
-  repo: "https://github.com/magento/magento2/blob/2.3/app/code/Magento/Catalog/Test/Mftf/Test/AdminUpdateCategoryWithInactiveIncludeInMenuTest.xml"
-  module: "Catalog"
-  tests:
-    - testname: "AdminUpdateCategoryWithInactiveIncludeInMenuTest"
-      title: "Update category, name description urlkey metatitle exclude from menu"
-      description: "Login as admin and update category name, description, urlKey, metatitle and exclude from menu"
- 
-- filename: "AdminShouldBeAbleToAssociateSimpleProductToWebsitesTest.xml"
-  repo: "https://github.com/magento/magento2/blob/2.3/app/code/Magento/Catalog/Test/Mftf/Test/AdminShouldBeAbleToAssociateSimpleProductToWebsitesTest.xml"
-  module: "Catalog"
-  tests:
-    - testname: "AdminShouldBeAbleToAssociateSimpleProductToWebsitesTest"
-      title: "Admin should be able to associate simple product to websites"
-      description: "Admin should be able to associate simple product to websites"
- 
-- filename: "AdminStoresAttributeSetNavigateMenuTest.xml"
-  repo: "https://github.com/magento/magento2/blob/2.3/app/code/Magento/Catalog/Test/Mftf/Test/AdminStoresAttributeSetNavigateMenuTest.xml"
-  module: "Catalog"
-  tests:
-    - testname: "AdminStoresAttributeSetNavigateMenuTest"
-      title: "Admin stores attribute set navigate menu test"
-      description: "Admin should be able to navigate to Stores &gt; Attribute Set"
- 
-- filename: "AdminUpdateVirtualProductWithSpecialPriceOutOfStockVisibleInCategoryAndSearchTest.xml"
-  repo: "https://github.com/magento/magento2/blob/2.3/app/code/Magento/Catalog/Test/Mftf/Test/AdminUpdateVirtualProductWithSpecialPriceOutOfStockVisibleInCategoryAndSearchTest.xml"
-  module: "Catalog"
-  tests:
-    - testname: "UpdateVirtualProductWithSpecialPriceOutOfStockVisibleInCategoryAndSearchTest"
-      title: "Update Virtual Product with Special Price (Out of Stock) Visible in Category and Search"
-      description: "Test log in to Update Virtual Product and Update Virtual Product with Special Price (Out of Stock) Visible in Category and Search"
- 
-- filename: "AdminCreateMultipleSelectProductAttributeVisibleInStorefrontAdvancedSearchFormTest.xml"
-  repo: "https://github.com/magento/magento2/blob/2.3/app/code/Magento/Catalog/Test/Mftf/Test/AdminCreateMultipleSelectProductAttributeVisibleInStorefrontAdvancedSearchFormTest.xml"
-  module: "Catalog"
-  tests:
-    - testname: "AdminCreateMultipleSelectProductAttributeVisibleInStorefrontAdvancedSearchFormTest"
-      title: "Create product attribute of type Multiple Select and check its visibility on frontend in Advanced Search form"
-      description: "Admin should be able to create product attribute of type Multiple Select and check its visibility on frontend in Advanced Search form"
- 
-- filename: "NewProductsListWidgetSimpleProductTest.xml"
-  repo: "https://github.com/magento/magento2/blob/2.3/app/code/Magento/Catalog/Test/Mftf/Test/NewProductsListWidgetSimpleProductTest.xml"
-  module: "Catalog"
-  tests:
-    - testname: "NewProductsListWidgetSimpleProductTest"
-      title: "Admin should be able to set Simple Product as new so that it shows up in the Catalog New Products List Widget"
-      description: "Admin should be able to set Simple Product as new so that it shows up in the Catalog New Products List Widget"
- 
-- filename: "AdminCreateCustomProductAttributeWithDropdownFieldTest.xml"
-  repo: "https://github.com/magento/magento2/blob/2.3/app/code/Magento/Catalog/Test/Mftf/Test/AdminCreateCustomProductAttributeWithDropdownFieldTest.xml"
-  module: "Catalog"
-  tests:
-    - testname: "AdminCreateCustomProductAttributeWithDropdownFieldTest"
-      title: "Create Custom Product Attribute Dropdown Field (Not Required) from Product Page"
-      description: "login as admin and create configurable product attribute with Dropdown field"
- 
-- filename: "AdminCreateCategoryWithInactiveCategoryTest.xml"
-  repo: "https://github.com/magento/magento2/blob/2.3/app/code/Magento/Catalog/Test/Mftf/Test/AdminCreateCategoryWithInactiveCategoryTest.xml"
-  module: "Catalog"
-  tests:
-    - testname: "AdminCreateCategoryWithInactiveCategoryTest"
-      title: "Create disabled subcategory"
-      description: "Login as admin and create category with inactivated enable category option"
- 
-- filename: "AdminUpdateVirtualProductWithRegularPriceOutOfStockVisibleInCategoryOnlyTest.xml"
-  repo: "https://github.com/magento/magento2/blob/2.3/app/code/Magento/Catalog/Test/Mftf/Test/AdminUpdateVirtualProductWithRegularPriceOutOfStockVisibleInCategoryOnlyTest.xml"
-  module: "Catalog"
-  tests:
-    - testname: "AdminUpdateVirtualProductWithRegularPriceOutOfStockVisibleInCategoryOnlyTest"
-      title: "Update Virtual Product with Regular Price (Out of Stock) Visible in Category Only"
-      description: "Test log in to Update Virtual Product and Update Virtual Product with Regular Price (Out of Stock) Visible in Category Only"
- 
-- filename: "AdminUpdateSimpleProductWithRegularPriceInStockEnabledFlatTest.xml"
-  repo: "https://github.com/magento/magento2/blob/2.3/app/code/Magento/Catalog/Test/Mftf/Test/AdminUpdateSimpleProductWithRegularPriceInStockEnabledFlatTest.xml"
-  module: "Catalog"
-  tests:
-    - testname: "AdminUpdateSimpleProductWithRegularPriceInStockEnabledFlatTest"
-      title: "Update Simple Product with Regular Price (In Stock) Enabled Flat"
-      description: "Test log in to Update Simple Product and Update Simple Product with Regular Price (In Stock) Enabled Flat"
- 
-- filename: "AdminDeleteProductAttributeTest.xml"
-  repo: "https://github.com/magento/magento2/blob/2.3/app/code/Magento/Catalog/Test/Mftf/Test/AdminDeleteProductAttributeTest.xml"
-  module: "Catalog"
-  tests:
-    - testname: "DeleteProductAttributeTest"
-      title: "Delete Product Attribute"
-      description: "Admin should able to delete a product attribute"
- 
-- filename: "AdminAddDefaultVideoVirtualProductTest.xml"
-  repo: "https://github.com/magento/magento2/blob/2.3/app/code/Magento/Catalog/Test/Mftf/Test/AdminAddDefaultVideoVirtualProductTest.xml"
-  module: "Catalog"
-  tests:
-    - testname: "AdminAddDefaultVideoVirtualProductTest"
-      title: "Admin should be able to add default product video for a Virtual Product"
-      description: "Admin should be able to add default product video for a Virtual Product"
- 
-- filename: "AdminCreateVirtualProductFillingRequiredFieldsOnlyTest.xml"
-  repo: "https://github.com/magento/magento2/blob/2.3/app/code/Magento/Catalog/Test/Mftf/Test/AdminCreateVirtualProductFillingRequiredFieldsOnlyTest.xml"
-  module: "Catalog"
-  tests:
-    - testname: "AdminCreateVirtualProductFillingRequiredFieldsOnlyTest"
-      title: "Create virtual product filling required fields only"
-      description: "Test log in to Create virtual product and Create virtual product filling required fields only"
- 
-- filename: "AdminMassUpdateProductAttributesGlobalScopeTest.xml"
-  repo: "https://github.com/magento/magento2/blob/2.3/app/code/Magento/Catalog/Test/Mftf/Test/AdminMassUpdateProductAttributesGlobalScopeTest.xml"
-  module: "Catalog"
-  tests:
-    - testname: "AdminMassUpdateProductAttributesGlobalScopeTest"
-      title: "Admin should be able to mass update product attributes in global scope"
-      description: "Admin should be able to mass update product attributes in global scope"
- 
-- filename: "AdminCreateVirtualProductOutOfStockWithTierPriceTest.xml"
-  repo: "https://github.com/magento/magento2/blob/2.3/app/code/Magento/Catalog/Test/Mftf/Test/AdminCreateVirtualProductOutOfStockWithTierPriceTest.xml"
-  module: "Catalog"
-  tests:
-    - testname: "AdminCreateVirtualProductOutOfStockWithTierPriceTest"
-      title: "Create virtual product out of stock with tier price"
-      description: "Test log in to Create virtual product and Create virtual product out of stock with tier price"
- 
-- filename: "AdminProductImageAssignmentForMultipleStoresTest.xml"
-  repo: "https://github.com/magento/magento2/blob/2.3/app/code/Magento/Catalog/Test/Mftf/Test/AdminProductImageAssignmentForMultipleStoresTest.xml"
-  module: "Catalog"
-  tests:
-    - testname: "AdminProductImageAssignmentForMultipleStoresTest"
-      title: "Product image assignment for multiple stores"
-      description: "Product image assignment for multiple stores"
- 
-- filename: "AdminCloneProductWithDuplicateUrlTest.xml"
-  repo: "https://github.com/magento/magento2/blob/2.3/app/code/Magento/Catalog/Test/Mftf/Test/AdminCloneProductWithDuplicateUrlTest.xml"
-  module: "Catalog"
-  tests:
-    - testname: "AdminCloneProductWithDuplicateUrlTest"
-      title: "Cloning a product with duplicate URL key"
-      description: "Check product cloning with duplicate URL key"
- 
-- filename: "AdminRemoveCustomOptionsFromProductTest.xml"
-  repo: "https://github.com/magento/magento2/blob/2.3/app/code/Magento/Catalog/Test/Mftf/Test/AdminRemoveCustomOptionsFromProductTest.xml"
-  module: "Catalog"
-  tests:
-    - testname: "AdminRemoveCustomOptionsFromProductTest"
-      title: "Remove custom options from product"
-      description: "Remove custom options from product"
- 
-- filename: "AdminUpdateTopCategoryUrlWithNoRedirectTest.xml"
-  repo: "https://github.com/magento/magento2/blob/2.3/app/code/Magento/Catalog/Test/Mftf/Test/AdminUpdateTopCategoryUrlWithNoRedirectTest.xml"
-  module: "Catalog"
-  tests:
-    - testname: "AdminUpdateTopCategoryUrlWithNoRedirectTest"
-      title: "Update top category url and do not create redirect"
-      description: "Login as admin and update top category url and do not create redirect"
- 
-- filename: "AdminCheckOutOfStockProductIsNotVisibleInCategoryTest.xml"
-  repo: "https://github.com/magento/magento2/blob/2.3/app/code/Magento/Catalog/Test/Mftf/Test/AdminCheckOutOfStockProductIsNotVisibleInCategoryTest.xml"
-  module: "Catalog"
-  tests:
-    - testname: "AdminCheckOutOfStockProductIsNotVisibleInCategoryTest"
-      title: "Out of Stock Product is Not Visible in Category"
-      description: "Login as admin and check out of stock product is not visible in category"
- 
-- filename: "AdminUpdateSimpleProductWithRegularPriceInStockVisibleInSearchOnlyTest.xml"
-  repo: "https://github.com/magento/magento2/blob/2.3/app/code/Magento/Catalog/Test/Mftf/Test/AdminUpdateSimpleProductWithRegularPriceInStockVisibleInSearchOnlyTest.xml"
-  module: "Catalog"
-  tests:
-    - testname: "AdminUpdateSimpleProductWithRegularPriceInStockVisibleInSearchOnlyTest"
-      title: "Update Simple Product with Regular Price (In Stock) Visible in Search Only"
-      description: "Test log in to Update Simple Product and Update Simple Product with Regular Price (In Stock) Visible in Search Only"
- 
-- filename: "AdminDeleteProductWithCustomOptionTest.xml"
-  repo: "https://github.com/magento/magento2/blob/2.3/app/code/Magento/Catalog/Test/Mftf/Test/AdminDeleteProductWithCustomOptionTest.xml"
-  module: "Catalog"
-  tests:
-    - testname: "AdminDeleteProductWithCustomOptionTest"
-      title: "Delete Product with Custom Option"
-      description: "Admin should be able to delete a product with custom option"
- 
-- filename: "VerifyTinyMCEv4IsNativeWYSIWYGOnProductTest.xml"
-  repo: "https://github.com/magento/magento2/blob/2.3/app/code/Magento/Catalog/Test/Mftf/Test/VerifyTinyMCEv4IsNativeWYSIWYGOnProductTest.xml"
-  module: "Catalog"
-  tests:
-    - testname: "VerifyTinyMCEv4IsNativeWYSIWYGOnProductTest"
-      title: "Admin should see TinyMCEv4.6 is the native WYSIWYG on Product Page"
-      description: "Admin should see TinyMCEv4.6 is the native WYSIWYG on Product Page"
- 
-- filename: "AdminCreateRootCategoryAndSubcategoriesTest.xml"
-  repo: "https://github.com/magento/magento2/blob/2.3/app/code/Magento/Catalog/Test/Mftf/Test/AdminCreateRootCategoryAndSubcategoriesTest.xml"
-  module: "Catalog"
-  tests:
-    - testname: "AdminCreateRootCategoryAndSubcategoriesTest"
-      title: "Admin should be able to create a Root Category and a Subcategory"
-      description: "Admin should be able to create a Root Category and a Subcategory"
- 
-- filename: "AdminImportCustomizableOptionToProductWithSKUTest.xml"
-  repo: "https://github.com/magento/magento2/blob/2.3/app/code/Magento/Catalog/Test/Mftf/Test/AdminImportCustomizableOptionToProductWithSKUTest.xml"
-  module: "Catalog"
-  tests:
-    - testname: "AdminImportCustomizableOptionToProductWithSKUTest"
-      title: "Import customizable options to a product with existing SKU"
-      description: "Import customizable options to a product with existing SKU"
- 
-- filename: "AdminUpdateSimpleProductWithRegularPriceInStockDisabledProductTest.xml"
-  repo: "https://github.com/magento/magento2/blob/2.3/app/code/Magento/Catalog/Test/Mftf/Test/AdminUpdateSimpleProductWithRegularPriceInStockDisabledProductTest.xml"
-  module: "Catalog"
-  tests:
-    - testname: "AdminUpdateSimpleProductWithRegularPriceInStockDisabledProductTest"
-      title: "Update Simple Product with Regular Price (In Stock), Disabled Product"
-      description: "Test log in to Update Simple Product and Update Simple Product with Regular Price (In Stock), Disabled Product"
- 
-- filename: "AdminUpdateTopCategoryUrlWithRedirectTest.xml"
-  repo: "https://github.com/magento/magento2/blob/2.3/app/code/Magento/Catalog/Test/Mftf/Test/AdminUpdateTopCategoryUrlWithRedirectTest.xml"
-  module: "Catalog"
-  tests:
-    - testname: "AdminUpdateTopCategoryUrlWithRedirectTest"
-      title: "Update top category url and create redirect"
-      description: "Login as admin and update top category url and create redirect"
- 
-- filename: "AdminCreateCategoryWithCustomRootCategoryTest.xml"
-  repo: "https://github.com/magento/magento2/blob/2.3/app/code/Magento/Catalog/Test/Mftf/Test/AdminCreateCategoryWithCustomRootCategoryTest.xml"
-  module: "Catalog"
-  tests:
-    - testname: "AdminCreateCategoryWithCustomRootCategoryTest"
-      title: "Create category in the custom root category that is used for custom website"
-      description: "Login as admin and create a root category with nested sub category and verify category in store front "
- 
-- filename: "AdminUpdateFlatCategoryAndAddProductsTest.xml"
-  repo: "https://github.com/magento/magento2/blob/2.3/app/code/Magento/Catalog/Test/Mftf/Test/AdminUpdateFlatCategoryAndAddProductsTest.xml"
-  module: "Catalog"
-  tests:
-    - testname: "AdminUpdateFlatCategoryAndAddProductsTest"
-      title: "Flat Catalog - Assign Simple Product to Category"
-      description: "Login as admin, update flat category by adding a simple product"
- 
-- filename: "AdminDeleteTextFieldProductAttributeFromAttributeSetTest.xml"
-  repo: "https://github.com/magento/magento2/blob/2.3/app/code/Magento/Catalog/Test/Mftf/Test/AdminDeleteTextFieldProductAttributeFromAttributeSetTest.xml"
-  module: "Catalog"
-  tests:
-    - testname: "AdminDeleteTextFieldProductAttributeFromAttributeSetTest"
-      title: "Delete Product Attribute, Text Field, from Attribute Set"
-      description: "Login as admin and delete Text Field type product attribute from attribute set"
- 
-- filename: "EndToEndB2CLoggedInUserTest.xml"
-  repo: "https://github.com/magento/magento2/blob/2.3/app/code/Magento/Catalog/Test/Mftf/Test/EndToEndB2CLoggedInUserTest.xml"
-  module: "Catalog"
-  tests:
-    - testname: "EndToEndB2CLoggedInUserTest"
-      title: ""
-      description: ""
- 
-- filename: "AdminAddImageForCategoryTest.xml"
-  repo: "https://github.com/magento/magento2/blob/2.3/app/code/Magento/Catalog/Test/Mftf/Test/AdminAddImageForCategoryTest.xml"
-  module: "Catalog"
-  tests:
-    - testname: "AdminAddImageForCategoryTest"
-      title: "Admin should be able to add image to a Category"
-      description: "Admin should be able to add image to a Category"
- 
-- filename: "AdminMassUpdateProductStatusStoreViewScopeTest.xml"
-  repo: "https://github.com/magento/magento2/blob/2.3/app/code/Magento/Catalog/Test/Mftf/Test/AdminMassUpdateProductStatusStoreViewScopeTest.xml"
-  module: "Catalog"
-  tests:
-    - testname: "AdminMassUpdateProductStatusStoreViewScopeTest"
-      title: "Admin should be able to mass update product statuses in store view scope"
-      description: "Admin should be able to mass update product statuses in store view scope"
-
-    - testname: "AdminMassUpdateProductStatusStoreViewScopeMysqlTest"
-      title: "Admin should be able to mass update product statuses in store view scope using the Mysql search engine"
-      description: "Admin should be able to mass update product statuses in store view scope using the Mysql search engine"
- 
-- filename: "AdminUpdateVirtualProductWithRegularPriceOutOfStockVisibleInSearchOnlyTest.xml"
-  repo: "https://github.com/magento/magento2/blob/2.3/app/code/Magento/Catalog/Test/Mftf/Test/AdminUpdateVirtualProductWithRegularPriceOutOfStockVisibleInSearchOnlyTest.xml"
-  module: "Catalog"
-  tests:
-    - testname: "AdminUpdateVirtualProductWithRegularPriceOutOfStockVisibleInSearchOnlyTest"
-      title: "Update Virtual Product with Regular Price (Out of Stock) Visible in Search Only"
-      description: "Test log in to Update Virtual Product and Update Virtual Product with Regular Price (Out of Stock) Visible in Search Only"
- 
-- filename: "AdminCreateVirtualProductWithTierPriceTest.xml"
-  repo: "https://github.com/magento/magento2/blob/2.3/app/code/Magento/Catalog/Test/Mftf/Test/AdminCreateVirtualProductWithTierPriceTest.xml"
-  module: "Catalog"
-  tests:
-    - testname: "AdminCreateVirtualProductWithTierPriceTest"
-      title: "Create virtual product with tier price"
-      description: "Test log in to Create virtual product and Create virtual product with tier price"
- 
-- filename: "AdminCreateCategoryWithFiveNestingTest.xml"
-  repo: "https://github.com/magento/magento2/blob/2.3/app/code/Magento/Catalog/Test/Mftf/Test/AdminCreateCategoryWithFiveNestingTest.xml"
-  module: "Catalog"
-  tests:
-    - testname: "AdminCreateCategoryWithFiveNestingTest"
-      title: "Create category with five nesting"
-      description: "Login as admin and create nested sub category and verify the subcategory displayed in store front page  "
- 
-- filename: "CheckTierPricingOfProductsTest.xml"
-  repo: "https://github.com/magento/magento2/blob/2.3/app/code/Magento/Catalog/Test/Mftf/Test/CheckTierPricingOfProductsTest.xml"
-  module: "Catalog"
-  tests:
-    - testname: "CheckTierPricingOfProductsTest"
-      title: "Checking 'Tier Pricing' of Products and 'Price' (without discount) in the Order of B2B Store View"
-      description: "Checking 'Tier Pricing' of Products and 'Price' (without discount) in the Order of B2B Store View"
- 
-- filename: "AdminCreateDuplicateCategoryTest.xml"
-  repo: "https://github.com/magento/magento2/blob/2.3/app/code/Magento/Catalog/Test/Mftf/Test/AdminCreateDuplicateCategoryTest.xml"
-  module: "Catalog"
-  tests:
-    - testname: "AdminCreateDuplicateCategoryTest"
-      title: "Create Duplicate Category With Already Existed UrlKey"
-      description: "Login as admin and create duplicate category"
- 
-- filename: "AdminSimpleSetEditRelatedProductsTest.xml"
-  repo: "https://github.com/magento/magento2/blob/2.3/app/code/Magento/Catalog/Test/Mftf/Test/AdminSimpleSetEditRelatedProductsTest.xml"
-  module: "Catalog"
-  tests:
-    - testname: "AdminSimpleSetEditRelatedProductsTest"
-      title: "Admin should be able to set/edit Related Products information when editing a simple product"
-      description: "Admin should be able to set/edit Related Products information when editing a simple product"
- 
-- filename: "AdminStoresProductNavigateMenuTest.xml"
-  repo: "https://github.com/magento/magento2/blob/2.3/app/code/Magento/Catalog/Test/Mftf/Test/AdminStoresProductNavigateMenuTest.xml"
-  module: "Catalog"
-  tests:
-    - testname: "AdminStoresProductNavigateMenuTest"
-      title: "Admin stores product navigate menu test"
-      description: "Admin should be able to navigate to Stores &gt; Product"
- 
-- filename: "AdminDeleteRootSubCategoryTest.xml"
-  repo: "https://github.com/magento/magento2/blob/2.3/app/code/Magento/Catalog/Test/Mftf/Test/AdminDeleteRootSubCategoryTest.xml"
-  module: "Catalog"
-  tests:
-    - testname: "AdminDeleteRootSubCategoryTest"
-      title: "Can delete a subcategory"
-      description: "Login as admin and delete a root sub category"
- 
-- filename: "AdminDeleteDropdownProductAttributeFromAttributeSetTest.xml"
-  repo: "https://github.com/magento/magento2/blob/2.3/app/code/Magento/Catalog/Test/Mftf/Test/AdminDeleteDropdownProductAttributeFromAttributeSetTest.xml"
-  module: "Catalog"
-  tests:
-    - testname: "AdminDeleteDropdownProductAttributeFromAttributeSetTest"
-      title: "Delete Product Attribute, Dropdown Type, from Attribute Set"
-      description: "Login as admin and delete dropdown type product attribute from attribute set"
- 
-- filename: "AdminCheckInactiveCategoryAndSubcategoryIsNotVisibleInNavigationMenuTest.xml"
-  repo: "https://github.com/magento/magento2/blob/2.3/app/code/Magento/Catalog/Test/Mftf/Test/AdminCheckInactiveCategoryAndSubcategoryIsNotVisibleInNavigationMenuTest.xml"
-  module: "Catalog"
-  tests:
-    - testname: "AdminCheckInactiveCategoryAndSubcategoryIsNotVisibleInNavigationMenuTest"
-      title: "Inactive Category and subcategory are not visible on navigation menu, Include in Menu = Yes"
-      description: "Login as admin and verify inactive category and subcategory is not visible in navigation menu"
- 
-- filename: "AdminCheckResultsOfColorAndOtherFiltersTest.xml"
-  repo: "https://github.com/magento/magento2/blob/2.3/app/code/Magento/LayeredNavigation/Test/Mftf/Test/AdminCheckResultsOfColorAndOtherFiltersTest.xml"
-  module: "LayeredNavigation"
-  tests:
-    - testname: "AdminCheckResultsOfColorAndOtherFiltersTest"
-      title: ""
-      description: ""
- 
-- filename: "AdminSpecifyLayerNavigationConfigurationTest.xml"
-  repo: "https://github.com/magento/magento2/blob/2.3/app/code/Magento/LayeredNavigation/Test/Mftf/Test/AdminSpecifyLayerNavigationConfigurationTest.xml"
-  module: "LayeredNavigation"
-  tests:
-    - testname: "AdminSpecifyLayerNavigationConfigurationTest"
-      title: "Admin should be able to uncheck Default Value checkbox for dependent field"
-      description: "Admin should be able to uncheck Default Value checkbox for dependent field"
- 
-- filename: "AdminMarketingSiteMapNavigateMenuTest.xml"
-  repo: "https://github.com/magento/magento2/blob/2.3/app/code/Magento/Sitemap/Test/Mftf/Test/AdminMarketingSiteMapNavigateMenuTest.xml"
-  module: "Sitemap"
-  tests:
-    - testname: "AdminMarketingSiteMapNavigateMenuTest"
-      title: "Admin marketing site map navigate menu test"
-      description: "Admin should be able to navigate to Marketing &gt; Site Map"
- 
-- filename: "AdminMarketingSiteMapCreateNewTest.xml"
-  repo: "https://github.com/magento/magento2/blob/2.3/app/code/Magento/Sitemap/Test/Mftf/Test/AdminMarketingSiteMapCreateNewTest.xml"
-  module: "Sitemap"
-  tests:
-    - testname: "AdminMarketingSiteMapCreateNewTest"
-      title: "Create New Site Map with valid data"
-      description: "Create New Site Map with valid data"
- 
-- filename: "AdminCreateTaxRateWiderZipCodeRangeTest.xml"
-  repo: "https://github.com/magento/magento2/blob/2.3/app/code/Magento/Tax/Test/Mftf/Test/AdminCreateTaxRateWiderZipCodeRangeTest.xml"
-  module: "Tax"
-  tests:
-    - testname: "AdminCreateTaxRateWiderZipCodeRangeTest"
-      title: "Create tax rate, wider zip code range"
-      description: "Test log in to Create Tax Rate and Create Wider Zip Code Range"
- 
-- filename: "AdminCreateTaxRateSpecificPostcodeTest.xml"
-  repo: "https://github.com/magento/magento2/blob/2.3/app/code/Magento/Tax/Test/Mftf/Test/AdminCreateTaxRateSpecificPostcodeTest.xml"
-  module: "Tax"
-  tests:
-    - testname: "AdminCreateTaxRateSpecificPostcodeTest"
-      title: "Create tax rate, specific postcode"
-      description: "Test log in to Create Tax Rate and Create specific Postcode"
- 
-- filename: "Update01TaxRateEntityTest.xml"
-  repo: "https://github.com/magento/magento2/blob/2.3/app/code/Magento/Tax/Test/Mftf/Test/Update01TaxRateEntityTest.xml"
-  module: "Tax"
-  tests:
-    - testname: "Update01TaxRateEntityTest"
-      title: "Update tax rate, 0.1 rate"
-      description: "Test log in to Tax Rate and Update 0.1 Rate"
- 
-- filename: "AdminCreateTaxRuleWithCustomerAndProductTaxClassTest.xml"
-  repo: "https://github.com/magento/magento2/blob/2.3/app/code/Magento/Tax/Test/Mftf/Test/AdminCreateTaxRuleWithCustomerAndProductTaxClassTest.xml"
-  module: "Tax"
-  tests:
-    - testname: "AdminCreateTaxRuleWithCustomerAndProductTaxClassTest"
-      title: "Create tax rule, with customer and product tax class"
-      description: "Test log in to Tax Rule and Create tax rule with customer and product tax class"
- 
-- filename: "AdminUpdateDefaultTaxRuleTest.xml"
-  repo: "https://github.com/magento/magento2/blob/2.3/app/code/Magento/Tax/Test/Mftf/Test/AdminUpdateDefaultTaxRuleTest.xml"
-  module: "Tax"
-  tests:
-    - testname: "AdminUpdateDefaultTaxRuleTest"
-      title: "Update tax rule, tax rule default"
-      description: "Test log in to Update tax rule and Update default tax rule"
- 
-- filename: "Update1299TaxRateEntityTest.xml"
-  repo: "https://github.com/magento/magento2/blob/2.3/app/code/Magento/Tax/Test/Mftf/Test/Update1299TaxRateEntityTest.xml"
-  module: "Tax"
-  tests:
-    - testname: "Update1299TaxRateEntityTest"
-      title: "Update tax rate, 12.99 rate"
-      description: "Test log in to Tax Rate and Update 12.99 Rate"
- 
-- filename: "StorefrontTaxInformationInShoppingCartForCustomerPhysicalQuoteTest.xml"
-  repo: "https://github.com/magento/magento2/blob/2.3/app/code/Magento/Tax/Test/Mftf/Test/StorefrontTaxInformationInShoppingCartForCustomerPhysicalQuoteTest.xml"
-  module: "Tax"
-  tests:
-    - testname: "StorefrontTaxInformationInShoppingCartForCustomerPhysicalQuoteTest"
-      title: "Tax information are updating/recalculating on fly in shopping cart for Customer with default addresses (physical quote)"
-      description: "Tax information are updating/recalculating on fly in shopping cart for Customer with default addresses (physical quote)"
- 
-- filename: "CheckCreditMemoTotalsTest.xml"
-  repo: "https://github.com/magento/magento2/blob/2.3/app/code/Magento/Tax/Test/Mftf/Test/CheckCreditMemoTotalsTest.xml"
-  module: "Tax"
-  tests:
-    - testname: "CheckCreditMemoTotalsTest"
-      title: "Checking Credit memo Totals"
-      description: "Checking Credit memo Totals"
- 
-- filename: "AdminCreateTaxRateAllPostCodesTest.xml"
-  repo: "https://github.com/magento/magento2/blob/2.3/app/code/Magento/Tax/Test/Mftf/Test/AdminCreateTaxRateAllPostCodesTest.xml"
-  module: "Tax"
-  tests:
-    - testname: "AdminCreateTaxRateAllPostCodesTest"
-      title: "Create tax rate, all postcodes"
-      description: "Tests log into Create tax rate and create all postcodes"
- 
-- filename: "AdminCreateTaxRateLargeRateTest.xml"
-  repo: "https://github.com/magento/magento2/blob/2.3/app/code/Magento/Tax/Test/Mftf/Test/AdminCreateTaxRateLargeRateTest.xml"
-  module: "Tax"
-  tests:
-    - testname: "AdminCreateTaxRateLargeRateTest"
-      title: "Create tax rate, large rate"
-      description: "Test log in to Create Tax Rate and Create Large Rate"
- 
-- filename: "DeleteTaxRateEntityTest.xml"
-  repo: "https://github.com/magento/magento2/blob/2.3/app/code/Magento/Tax/Test/Mftf/Test/DeleteTaxRateEntityTest.xml"
-  module: "Tax"
-  tests:
-    - testname: "DeleteTaxRateEntityTest"
-      title: "Delete tax rate"
-      description: "Test log in to Tax Rate and Delete Tax Rate"
- 
-- filename: "UpdateLargeTaxRateEntityTest.xml"
-  repo: "https://github.com/magento/magento2/blob/2.3/app/code/Magento/Tax/Test/Mftf/Test/UpdateLargeTaxRateEntityTest.xml"
-  module: "Tax"
-  tests:
-    - testname: "UpdateLargeTaxRateEntityTest"
-      title: "Update tax rate, large rate"
-      description: "Test log in to Tax Rate and Update Large Rate"
- 
-- filename: "StorefrontTaxInformationInShoppingCartForGuestPhysicalQuoteTest.xml"
-  repo: "https://github.com/magento/magento2/blob/2.3/app/code/Magento/Tax/Test/Mftf/Test/StorefrontTaxInformationInShoppingCartForGuestPhysicalQuoteTest.xml"
-  module: "Tax"
-  tests:
-    - testname: "StorefrontTaxInformationInShoppingCartForGuestPhysicalQuoteTest"
-      title: "Tax information are updating/recalculating on fly in shopping cart for Guest (physical quote)"
-      description: "Tax information are updating/recalculating on fly in shopping cart for Guest (physical quote)"
- 
-- filename: "AdminUpdateTaxRuleWithFixedZipUtahTest.xml"
-  repo: "https://github.com/magento/magento2/blob/2.3/app/code/Magento/Tax/Test/Mftf/Test/AdminUpdateTaxRuleWithFixedZipUtahTest.xml"
-  module: "Tax"
-  tests:
-    - testname: "AdminUpdateTaxRuleWithFixedZipUtahTest"
-      title: "Update tax rule, fixed zip Utah"
-      description: "Test log in to Update tax rule and Update tax rule with fixed zip Utah"
- 
-- filename: "AdminTaxReportGridTest.xml"
-  repo: "https://github.com/magento/magento2/blob/2.3/app/code/Magento/Tax/Test/Mftf/Test/AdminTaxReportGridTest.xml"
-  module: "Tax"
-  tests:
-    - testname: "AdminTaxReportGridTest"
-      title: "Checking Tax Report grid"
-      description: "Tax Report Grid displays Tax amount in rows 'Total' and 'Subtotal' is a sum of all tax amounts"
- 
-- filename: "StorefrontTaxQuoteCheckoutTest.xml"
-  repo: "https://github.com/magento/magento2/blob/2.3/app/code/Magento/Tax/Test/Mftf/Test/StorefrontTaxQuoteCheckoutTest.xml"
-  module: "Tax"
-  tests:
-    - testname: "StorefrontTaxQuoteCheckoutGuestVirtual"
-      title: "Tax for Virtual Product Quote should be recalculated according to inputted data on Checkout flow for Guest Customer"
-      description: "Tax for Virtual Product Quote should be recalculated according to inputted data on Checkout flow for Guest Customer"
-
-    - testname: "StorefrontTaxQuoteCheckoutLoggedInSimple"
-      title: "Tax for Simple Product Quote should be recalculated according to inputted data on Checkout flow for Logged in Customer"
-      description: "Tax for Simple Product Quote should be recalculated according to inputted data on Checkout flow for Logged in Customer"
-
-    - testname: "StorefrontTaxQuoteCheckoutGuestSimple"
-      title: "Tax for Simple Product Quote should be recalculated according to inputted data on Checkout flow for Guest Customer"
-      description: "Tax for Simple Product Quote should be recalculated according to inputted data on Checkout flow for Guest Customer"
-
-    - testname: "StorefrontTaxQuoteCheckoutLoggedInVirtual"
-      title: "Tax for Virtual Product Quote should be recalculated according to inputted data on Checkout flow for Logged in Customer"
-      description: "Tax for Virtual Product Quote should be recalculated according to inputted data on Checkout flow for Logged in Customer"
- 
-- filename: "AdminSystemImportExportTaxRatesNavigateMenuTest.xml"
-  repo: "https://github.com/magento/magento2/blob/2.3/app/code/Magento/Tax/Test/Mftf/Test/AdminSystemImportExportTaxRatesNavigateMenuTest.xml"
-  module: "Tax"
-  tests:
-    - testname: "AdminSystemImportExportTaxRatesNavigateMenuTest"
-      title: "Admin system import export tax rates navigate menu test"
-      description: "Admin should be able to navigate to System &gt; Import/Export Tax Rates"
- 
-- filename: "AdminCreateTaxRuleWithNewTaxClassesAndTaxRateTest.xml"
-  repo: "https://github.com/magento/magento2/blob/2.3/app/code/Magento/Tax/Test/Mftf/Test/AdminCreateTaxRuleWithNewTaxClassesAndTaxRateTest.xml"
-  module: "Tax"
-  tests:
-    - testname: "AdminCreateTaxRuleWithNewTaxClassesAndTaxRateTest"
-      title: "Creating tax rule with new tax classes and tax rate"
-      description: "Test log in to Create Tax Rule and Create tax rule with New Tax Classes and Tax Rate"
- 
-- filename: "AdminCreateTaxRuleWithZipRangeTest.xml"
-  repo: "https://github.com/magento/magento2/blob/2.3/app/code/Magento/Tax/Test/Mftf/Test/AdminCreateTaxRuleWithZipRangeTest.xml"
-  module: "Tax"
-  tests:
-    - testname: "AdminCreateTaxRuleWithZipRangeTest"
-      title: "Create tax rule, with zip range"
-      description: "Test log in to Create Tax Rule and Create tax rule with Zip Range"
- 
-- filename: "AdminDeleteTaxRuleTest.xml"
-  repo: "https://github.com/magento/magento2/blob/2.3/app/code/Magento/Tax/Test/Mftf/Test/AdminDeleteTaxRuleTest.xml"
-  module: "Tax"
-  tests:
-    - testname: "AdminDeleteTaxRuleTest"
-      title: "Delete tax rule"
-      description: "Test log in to tax rule and Delete tax rule"
- 
-- filename: "UpdateDecimalTaxRateEntityTest.xml"
-  repo: "https://github.com/magento/magento2/blob/2.3/app/code/Magento/Tax/Test/Mftf/Test/UpdateDecimalTaxRateEntityTest.xml"
-  module: "Tax"
-  tests:
-    - testname: "UpdateDecimalTaxRateEntityTest"
-      title: "Update tax rate, decimal rate"
-      description: "Test log in to Tax Rate and Update Decimal Tax Rate"
- 
-- filename: "StorefrontTaxInformationInShoppingCartForCustomerVirtualQuoteTest.xml"
-  repo: "https://github.com/magento/magento2/blob/2.3/app/code/Magento/Tax/Test/Mftf/Test/StorefrontTaxInformationInShoppingCartForCustomerVirtualQuoteTest.xml"
-  module: "Tax"
-  tests:
-    - testname: "StorefrontTaxInformationInShoppingCartForCustomerVirtualQuoteTest"
-      title: "Tax information are updating/recalculating on fly in shopping cart for Customer with default addresses (virtual quote)"
-      description: "Tax information are updating/recalculating on fly in shopping cart for Customer with default addresses (virtual quote)"
- 
-- filename: "AdminTaxCalcWithApplyTaxOnSettingTest.xml"
-  repo: "https://github.com/magento/magento2/blob/2.3/app/code/Magento/Tax/Test/Mftf/Test/AdminTaxCalcWithApplyTaxOnSettingTest.xml"
-  module: "Tax"
-  tests:
-    - testname: "AdminTaxCalcWithApplyTaxOnSettingTest"
-      title: "Tax calculation process following 'Apply Tax On' setting"
-      description: "Tax calculation process following 'Apply Tax On' setting"
- 
-- filename: "UpdateAnyRegionTaxRateEntityTest.xml"
-  repo: "https://github.com/magento/magento2/blob/2.3/app/code/Magento/Tax/Test/Mftf/Test/UpdateAnyRegionTaxRateEntityTest.xml"
-  module: "Tax"
-  tests:
-    - testname: "UpdateAnyRegionTaxRateEntityTest"
-      title: "Update tax rate, any region"
-      description: "Test log in to Tax Rate and Update Any Region"
- 
-- filename: "StorefrontTaxQuoteCartTest.xml"
-  repo: "https://github.com/magento/magento2/blob/2.3/app/code/Magento/Tax/Test/Mftf/Test/StorefrontTaxQuoteCartTest.xml"
-  module: "Tax"
-  tests:
-    - testname: "StorefrontTaxQuoteCartLoggedInSimple"
-      title: "Tax for Simple Product Quote should be recalculated in Shopping Cart for Logged in Customer with Default Address"
-      description: "Tax for Simple Product Quote should be recalculated in Shopping Cart for Logged in Customer with Default Address"
-
-    - testname: "StorefrontTaxQuoteCartLoggedInVirtual"
-      title: "Tax for Virtual Product Quote should be recalculated in Shopping Cart for Logged in Customer with Default Address"
-      description: "Tax for Virtual Product Quote should be recalculated in Shopping Cart for Logged in Customer with Default Address"
-
-    - testname: "StorefrontTaxQuoteCartGuestSimple"
-      title: "Tax for Simple Product Quote should be recalculated in Shopping Cart for Guest Customer"
-      description: "Tax for Simple Product Quote should be recalculated in Shopping Cart for Guest Customer#anch"
-
-    - testname: "StorefrontTaxQuoteCartGuestVirtual"
-      title: "Tax for Virtual Product Quote should be recalculated in Shopping Cart for Guest Customer"
-      description: "Tax for Virtual Product Quote should be recalculated in Shopping Cart for Guest Customer"
- 
-- filename: "AdminUpdateTaxRuleWithCustomClassesTest.xml"
-  repo: "https://github.com/magento/magento2/blob/2.3/app/code/Magento/Tax/Test/Mftf/Test/AdminUpdateTaxRuleWithCustomClassesTest.xml"
-  module: "Tax"
-  tests:
-    - testname: "AdminUpdateTaxRuleWithCustomClassesTest"
-      title: "Update tax rule, tax rule with custom classes"
-      description: "Test log in to Update tax rule and Update tax rule with custom classes"
- 
-- filename: "AdminCreateTaxRateZipCodeRangeTest.xml"
-  repo: "https://github.com/magento/magento2/blob/2.3/app/code/Magento/Tax/Test/Mftf/Test/AdminCreateTaxRateZipCodeRangeTest.xml"
-  module: "Tax"
-  tests:
-    - testname: "AdminCreateTaxRateZipCodeRangeTest"
-      title: "Create tax rate, zip code range"
-      description: "Test log in to Create Tax Rate and Create Zip Code Range"
- 
-- filename: "AdminStoresTaxZonesAndRatesNavigateMenuTest.xml"
-  repo: "https://github.com/magento/magento2/blob/2.3/app/code/Magento/Tax/Test/Mftf/Test/AdminStoresTaxZonesAndRatesNavigateMenuTest.xml"
-  module: "Tax"
-  tests:
-    - testname: "AdminStoresTaxZonesAndRatesNavigateMenuTest"
-      title: "Admin stores tax  zones and rates navigate menu test"
-      description: "Admin should be able to navigate to Stores &gt; Tax Zones and Rates"
- 
-- filename: "AdminCreateDefaultsTaxRuleTest.xml"
-  repo: "https://github.com/magento/magento2/blob/2.3/app/code/Magento/Tax/Test/Mftf/Test/AdminCreateDefaultsTaxRuleTest.xml"
-  module: "Tax"
-  tests:
-    - testname: "AdminCreateDefaultsTaxRuleTest"
-      title: "Create tax rule, defaults"
-      description: "Test log in to Create Tax Rule and Create Defaults Tax Rule"
- 
-- filename: "Update100TaxRateEntityTest.xml"
-  repo: "https://github.com/magento/magento2/blob/2.3/app/code/Magento/Tax/Test/Mftf/Test/Update100TaxRateEntityTest.xml"
-  module: "Tax"
-  tests:
-    - testname: "Update100TaxRateEntityTest"
-      title: "Update tax rate, 100 rate"
-      description: "Test log in to Tax Rate and Update 100 Rate"
- 
-- filename: "AdminCreateTaxRuleWithNewAndExistingTaxRateAndCustomerAndProductTaxClassTest.xml"
-  repo: "https://github.com/magento/magento2/blob/2.3/app/code/Magento/Tax/Test/Mftf/Test/AdminCreateTaxRuleWithNewAndExistingTaxRateAndCustomerAndProductTaxClassTest.xml"
-  module: "Tax"
-  tests:
-    - testname: "AdminCreateTaxRuleWithNewAndExistingTaxRateAndCustomerAndProductTaxClassTest"
-      title: "Test log in to Create Tax Rule and Create Tax Rule with New and Existing Tax Rate, Customer Tax Class, Product Tax Class"
-      description: "Test log in to Create tax rule and Create tax rule with New and Existing Tax Rate, Customer Tax Class, Product Tax Class"
- 
-- filename: "StorefrontTaxInformationInShoppingCartForGuestVirtualQuoteTest.xml"
-  repo: "https://github.com/magento/magento2/blob/2.3/app/code/Magento/Tax/Test/Mftf/Test/StorefrontTaxInformationInShoppingCartForGuestVirtualQuoteTest.xml"
-  module: "Tax"
-  tests:
-    - testname: "StorefrontTaxInformationInShoppingCartForGuestVirtualQuoteTest"
-      title: "Tax information are updating/recalculating on fly in shopping cart for Guest (virtual quote)"
-      description: "Tax information are updating/recalculating on fly in shopping cart for Guest (virtual quote)"
- 
-- filename: "AdminStoresTaxRulesNavigateMenuTest.xml"
-  repo: "https://github.com/magento/magento2/blob/2.3/app/code/Magento/Tax/Test/Mftf/Test/AdminStoresTaxRulesNavigateMenuTest.xml"
-  module: "Tax"
-  tests:
-    - testname: "AdminStoresTaxRulesNavigateMenuTest"
-      title: "Admin stores tax rules navigate menu test"
-      description: "Admin should be able to navigate to Stores &gt; Tax Rules"
- 
-- filename: "StorefrontSortBundleProductsByPriceTest.xml"
-  repo: "https://github.com/magento/magento2/blob/2.3/app/code/Magento/Bundle/Test/Mftf/Test/StorefrontSortBundleProductsByPriceTest.xml"
-  module: "Bundle"
-  tests:
-    - testname: "StorefrontSortBundleProductsByPriceTest"
-      title: "Customer should be able to sort bundle products by price when viewing products list"
-      description: "Customer should be able to sort bundle products by price when viewing products list"
- 
-- filename: "StorefrontSpecialPriceBundleProductInCartTest.xml"
-  repo: "https://github.com/magento/magento2/blob/2.3/app/code/Magento/Bundle/Test/Mftf/Test/StorefrontSpecialPriceBundleProductInCartTest.xml"
-  module: "Bundle"
-  tests:
-    - testname: "StorefrontSpecialPriceBundleProductInCartTest"
-      title: "Customer should not be able to add a Bundle Product to the cart when added a special price for associated products"
-      description: "Customer should not be able to add a Bundle Product to the cart when added a special price for associated products"
- 
-- filename: "StorefrontBundleProductDetailsTest.xml"
-  repo: "https://github.com/magento/magento2/blob/2.3/app/code/Magento/Bundle/Test/Mftf/Test/StorefrontBundleProductDetailsTest.xml"
-  module: "Bundle"
-  tests:
-    - testname: "StorefrontBundleProductDetailsTest"
-      title: "Customer should be able to see basic bundle product details"
-      description: "Customer should be able to see basic bundle product details"
- 
-- filename: "AdminRemoveDefaultImageBundleProductTest.xml"
-  repo: "https://github.com/magento/magento2/blob/2.3/app/code/Magento/Bundle/Test/Mftf/Test/AdminRemoveDefaultImageBundleProductTest.xml"
-  module: "Bundle"
-  tests:
-    - testname: "AdminRemoveDefaultImageBundleProductTest"
-      title: "Admin should be able to remove default images from a Bundle Product"
-      description: "Admin should be able to remove default images from a Bundle Product"
- 
-- filename: "AdminCreateAndEditBundleProductSettingsTest.xml"
-  repo: "https://github.com/magento/magento2/blob/2.3/app/code/Magento/Bundle/Test/Mftf/Test/AdminCreateAndEditBundleProductSettingsTest.xml"
-  module: "Bundle"
-  tests:
-    - testname: "AdminCreateAndEditBundleProductSettingsTest"
-      title: "Admin should be able to set/edit other product information when creating/editing a bundle product"
-      description: "Admin should be able to set/edit other product information when creating/editing a bundle product"
-
-    - testname: "AdminCreateAndEditBundleProductOptionsNegativeTest"
-      title: "Admin should be able to remove any bundle option a bundle product"
-      description: "Admin should be able to set/edit other product information when creating/editing a bundle product"
- 
-- filename: "AdminEditRelatedBundleProductTest.xml"
-  repo: "https://github.com/magento/magento2/blob/2.3/app/code/Magento/Bundle/Test/Mftf/Test/AdminEditRelatedBundleProductTest.xml"
-  module: "Bundle"
-  tests:
-    - testname: "AdminEditRelatedBundleProductTest"
-      title: "Admin should be able to set/edit Related Products information when editing a bundle product"
-      description: "Admin should be able to set/edit Related Products information when editing a bundle product"
- 
-- filename: "BundleProductWithTierPriceInCartTest.xml"
-  repo: "https://github.com/magento/magento2/blob/2.3/app/code/Magento/Bundle/Test/Mftf/Test/BundleProductWithTierPriceInCartTest.xml"
-  module: "Bundle"
-  tests:
-    - testname: "BundleProductWithTierPriceInCartTest"
-      title: "Customer should get the right subtotal in cart when the bundle product added to the cart twice"
-      description: "Customer should be able to add one more bundle product to the cart and get the right price"
- 
-- filename: "StorefrontGoToDetailsPageWhenAddingToCartTest.xml"
-  repo: "https://github.com/magento/magento2/blob/2.3/app/code/Magento/Bundle/Test/Mftf/Test/StorefrontGoToDetailsPageWhenAddingToCartTest.xml"
-  module: "Bundle"
-  tests:
-    - testname: "StorefrontGoToDetailsPageWhenAddingToCart"
-      title: "Customer should be taken to bundle product details page when clicking “Add to Cart” button"
-      description: "Customer should be taken to bundle product details page when clicking “Add to Cart” button"
- 
-- filename: "AdminDeleteBundleFixedProductTest.xml"
-  repo: "https://github.com/magento/magento2/blob/2.3/app/code/Magento/Bundle/Test/Mftf/Test/AdminDeleteBundleFixedProductTest.xml"
-  module: "Bundle"
-  tests:
-    - testname: "AdminDeleteBundleFixedProductTest"
-      title: "Delete Bundle Fixed Product"
-      description: "Admin should be able to delete a bundle fixed product"
- 
-- filename: "NewBundleProductSelectionTest.xml"
-  repo: "https://github.com/magento/magento2/blob/2.3/app/code/Magento/Bundle/Test/Mftf/Test/NewBundleProductSelectionTest.xml"
-  module: "Bundle"
-  tests:
-    - testname: "NewBundleProductSelectionTest"
-      title: "Admin should be able to select a “Bundle Product” product type when adding a new product"
-      description: "Admin should be able to select a “Bundle Product” product type when adding a new product"
- 
-- filename: "AdminAssociateBundleProductToWebsitesTest.xml"
-  repo: "https://github.com/magento/magento2/blob/2.3/app/code/Magento/Bundle/Test/Mftf/Test/AdminAssociateBundleProductToWebsitesTest.xml"
-  module: "Bundle"
-  tests:
-    - testname: "AdminAssociateBundleProductToWebsitesTest"
-      title: "Admin should be able to associate bundle product to websites"
-      description: "Admin should be able to associate bundle product to websites"
- 
-- filename: "AdminAddDefaultImageBundleProductTest.xml"
-  repo: "https://github.com/magento/magento2/blob/2.3/app/code/Magento/Bundle/Test/Mftf/Test/AdminAddDefaultImageBundleProductTest.xml"
-  module: "Bundle"
-  tests:
-    - testname: "AdminAddDefaultImageBundleProductTest"
-      title: "Admin should be able to add default images for a Bundle Product"
-      description: "Admin should be able to add default images for a Bundle Product"
- 
-- filename: "StorefrontCustomerSelectAndSetBundleOptionsTest.xml"
-  repo: "https://github.com/magento/magento2/blob/2.3/app/code/Magento/Bundle/Test/Mftf/Test/StorefrontCustomerSelectAndSetBundleOptionsTest.xml"
-  module: "Bundle"
-  tests:
-    - testname: "StorefrontCustomerSelectAndSetBundleOptionsTest"
-      title: "Customer should be able to select customisable bundle product options and set quantity for them"
-      description: "Customer should be able to select customisable bundle product options and set quantity for them"
- 
-- filename: "AdminBasicBundleProductAttributesTest.xml"
-  repo: "https://github.com/magento/magento2/blob/2.3/app/code/Magento/Bundle/Test/Mftf/Test/AdminBasicBundleProductAttributesTest.xml"
-  module: "Bundle"
-  tests:
-    - testname: "AdminBasicBundleProductAttributesTest"
-      title: "Admin should be able to set/edit all the basic product attributes when creating/editing a bundle product"
-      description: "Admin should be able to set/edit all the basic product attributes when creating/editing a bundle product"
- 
-- filename: "StorefrontAdvanceCatalogSearchBundleBySkuWithHyphenTest.xml"
-  repo: "https://github.com/magento/magento2/blob/2.3/app/code/Magento/Bundle/Test/Mftf/Test/StorefrontAdvanceCatalogSearchBundleBySkuWithHyphenTest.xml"
-  module: "Bundle"
-  tests:
-    - testname: "StorefrontAdvanceCatalogSearchBundleBySkuWithHyphenTest"
-      title: "Guest customer should be able to advance search Bundle product with product sku that contains hyphen"
-      description: "Guest customer should be able to advance search Bundle product with product sku that contains hyphen"
- 
-- filename: "StorefrontVerifyDynamicBundleProductPricesForCombinationOfOptionsTest.xml"
-  repo: "https://github.com/magento/magento2/blob/2.3/app/code/Magento/Bundle/Test/Mftf/Test/StorefrontVerifyDynamicBundleProductPricesForCombinationOfOptionsTest.xml"
-  module: "Bundle"
-  tests:
-    - testname: "StorefrontVerifyDynamicBundleProductPricesForCombinationOfOptionsTest"
-      title: "Verify dynamic bundle product prices for combination of options"
-      description: "Verify prices for various configurations of Dynamic Bundle product"
- 
-- filename: "AdminAddBundleProductToCartFromWishListPageTest.xml"
-  repo: "https://github.com/magento/magento2/blob/2.3/app/code/Magento/Bundle/Test/Mftf/Test/AdminAddBundleProductToCartFromWishListPageTest.xml"
-  module: "Bundle"
-  tests:
-    - testname: "AdminAddBundleProductToCartFromWishListPageTest"
-      title: "Add bundle product to Cart from Wish list page"
-      description: "Add bundle product to Cart from Wish list page"
- 
-- filename: "EndToEndB2CAdminTest.xml"
-  repo: "https://github.com/magento/magento2/blob/2.3/app/code/Magento/Bundle/Test/Mftf/Test/EndToEndB2CAdminTest.xml"
-  module: "Bundle"
-  tests:
-    - testname: "EndToEndB2CAdminTest"
-      title: ""
-      description: ""
- 
-- filename: "AdminBundleProductSetEditContentTest.xml"
-  repo: "https://github.com/magento/magento2/blob/2.3/app/code/Magento/Bundle/Test/Mftf/Test/AdminBundleProductSetEditContentTest.xml"
-  module: "Bundle"
-  tests:
-    - testname: "AdminBundleProductSetEditContentTest"
-      title: "Admin should be able to set/edit product Content when editing a bundle product"
-      description: "Admin should be able to set/edit product Content when editing a bundle product"
- 
-- filename: "StorefrontBundleCartTest.xml"
-  repo: "https://github.com/magento/magento2/blob/2.3/app/code/Magento/Bundle/Test/Mftf/Test/StorefrontBundleCartTest.xml"
-  module: "Bundle"
-  tests:
-    - testname: "StorefrontBundleCartTest"
-      title: "Customer should not be able to add a Bundle Product to the cart without selecting options"
-      description: "Customer should not be able to add a Bundle Product to the cart without selecting options"
-
-    - testname: "StorefrontBundleAddToCartSuccessTest"
-      title: "Customer should be able to add the bundle product to the cart"
-      description: "Customer should be able to add the bundle product to the cart"
- 
-- filename: "AdminAddDefaultVideoBundleProductTest.xml"
-  repo: "https://github.com/magento/magento2/blob/2.3/app/code/Magento/Bundle/Test/Mftf/Test/AdminAddDefaultVideoBundleProductTest.xml"
-  module: "Bundle"
-  tests:
-    - testname: "AdminAddDefaultVideoBundleProductTest"
-      title: "Admin should be able to add default video for a Bundle Product"
-      description: "Admin should be able to add default video for a Bundle Product"
- 
-- filename: "AdvanceCatalogSearchBundleProductTest.xml"
-  repo: "https://github.com/magento/magento2/blob/2.3/app/code/Magento/Bundle/Test/Mftf/Test/AdvanceCatalogSearchBundleProductTest.xml"
-  module: "Bundle"
-  tests:
-    - testname: "AdvanceCatalogSearchBundleByNameTest"
-      title: "Guest customer should be able to advance search Bundle product with product name"
-      description: "Guest customer should be able to advance search Bundle product with product name"
-
-    - testname: "AdvanceCatalogSearchBundleByNameMysqlTest"
-      title: "Guest customer should be able to advance search Bundle product with product name using the MySQL search engine"
-      description: "Guest customer should be able to advance search Bundle product with product name using the MySQL search engine"
-
-    - testname: "AdvanceCatalogSearchBundleBySkuTest"
-      title: "Guest customer should be able to advance search Bundle product with product sku"
-      description: "Guest customer should be able to advance search Bundle product with product sku"
-
-    - testname: "AdvanceCatalogSearchBundleByDescriptionTest"
-      title: "Guest customer should be able to advance search Bundle product with product description"
-      description: "Guest customer should be able to advance search Bundle product with product description"
-
-    - testname: "AdvanceCatalogSearchBundleByDescriptionMysqlTest"
-      title: "Guest customer should be able to advance search Bundle product with product description using the MySQL search engine"
-      description: "Guest customer should be able to advance search Bundle product with product description using the MySQL search engine"
-
-    - testname: "AdvanceCatalogSearchBundleByShortDescriptionTest"
-      title: "Guest customer should be able to advance search Bundle product with product short description"
-      description: "Guest customer should be able to advance search Bundle product with product short description"
-
-    - testname: "AdvanceCatalogSearchBundleByShortDescriptionMysqlTest"
-      title: "Guest customer should be able to advance search Bundle product with product short description using the MySQL search engine"
-      description: "Guest customer should be able to advance search Bundle product with product short description using the MySQL search engine"
-
-    - testname: "AdvanceCatalogSearchBundleByPriceTest"
-      title: "Guest customer should be able to advance search Bundle product with product price"
-      description: "Guest customer should be able to advance search Bundle product with product price"
-
-    - testname: "AdvanceCatalogSearchBundleByPriceMysqlTest"
-      title: "Guest customer should be able to advance search Bundle product with product price using the MySQL search engine"
-      description: "Guest customer should be able to advance search Bundle product with product price the MySQL search engine"
- 
-- filename: "EnableDisableBundleProductStatusTest.xml"
-  repo: "https://github.com/magento/magento2/blob/2.3/app/code/Magento/Bundle/Test/Mftf/Test/EnableDisableBundleProductStatusTest.xml"
-  module: "Bundle"
-  tests:
-    - testname: "EnableDisableBundleProductStatusTest"
-      title: "Admin should be able to change a bundle product status to Enabled/Disabled"
-      description: "Admin should be able to change a bundle product status to Enabled/Disabled"
- 
-- filename: "AdminShouldBeAbleToMassUpdateAttributesForBundleProductsTest.xml"
-  repo: "https://github.com/magento/magento2/blob/2.3/app/code/Magento/Bundle/Test/Mftf/Test/AdminShouldBeAbleToMassUpdateAttributesForBundleProductsTest.xml"
-  module: "Bundle"
-  tests:
-    - testname: "AdminShouldBeAbleToMassUpdateAttributesForBundleProductsTest"
-      title: "Admin should be able to mass update attributes for bundle products"
-      description: "Admin should be able to mass update attributes for bundle products"
- 
-- filename: "BundleProductFixedPricingTest.xml"
-  repo: "https://github.com/magento/magento2/blob/2.3/app/code/Magento/Bundle/Test/Mftf/Test/BundleProductFixedPricingTest.xml"
-  module: "Bundle"
-  tests:
-    - testname: "BundleProductFixedPricingTest"
-      title: "Admin should be able to apply fixed pricing for Bundled Product"
-      description: "Admin should be able to apply fixed pricing for Bundled Product"
- 
-- filename: "AdminAttributeSetSelectionTest.xml"
-  repo: "https://github.com/magento/magento2/blob/2.3/app/code/Magento/Bundle/Test/Mftf/Test/AdminAttributeSetSelectionTest.xml"
-  module: "Bundle"
-  tests:
-    - testname: "AdminAttributeSetSelectionTest"
-      title: "Admin should be able to select/edit the “Attributes Set” when creating/editing a bundle product"
-      description: "Admin should be able to select/edit the “Attributes Set” when creating/editing a bundle product"
- 
-- filename: "StorefrontEditBundleProductTest.xml"
-  repo: "https://github.com/magento/magento2/blob/2.3/app/code/Magento/Bundle/Test/Mftf/Test/StorefrontEditBundleProductTest.xml"
-  module: "Bundle"
-  tests:
-    - testname: "StorefrontEditBundleProductTest"
-      title: "Customer should be able to change chosen options for Bundle Product when clicking Edit button in Shopping Cart page"
-      description: "Customer should be able to change chosen options for Bundle Product when clicking Edit button in Shopping Cart page"
- 
-- filename: "AdminAddBundleItemsTest.xml"
-  repo: "https://github.com/magento/magento2/blob/2.3/app/code/Magento/Bundle/Test/Mftf/Test/AdminAddBundleItemsTest.xml"
-  module: "Bundle"
-  tests:
-    - testname: "AdminAddBundleItemsTest"
-      title: "Admin should be able to add/edit bundle items when creating/editing a bundle product"
-      description: "Admin should be able to add/edit bundle items when creating/editing a bundle product"
- 
-- filename: "AdminProductBundleCreationTest.xml"
-  repo: "https://github.com/magento/magento2/blob/2.3/app/code/Magento/Bundle/Test/Mftf/Test/AdminProductBundleCreationTest.xml"
-  module: "Bundle"
-  tests:
-    - testname: "AdminProductBundleCreationTest"
-      title: "Admin should be able to save and publish a bundle product"
-      description: "Admin should be able to save and publish a bundle product"
- 
-- filename: "CurrencyChangingBundleProductInCartTest.xml"
-  repo: "https://github.com/magento/magento2/blob/2.3/app/code/Magento/Bundle/Test/Mftf/Test/CurrencyChangingBundleProductInCartTest.xml"
-  module: "Bundle"
-  tests:
-    - testname: "CurrencyChangingBundleProductInCartTest"
-      title: "User should be able change the currency and get right price in cart when the bundle product added to the cart"
-      description: "User should be able change the currency and add one more product in cart and get right price in previous currency"
- 
-- filename: "MassEnableDisableBundleProductsTest.xml"
-  repo: "https://github.com/magento/magento2/blob/2.3/app/code/Magento/Bundle/Test/Mftf/Test/MassEnableDisableBundleProductsTest.xml"
-  module: "Bundle"
-  tests:
-    - testname: "MassEnableDisableBundleProductsTest"
-      title: "Admin should be able to mass change bundle products status to Enabled/Disabled"
-      description: "Admin should be able to mass change bundle products status to Enabled/Disabled"
- 
-- filename: "NewProductsListWidgetBundleProductTest.xml"
-  repo: "https://github.com/magento/magento2/blob/2.3/app/code/Magento/Bundle/Test/Mftf/Test/NewProductsListWidgetBundleProductTest.xml"
-  module: "Bundle"
-  tests:
-    - testname: "NewProductsListWidgetBundleProductTest"
-      title: "Admin should be able to set Bundle Product as new so that it shows up in the Catalog New Products List Widget"
-      description: "Admin should be able to set Bundle Product as new so that it shows up in the Catalog New Products List Widget"
- 
-- filename: "AdminRemoveDefaultVideoBundleProductTest.xml"
-  repo: "https://github.com/magento/magento2/blob/2.3/app/code/Magento/Bundle/Test/Mftf/Test/AdminRemoveDefaultVideoBundleProductTest.xml"
-  module: "Bundle"
-  tests:
-    - testname: "AdminRemoveDefaultVideoBundleProductTest"
-      title: "Admin should be able to remove default video from a Bundle Product"
-      description: "Admin should be able to remove default video from a Bundle Product"
- 
-- filename: "StorefrontCustomerSearchBundleProductsByKeywordsTest.xml"
-  repo: "https://github.com/magento/magento2/blob/2.3/app/code/Magento/Bundle/Test/Mftf/Test/StorefrontCustomerSearchBundleProductsByKeywordsTest.xml"
-  module: "Bundle"
-  tests:
-    - testname: "StorefrontCustomerSearchBundleProductsByKeywordsTest"
-      title: "Customer should be able to see search results when searching for bundle products by keyword"
-      description: "Customer should be able to see search results when searching for bundle products by keyword"
- 
-- filename: "StorefrontAdminEditDataTest.xml"
-  repo: "https://github.com/magento/magento2/blob/2.3/app/code/Magento/Bundle/Test/Mftf/Test/StorefrontAdminEditDataTest.xml"
-  module: "Bundle"
-  tests:
-    - testname: "StorefrontAdminEditDataTest"
-      title: "Customer should be able to see chosen options for Bundle Product in Shopping Cart when Option Title is edited in Admin"
-      description: "Customer should be able to see chosen options for Bundle Product in Shopping Cart when Option Title is edited in Admin"
- 
-- filename: "AdminDeleteBundleDynamicProductTest.xml"
-  repo: "https://github.com/magento/magento2/blob/2.3/app/code/Magento/Bundle/Test/Mftf/Test/AdminDeleteBundleDynamicProductTest.xml"
-  module: "Bundle"
-  tests:
-    - testname: "AdminDeleteBundleDynamicProductTest"
-      title: "Delete Bundle Dynamic Product"
-      description: "Admin should be able to delete a bundle dynamic product"
- 
-- filename: "StorefrontAddBundleProductWithZeroPriceToShoppingCartTest.xml"
-  repo: "https://github.com/magento/magento2/blob/2.3/app/code/Magento/Bundle/Test/Mftf/Test/StorefrontAddBundleProductWithZeroPriceToShoppingCartTest.xml"
-  module: "Bundle"
-  tests:
-    - testname: "StorefrontAddBundleProductWithZeroPriceToShoppingCartTest"
-      title: "Add Bundle product with zero price to shopping cart"
-      description: "Add Bundle product with zero price to shopping cart"
- 
-- filename: "StorefrontAddBundleOptionsToCartTest.xml"
-  repo: "https://github.com/magento/magento2/blob/2.3/app/code/Magento/Bundle/Test/Mftf/Test/StorefrontAddBundleOptionsToCartTest.xml"
-  module: "Bundle"
-  tests:
-    - testname: "StorefrontAddBundleOptionsToCartTest"
-      title: "Checking adding of bundle options to the cart"
-      description: "Verifying adding of bundle options to the cart"
- 
-- filename: "AdminResetUserPasswordFailedTest.xml"
-  repo: "https://github.com/magento/magento2/blob/2.3/app/code/Magento/User/Test/Mftf/Test/AdminResetUserPasswordFailedTest.xml"
-  module: "User"
-  tests:
-    - testname: "AdminResetUserPasswordFailedTest"
-      title: "Admin user should not be able to trigger the password reset procedure twice"
-      description: "Admin user should not be able to trigger the password reset procedure twice"
- 
-- filename: "AdminUpdateUserTest.xml"
-  repo: "https://github.com/magento/magento2/blob/2.3/app/code/Magento/User/Test/Mftf/Test/AdminUpdateUserTest.xml"
-  module: "User"
-  tests:
-    - testname: "AdminUpdateUserTest"
-      title: "Update admin user entity by changing user role"
-      description: "Change full access role for admin user to custom one with restricted permission (Sales)"
- 
-- filename: "AdminSystemUserRolesNavigateMenuTest.xml"
-  repo: "https://github.com/magento/magento2/blob/2.3/app/code/Magento/User/Test/Mftf/Test/AdminSystemUserRolesNavigateMenuTest.xml"
-  module: "User"
-  tests:
-    - testname: "AdminSystemUserRolesNavigateMenuTest"
-      title: "Admin system user roles navigate menu test"
-      description: "Admin should be able to navigate to System &gt; User Roles"
- 
-- filename: "AdminSystemAllUsersNavigateMenuTest.xml"
-  repo: "https://github.com/magento/magento2/blob/2.3/app/code/Magento/User/Test/Mftf/Test/AdminSystemAllUsersNavigateMenuTest.xml"
-  module: "User"
-  tests:
-    - testname: "AdminSystemAllUsersNavigateMenuTest"
-      title: "Admin system all users navigate menu test"
-      description: "Admin should be able to navigate to System &gt; All Users"
- 
-- filename: "AdminSystemLockedUsersNavigateMenuTest.xml"
-  repo: "https://github.com/magento/magento2/blob/2.3/app/code/Magento/User/Test/Mftf/Test/AdminSystemLockedUsersNavigateMenuTest.xml"
-  module: "User"
-  tests:
-    - testname: "AdminSystemLockedUsersNavigateMenuTest"
-      title: "Admin system locked users navigate menu test"
-      description: "Admin should be able to navigate to System &gt; Locked Users"
- 
-- filename: "AdminBulkOperationsLogIsNotAccessibleForAdminUserWithLimitedAccessTest.xml"
-  repo: "https://github.com/magento/magento2/blob/2.3/app/code/Magento/User/Test/Mftf/Test/AdminBulkOperationsLogIsNotAccessibleForAdminUserWithLimitedAccessTest.xml"
-  module: "User"
-  tests:
-    - testname: "AdminBulkOperationsLogIsNotAccessibleForAdminUserWithLimitedAccessTest"
-      title: "'Your Bulk Operations Log' isn't accessible if admin user doesn't have privileges for it"
-      description: "An admin user can view his own bulk operations only in a separate grid if his role has Bulk Operations resource."
- 
-- filename: "AdminLockAdminUserEntityTest.xml"
-  repo: "https://github.com/magento/magento2/blob/2.3/app/code/Magento/User/Test/Mftf/Test/AdminLockAdminUserEntityTest.xml"
-  module: "User"
-  tests:
-    - testname: "AdminLockAdminUserEntityTest"
-      title: "Lock admin  user after entering incorrect password specified number of times"
-      description: "Lock admin  user after entering incorrect password specified number of times"
- 
-- filename: "AdminSystemManageEncryptionKeyNavigateMenuTest.xml"
-  repo: "https://github.com/magento/magento2/blob/2.3/app/code/Magento/User/Test/Mftf/Test/AdminSystemManageEncryptionKeyNavigateMenuTest.xml"
-  module: "User"
-  tests:
-    - testname: "AdminSystemManageEncryptionKeyNavigateMenuTest"
-      title: "Admin system manage encryption key navigate menu test"
-      description: "Admin should be able to navigate to System &gt; Manage Encryption Key"
- 
-- filename: "AdminExpireCustomerSessionTest.xml"
-  repo: "https://github.com/magento/magento2/blob/2.3/app/code/Magento/Backend/Test/Mftf/Test/AdminExpireCustomerSessionTest.xml"
-  module: "Backend"
-  tests:
-    - testname: "AdminExpireCustomerSessionTest"
-      title: "Customer Session Expireon"
-      description: "Customer Session Expire"
- 
-- filename: "AdminAttributeTextSwatchesCanBeFiledTest.xml"
-  repo: "https://github.com/magento/magento2/blob/2.3/app/code/Magento/Backend/Test/Mftf/Test/AdminAttributeTextSwatchesCanBeFiledTest.xml"
-  module: "Backend"
-  tests:
-    - testname: "AdminAttributeTextSwatchesCanBeFiledTest"
-      title: "Check that attribute text swatches can be filed"
-      description: "Check that attribute text swatches can be filed"
- 
-- filename: "AdminUserLoginWithStoreCodeInUrlTest.xml"
-  repo: "https://github.com/magento/magento2/blob/2.3/app/code/Magento/Backend/Test/Mftf/Test/AdminUserLoginWithStoreCodeInUrlTest.xml"
-  module: "Backend"
-  tests:
-    - testname: "AdminUserLoginWithStoreCodeInUrlTest"
-      title: "Admin panel should be accessible with Add Store Code to URL setting enabled"
-      description: "Admin panel should be accessible with Add Store Code to URL setting enabled"
- 
-- filename: "AdminExpireAdminSessionTest.xml"
-  repo: "https://github.com/magento/magento2/blob/2.3/app/code/Magento/Backend/Test/Mftf/Test/AdminExpireAdminSessionTest.xml"
-  module: "Backend"
-  tests:
-    - testname: "AdminExpireAdminSessionTest"
-      title: "Admin Session Expire"
-      description: "Admin Session Expire"
- 
-- filename: "AdminPrivacyPolicyTest.xml"
-  repo: "https://github.com/magento/magento2/blob/2.3/app/code/Magento/Backend/Test/Mftf/Test/AdminPrivacyPolicyTest.xml"
-  module: "Backend"
-  tests:
-    - testname: "AdminPrivacyPolicyTest"
-      title: "There should be a privacy policy url in the admin page and every sub page"
-      description: "There should be a privacy policy url in the admin page and every sub page"
- 
-- filename: "AdminContentScheduleNavigateMenuTest.xml"
-  repo: "https://github.com/magento/magento2/blob/2.3/app/code/Magento/Backend/Test/Mftf/Test/AdminContentScheduleNavigateMenuTest.xml"
-  module: "Backend"
-  tests:
-    - testname: "AdminContentScheduleNavigateMenuTest"
-      title: "Admin content schedule navigate menu test"
-      description: "Admin should be able to navigate to Content &gt; Schedule"
- 
-- filename: "AdminLoginAfterChangeCookieDomainTest.xml"
-  repo: "https://github.com/magento/magento2/blob/2.3/app/code/Magento/Backend/Test/Mftf/Test/AdminLoginAfterChangeCookieDomainTest.xml"
-  module: "Backend"
-  tests:
-    - testname: "AdminLoginAfterChangeCookieDomainTest"
-      title: "Admin user can login after changing cookie domain on main website scope without changing cookie domain on default scope"
-      description: "Admin user can login after changing cookie domain on main website scope without changing cookie domain on default scope"
- 
-- filename: "AdminSystemCacheManagementNavigateMenuTest.xml"
-  repo: "https://github.com/magento/magento2/blob/2.3/app/code/Magento/Backend/Test/Mftf/Test/AdminSystemCacheManagementNavigateMenuTest.xml"
-  module: "Backend"
-  tests:
-    - testname: "AdminSystemCacheManagementNavigateMenuTest"
-      title: "Admin system cache management navigate menu test"
-      description: "Admin should be able to navigate to System &gt; Cache Management"
- 
-- filename: "AdminStoresAllStoresNavigateMenuTest.xml"
-  repo: "https://github.com/magento/magento2/blob/2.3/app/code/Magento/Backend/Test/Mftf/Test/AdminStoresAllStoresNavigateMenuTest.xml"
-  module: "Backend"
-  tests:
-    - testname: "AdminStoresAllStoresNavigateMenuTest"
-      title: "Admin stores all stores navigate menu test"
-      description: "Admin should be able to navigate to Stores &gt; All Stores"
- 
-- filename: "AdminLoginAfterJSMinificationTest.xml"
-  repo: "https://github.com/magento/magento2/blob/2.3/app/code/Magento/Backend/Test/Mftf/Test/AdminLoginAfterJSMinificationTest.xml"
-  module: "Backend"
-  tests:
-    - testname: "AdminLoginAfterJSMinificationTest"
-      title: "Admin panel should be accessible with JS minification enabled"
-      description: "Admin panel should be accessible with JS minification enabled"
- 
-- filename: "AdminLoginTest.xml"
-  repo: "https://github.com/magento/magento2/blob/2.3/app/code/Magento/Backend/Test/Mftf/Test/AdminLoginTest.xml"
-  module: "Backend"
-  tests:
-    - testname: "AdminLoginTest"
-      title: "Admin should be able to log into the Magento Admin backend"
-      description: "Admin should be able to log into the Magento Admin backend"
- 
-- filename: "AdminMenuNavigationWithSecretKeysTest.xml"
-  repo: "https://github.com/magento/magento2/blob/2.3/app/code/Magento/Backend/Test/Mftf/Test/AdminMenuNavigationWithSecretKeysTest.xml"
-  module: "Backend"
-  tests:
-    - testname: "AdminMenuNavigationWithSecretKeysTest"
-      title: "Admin should be able to navigate between menu options with secret url keys enabled"
-      description: "Admin should be able to navigate between menu options with secret url keys enabled"
- 
-- filename: "AdminCheckLocaleAndDeveloperConfigInDeveloperModeTest.xml"
-  repo: "https://github.com/magento/magento2/blob/2.3/app/code/Magento/Backend/Test/Mftf/Test/AdminCheckLocaleAndDeveloperConfigInDeveloperModeTest.xml"
-  module: "Backend"
-  tests:
-    - testname: "AdminCheckLocaleAndDeveloperConfigInDeveloperModeTest"
-      title: "Check locale dropdown and developer configuration page are available in developer mode"
-      description: "Check locale dropdown and developer configuration page are available in developer mode"
- 
-- filename: "AdminCheckLocaleAndDeveloperConfigInProductionModeTest.xml"
-  repo: "https://github.com/magento/magento2/blob/2.3/app/code/Magento/Backend/Test/Mftf/Test/AdminCheckLocaleAndDeveloperConfigInProductionModeTest.xml"
-  module: "Backend"
-  tests:
-    - testname: "AdminCheckLocaleAndDeveloperConfigInProductionModeTest"
-      title: "Check locale dropdown and developer configuration page are not available in production mode"
-      description: "Check locale dropdown and developer configuration page are not available in production mode"
- 
-- filename: "AdminStoresConfigurationNavigateMenuTest.xml"
-  repo: "https://github.com/magento/magento2/blob/2.3/app/code/Magento/Backend/Test/Mftf/Test/AdminStoresConfigurationNavigateMenuTest.xml"
-  module: "Backend"
-  tests:
-    - testname: "AdminStoresConfigurationNavigateMenuTest"
-      title: "Admin stores configuration navigate menu test"
-      description: "Admin should be able to navigate to Stores &gt; Configuration"
- 
-- filename: "AdminDashboardNavigateMenuTest.xml"
-  repo: "https://github.com/magento/magento2/blob/2.3/app/code/Magento/Backend/Test/Mftf/Test/AdminDashboardNavigateMenuTest.xml"
-  module: "Backend"
-  tests:
-    - testname: "AdminDashboardNavigateMenuTest"
-      title: "Admin dashboard navigate menu test"
-      description: "Admin should be able to navigate to Dashboard"
- 
-- filename: "AdminProductImportCSVFileCorrectDifferentFilesTest.xml"
-  repo: "https://github.com/magento/magento2/blob/2.3/app/code/Magento/ImportExport/Test/Mftf/Test/AdminProductImportCSVFileCorrectDifferentFilesTest.xml"
-  module: "ImportExport"
-  tests:
-    - testname: "AdminProductImportCSVFileCorrectDifferentFilesTest"
-      title: "Product import from CSV file correct from different files."
-      description: "Product import from CSV file correct from different files."
- 
-- filename: "AdminCheckDoubleImportOfProductsTest.xml"
-  repo: "https://github.com/magento/magento2/blob/2.3/app/code/Magento/ImportExport/Test/Mftf/Test/AdminCheckDoubleImportOfProductsTest.xml"
-  module: "ImportExport"
-  tests:
-    - testname: "AdminCheckDoubleImportOfProductsTest"
-      title: "Admin check double import of products test"
-      description: "Checking double Import of products CSV file"
- 
-- filename: "AdminImportProductsWithErrorEntriesTest.xml"
-  repo: "https://github.com/magento/magento2/blob/2.3/app/code/Magento/ImportExport/Test/Mftf/Test/AdminImportProductsWithErrorEntriesTest.xml"
-  module: "ImportExport"
-  tests:
-    - testname: "AdminImportProductsWithErrorEntriesTest"
-      title: "Import products with error entries"
-      description: "Verify import status during import products with error entries"
- 
-- filename: "AdminImportProductsWithAddUpdateBehaviorTest.xml"
-  repo: "https://github.com/magento/magento2/blob/2.3/app/code/Magento/ImportExport/Test/Mftf/Test/AdminImportProductsWithAddUpdateBehaviorTest.xml"
-  module: "ImportExport"
-  tests:
-    - testname: "AdminImportProductsWithAddUpdateBehaviorTest"
-      title: "Verify Magento native import products with add/update behavior."
-      description: "Verify Magento native import products with add/update behavior."
- 
-- filename: "AdminExportPagerGridTest.xml"
-  repo: "https://github.com/magento/magento2/blob/2.3/app/code/Magento/ImportExport/Test/Mftf/Test/AdminExportPagerGridTest.xml"
-  module: "ImportExport"
-  tests:
-    - testname: "AdminExportPagerGridTest"
-      title: "Testing if the grid is present on export page"
-      description: "Admin should be able to see the grid onn export page"
- 
-- filename: "AdminImportProductsWithDeleteBehaviorTest.xml"
-  repo: "https://github.com/magento/magento2/blob/2.3/app/code/Magento/ImportExport/Test/Mftf/Test/AdminImportProductsWithDeleteBehaviorTest.xml"
-  module: "ImportExport"
-  tests:
-    - testname: "AdminImportProductsWithDeleteBehaviorTest"
-      title: "Verify Magento native import products with delete behavior."
-      description: "Verify Magento native import products with delete behavior."
- 
-- filename: "AdminImportCSVWithSpecialCharactersTest.xml"
-  repo: "https://github.com/magento/magento2/blob/2.3/app/code/Magento/ImportExport/Test/Mftf/Test/AdminImportCSVWithSpecialCharactersTest.xml"
-  module: "ImportExport"
-  tests:
-    - testname: "AdminImportCSVWithSpecialCharactersTest"
-      title: "Import CSV with special characters"
-      description: "Import CSV with special characters"
- 
-- filename: "AdminURLKeyWorksWhenUpdatingProductThroughImportingCSVTest.xml"
-  repo: "https://github.com/magento/magento2/blob/2.3/app/code/Magento/ImportExport/Test/Mftf/Test/AdminURLKeyWorksWhenUpdatingProductThroughImportingCSVTest.xml"
-  module: "ImportExport"
-  tests:
-    - testname: "AdminURLKeyWorksWhenUpdatingProductThroughImportingCSVTest"
-      title: "Check that new URL Key works after updating a product through importing CSV file"
-      description: "Check that new URL Key works after updating a product through importing CSV file"
- 
-- filename: "AdminCheckThatSomeAttributesChangedValueToEmptyAfterImportTest.xml"
-  repo: "https://github.com/magento/magento2/blob/2.3/app/code/Magento/ImportExport/Test/Mftf/Test/AdminCheckThatSomeAttributesChangedValueToEmptyAfterImportTest.xml"
-  module: "ImportExport"
-  tests:
-    - testname: "AdminCheckThatSomeAttributesChangedValueToEmptyAfterImportTest"
-      title: "Check that some attributes changed the value to an empty after import CSV"
-      description: "Check that some attributes changed the value to an empty after import CSV"
- 
-- filename: "AdminExportPageNavigateMenuTest.xml"
-  repo: "https://github.com/magento/magento2/blob/2.3/app/code/Magento/ImportExport/Test/Mftf/Test/AdminExportPageNavigateMenuTest.xml"
-  module: "ImportExport"
-  tests:
-    - testname: "AdminExportPageNavigateMenuTest"
-      title: "Admin export page navigate menu test"
-      description: "Admin should be able to navigate to System &gt; Export"
- 
-- filename: "AdminProductVisibilityDifferentStoreViewsAfterImportTest.xml"
-  repo: "https://github.com/magento/magento2/blob/2.3/app/code/Magento/ImportExport/Test/Mftf/Test/AdminProductVisibilityDifferentStoreViewsAfterImportTest.xml"
-  module: "ImportExport"
-  tests:
-    - testname: "AdminProductVisibilityDifferentStoreViewsAfterImportTest"
-      title: "Checking product visibility in different store views after product importing"
-      description: "Checking product visibility in different store views after product importing"
- 
-- filename: "AdminSystemImportNavigateMenuTest.xml"
-  repo: "https://github.com/magento/magento2/blob/2.3/app/code/Magento/ImportExport/Test/Mftf/Test/AdminSystemImportNavigateMenuTest.xml"
-  module: "ImportExport"
-  tests:
-    - testname: "AdminSystemImportNavigateMenuTest"
-      title: "Admin system import navigate menu test"
-      description: "Admin should be able to navigate to System &gt; Import"
- 
-- filename: "AdminImportProductsWithReplaceBehaviorTest.xml"
-  repo: "https://github.com/magento/magento2/blob/2.3/app/code/Magento/ImportExport/Test/Mftf/Test/AdminImportProductsWithReplaceBehaviorTest.xml"
-  module: "ImportExport"
-  tests:
-    - testname: "AdminImportProductsWithReplaceBehaviorTest"
-      title: "Verify Magento native import products with replace behavior."
-      description: "Verify Magento native import products with replace behavior."
- 
-- filename: "AdminCreateOrderCustomStoreShippingMethodTableRatesTest.xml"
-  repo: "https://github.com/magento/magento2/blob/2.3/app/code/Magento/Shipping/Test/Mftf/Test/AdminCreateOrderCustomStoreShippingMethodTableRatesTest.xml"
-  module: "Shipping"
-  tests:
-    - testname: "AdminCreateOrderCustomStoreShippingMethodTableRatesTest"
-      title: "Create order on second store with shipping method Table Rates"
-      description: "Create order on second store with shipping method Table Rates"
- 
-- filename: "AdminCreateShipmentEntityTest.xml"
-  repo: "https://github.com/magento/magento2/blob/2.3/app/code/Magento/Shipping/Test/Mftf/Test/AdminCreateShipmentEntityTest.xml"
-  module: "Shipping"
-  tests:
-    - testname: "AdminCreateShipmentEntityWithTrackingNumberTest"
-      title: "Create Shipment for Offline Payment Methods"
-      description: "Admin Should be Able to Create Shipments"
- 
-- filename: "AdminValidateShippingTrackingNumberTest.xml"
-  repo: "https://github.com/magento/magento2/blob/2.3/app/code/Magento/Shipping/Test/Mftf/Test/AdminValidateShippingTrackingNumberTest.xml"
-  module: "Shipping"
-  tests:
-    - testname: "AdminValidateShippingTrackingNumberTest"
-      title: "Admin validate the shipping tracking number for an order"
-      description: "Testing for a required tracking number when adding new shipping information"
- 
-- filename: "TableRatesShippingMethodForDifferentStatesTest.xml"
-  repo: "https://github.com/magento/magento2/blob/2.3/app/code/Magento/Shipping/Test/Mftf/Test/TableRatesShippingMethodForDifferentStatesTest.xml"
-  module: "Shipping"
-  tests:
-    - testname: "TableRatesShippingMethodForDifferentStatesTest"
-      title: "Table rates shipping method for different states test"
-      description: "Checkout with Table Rates for different states of the USA"
- 
-- filename: "EndToEndB2CAdminTest.xml"
-  repo: "https://github.com/magento/magento2/blob/2.3/app/code/Magento/Shipping/Test/Mftf/Test/EndToEndB2CAdminTest.xml"
-  module: "Shipping"
-  tests:
-    - testname: "EndToEndB2CAdminTest"
-      title: ""
-      description: ""
- 
-- filename: "AdminCheckInputFieldsDisabledAfterAppConfigDumpTest.xml"
-  repo: "https://github.com/magento/magento2/blob/2.3/app/code/Magento/Shipping/Test/Mftf/Test/AdminCheckInputFieldsDisabledAfterAppConfigDumpTest.xml"
-  module: "Shipping"
-  tests:
-    - testname: "AdminCheckInputFieldsDisabledAfterAppConfigDumpTest"
-      title: "Check that all input fields disabled after executing CLI app:config:dump"
-      description: "Check that all input fields disabled after executing CLI app:config:dump"
- 
-- filename: "AdminCreatePartialShipmentEntityTest.xml"
-  repo: "https://github.com/magento/magento2/blob/2.3/app/code/Magento/Shipping/Test/Mftf/Test/AdminCreatePartialShipmentEntityTest.xml"
-  module: "Shipping"
-  tests:
-    - testname: "AdminCreatePartialShipmentEntityTest"
-      title: "Create Partial Shipment for Offline Payment Methods"
-      description: "Admin Should be Able to Create Partial Shipments"
- 
-- filename: "AdminCheckTheConfirmationPopupTest.xml"
-  repo: "https://github.com/magento/magento2/blob/2.3/app/code/Magento/Shipping/Test/Mftf/Test/AdminCheckTheConfirmationPopupTest.xml"
-  module: "Shipping"
-  tests:
-    - testname: "AdminCheckTheConfirmationPopupTest"
-      title: "Admin confirmation modal should be in Magento style"
-      description: "Testing the confirmation modal for removing the tracking number"
- 
-- filename: "StorefrontDisplayTableRatesShippingMethodForAETest.xml"
-  repo: "https://github.com/magento/magento2/blob/2.3/app/code/Magento/Shipping/Test/Mftf/Test/StorefrontDisplayTableRatesShippingMethodForAETest.xml"
-  module: "Shipping"
-  tests:
-    - testname: "StorefrontDisplayTableRatesShippingMethodForAETest"
-      title: "Displaying of Table Rates for Armed Forces Europe (AE)"
-      description: "Displaying of Table Rates for Armed Forces Europe (AE)"
- 
-- filename: "AdvanceCatalogSearchDownloadableProductTest.xml"
-  repo: "https://github.com/magento/magento2/blob/2.3/app/code/Magento/Downloadable/Test/Mftf/Test/AdvanceCatalogSearchDownloadableProductTest.xml"
-  module: "Downloadable"
-  tests:
-    - testname: "AdvanceCatalogSearchDownloadableByNameTest"
-      title: "Guest customer should be able to advance search Downloadable product with product name"
-      description: "Guest customer should be able to advance search Downloadable product with product name"
-
-    - testname: "AdvanceCatalogSearchDownloadableBySkuTest"
-      title: "Guest customer should be able to advance search Downloadable product with product sku"
-      description: "Guest customer should be able to advance search Downloadable product with product sku"
-
-    - testname: "AdvanceCatalogSearchDownloadableByDescriptionTest"
-      title: "Guest customer should be able to advance search Downloadable product with product description"
-      description: "Guest customer should be able to advance search Downloadable product with product description"
-
-    - testname: "AdvanceCatalogSearchDownloadableByShortDescriptionTest"
-      title: "Guest customer should be able to advance search Downloadable product with product short description"
-      description: "Guest customer should be able to advance search Downloadable product with product short description"
-
-    - testname: "AdvanceCatalogSearchDownloadableByPriceTest"
-      title: "Guest customer should be able to advance search Downloadable product with product price"
-      description: "Guest customer should be able to advance search Downloadable product with product price"
- 
-- filename: "StorefrontAdvanceCatalogSearchDownloadableBySkuWithHyphenTest.xml"
-  repo: "https://github.com/magento/magento2/blob/2.3/app/code/Magento/Downloadable/Test/Mftf/Test/StorefrontAdvanceCatalogSearchDownloadableBySkuWithHyphenTest.xml"
-  module: "Downloadable"
-  tests:
-    - testname: "StorefrontAdvanceCatalogSearchDownloadableBySkuWithHyphenTest"
-      title: "Guest customer should be able to advance search Downloadable product with product sku that contains hyphen"
-      description: "Guest customer should be able to advance search Downloadable product with product that contains hyphen"
- 
-- filename: "AdminProductTypeSwitchingOnEditingTest.xml"
-  repo: "https://github.com/magento/magento2/blob/2.3/app/code/Magento/Downloadable/Test/Mftf/Test/AdminProductTypeSwitchingOnEditingTest.xml"
-  module: "Downloadable"
-  tests:
-    - testname: "AdminDownloadableProductTypeSwitchingToConfigurableProductTest"
-      title: "Downloadable product type switching on editing to configurable product"
-      description: "Downloadable product type switching on editing to configurable product"
-
-    - testname: "AdminSimpleProductTypeSwitchingToDownloadableProductTest"
-      title: "Simple product type switching on editing to downloadable product"
-      description: "Simple product type switching on editing to downloadable product"
- 
-- filename: "StorefrontVerifySecureURLRedirectDownloadableTest.xml"
-  repo: "https://github.com/magento/magento2/blob/2.3/app/code/Magento/Downloadable/Test/Mftf/Test/StorefrontVerifySecureURLRedirectDownloadableTest.xml"
-  module: "Downloadable"
-  tests:
-    - testname: "StorefrontVerifySecureURLRedirectDownloadable"
-      title: "Verify Secure URLs For Storefront Downloadable Pages"
-      description: "Verify that the Secure URL configuration applies to the Downloadable pages on the Storefront"
- 
-- filename: "AdminRemoveDefaultVideoDownloadableProductTest.xml"
-  repo: "https://github.com/magento/magento2/blob/2.3/app/code/Magento/Downloadable/Test/Mftf/Test/AdminRemoveDefaultVideoDownloadableProductTest.xml"
-  module: "Downloadable"
-  tests:
-    - testname: "AdminRemoveDefaultVideoDownloadableProductTest"
-      title: "Admin should be able to remove default video from a Downloadable Product"
-      description: "Admin should be able to remove default video from a Downloadable Product"
- 
-- filename: "AdminCreateDownloadableProductWithOutOfStockStatusTest.xml"
-  repo: "https://github.com/magento/magento2/blob/2.3/app/code/Magento/Downloadable/Test/Mftf/Test/AdminCreateDownloadableProductWithOutOfStockStatusTest.xml"
-  module: "Downloadable"
-  tests:
-    - testname: "AdminCreateDownloadableProductWithOutOfStockStatusTest"
-      title: "Create downloadable product with out of stock status test"
-      description: "Admin should be able to create downloadable product with out of stock status"
- 
-- filename: "SelectAllDownloadableLinksDownloadableProductTest.xml"
-  repo: "https://github.com/magento/magento2/blob/2.3/app/code/Magento/Downloadable/Test/Mftf/Test/SelectAllDownloadableLinksDownloadableProductTest.xml"
-  module: "Downloadable"
-  tests:
-    - testname: "SelectAllDownloadableLinksDownloadableProductTest"
-      title: "Select all downloadable links downloadable product test"
-      description: "All the downloadable links must be selected or unselected when anyone click on select all or unselect all checkbox respectively."
- 
-- filename: "AdminCreateDownloadableProductWithoutTaxClassIdTest.xml"
-  repo: "https://github.com/magento/magento2/blob/2.3/app/code/Magento/Downloadable/Test/Mftf/Test/AdminCreateDownloadableProductWithoutTaxClassIdTest.xml"
-  module: "Downloadable"
-  tests:
-    - testname: "AdminCreateDownloadableProductWithoutTaxClassIdTest"
-      title: "Create downloadable product without tax class id test"
-      description: "Admin should be able to create downloadable product without tax class id"
- 
-- filename: "VerifyDisableDownloadableProductSamplesAreNotAccessibleTest.xml"
-  repo: "https://github.com/magento/magento2/blob/2.3/app/code/Magento/Downloadable/Test/Mftf/Test/VerifyDisableDownloadableProductSamplesAreNotAccessibleTest.xml"
-  module: "Downloadable"
-  tests:
-    - testname: "VerifyDisableDownloadableProductSamplesAreNotAccessibleTest"
-      title: "Samples of Downloadable Products are not accessible, if product is disabled"
-      description: "Samples of Downloadable Products are not accessible, if product is disabled"
- 
-- filename: "AdminDeleteDownloadableProductTest.xml"
-  repo: "https://github.com/magento/magento2/blob/2.3/app/code/Magento/Downloadable/Test/Mftf/Test/AdminDeleteDownloadableProductTest.xml"
-  module: "Downloadable"
-  tests:
-    - testname: "AdminDeleteDownloadableProductTest"
-      title: "Delete Downloadable Product"
-      description: "Admin should be able to delete a downloadable product"
- 
-- filename: "AdminAddDefaultVideoDownloadableProductTest.xml"
-  repo: "https://github.com/magento/magento2/blob/2.3/app/code/Magento/Downloadable/Test/Mftf/Test/AdminAddDefaultVideoDownloadableProductTest.xml"
-  module: "Downloadable"
-  tests:
-    - testname: "AdminAddDefaultVideoDownloadableProductTest"
-      title: "Admin should be able to add default video for a Downloadable Product"
-      description: "Admin should be able to add default video for a Downloadable Product"
- 
-- filename: "AdminCreateDownloadableProductWithInvalidDomainLinkUrlTest.xml"
-  repo: "https://github.com/magento/magento2/blob/2.3/app/code/Magento/Downloadable/Test/Mftf/Test/AdminCreateDownloadableProductWithInvalidDomainLinkUrlTest.xml"
-  module: "Downloadable"
-  tests:
-    - testname: "AdminCreateDownloadableProductWithInvalidDomainLinkUrlTest"
-      title: "Create Downloadable Product with invalid domain link url"
-      description: "Admin should not be able to create downloadable product with invalid domain link url"
- 
-- filename: "EndToEndB2CAdminTest.xml"
-  repo: "https://github.com/magento/magento2/blob/2.3/app/code/Magento/Downloadable/Test/Mftf/Test/EndToEndB2CAdminTest.xml"
-  module: "Downloadable"
-  tests:
-    - testname: "EndToEndB2CAdminTest"
-      title: ""
-      description: ""
- 
-- filename: "AdminCreateDownloadableProductWithManageStockTest.xml"
-  repo: "https://github.com/magento/magento2/blob/2.3/app/code/Magento/Downloadable/Test/Mftf/Test/AdminCreateDownloadableProductWithManageStockTest.xml"
-  module: "Downloadable"
-  tests:
-    - testname: "AdminCreateDownloadableProductWithManageStockTest"
-      title: "Create downloadable product with manage stock test"
-      description: "Admin should be able to create downloadable product with manage stock"
- 
-- filename: "AdminCreateDownloadableProductWithGroupPriceTest.xml"
-  repo: "https://github.com/magento/magento2/blob/2.3/app/code/Magento/Downloadable/Test/Mftf/Test/AdminCreateDownloadableProductWithGroupPriceTest.xml"
-  module: "Downloadable"
-  tests:
-    - testname: "AdminCreateDownloadableProductWithGroupPriceTest"
-      title: "Create downloadable product with group price test"
-      description: "Admin should be able to create downloadable product with group price"
- 
-- filename: "AdminDownloadableSetEditRelatedProductsTest.xml"
-  repo: "https://github.com/magento/magento2/blob/2.3/app/code/Magento/Downloadable/Test/Mftf/Test/AdminDownloadableSetEditRelatedProductsTest.xml"
-  module: "Downloadable"
-  tests:
-    - testname: "AdminDownloadableSetEditRelatedProductsTest"
-      title: "Admin should be able to set/edit Related Products information when editing a downloadable product"
-      description: "Admin should be able to set/edit Related Products information when editing a downloadable product"
- 
-- filename: "AdminRemoveDefaultImageDownloadableProductTest.xml"
-  repo: "https://github.com/magento/magento2/blob/2.3/app/code/Magento/Downloadable/Test/Mftf/Test/AdminRemoveDefaultImageDownloadableProductTest.xml"
-  module: "Downloadable"
-  tests:
-    - testname: "AdminRemoveDefaultImageDownloadableProductTest"
-      title: "Admin should be able to remove default images from a Downloadable Product"
-      description: "Admin should be able to remove default images from a Downloadable Product"
- 
-- filename: "EditDownloadableProductWithSeparateLinksFromCartTest.xml"
-  repo: "https://github.com/magento/magento2/blob/2.3/app/code/Magento/Downloadable/Test/Mftf/Test/EditDownloadableProductWithSeparateLinksFromCartTest.xml"
-  module: "Downloadable"
-  tests:
-    - testname: "EditDownloadableProductWithSeparateLinksFromCartTest"
-      title: "Edit downloadable product with separate links from cart test"
-      description: "Product price should remain correct when editing downloadable product with separate links from cart."
- 
-- filename: "AdminCreateDownloadableProductWithDefaultSetLinksTest.xml"
-  repo: "https://github.com/magento/magento2/blob/2.3/app/code/Magento/Downloadable/Test/Mftf/Test/AdminCreateDownloadableProductWithDefaultSetLinksTest.xml"
-  module: "Downloadable"
-  tests:
-    - testname: "AdminCreateDownloadableProductWithDefaultSetLinksTest"
-      title: "Create downloadable product with default set links"
-      description: "Admin should be able to create downloadable product with default set links"
- 
-- filename: "AdminDownloadableProductSetEditContentTest.xml"
-  repo: "https://github.com/magento/magento2/blob/2.3/app/code/Magento/Downloadable/Test/Mftf/Test/AdminDownloadableProductSetEditContentTest.xml"
-  module: "Downloadable"
-  tests:
-    - testname: "AdminDownloadableProductSetEditContentTest"
-      title: "Admin should be able to set/edit product Content when editing a downloadable product"
-      description: "Admin should be able to set/edit product Content when editing a downloadable product"
- 
-- filename: "AdminCreateDownloadableProductWithLinkTest.xml"
-  repo: "https://github.com/magento/magento2/blob/2.3/app/code/Magento/Downloadable/Test/Mftf/Test/AdminCreateDownloadableProductWithLinkTest.xml"
-  module: "Downloadable"
-  tests:
-    - testname: "AdminCreateDownloadableProductWithLinkTest"
-      title: "Create Downloadable Product with link"
-      description: "Admin should be able to create downloadable product with one simple link"
- 
-- filename: "ManualSelectAllDownloadableLinksDownloadableProductTest.xml"
-  repo: "https://github.com/magento/magento2/blob/2.3/app/code/Magento/Downloadable/Test/Mftf/Test/ManualSelectAllDownloadableLinksDownloadableProductTest.xml"
-  module: "Downloadable"
-  tests:
-    - testname: "ManualSelectAllDownloadableLinksDownloadableProductTest"
-      title: "Manual select all downloadable links downloadable product test"
-      description: "Manually selecting all downloadable links must change 'Select/Unselect all' button label to 'Unselect all', and 'Select all' otherwise"
- 
-- filename: "AdminCreateDownloadableProductAndAssignItToCustomStoreTest.xml"
-  repo: "https://github.com/magento/magento2/blob/2.3/app/code/Magento/Downloadable/Test/Mftf/Test/AdminCreateDownloadableProductAndAssignItToCustomStoreTest.xml"
-  module: "Downloadable"
-  tests:
-    - testname: "AdminCreateDownloadableProductAndAssignItToCustomStoreTest"
-      title: "Create downloadable product and assign it to custom store test"
-      description: "Admin should be able to create downloadable and assign it to custom website"
- 
-- filename: "NewProductsListWidgetDownloadableProductTest.xml"
-  repo: "https://github.com/magento/magento2/blob/2.3/app/code/Magento/Downloadable/Test/Mftf/Test/NewProductsListWidgetDownloadableProductTest.xml"
-  module: "Downloadable"
-  tests:
-    - testname: "NewProductsListWidgetDownloadableProductTest"
-      title: "Admin should be able to set Downloadable Product as new so that it shows up in the Catalog New Products List Widget"
-      description: "Admin should be able to set Downloadable Product as new so that it shows up in the Catalog New Products List Widget"
- 
-- filename: "AdminAddDefaultImageDownloadableProductTest.xml"
-  repo: "https://github.com/magento/magento2/blob/2.3/app/code/Magento/Downloadable/Test/Mftf/Test/AdminAddDefaultImageDownloadableProductTest.xml"
-  module: "Downloadable"
-  tests:
-    - testname: "AdminAddDefaultImageDownloadableProductTest"
-      title: "Admin should be able to add default images for a Downloadable Product"
-      description: "Admin should be able to add default images for a Downloadable Product"
- 
-- filename: "AdminCreateDownloadableProductWithCustomOptionsTest.xml"
-  repo: "https://github.com/magento/magento2/blob/2.3/app/code/Magento/Downloadable/Test/Mftf/Test/AdminCreateDownloadableProductWithCustomOptionsTest.xml"
-  module: "Downloadable"
-  tests:
-    - testname: "AdminCreateDownloadableProductWithCustomOptionsTest"
-      title: "Create downloadable product with custom options test"
-      description: "Admin should be able to create downloadable product with custom options"
- 
-- filename: "LinkDownloadableProductFromGuestToCustomerTest.xml"
-  repo: "https://github.com/magento/magento2/blob/2.3/app/code/Magento/Downloadable/Test/Mftf/Test/LinkDownloadableProductFromGuestToCustomerTest.xml"
-  module: "Downloadable"
-  tests:
-    - testname: "LinkDownloadableProductFromGuestToCustomerTest"
-      title: "Customer should see downloadable products after place order as guest and registering after that"
-      description: "Verify that in 'My Downloadable Products' section in customer account user can see products."
- 
-- filename: "AdminCreateDownloadableProductWithoutFillingQuantityAndStockTest.xml"
-  repo: "https://github.com/magento/magento2/blob/2.3/app/code/Magento/Downloadable/Test/Mftf/Test/AdminCreateDownloadableProductWithoutFillingQuantityAndStockTest.xml"
-  module: "Downloadable"
-  tests:
-    - testname: "AdminCreateDownloadableProductWithoutFillingQuantityAndStockTest"
-      title: "Create downloadable product without filling quantity and stock test"
-      description: "Admin should be able to create downloadable product without filling quantity and stock"
- 
-- filename: "AdminCreateDownloadableProductWithSpecialPriceTest.xml"
-  repo: "https://github.com/magento/magento2/blob/2.3/app/code/Magento/Downloadable/Test/Mftf/Test/AdminCreateDownloadableProductWithSpecialPriceTest.xml"
-  module: "Downloadable"
-  tests:
-    - testname: "AdminCreateDownloadableProductWithSpecialPriceTest"
-      title: "Create downloadable product with special price test"
-      description: "Admin should be able to create downloadable product with special price"
- 
-- filename: "AdminCreateAndEditDownloadableProductSettingsTest.xml"
-  repo: "https://github.com/magento/magento2/blob/2.3/app/code/Magento/Downloadable/Test/Mftf/Test/AdminCreateAndEditDownloadableProductSettingsTest.xml"
-  module: "Downloadable"
-  tests:
-    - testname: "AdminCreateAndEditDownloadableProductSettingsTest"
-      title: "Admin should be able to set/edit other product information when creating/editing a downloadable product"
-      description: "Admin should be able to set/edit other product information when creating/editing a downloadable product"
- 
-- filename: "AdminExportSimpleProductAssignedToMainWebsiteAndConfigurableProductAssignedToCustomWebsiteTest.xml"
-  repo: "https://github.com/magento/magento2/blob/2.3/app/code/Magento/CatalogImportExport/Test/Mftf/Test/AdminExportSimpleProductAssignedToMainWebsiteAndConfigurableProductAssignedToCustomWebsiteTest.xml"
-  module: "CatalogImportExport"
-  tests:
-    - testname: "AdminExportSimpleProductAssignedToMainWebsiteAndConfigurableProductAssignedToCustomWebsiteTest"
-      title: "Export Simple Product assigned to Main Website and Configurable Product assigned to Custom Website"
-      description: "Admin should be able to export Simple Product assigned to Main Website and Configurable Product assigned to Custom Website"
- 
-- filename: "AdminExportSimpleProductAndConfigurableProductsWithAssignedImagesTest.xml"
-  repo: "https://github.com/magento/magento2/blob/2.3/app/code/Magento/CatalogImportExport/Test/Mftf/Test/AdminExportSimpleProductAndConfigurableProductsWithAssignedImagesTest.xml"
-  module: "CatalogImportExport"
-  tests:
-    - testname: "AdminExportSimpleProductAndConfigurableProductsWithAssignedImagesTest"
-      title: "Export Simple product and Configurable products with assigned images"
-      description: "Admin should be able to export Simple and Configurable products with assigned images"
- 
-- filename: "AdminExportGroupedProductWithSpecialPriceTest.xml"
-  repo: "https://github.com/magento/magento2/blob/2.3/app/code/Magento/CatalogImportExport/Test/Mftf/Test/AdminExportGroupedProductWithSpecialPriceTest.xml"
-  module: "CatalogImportExport"
-  tests:
-    - testname: "AdminExportGroupedProductWithSpecialPriceTest"
-      title: "Export grouped product with special price"
-      description: "Admin should be able to export grouped product with special price"
- 
-- filename: "AdminExportBundleProductTest.xml"
-  repo: "https://github.com/magento/magento2/blob/2.3/app/code/Magento/CatalogImportExport/Test/Mftf/Test/AdminExportBundleProductTest.xml"
-  module: "CatalogImportExport"
-  tests:
-    - testname: "AdminExportBundleProductTest"
-      title: "Export Bundle Product"
-      description: "Admin should be able to export Bundle Product"
- 
-- filename: "AdminExportImportConfigurableProductWithImagesTest.xml"
-  repo: "https://github.com/magento/magento2/blob/2.3/app/code/Magento/CatalogImportExport/Test/Mftf/Test/AdminExportImportConfigurableProductWithImagesTest.xml"
-  module: "CatalogImportExport"
-  tests:
-    - testname: "AdminExportImportConfigurableProductWithImagesTest"
-      title: "Check importing of configurable products with images present in filesystem"
-      description: "Check importing of configurable products with images present in filesystem"
- 
-- filename: "AdminExportSimpleAndConfigurableProductsWithCustomOptionsTest.xml"
-  repo: "https://github.com/magento/magento2/blob/2.3/app/code/Magento/CatalogImportExport/Test/Mftf/Test/AdminExportSimpleAndConfigurableProductsWithCustomOptionsTest.xml"
-  module: "CatalogImportExport"
-  tests:
-    - testname: "AdminExportSimpleAndConfigurableProductsWithCustomOptionsTest"
-      title: "Export Simple and Configurable products with custom options"
-      description: "Admin should be able to export Simple and Configurable products with custom options"
- 
-- filename: "AdminExportSimpleProductWithCustomAttributeTest.xml"
-  repo: "https://github.com/magento/magento2/blob/2.3/app/code/Magento/CatalogImportExport/Test/Mftf/Test/AdminExportSimpleProductWithCustomAttributeTest.xml"
-  module: "CatalogImportExport"
-  tests:
-    - testname: "AdminExportSimpleProductWithCustomAttributeTest"
-      title: "Export Simple Product with custom attribute"
-      description: "Admin should be able to export Simple Product with custom attribute"
- 
-- filename: "StorefrontCheckoutWithDifferentShippingAndBillingAddressAndRegisterCustomerAfterCheckoutTest.xml"
-  repo: "https://github.com/magento/magento2/blob/2.3/app/code/Magento/Checkout/Test/Mftf/Test/StorefrontCheckoutWithDifferentShippingAndBillingAddressAndRegisterCustomerAfterCheckoutTest.xml"
-  module: "Checkout"
-  tests:
-    - testname: "StorefrontCheckoutWithDifferentShippingAndBillingAddressAndRegisterCustomerAfterCheckoutTest"
-      title: "Verify UK customer checkout with different billing and shipping address and register customer after checkout"
-      description: "Checkout as UK customer with different shipping/billing address and register checkout method"
- 
-- filename: "StorefrontAddBundleDynamicProductToShoppingCartTest.xml"
-  repo: "https://github.com/magento/magento2/blob/2.3/app/code/Magento/Checkout/Test/Mftf/Test/StorefrontAddBundleDynamicProductToShoppingCartTest.xml"
-  module: "Checkout"
-  tests:
-    - testname: "StorefrontAddBundleDynamicProductToShoppingCartTest"
-      title: "Add bundle dynamic product to the cart"
-      description: "Add bundle dynamic product to the cart"
- 
-- filename: "StoreFrontCheckCustomerInfoCreatedByGuestTest.xml"
-  repo: "https://github.com/magento/magento2/blob/2.3/app/code/Magento/Checkout/Test/Mftf/Test/StoreFrontCheckCustomerInfoCreatedByGuestTest.xml"
-  module: "Checkout"
-  tests:
-    - testname: "StoreFrontCheckCustomerInfoCreatedByGuestTest"
-      title: "Check Customer Information Created By Guest"
-      description: "Check customer information after placing the order as the guest who created an account"
- 
-- filename: "StorefrontUpdateShoppingCartSimpleWithCustomOptionsProductQtyTest.xml"
-  repo: "https://github.com/magento/magento2/blob/2.3/app/code/Magento/Checkout/Test/Mftf/Test/StorefrontUpdateShoppingCartSimpleWithCustomOptionsProductQtyTest.xml"
-  module: "Checkout"
-  tests:
-    - testname: "StorefrontUpdateShoppingCartSimpleWithCustomOptionsProductQtyTest"
-      title: "Check updating shopping cart while updating qty of items with custom options"
-      description: "Check updating shopping cart while updating qty of items with custom options"
- 
-- filename: "StorefrontAddConfigurableProductToShoppingCartTest.xml"
-  repo: "https://github.com/magento/magento2/blob/2.3/app/code/Magento/Checkout/Test/Mftf/Test/StorefrontAddConfigurableProductToShoppingCartTest.xml"
-  module: "Checkout"
-  tests:
-    - testname: "StorefrontAddConfigurableProductToShoppingCartTest"
-      title: "Create configurable product with three options and add configurable product to the cart"
-      description: "Create configurable product with three options and add configurable product to the cart"
- 
-- filename: "StoreFrontAddProductWithAllTypesOfCustomOptionToTheShoppingCartWithoutAnySelectedOptionTest.xml"
-  repo: "https://github.com/magento/magento2/blob/2.3/app/code/Magento/Checkout/Test/Mftf/Test/StoreFrontAddProductWithAllTypesOfCustomOptionToTheShoppingCartWithoutAnySelectedOptionTest.xml"
-  module: "Checkout"
-  tests:
-    - testname: "StoreFrontAddProductWithAllTypesOfCustomOptionToTheShoppingCartWithoutAnySelectedOptionTest"
-      title: "Add simple product with all types of custom options to cart without selecting any options"
-      description: "Add simple product with all types of custom options to cart without selecting any options"
- 
-- filename: "StorefrontCustomerCheckoutWithNewCustomerRegistrationAndDisableGuestCheckoutTest.xml"
-  repo: "https://github.com/magento/magento2/blob/2.3/app/code/Magento/Checkout/Test/Mftf/Test/StorefrontCustomerCheckoutWithNewCustomerRegistrationAndDisableGuestCheckoutTest.xml"
-  module: "Checkout"
-  tests:
-    - testname: "StorefrontCustomerCheckoutWithNewCustomerRegistrationAndDisableGuestCheckoutTest"
-      title: "Verify customer checkout by following new customer registration when guest checkout is disabled"
-      description: "Customer is redirected to checkout on login, follow the new Customer registration when guest checkout is disabled"
- 
-- filename: "StorefrontDeleteProductsWithCartItemsDisplayDefaultLimitationFromMiniShoppingCartTest.xml"
-  repo: "https://github.com/magento/magento2/blob/2.3/app/code/Magento/Checkout/Test/Mftf/Test/StorefrontDeleteProductsWithCartItemsDisplayDefaultLimitationFromMiniShoppingCartTest.xml"
-  module: "Checkout"
-  tests:
-    - testname: "StorefrontDeleteProductsWithCartItemsDisplayDefaultLimitationFromMiniShoppingCartTest"
-      title: "Storefront Delete Products With Cart Items Display Default Limitation From Mini Shopping Cart Test"
-      description: "Test log in to Shopping Cart and Delete Products With Cart Items Display Default Limitation From Mini Shopping Cart Test"
- 
-- filename: "DeleteVirtualProductFromShoppingCartTest.xml"
-  repo: "https://github.com/magento/magento2/blob/2.3/app/code/Magento/Checkout/Test/Mftf/Test/DeleteVirtualProductFromShoppingCartTest.xml"
-  module: "Checkout"
-  tests:
-    - testname: "DeleteVirtualProductFromShoppingCartTest"
-      title: "Delete virtual product from shopping cart test"
-      description: "Delete virtual product from shopping cart"
- 
-- filename: "StorefrontProductQuantityChangesInBackendAfterCustomerCheckoutTest.xml"
-  repo: "https://github.com/magento/magento2/blob/2.3/app/code/Magento/Checkout/Test/Mftf/Test/StorefrontProductQuantityChangesInBackendAfterCustomerCheckoutTest.xml"
-  module: "Checkout"
-  tests:
-    - testname: "StorefrontProductQuantityChangesInBackendAfterCustomerCheckoutTest"
-      title: "Verify product quantity changes in backend after customer checkout"
-      description: "Checkout as UK customer with bank transfer payment method and verify product quantity reduced after order processed "
- 
-- filename: "StoreFrontUpdateShoppingCartWhileUpdateMinicartTest.xml"
-  repo: "https://github.com/magento/magento2/blob/2.3/app/code/Magento/Checkout/Test/Mftf/Test/StoreFrontUpdateShoppingCartWhileUpdateMinicartTest.xml"
-  module: "Checkout"
-  tests:
-    - testname: "StoreFrontUpdateShoppingCartWhileUpdateMinicartTest"
-      title: "Check updating shopping cart while updating items from minicart"
-      description: "Check updating shopping cart while updating items from minicart"
- 
-- filename: "StorefrontDeleteBundleProductFromMiniShoppingCartTest.xml"
-  repo: "https://github.com/magento/magento2/blob/2.3/app/code/Magento/Checkout/Test/Mftf/Test/StorefrontDeleteBundleProductFromMiniShoppingCartTest.xml"
-  module: "Checkout"
-  tests:
-    - testname: "StorefrontDeleteBundleProductFromMiniShoppingCartTest"
-      title: "Storefront Delete Bundle Product From Mini Shopping Cart Test"
-      description: "Test log in to Shopping Cart and Delete Bundle Product From Mini Shopping Cart Test"
- 
-- filename: "StorefrontAddProductWithAllTypesOfCustomOptionToTheShoppingCartTest.xml"
-  repo: "https://github.com/magento/magento2/blob/2.3/app/code/Magento/Checkout/Test/Mftf/Test/StorefrontAddProductWithAllTypesOfCustomOptionToTheShoppingCartTest.xml"
-  module: "Checkout"
-  tests:
-    - testname: "StorefrontAddProductWithAllTypesOfCustomOptionToTheShoppingCartTest"
-      title: "Create a simple products with all types of oprtions and add it to the cart"
-      description: "Create a simple products with all types of oprtions and add it to the cart"
- 
-- filename: "ConfiguringInstantPurchaseFunctionalityTest.xml"
-  repo: "https://github.com/magento/magento2/blob/2.3/app/code/Magento/Checkout/Test/Mftf/Test/ConfiguringInstantPurchaseFunctionalityTest.xml"
-  module: "Checkout"
-  tests:
-    - testname: "ConfiguringInstantPurchaseFunctionalityTest"
-      title: "Configuring instant purchase functionality test"
-      description: "Configuring instant purchase"
- 
-- filename: "ShoppingCartAndMiniShoppingCartPerCustomerTest.xml"
-  repo: "https://github.com/magento/magento2/blob/2.3/app/code/Magento/Checkout/Test/Mftf/Test/ShoppingCartAndMiniShoppingCartPerCustomerTest.xml"
-  module: "Checkout"
-  tests:
-    - testname: "ShoppingCartAndMiniShoppingCartPerCustomerTest"
-      title: "Shopping cart and mini shopping cart per customer test"
-      description: "Shopping cart and mini shopping cart per customer with enabled cached"
- 
-- filename: "StorefrontCheckoutWithDifferentShippingAndBillingAddressAndProductWithTierPricesTest.xml"
-  repo: "https://github.com/magento/magento2/blob/2.3/app/code/Magento/Checkout/Test/Mftf/Test/StorefrontCheckoutWithDifferentShippingAndBillingAddressAndProductWithTierPricesTest.xml"
-  module: "Checkout"
-  tests:
-    - testname: "StorefrontCheckoutWithDifferentShippingAndBillingAddressAndProductWithTierPricesTest"
-      title: "Verify checkout with different shipping and billing address and product with tier prices"
-      description: "Checkout as a customer with different shipping and billing address and  product with tier prices"
- 
-- filename: "StorefrontAddGroupedProductToShoppingCartTest.xml"
-  repo: "https://github.com/magento/magento2/blob/2.3/app/code/Magento/Checkout/Test/Mftf/Test/StorefrontAddGroupedProductToShoppingCartTest.xml"
-  module: "Checkout"
-  tests:
-    - testname: "StorefrontAddGroupedProductToShoppingCartTest"
-      title: "Create grouped product with three simple product and Add grouped product to the cart"
-      description: "Create grouped product with three simple product and Add grouped product to the cart"
- 
-- filename: "StorefrontAddDownloadableProductToShoppingCartTest.xml"
-  repo: "https://github.com/magento/magento2/blob/2.3/app/code/Magento/Checkout/Test/Mftf/Test/StorefrontAddDownloadableProductToShoppingCartTest.xml"
-  module: "Checkout"
-  tests:
-    - testname: "StorefrontAddDownloadableProductToShoppingCartTest"
-      title: "Create Downloadable product with two links and add to the shopping cart"
-      description: "Create Downloadable product with two links and add to the shopping cart"
- 
-- filename: "OnePageCheckoutAsCustomerUsingDefaultAddressTest.xml"
-  repo: "https://github.com/magento/magento2/blob/2.3/app/code/Magento/Checkout/Test/Mftf/Test/OnePageCheckoutAsCustomerUsingDefaultAddressTest.xml"
-  module: "Checkout"
-  tests:
-    - testname: "OnePageCheckoutAsCustomerUsingDefaultAddressTest"
-      title: "OnePageCheckout as customer using default address test"
-      description: "Checkout as customer using default address"
- 
-- filename: "EndToEndB2CGuestUserTest.xml"
-  repo: "https://github.com/magento/magento2/blob/2.3/app/code/Magento/Checkout/Test/Mftf/Test/EndToEndB2CGuestUserTest.xml"
-  module: "Checkout"
-  tests:
-    - testname: "EndToEndB2CGuestUserTest"
-      title: ""
-      description: ""
-
-    - testname: "EndToEndB2CGuestUserMysqlTest"
-      title: ""
-      description: ""
- 
-- filename: "StoreFrontFreeShippingRecalculationAfterCouponCodeAddedTest.xml"
-  repo: "https://github.com/magento/magento2/blob/2.3/app/code/Magento/Checkout/Test/Mftf/Test/StoreFrontFreeShippingRecalculationAfterCouponCodeAddedTest.xml"
-  module: "Checkout"
-  tests:
-    - testname: "StoreFrontFreeShippingRecalculationAfterCouponCodeAddedTest"
-      title: "Checkout Free Shipping Recalculation after Coupon Code Added"
-      description: "User should be able to do checkout free shipping recalculation after adding coupon code"
- 
-- filename: "CheckoutSpecificDestinationsTest.xml"
-  repo: "https://github.com/magento/magento2/blob/2.3/app/code/Magento/Checkout/Test/Mftf/Test/CheckoutSpecificDestinationsTest.xml"
-  module: "Checkout"
-  tests:
-    - testname: "CheckoutSpecificDestinationsTest"
-      title: "Check that top destinations can be removed after a selection was previously saved"
-      description: "Check that top destinations can be removed after a selection was previously saved"
- 
-- filename: "StorefrontPersistentDataForGuestCustomerWithPhysicalQuoteTest.xml"
-  repo: "https://github.com/magento/magento2/blob/2.3/app/code/Magento/Checkout/Test/Mftf/Test/StorefrontPersistentDataForGuestCustomerWithPhysicalQuoteTest.xml"
-  module: "Checkout"
-  tests:
-    - testname: "StorefrontPersistentDataForGuestCustomerWithPhysicalQuoteTest"
-      title: "Persistent Data for Guest Customer with physical quote"
-      description: "One can use Persistent Data for Guest Customer with physical quote"
- 
-- filename: "StorefrontAddOneBundleMultiSelectOptionToTheShoppingCartTest.xml"
-  repo: "https://github.com/magento/magento2/blob/2.3/app/code/Magento/Checkout/Test/Mftf/Test/StorefrontAddOneBundleMultiSelectOptionToTheShoppingCartTest.xml"
-  module: "Checkout"
-  tests:
-    - testname: "StorefrontAddOneBundleMultiSelectOptionToTheShoppingCartTest"
-      title: "Select one multi select option of a bundle product and add to the shopping cart"
-      description: "Select one multi select option of a bundle product and add to the shopping cart "
- 
-- filename: "StorefrontCheckPagerShoppingCartWithMoreThan20ProductsTest.xml"
-  repo: "https://github.com/magento/magento2/blob/2.3/app/code/Magento/Checkout/Test/Mftf/Test/StorefrontCheckPagerShoppingCartWithMoreThan20ProductsTest.xml"
-  module: "Checkout"
-  tests:
-    - testname: "StorefrontCheckPagerShoppingCartWithMoreThan20ProductsTest"
-      title: "Test if the cart pager is visible with more than 20 cart items and the pager disappears if an item is removed from cart."
-      description: "Test if the cart pager is visible with more than 20 cart items and the pager disappears if an item is removed from cart."
- 
-- filename: "StorefrontProductNameMinicartOnCheckoutPageDifferentStoreViewsTest.xml"
-  repo: "https://github.com/magento/magento2/blob/2.3/app/code/Magento/Checkout/Test/Mftf/Test/StorefrontProductNameMinicartOnCheckoutPageDifferentStoreViewsTest.xml"
-  module: "Checkout"
-  tests:
-    - testname: "StorefrontProductNameMinicartOnCheckoutPageDifferentStoreViewsTest"
-      title: "Checking Product name in Minicart and on Checkout page with different store views"
-      description: "Checking Product name in Minicart and on Checkout page with different store views"
- 
-- filename: "StorefrontUSCustomerCheckoutWithCouponAndBankTransferPaymentMethodTest.xml"
-  repo: "https://github.com/magento/magento2/blob/2.3/app/code/Magento/Checkout/Test/Mftf/Test/StorefrontUSCustomerCheckoutWithCouponAndBankTransferPaymentMethodTest.xml"
-  module: "Checkout"
-  tests:
-    - testname: "StorefrontUSCustomerCheckoutWithCouponAndBankTransferPaymentMethodTest"
-      title: "Verify US customer checkout using coupon and bank transfer payment method"
-      description: "Checkout as US customer using coupon and bank transfer payment method"
- 
-- filename: "DeleteDownloadableProductFromShoppingCartTest.xml"
-  repo: "https://github.com/magento/magento2/blob/2.3/app/code/Magento/Checkout/Test/Mftf/Test/DeleteDownloadableProductFromShoppingCartTest.xml"
-  module: "Checkout"
-  tests:
-    - testname: "DeleteDownloadableProductFromShoppingCartTest"
-      title: "Delete downloadable product from shopping cart test"
-      description: "Delete downloadable product from shopping cart"
- 
-- filename: "DefaultBillingAddressShouldBeCheckedOnPaymentPageTest.xml"
-  repo: "https://github.com/magento/magento2/blob/2.3/app/code/Magento/Checkout/Test/Mftf/Test/DefaultBillingAddressShouldBeCheckedOnPaymentPageTest.xml"
-  module: "Checkout"
-  tests:
-    - testname: "DefaultBillingAddressShouldBeCheckedOnPaymentPageTest"
-      title: "The default billing address should be used on checkout"
-      description: "Default billing address should be preselected on payments page on checkout if it exist"
- 
-- filename: "StorefrontDeleteSimpleProductFromMiniShoppingCartTest.xml"
-  repo: "https://github.com/magento/magento2/blob/2.3/app/code/Magento/Checkout/Test/Mftf/Test/StorefrontDeleteSimpleProductFromMiniShoppingCartTest.xml"
-  module: "Checkout"
-  tests:
-    - testname: "StorefrontDeleteSimpleProductFromMiniShoppingCartTest"
-      title: "Storefront Delete Simple Product From Mini Shopping Cart Test"
-      description: "Test log in to Shopping Cart and Delete Simple Product From Mini Shopping Cart Test"
- 
-- filename: "StorefrontUKGuestCheckoutWithConditionProductQuantityEqualsToOrderedQuantityTest.xml"
-  repo: "https://github.com/magento/magento2/blob/2.3/app/code/Magento/Checkout/Test/Mftf/Test/StorefrontUKGuestCheckoutWithConditionProductQuantityEqualsToOrderedQuantityTest.xml"
-  module: "Checkout"
-  tests:
-    - testname: "StorefrontUKGuestCheckoutWithConditionProductQuantityEqualsToOrderedQuantityTest"
-      title: "Checkout as UK guest with condition available product quantity equals to ordered product quantity"
-      description: "Checkout as UK guest with condition available product quantity equals to ordered product quantity"
- 
-- filename: "StorefrontValidateEmailOnCheckoutTest.xml"
-  repo: "https://github.com/magento/magento2/blob/2.3/app/code/Magento/Checkout/Test/Mftf/Test/StorefrontValidateEmailOnCheckoutTest.xml"
-  module: "Checkout"
-  tests:
-    - testname: "StorefrontValidateEmailOnCheckoutTest"
-      title: "Guest e-mail address validation on Checkout process"
-      description: "Guest should not be able to place an order when invalid e-mail address provided"
- 
-- filename: "DeleteBundleDynamicProductFromShoppingCartTest.xml"
-  repo: "https://github.com/magento/magento2/blob/2.3/app/code/Magento/Checkout/Test/Mftf/Test/DeleteBundleDynamicProductFromShoppingCartTest.xml"
-  module: "Checkout"
-  tests:
-    - testname: "DeleteBundleDynamicProductFromShoppingCartTest"
-      title: "Delete bundle dynamic product from shopping cart test"
-      description: "Delete bundle dynamic product from shopping cart"
- 
-- filename: "StorefrontGuestCheckoutForSpecificCountriesTest.xml"
-  repo: "https://github.com/magento/magento2/blob/2.3/app/code/Magento/Checkout/Test/Mftf/Test/StorefrontGuestCheckoutForSpecificCountriesTest.xml"
-  module: "Checkout"
-  tests:
-    - testname: "StorefrontGuestCheckoutForSpecificCountriesTest"
-      title: "Storefront guest checkout for specific countries test"
-      description: "Checkout flow if shipping rates are not available"
- 
-- filename: "StorefrontMissingPagerShoppingCartWith20ProductsTest.xml"
-  repo: "https://github.com/magento/magento2/blob/2.3/app/code/Magento/Checkout/Test/Mftf/Test/StorefrontMissingPagerShoppingCartWith20ProductsTest.xml"
-  module: "Checkout"
-  tests:
-    - testname: "StorefrontMissingPagerShoppingCartWith20ProductsTest"
-      title: "Test if the cart pager is missing with 20 cart items."
-      description: "Test if the cart pager is missing with 20 cart items."
- 
-- filename: "StorefrontAddTwoBundleMultiSelectOptionsToTheShoppingCartTest.xml"
-  repo: "https://github.com/magento/magento2/blob/2.3/app/code/Magento/Checkout/Test/Mftf/Test/StorefrontAddTwoBundleMultiSelectOptionsToTheShoppingCartTest.xml"
-  module: "Checkout"
-  tests:
-    - testname: "StorefrontAddTwoBundleMultiSelectOptionsToTheShoppingCartTest"
-      title: "Add two products to the cart from multi select options of a bundle product"
-      description: "Add two products to the cart from multi select options of a bundle product."
- 
-- filename: "ZeroSubtotalOrdersWithProcessingStatusTest.xml"
-  repo: "https://github.com/magento/magento2/blob/2.3/app/code/Magento/Checkout/Test/Mftf/Test/ZeroSubtotalOrdersWithProcessingStatusTest.xml"
-  module: "Checkout"
-  tests:
-    - testname: "ZeroSubtotalOrdersWithProcessingStatusTest"
-      title: "Checking status of Zero Subtotal Orders with 'Processing' New Order Status"
-      description: "Created order should be in Processing status"
- 
-- filename: "StorefrontCustomerCheckoutOnLoginWhenGuestCheckoutIsDisabledTest.xml"
-  repo: "https://github.com/magento/magento2/blob/2.3/app/code/Magento/Checkout/Test/Mftf/Test/StorefrontCustomerCheckoutOnLoginWhenGuestCheckoutIsDisabledTest.xml"
-  module: "Checkout"
-  tests:
-    - testname: "StorefrontCustomerCheckoutOnLoginWhenGuestCheckoutIsDisabledTest"
-      title: "Verify customer is redirected to checkout on login when guest checkout is disabled"
-      description: "Customer is redirected to checkout on login when guest checkout is disabled"
- 
-- filename: "StorefrontVerifySecureURLRedirectCheckoutTest.xml"
-  repo: "https://github.com/magento/magento2/blob/2.3/app/code/Magento/Checkout/Test/Mftf/Test/StorefrontVerifySecureURLRedirectCheckoutTest.xml"
-  module: "Checkout"
-  tests:
-    - testname: "StorefrontVerifySecureURLRedirectCheckout"
-      title: "Verify Secure URLs For Storefront Checkout Pages"
-      description: "Verify that the Secure URL configuration applies to the Checkout pages on the Storefront"
- 
-- filename: "DeleteConfigurableProductFromShoppingCartTest.xml"
-  repo: "https://github.com/magento/magento2/blob/2.3/app/code/Magento/Checkout/Test/Mftf/Test/DeleteConfigurableProductFromShoppingCartTest.xml"
-  module: "Checkout"
-  tests:
-    - testname: "DeleteConfigurableProductFromShoppingCartTest"
-      title: "Delete configurable product from shopping cart test"
-      description: "Delete configurable product from shopping cart"
- 
-- filename: "StorefrontCustomerCheckoutDisabledProductAndCouponTest.xml"
-  repo: "https://github.com/magento/magento2/blob/2.3/app/code/Magento/Checkout/Test/Mftf/Test/StorefrontCustomerCheckoutDisabledProductAndCouponTest.xml"
-  module: "Checkout"
-  tests:
-    - testname: "StorefrontCustomerCheckoutDisabledProductAndCouponTest"
-      title: "Customer can login if product in his cart was disabled"
-      description: "Customer can login with disabled product in the cart and a coupon applied"
- 
-- filename: "StorefrontUKCustomerCheckoutWithCouponTest.xml"
-  repo: "https://github.com/magento/magento2/blob/2.3/app/code/Magento/Checkout/Test/Mftf/Test/StorefrontUKCustomerCheckoutWithCouponTest.xml"
-  module: "Checkout"
-  tests:
-    - testname: "StorefrontUKCustomerCheckoutWithCouponTest"
-      title: "Verify UK customer checkout with Virtual and Downloadable products using coupon"
-      description: "Checkout as UK Customer with virtual product and downloadable product using coupon"
- 
-- filename: "StorefrontUpdatePriceInShoppingCartAfterProductSaveTest.xml"
-  repo: "https://github.com/magento/magento2/blob/2.3/app/code/Magento/Checkout/Test/Mftf/Test/StorefrontUpdatePriceInShoppingCartAfterProductSaveTest.xml"
-  module: "Checkout"
-  tests:
-    - testname: "StorefrontUpdatePriceInShoppingCartAfterProductSaveTest"
-      title: "Update price in shopping cart after product save"
-      description: "Price in shopping cart should be updated after product save with changed price"
- 
-- filename: "AdminCheckConfigsChangesIsNotAffectedStartedCheckoutProcessTest.xml"
-  repo: "https://github.com/magento/magento2/blob/2.3/app/code/Magento/Checkout/Test/Mftf/Test/AdminCheckConfigsChangesIsNotAffectedStartedCheckoutProcessTest.xml"
-  module: "Checkout"
-  tests:
-    - testname: "AdminCheckConfigsChangesAreNotAffectedStartedCheckoutProcessTest"
-      title: "Admin check configs changes are not affected started checkout process test"
-      description: "Changes in admin for shipping rates are not affecting checkout process that has been started"
- 
-- filename: "DeleteBundleFixedProductFromShoppingCartTest.xml"
-  repo: "https://github.com/magento/magento2/blob/2.3/app/code/Magento/Checkout/Test/Mftf/Test/DeleteBundleFixedProductFromShoppingCartTest.xml"
-  module: "Checkout"
-  tests:
-    - testname: "DeleteBundleFixedProductFromShoppingCartTest"
-      title: "Delete bundle fixed product from shopping cart test"
-      description: "Delete bundle fixed product from shopping cart"
- 
-- filename: "StorefrontCheckCartItemDisplayWhenMoreItemsAddedToTheCartThanDefaultDisplayLimitTest.xml"
-  repo: "https://github.com/magento/magento2/blob/2.3/app/code/Magento/Checkout/Test/Mftf/Test/StorefrontCheckCartItemDisplayWhenMoreItemsAddedToTheCartThanDefaultDisplayLimitTest.xml"
-  module: "Checkout"
-  tests:
-    - testname: "StorefrontCheckCartItemDisplayWhenMoreItemsAddedToTheCartThanDefaultDisplayLimitTest"
-      title: "Add 11 Simple product to the cart and check cart display with default display limit"
-      description: "Add 11 Simple product to the cart and check cart display with default display limit"
- 
-- filename: "AddressStateFieldForUKCustomerRemainOptionAfterRefreshTest.xml"
-  repo: "https://github.com/magento/magento2/blob/2.3/app/code/Magento/Checkout/Test/Mftf/Test/AddressStateFieldForUKCustomerRemainOptionAfterRefreshTest.xml"
-  module: "Checkout"
-  tests:
-    - testname: "AddressStateFieldForUKCustomerRemainOptionAfterRefreshTest"
-      title: "Address State Field For UK Customers Remain Option even After Browser Refresh"
-      description: "Address State Field For UK Customers Remain Option even After Browser Refresh"
- 
-- filename: "StorefrontUpdateShoppingCartSimpleProductQtyTest.xml"
-  repo: "https://github.com/magento/magento2/blob/2.3/app/code/Magento/Checkout/Test/Mftf/Test/StorefrontUpdateShoppingCartSimpleProductQtyTest.xml"
-  module: "Checkout"
-  tests:
-    - testname: "StorefrontUpdateShoppingCartSimpleProductQtyTest"
-      title: "Check updating shopping cart while updating items qty"
-      description: "Check updating shopping cart while updating items qty"
- 
-- filename: "StorefrontCheckSimpleProductCartItemDisplayWithDefaultLimitationTest.xml"
-  repo: "https://github.com/magento/magento2/blob/2.3/app/code/Magento/Checkout/Test/Mftf/Test/StorefrontCheckSimpleProductCartItemDisplayWithDefaultLimitationTest.xml"
-  module: "Checkout"
-  tests:
-    - testname: "StorefrontCheckSimpleProductCartItemDisplayWithDefaultLimitationTest"
-      title: "Add 10 SimpleProducts to the cart and check cart display with default display limit"
-      description: "Add 10 SimpleProducts to the cart and check cart display with default display limit"
- 
-- filename: "OnePageCheckoutAsCustomerUsingNonDefaultAddressTest.xml"
-  repo: "https://github.com/magento/magento2/blob/2.3/app/code/Magento/Checkout/Test/Mftf/Test/OnePageCheckoutAsCustomerUsingNonDefaultAddressTest.xml"
-  module: "Checkout"
-  tests:
-    - testname: "OnePageCheckoutAsCustomerUsingNonDefaultAddressTest"
-      title: "OnePageCheckout as customer using non default address test"
-      description: "Checkout as customer using non default address"
- 
-- filename: "StorefrontGuestCheckoutUsingFreeShippingAndTaxesTest.xml"
-  repo: "https://github.com/magento/magento2/blob/2.3/app/code/Magento/Checkout/Test/Mftf/Test/StorefrontGuestCheckoutUsingFreeShippingAndTaxesTest.xml"
-  module: "Checkout"
-  tests:
-    - testname: "StorefrontGuestCheckoutUsingFreeShippingAndTaxesTest"
-      title: "Verify guest checkout using free shipping and tax variations"
-      description: "Verify guest checkout using free shipping and tax variations"
- 
-- filename: "StorefrontAddBundleDynamicProductToShoppingCartWithDisableMiniCartSidebarTest.xml"
-  repo: "https://github.com/magento/magento2/blob/2.3/app/code/Magento/Checkout/Test/Mftf/Test/StorefrontAddBundleDynamicProductToShoppingCartWithDisableMiniCartSidebarTest.xml"
-  module: "Checkout"
-  tests:
-    - testname: "StorefrontAddBundleDynamicProductToShoppingCartWithDisableMiniCartSidebarTest"
-      title: "Create Grouped product and verify mini cart action with disabled and enable Mini Cart Sidebar"
-      description: "Create Grouped product and verify mini cart action with disabled and enable Mini Cart Sidebar"
- 
-- filename: "StorefrontCustomerCheckoutTest.xml"
-  repo: "https://github.com/magento/magento2/blob/2.3/app/code/Magento/Checkout/Test/Mftf/Test/StorefrontCustomerCheckoutTest.xml"
-  module: "Checkout"
-  tests:
-    - testname: "StorefrontCustomerCheckoutTest"
-      title: "Customer Checkout via the Admin"
-      description: "Should be able to place an order as a customer."
-
-    - testname: "StorefrontCustomerCheckoutTestWithMultipleAddressesAndTaxRates"
-      title: "Customer Checkout with multiple addresses and tax rates"
-      description: "Should be able to place an order as a customer with multiple addresses and tax rates."
-
-    - testname: "StorefrontCustomerCheckoutTestWithRestrictedCountriesForPayment"
-      title: "Checkout via Customer Checkout with restricted countries for payment"
-      description: "Should be able to place an order as a Customer with restricted countries for payment."
- 
-- filename: "CheckCheckoutSuccessPageTest.xml"
-  repo: "https://github.com/magento/magento2/blob/2.3/app/code/Magento/Checkout/Test/Mftf/Test/CheckCheckoutSuccessPageTest.xml"
-  module: "Checkout"
-  tests:
-    - testname: "CheckCheckoutSuccessPageAsRegisterCustomer"
-      title: "Customer Checkout"
-      description: "To be sure that other elements of Success page are shown for placed order as registered Customer."
-
-    - testname: "CheckCheckoutSuccessPageAsGuest"
-      title: "Guest Checkout - elements of success page are presented for placed order as guest"
-      description: "To be sure that other elements of Success page are presented for placed order as Guest"
- 
-- filename: "EditShippingAddressOnePageCheckoutTest.xml"
-  repo: "https://github.com/magento/magento2/blob/2.3/app/code/Magento/Checkout/Test/Mftf/Test/EditShippingAddressOnePageCheckoutTest.xml"
-  module: "Checkout"
-  tests:
-    - testname: "EditShippingAddressOnePageCheckoutTest"
-      title: "Edit Shipping Address on Checkout Page."
-      description: "Edit Shipping Address on Checkout Page."
- 
-- filename: "StorefrontDeleteDownloadableProductFromMiniShoppingCartTest.xml"
-  repo: "https://github.com/magento/magento2/blob/2.3/app/code/Magento/Checkout/Test/Mftf/Test/StorefrontDeleteDownloadableProductFromMiniShoppingCartTest.xml"
-  module: "Checkout"
-  tests:
-    - testname: "StorefrontDeleteDownloadableProductFromMiniShoppingCartTest"
-      title: "Storefront Delete Downloadable Product From Mini Shopping Cart Test"
-      description: "Test log in to Shopping Cart and Delete Downloadable Product From Mini Shopping Cart Test"
- 
-- filename: "StorefrontCheckCartAndSummaryBlockItemDisplayWithDefaultDisplayLimitationTest.xml"
-  repo: "https://github.com/magento/magento2/blob/2.3/app/code/Magento/Checkout/Test/Mftf/Test/StorefrontCheckCartAndSummaryBlockItemDisplayWithDefaultDisplayLimitationTest.xml"
-  module: "Checkout"
-  tests:
-    - testname: "StorefrontCheckCartAndSummaryBlockItemDisplayWithDefaultDisplayLimitationTest"
-      title: "Add 10 items to the cart and check cart and summary block display with default display limit"
-      description: "Add 10 items to the cart and check cart and summary block display with default display limit"
- 
-- filename: "NoErrorCartCheckoutForProductsDeletedFromMiniCartTest.xml"
-  repo: "https://github.com/magento/magento2/blob/2.3/app/code/Magento/Checkout/Test/Mftf/Test/NoErrorCartCheckoutForProductsDeletedFromMiniCartTest.xml"
-  module: "Checkout"
-  tests:
-    - testname: "NoErrorCartCheckoutForProductsDeletedFromMiniCartTest"
-      title: "Delete product from Checkout"
-      description: "No error from cart should be thrown for product deleted from minicart"
- 
-- filename: "StorefrontOnePageCheckoutJsValidationTest.xml"
-  repo: "https://github.com/magento/magento2/blob/2.3/app/code/Magento/Checkout/Test/Mftf/Test/StorefrontOnePageCheckoutJsValidationTest.xml"
-  module: "Checkout"
-  tests:
-    - testname: "StorefrontOnePageCheckoutJsValidationTest"
-      title: "Js validation error messages must be absent for required fields after checkout start."
-      description: "Js validation error messages must be absent for required fields after checkout start."
- 
-- filename: "OnePageCheckoutAsCustomerUsingNewAddressTest.xml"
-  repo: "https://github.com/magento/magento2/blob/2.3/app/code/Magento/Checkout/Test/Mftf/Test/OnePageCheckoutAsCustomerUsingNewAddressTest.xml"
-  module: "Checkout"
-  tests:
-    - testname: "OnePageCheckoutAsCustomerUsingNewAddressTest"
-      title: "OnePageCheckout as customer using new address test"
-      description: "Checkout as customer using new address"
- 
-- filename: "AddressStateFieldShouldNotAcceptJustIntegerValuesTest.xml"
-  repo: "https://github.com/magento/magento2/blob/2.3/app/code/Magento/Checkout/Test/Mftf/Test/AddressStateFieldShouldNotAcceptJustIntegerValuesTest.xml"
-  module: "Checkout"
-  tests:
-    - testname: "AddressStateFieldShouldNotAcceptJustIntegerValuesTest"
-      title: "Guest Checkout - address State field should not allow just integer values"
-      description: "Address State field should not allow just integer values"
- 
-- filename: "StorefrontNotApplicableShippingMethodInReviewAndPaymentStepTest.xml"
-  repo: "https://github.com/magento/magento2/blob/2.3/app/code/Magento/Checkout/Test/Mftf/Test/StorefrontNotApplicableShippingMethodInReviewAndPaymentStepTest.xml"
-  module: "Checkout"
-  tests:
-    - testname: "StorefrontNotApplicableShippingMethodInReviewAndPaymentStepTest"
-      title: "Not applicable Shipping Method In Review and Payment Step"
-      description: "User should not be able to place order when free shipping declined after applying coupon code"
- 
-- filename: "CheckNotVisibleProductInMinicartTest.xml"
-  repo: "https://github.com/magento/magento2/blob/2.3/app/code/Magento/Checkout/Test/Mftf/Test/CheckNotVisibleProductInMinicartTest.xml"
-  module: "Checkout"
-  tests:
-    - testname: "CheckNotVisibleProductInMinicartTest"
-      title: "Not visible individually product in mini-shopping cart."
-      description: "To be sure that product in mini-shopping cart remains visible after admin makes it not visible individually"
- 
-- filename: "StorefrontRefreshPageDuringGuestCheckoutTest.xml"
-  repo: "https://github.com/magento/magento2/blob/2.3/app/code/Magento/Checkout/Test/Mftf/Test/StorefrontRefreshPageDuringGuestCheckoutTest.xml"
-  module: "Checkout"
-  tests:
-    - testname: "StorefrontRefreshPageDuringGuestCheckoutTest"
-      title: "Storefront refresh page during guest checkout test"
-      description: "Address is not lost for guest checkout if guest refresh page during checkout"
- 
-- filename: "StorefrontCustomerLoginDuringCheckoutTest.xml"
-  repo: "https://github.com/magento/magento2/blob/2.3/app/code/Magento/Checkout/Test/Mftf/Test/StorefrontCustomerLoginDuringCheckoutTest.xml"
-  module: "Checkout"
-  tests:
-    - testname: "StorefrontCustomerLoginDuringCheckoutTest"
-      title: "Storefront customer login during checkout test"
-      description: "Logging during checkout for customer without addresses in address book"
- 
-- filename: "UpdateProductFromMiniShoppingCartEntityTest.xml"
-  repo: "https://github.com/magento/magento2/blob/2.3/app/code/Magento/Checkout/Test/Mftf/Test/UpdateProductFromMiniShoppingCartEntityTest.xml"
-  module: "Checkout"
-  tests:
-    - testname: "UpdateProductFromMiniShoppingCartEntityTest"
-      title: "Check updating product from mini shopping cart"
-      description: "Update Product Qty on Mini Shopping Cart"
- 
-- filename: "StorefrontCustomerCheckoutWithoutRegionTest.xml"
-  repo: "https://github.com/magento/magento2/blob/2.3/app/code/Magento/Checkout/Test/Mftf/Test/StorefrontCustomerCheckoutWithoutRegionTest.xml"
-  module: "Checkout"
-  tests:
-    - testname: "StorefrontCustomerCheckoutWithoutRegionTest"
-      title: "Shipping address is not validated in checkout when proceeding step as logged in user with default shipping address"
-      description: "Shouldn't be able to place an order as a customer without state if it's required."
- 
-- filename: "StorefrontOnePageCheckoutDataWhenChangeQtyTest.xml"
-  repo: "https://github.com/magento/magento2/blob/2.3/app/code/Magento/Checkout/Test/Mftf/Test/StorefrontOnePageCheckoutDataWhenChangeQtyTest.xml"
-  module: "Checkout"
-  tests:
-    - testname: "StorefrontOnePageCheckoutDataWhenChangeQtyTest"
-      title: "One page Checkout Customer data when changing Product Qty"
-      description: "One page Checkout Customer data when changing Product Qty"
- 
-- filename: "StorefrontGuestCheckoutWithCouponAndZeroSubtotalTest.xml"
-  repo: "https://github.com/magento/magento2/blob/2.3/app/code/Magento/Checkout/Test/Mftf/Test/StorefrontGuestCheckoutWithCouponAndZeroSubtotalTest.xml"
-  module: "Checkout"
-  tests:
-    - testname: "StorefrontGuestCheckoutWithCouponAndZeroSubtotalTest"
-      title: "Verify guest checkout with virtual product using coupon for not logged in customers with Zero Subtotal"
-      description: "Checkout with virtual product using coupon for not logged in customers with Zero Subtotal"
- 
-- filename: "StorefrontShoppingCartPagerForOneItemPerPageAnd2ProductsTest.xml"
-  repo: "https://github.com/magento/magento2/blob/2.3/app/code/Magento/Checkout/Test/Mftf/Test/StorefrontShoppingCartPagerForOneItemPerPageAnd2ProductsTest.xml"
-  module: "Checkout"
-  tests:
-    - testname: "StorefrontShoppingCartPagerForOneItemPerPageAnd2ProductsTest"
-      title: "Test if the cart pager is visible with 2 cart items and one item per page."
-      description: "Test if the cart pager is visible with 2 cart items and one item per page."
- 
-- filename: "StorefrontCheckoutWithSpecialPriceProductsTest.xml"
-  repo: "https://github.com/magento/magento2/blob/2.3/app/code/Magento/Checkout/Test/Mftf/Test/StorefrontCheckoutWithSpecialPriceProductsTest.xml"
-  module: "Checkout"
-  tests:
-    - testname: "StorefrontCheckoutWithSpecialPriceProductsTest"
-      title: "Verify customer checkout with special price simple and configurable products"
-      description: "Create simple and configurable product with special prices and verify customer checkout"
- 
-- filename: "StorefrontCheckCartItemDisplayWithDefaultDisplayLimitAndDefaultTotalQuantityTest.xml"
-  repo: "https://github.com/magento/magento2/blob/2.3/app/code/Magento/Checkout/Test/Mftf/Test/StorefrontCheckCartItemDisplayWithDefaultDisplayLimitAndDefaultTotalQuantityTest.xml"
-  module: "Checkout"
-  tests:
-    - testname: "StorefrontCheckCartItemDisplayWithDefaultDisplayLimitAndDefaultTotalQuantityTest"
-      title: "Add 10 items to the cart and check cart display with default display limit"
-      description: "Add 10 items to the cart and check cart display with default display limit"
- 
-- filename: "StorefrontShoppingCartCheckCustomerDefaultShippingAddressForVirtualQuoteTest.xml"
-  repo: "https://github.com/magento/magento2/blob/2.3/app/code/Magento/Checkout/Test/Mftf/Test/StorefrontShoppingCartCheckCustomerDefaultShippingAddressForVirtualQuoteTest.xml"
-  module: "Checkout"
-  tests:
-    - testname: "StorefrontShoppingCartCheckCustomerDefaultShippingAddressForVirtualQuoteTest"
-      title: "Estimator in Shopping cart must be pre-filled by Customer default shipping address for virtual quote"
-      description: "Estimator in Shopping cart must be pre-filled by Customer default shipping address for virtual quote"
- 
-- filename: "StorefrontDeleteSimpleAndVirtualProductFromMiniShoppingCartTest.xml"
-  repo: "https://github.com/magento/magento2/blob/2.3/app/code/Magento/Checkout/Test/Mftf/Test/StorefrontDeleteSimpleAndVirtualProductFromMiniShoppingCartTest.xml"
-  module: "Checkout"
-  tests:
-    - testname: "StorefrontDeleteSimpleAndVirtualProductFromMiniShoppingCartTest"
-      title: "Storefront Delete Simple And Virtual Product From Mini Shopping Cart Test"
-      description: "Test log in to Shopping Cart and Delete Simple And Virtual Product From Mini Shopping Cart Test"
- 
-- filename: "DeleteGroupedProductFromShoppingCartTest.xml"
-  repo: "https://github.com/magento/magento2/blob/2.3/app/code/Magento/Checkout/Test/Mftf/Test/DeleteGroupedProductFromShoppingCartTest.xml"
-  module: "Checkout"
-  tests:
-    - testname: "DeleteGroupedProductFromShoppingCartTest"
-      title: "Delete grouped product from shopping cart test"
-      description: "Delete grouped product from shopping cart"
- 
-- filename: "StorefrontApplyPromoCodeDuringCheckoutTest.xml"
-  repo: "https://github.com/magento/magento2/blob/2.3/app/code/Magento/Checkout/Test/Mftf/Test/StorefrontApplyPromoCodeDuringCheckoutTest.xml"
-  module: "Checkout"
-  tests:
-    - testname: "StorefrontApplyPromoCodeDuringCheckoutTest"
-      title: "Storefront apply promo code during checkout test"
-      description: "Apply promo code during checkout for physical product"
- 
-- filename: "StorefrontCheckCartAndCheckoutItemsCountTest.xml"
-  repo: "https://github.com/magento/magento2/blob/2.3/app/code/Magento/Checkout/Test/Mftf/Test/StorefrontCheckCartAndCheckoutItemsCountTest.xml"
-  module: "Checkout"
-  tests:
-    - testname: "StorefrontCartItemsCountDisplayItemsQuantities"
-      title: "Checkout order summary has wrong item count - display items quantities"
-      description: "Items count in shopping cart and on checkout page should be consistent with settings 'checkout/cart_link/use_qty'"
-
-    - testname: "StorefrontCartItemsCountDisplayUniqueItems"
-      title: "Checkout order summary has wrong item count - display unique items"
-      description: "Items count in shopping cart and on checkout page should be consistent with settings 'checkout/cart_link/use_qty'"
- 
-- filename: "OnePageCheckoutWithAllProductTypesTest.xml"
-  repo: "https://github.com/magento/magento2/blob/2.3/app/code/Magento/Checkout/Test/Mftf/Test/OnePageCheckoutWithAllProductTypesTest.xml"
-  module: "Checkout"
-  tests:
-    - testname: "OnePageCheckoutWithAllProductTypesTest"
-      title: "OnePageCheckout with all product types test"
-      description: "Checkout with all product types"
- 
-- filename: "StorefrontRegionUpdatesAfterChangingCountryAndLeavingRegionSelectUnselectedTest.xml"
-  repo: "https://github.com/magento/magento2/blob/2.3/app/code/Magento/Checkout/Test/Mftf/Test/StorefrontRegionUpdatesAfterChangingCountryAndLeavingRegionSelectUnselectedTest.xml"
-  module: "Checkout"
-  tests:
-    - testname: "StorefrontRegionUpdatesAfterChangingCountryAndLeavingRegionSelectUnselectedTest"
-      title: "Region updates after changing country "
-      description: "Region dupdates after changing country and leaving region select unselected"
- 
-- filename: "StorefrontGuestCheckoutTest.xml"
-  repo: "https://github.com/magento/magento2/blob/2.3/app/code/Magento/Checkout/Test/Mftf/Test/StorefrontGuestCheckoutTest.xml"
-  module: "Checkout"
-  tests:
-    - testname: "StorefrontGuestCheckoutTest"
-      title: "Guest Checkout - guest should be able to place an order"
-      description: "Should be able to place an order as a Guest"
-
-    - testname: "StorefrontGuestCheckoutWithSidebarDisabledTest"
-      title: "Guest Checkout when Cart sidebar disabled"
-      description: "Should be able to place an order as a Guest when Cart sidebar is disabled"
-
-    - testname: "StorefrontGuestCheckoutTestWithRestrictedCountriesForPayment"
-      title: "Checkout via Guest Checkout with restricted countries for payment"
-      description: "Should be able to place an order as a Guest with restricted countries for payment."
- 
-- filename: "StorefrontDeleteConfigurableProductFromMiniShoppingCartTest.xml"
-  repo: "https://github.com/magento/magento2/blob/2.3/app/code/Magento/Checkout/Test/Mftf/Test/StorefrontDeleteConfigurableProductFromMiniShoppingCartTest.xml"
-  module: "Checkout"
-  tests:
-    - testname: "StorefrontDeleteConfigurableProductFromMiniShoppingCartTest"
-      title: "Storefront Delete Configurable Product From Mini Shopping Cart Test"
-      description: "Test log in to Shopping Cart and Delete Configurable Product From Mini Shopping Cart Test"
- 
-- filename: "EndToEndB2CLoggedInUserTest.xml"
-  repo: "https://github.com/magento/magento2/blob/2.3/app/code/Magento/Checkout/Test/Mftf/Test/EndToEndB2CLoggedInUserTest.xml"
-  module: "Checkout"
-  tests:
-    - testname: "EndToEndB2CLoggedInUserTest"
-      title: ""
-      description: ""
- 
-- filename: "IdentityOfDefaultBillingAndShippingAddressTest.xml"
-  repo: "https://github.com/magento/magento2/blob/2.3/app/code/Magento/Checkout/Test/Mftf/Test/IdentityOfDefaultBillingAndShippingAddressTest.xml"
-  module: "Checkout"
-  tests:
-    - testname: "IdentityOfDefaultBillingAndShippingAddressTest"
-      title: "Checking assignment of default billing address after placing an orde"
-      description: "In 'Address book' field 'Default Billing Address' should be the same as 'Default Shipping Address'"
- 
-- filename: "StorefrontCustomerPlaceOrderWithNewAddressesThatWasEditedTest.xml"
-  repo: "https://github.com/magento/magento2/blob/2.3/app/code/Magento/Checkout/Test/Mftf/Test/StorefrontCustomerPlaceOrderWithNewAddressesThatWasEditedTest.xml"
-  module: "Checkout"
-  tests:
-    - testname: "StorefrontCustomerPlaceOrderWithNewAddressesThatWasEditedTest"
-      title: "Customer can place order with new addresses that was edited during checkout with several conditions"
-      description: "Customer can place order with new addresses."
- 
-- filename: "StorefrontGuestCheckoutDataPersistTest.xml"
-  repo: "https://github.com/magento/magento2/blob/2.3/app/code/Magento/Checkout/Test/Mftf/Test/StorefrontGuestCheckoutDataPersistTest.xml"
-  module: "Checkout"
-  tests:
-    - testname: "StorefrontGuestCheckoutDataPersistTest"
-      title: "Check that checkout data persist after cart update"
-      description: "Checkout data should be persist after updating cart"
- 
-- filename: "OnePageCheckoutUsingSignInLinkTest.xml"
-  repo: "https://github.com/magento/magento2/blob/2.3/app/code/Magento/Checkout/Test/Mftf/Test/OnePageCheckoutUsingSignInLinkTest.xml"
-  module: "Checkout"
-  tests:
-    - testname: "OnePageCheckoutUsingSignInLinkTest"
-      title: "OnePageCheckout using sign in link test"
-      description: "Checkout using 'Sign In' link"
- 
-- filename: "StorefrontCheckVirtualProductCountDisplayWithCustomDisplayConfigurationTest.xml"
-  repo: "https://github.com/magento/magento2/blob/2.3/app/code/Magento/Checkout/Test/Mftf/Test/StorefrontCheckVirtualProductCountDisplayWithCustomDisplayConfigurationTest.xml"
-  module: "Checkout"
-  tests:
-    - testname: "StorefrontCheckVirtualProductCountDisplayWithCustomDisplayConfigurationTest"
-      title: "Verify virtual products count in mini cart and summary block with custom display configuration"
-      description: "Verify virtual products count in mini cart and summary block with custom display configuration"
- 
-- filename: "AdminResetUserPasswordFailedTest.xml"
-  repo: "https://github.com/magento/magento2/blob/2.3/app/code/Magento/Captcha/Test/Mftf/Test/AdminResetUserPasswordFailedTest.xml"
-  module: "Captcha"
-  tests:
-    - testname: "AdminResetUserPasswordFailedTest"
-      title: ""
-      description: ""
- 
-- filename: "StorefrontCaptchaEditCustomerEmailTest.xml"
-  repo: "https://github.com/magento/magento2/blob/2.3/app/code/Magento/Captcha/Test/Mftf/Test/StorefrontCaptchaEditCustomerEmailTest.xml"
-  module: "Captcha"
-  tests:
-    - testname: "StorefrontCaptchaEditCustomerEmailTest"
-      title: "Test for checking captcha on the customer account edit page."
-      description: "Test for checking captcha on the customer account edit page and customer is locked."
- 
-- filename: "StorefrontResetCustomerPasswordFailedTest.xml"
-  repo: "https://github.com/magento/magento2/blob/2.3/app/code/Magento/Captcha/Test/Mftf/Test/StorefrontResetCustomerPasswordFailedTest.xml"
-  module: "Captcha"
-  tests:
-    - testname: "StorefrontResetCustomerPasswordFailedTest"
-      title: ""
-      description: ""
- 
-- filename: "AdminLoginWithCaptchaTest.xml"
-  repo: "https://github.com/magento/magento2/blob/2.3/app/code/Magento/Captcha/Test/Mftf/Test/AdminLoginWithCaptchaTest.xml"
-  module: "Captcha"
-  tests:
-    - testname: "AdminLoginWithCaptchaTest"
-      title: "Captcha on Admin login form"
-      description: "Test creation for admin login with captcha."
- 
-- filename: "StorefrontCaptchaOnCustomerLoginTest.xml"
-  repo: "https://github.com/magento/magento2/blob/2.3/app/code/Magento/Captcha/Test/Mftf/Test/StorefrontCaptchaOnCustomerLoginTest.xml"
-  module: "Captcha"
-  tests:
-    - testname: "StorefrontCaptchaOnCustomerLoginTest"
-      title: "Captcha customer login page test"
-      description: "Check CAPTCHA on Storefront Login Page."
- 
-- filename: "StorefrontCaptchaOnContactUsTest.xml"
-  repo: "https://github.com/magento/magento2/blob/2.3/app/code/Magento/Captcha/Test/Mftf/Test/StorefrontCaptchaOnContactUsTest.xml"
-  module: "Captcha"
-  tests:
-    - testname: "StorefrontCaptchaOnContactUsTest"
-      title: "Captcha on contact us form test"
-      description: "Test creation for send comment using the contact us form with captcha."
- 
-- filename: "CaptchaFormsDisplayingTest.xml"
-  repo: "https://github.com/magento/magento2/blob/2.3/app/code/Magento/Captcha/Test/Mftf/Test/CaptchaFormsDisplayingTest.xml"
-  module: "Captcha"
-  tests:
-    - testname: "CaptchaFormsDisplayingTest"
-      title: "Captcha forms displaying"
-      description: "Captcha forms displaying"
-
-    - testname: "CaptchaWithDisabledGuestCheckout"
-      title: "Captcha is displaying on login form with disabled guest checkout"
-      description: "Captcha is displaying on login form with disabled guest checkout"
- 
-- filename: "StorefrontCaptchaRegisterNewCustomerTest.xml"
-  repo: "https://github.com/magento/magento2/blob/2.3/app/code/Magento/Captcha/Test/Mftf/Test/StorefrontCaptchaRegisterNewCustomerTest.xml"
-  module: "Captcha"
-  tests:
-    - testname: "StorefrontCaptchaRegisterNewCustomerTest"
-      title: "Test creation for customer register with captcha on storefront."
-      description: "Test creation for customer register with captcha on storefront."
- 
-- filename: "StorefrontVerifySearchSuggestionByProductShortDescriptionTest.xml"
-  repo: "https://github.com/magento/magento2/blob/2.3/app/code/Magento/Search/Test/Mftf/Test/StorefrontVerifySearchSuggestionByProductShortDescriptionTest.xml"
-  module: "Search"
-  tests:
-    - testname: "StorefrontVerifySearchSuggestionByProductShortDescriptionTest"
-      title: "Create search query using product short description and verify search suggestions"
-      description: "Storefront search by product short description, generate search query and verify dropdown product search suggestions"
- 
-- filename: "AdminMassDeleteSearchTermEntityTest.xml"
-  repo: "https://github.com/magento/magento2/blob/2.3/app/code/Magento/Search/Test/Mftf/Test/AdminMassDeleteSearchTermEntityTest.xml"
-  module: "Search"
-  tests:
-    - testname: "AdminMassDeleteSearchTermEntityTest"
-      title: "Admin mass delete search term entity test"
-      description: "Admin should be able to Mass Delete Search Term Entity Test"
- 
-- filename: "AdminGlobalSearchOnProductPageTest.xml"
-  repo: "https://github.com/magento/magento2/blob/2.3/app/code/Magento/Search/Test/Mftf/Test/AdminGlobalSearchOnProductPageTest.xml"
-  module: "Search"
-  tests:
-    - testname: "AdminGlobalSearchOnProductPageTest"
-      title: "Admin global search on product page test"
-      description: "Admin search displays settings and content items"
- 
-- filename: "StorefrontVerifySearchSuggestionByProductNameTest.xml"
-  repo: "https://github.com/magento/magento2/blob/2.3/app/code/Magento/Search/Test/Mftf/Test/StorefrontVerifySearchSuggestionByProductNameTest.xml"
-  module: "Search"
-  tests:
-    - testname: "StorefrontVerifySearchSuggestionByProductNameTest"
-      title: "Create search query using product name and verify search suggestions"
-      description: "Storefront search by product name and verify dropdown product search suggestions"
- 
-- filename: "StorefrontVerifySearchSuggestionByProductDescriptionTest.xml"
-  repo: "https://github.com/magento/magento2/blob/2.3/app/code/Magento/Search/Test/Mftf/Test/StorefrontVerifySearchSuggestionByProductDescriptionTest.xml"
-  module: "Search"
-  tests:
-    - testname: "StorefrontVerifySearchSuggestionByProductDescriptionTest"
-      title: "Create search query using product description and verify search suggestions"
-      description: "Storefront search by product description, generate search query and verify dropdown product search suggestions"
- 
-- filename: "StorefrontVerifySearchSuggestionByProductSkuTest.xml"
-  repo: "https://github.com/magento/magento2/blob/2.3/app/code/Magento/Search/Test/Mftf/Test/StorefrontVerifySearchSuggestionByProductSkuTest.xml"
-  module: "Search"
-  tests:
-    - testname: "StorefrontVerifySearchSuggestionByProductSkuTest"
-      title: "Create search query using product sku and verify search suggestions"
-      description: "Storefront search by product sku, generate search query and verify dropdown product search suggestions"
- 
-- filename: "AdminRemoveDefaultVideoGroupedProductTest.xml"
-  repo: "https://github.com/magento/magento2/blob/2.3/app/code/Magento/GroupedProduct/Test/Mftf/Test/AdminRemoveDefaultVideoGroupedProductTest.xml"
-  module: "GroupedProduct"
-  tests:
-    - testname: "AdminRemoveDefaultVideoGroupedProductTest"
-      title: "Admin should be able to remove default video from a Grouped Product"
-      description: "Admin should be able to remove default video from a Grouped Product"
- 
-- filename: "AdminDeleteGroupedProductTest.xml"
-  repo: "https://github.com/magento/magento2/blob/2.3/app/code/Magento/GroupedProduct/Test/Mftf/Test/AdminDeleteGroupedProductTest.xml"
-  module: "GroupedProduct"
-  tests:
-    - testname: "AdminDeleteGroupedProductTest"
-      title: "Delete Grouped Product"
-      description: "Admin should be able to delete a grouped product"
- 
-- filename: "AdminAssociateGroupedProductToWebsitesTest.xml"
-  repo: "https://github.com/magento/magento2/blob/2.3/app/code/Magento/GroupedProduct/Test/Mftf/Test/AdminAssociateGroupedProductToWebsitesTest.xml"
-  module: "GroupedProduct"
-  tests:
-    - testname: "AdminAssociateGroupedProductToWebsitesTest"
-      title: "Admin should be able to associate grouped product to websites"
-      description: "Admin should be able to associate grouped product to websites"
- 
-- filename: "AdminGroupedSetEditRelatedProductsTest.xml"
-  repo: "https://github.com/magento/magento2/blob/2.3/app/code/Magento/GroupedProduct/Test/Mftf/Test/AdminGroupedSetEditRelatedProductsTest.xml"
-  module: "GroupedProduct"
-  tests:
-    - testname: "AdminGroupedSetEditRelatedProductsTest"
-      title: "Admin should be able to set/edit Related Products information when editing a grouped product"
-      description: "Admin should be able to set/edit Related Products information when editing a grouped product"
- 
-- filename: "NewProductsListWidgetGroupedProductTest.xml"
-  repo: "https://github.com/magento/magento2/blob/2.3/app/code/Magento/GroupedProduct/Test/Mftf/Test/NewProductsListWidgetGroupedProductTest.xml"
-  module: "GroupedProduct"
-  tests:
-    - testname: "NewProductsListWidgetGroupedProductTest"
-      title: "Admin should be able to set Grouped Product as new so that it shows up in the Catalog New Products List Widget"
-      description: "Admin should be able to set Grouped Product as new so that it shows up in the Catalog New Products List Widget"
- 
-- filename: "AdminSortingAssociatedProductsTest.xml"
-  repo: "https://github.com/magento/magento2/blob/2.3/app/code/Magento/GroupedProduct/Test/Mftf/Test/AdminSortingAssociatedProductsTest.xml"
-  module: "GroupedProduct"
-  tests:
-    - testname: "AdminSortingAssociatedProductsTest"
-      title: "Grouped Products: Sorting Associated Products Between Pages"
-      description: "Make sure that products in grid were recalculated when sorting associated products between pages"
- 
-- filename: "AdminCreateAndEditGroupedProductSettingsTest.xml"
-  repo: "https://github.com/magento/magento2/blob/2.3/app/code/Magento/GroupedProduct/Test/Mftf/Test/AdminCreateAndEditGroupedProductSettingsTest.xml"
-  module: "GroupedProduct"
-  tests:
-    - testname: "AdminCreateAndEditGroupedProductSettingsTest"
-      title: "Admin should be able to set/edit other product information when creating/editing a grouped product"
-      description: "Admin should be able to set/edit other product information when creating/editing a grouped product"
- 
-- filename: "AdvanceCatalogSearchGroupedProductTest.xml"
-  repo: "https://github.com/magento/magento2/blob/2.3/app/code/Magento/GroupedProduct/Test/Mftf/Test/AdvanceCatalogSearchGroupedProductTest.xml"
-  module: "GroupedProduct"
-  tests:
-    - testname: "AdvanceCatalogSearchGroupedProductByNameTest"
-      title: "Guest customer should be able to advance search Grouped product with product name"
-      description: "Guest customer should be able to advance search Grouped product with product name"
-
-    - testname: "AdvanceCatalogSearchGroupedProductByNameMysqlTest"
-      title: "Guest customer should be able to advance search Grouped product with product name using the MySQL search engine"
-      description: "Guest customer should be able to advance search Grouped product with product name using the MySQL search engine"
-
-    - testname: "AdvanceCatalogSearchGroupedProductBySkuTest"
-      title: "Guest customer should be able to advance search Grouped product with product sku"
-      description: "Guest customer should be able to advance search Grouped product with product sku"
-
-    - testname: "AdvanceCatalogSearchGroupedProductByDescriptionTest"
-      title: "Guest customer should be able to advance search Grouped product with product description"
-      description: "Guest customer should be able to advance search Grouped product with product description"
-
-    - testname: "AdvanceCatalogSearchGroupedProductByDescriptionMysqlTest"
-      title: "Guest customer should be able to advance search Grouped product with product description using the MySQL search engine"
-      description: "Guest customer should be able to advance search Grouped product with product description using the MYSQL search engine"
-
-    - testname: "AdvanceCatalogSearchGroupedProductByShortDescriptionTest"
-      title: "Guest customer should be able to advance search Grouped product with product short description"
-      description: "Guest customer should be able to advance search Grouped product with product short description"
-
-    - testname: "AdvanceCatalogSearchGroupedProductByShortDescriptionMysqlTest"
-      title: "Guest customer should be able to advance search Grouped product with product short description using the MySQL search engine"
-      description: "Guest customer should be able to advance search Grouped product with product short description using the MySQL search engine"
-
-    - testname: "AdvanceCatalogSearchGroupedProductByPriceTest"
-      title: "Guest customer should be able to advance search Grouped product with product price"
-      description: "Guest customer should be able to advance search Grouped product with product price"
-
-    - testname: "AdvanceCatalogSearchGroupedProductByPriceMysqlTest"
-      title: "Guest customer should be able to advance search Grouped product with product price using the MySQL search engine"
-      description: "Guest customer should be able to advance search Grouped product with product price using the MySQL search engine"
- 
-- filename: "AdminGroupedProductSetEditContentTest.xml"
-  repo: "https://github.com/magento/magento2/blob/2.3/app/code/Magento/GroupedProduct/Test/Mftf/Test/AdminGroupedProductSetEditContentTest.xml"
-  module: "GroupedProduct"
-  tests:
-    - testname: "AdminGroupedProductSetEditContentTest"
-      title: "Admin should be able to set/edit product Content when editing a grouped product"
-      description: "Admin should be able to set/edit product Content when editing a grouped product"
- 
-- filename: "AdminRemoveDefaultImageGroupedProductTest.xml"
-  repo: "https://github.com/magento/magento2/blob/2.3/app/code/Magento/GroupedProduct/Test/Mftf/Test/AdminRemoveDefaultImageGroupedProductTest.xml"
-  module: "GroupedProduct"
-  tests:
-    - testname: "AdminRemoveDefaultImageGroupedProductTest"
-      title: "Admin should be able to remove default images from a Grouped Product"
-      description: "Admin should be able to remove default images from a Grouped Product"
- 
-- filename: "EndToEndB2CAdminTest.xml"
-  repo: "https://github.com/magento/magento2/blob/2.3/app/code/Magento/GroupedProduct/Test/Mftf/Test/EndToEndB2CAdminTest.xml"
-  module: "GroupedProduct"
-  tests:
-    - testname: "EndToEndB2CAdminTest"
-      title: ""
-      description: ""
- 
-- filename: "AdminGroupedProductsListTest.xml"
-  repo: "https://github.com/magento/magento2/blob/2.3/app/code/Magento/GroupedProduct/Test/Mftf/Test/AdminGroupedProductsListTest.xml"
-  module: "GroupedProduct"
-  tests:
-    - testname: "AdminGroupedProductsAreListedWhenOutOfStock"
-      title: "Products in group should show in admin list even when they are out of stock"
-      description: "Products in group should show in admin list even when they are out of stock"
- 
-- filename: "AdminAddDefaultImageGroupedProductTest.xml"
-  repo: "https://github.com/magento/magento2/blob/2.3/app/code/Magento/GroupedProduct/Test/Mftf/Test/AdminAddDefaultImageGroupedProductTest.xml"
-  module: "GroupedProduct"
-  tests:
-    - testname: "AdminAddDefaultImageGroupedProductTest"
-      title: "Admin should be able to add default images for a Grouped Product"
-      description: "Admin should be able to add default images for a Grouped Product"
- 
-- filename: "AdminAddDefaultVideoGroupedProductTest.xml"
-  repo: "https://github.com/magento/magento2/blob/2.3/app/code/Magento/GroupedProduct/Test/Mftf/Test/AdminAddDefaultVideoGroupedProductTest.xml"
-  module: "GroupedProduct"
-  tests:
-    - testname: "AdminAddDefaultVideoGroupedProductTest"
-      title: "Admin should be able to add default video for a Grouped Product"
-      description: "Admin should be able to add default video for a Grouped Product"
- 
-- filename: "StoreFrontCheckingWithSingleShipmentTest.xml"
-  repo: "https://github.com/magento/magento2/blob/2.3/app/code/Magento/Multishipping/Test/Mftf/Test/StoreFrontCheckingWithSingleShipmentTest.xml"
-  module: "Multishipping"
-  tests:
-    - testname: "StoreFrontCheckingWithSingleShipmentTest"
-      title: "Checking multi shipment with single shipment adresses on front end order page"
-      description: "Shipping price shows 0 when you return from multiple checkout to cart"
- 
-- filename: "StorefrontVerifySecureURLRedirectMultishippingTest.xml"
-  repo: "https://github.com/magento/magento2/blob/2.3/app/code/Magento/Multishipping/Test/Mftf/Test/StorefrontVerifySecureURLRedirectMultishippingTest.xml"
-  module: "Multishipping"
-  tests:
-    - testname: "StorefrontVerifySecureURLRedirectMultishipping"
-      title: "Verify Secure URLs For Storefront Multishipping Pages"
-      description: "Verify that the Secure URL configuration applies to the Multishipping pages on the Storefront"
- 
-- filename: "StoreFrontCheckingWithMultishipmentTest.xml"
-  repo: "https://github.com/magento/magento2/blob/2.3/app/code/Magento/Multishipping/Test/Mftf/Test/StoreFrontCheckingWithMultishipmentTest.xml"
-  module: "Multishipping"
-  tests:
-    - testname: "StoreFrontCheckingWithMultishipmentTest"
-      title: "Checking multi shipment with multiple shipment adresses on front end order page"
-      description: "Shipping price shows 0 when you return from multiple checkout to cart"
- 
-- filename: "StoreFrontMyAccountWithMultishipmentTest.xml"
-  repo: "https://github.com/magento/magento2/blob/2.3/app/code/Magento/Multishipping/Test/Mftf/Test/StoreFrontMyAccountWithMultishipmentTest.xml"
-  module: "Multishipping"
-  tests:
-    - testname: "StorefrontMyAccountWithMultishipmentTest"
-      title: "Verify Shipping price for Storefront after multiple address checkout"
-      description: "Verify that shipping price on My account matches with shipping method prices after multiple addresses checkout (Order view page)"
- 
-- filename: "StorefrontCheckingWithCartPriceRuleMatchingSubtotalForMultiShipmentTest.xml"
-  repo: "https://github.com/magento/magento2/blob/2.3/app/code/Magento/Multishipping/Test/Mftf/Test/StorefrontCheckingWithCartPriceRuleMatchingSubtotalForMultiShipmentTest.xml"
-  module: "Multishipping"
-  tests:
-    - testname: "StorefrontCheckingWithCartPriceRuleMatchingSubtotalForMultiShipmentTest"
-      title: "Checking sub total amount and free shipping is applied with multiple shipment addresses on front end order page"
-      description: "Cart Price Rules not working and free shipping not applied for Multi shipping "
- 
-- filename: "StorefrontProcessMultishippingCheckoutWhenCartPageIsOpenedInAnotherTabTest.xml"
-  repo: "https://github.com/magento/magento2/blob/2.3/app/code/Magento/Multishipping/Test/Mftf/Test/StorefrontProcessMultishippingCheckoutWhenCartPageIsOpenedInAnotherTabTest.xml"
-  module: "Multishipping"
-  tests:
-    - testname: "StorefrontProcessMultishippingCheckoutWhenCartPageIsOpenedInAnotherTabTest"
-      title: "Process multishipping checkout when Cart page is opened in another tab"
-      description: "Process multishipping checkout when Cart page is opened in another tab"
- 
-- filename: "StoreFrontMinicartWithMultishipmentTest.xml"
-  repo: "https://github.com/magento/magento2/blob/2.3/app/code/Magento/Multishipping/Test/Mftf/Test/StoreFrontMinicartWithMultishipmentTest.xml"
-  module: "Multishipping"
-  tests:
-    - testname: "StoreFrontMinicartWithMultishipmentTest"
-      title: "Checking multi shipment with multiple shipment at minicart from checkout"
-      description: "Shipping price shows 0 when you return from multiple checkout to cart"
- 
-- filename: "StorefrontCheckoutWithMultipleAddressesTest.xml"
-  repo: "https://github.com/magento/magento2/blob/2.3/app/code/Magento/Multishipping/Test/Mftf/Test/StorefrontCheckoutWithMultipleAddressesTest.xml"
-  module: "Multishipping"
-  tests:
-    - testname: "StorefrontCheckoutWithMultipleAddressesTest"
-      title: "Place an order with three different addresses"
-      description: "Place an order with three different addresses"
- 
-- filename: "StoreViewLanguageCorrectSwitchTest.xml"
-  repo: "https://github.com/magento/magento2/blob/2.3/app/code/Magento/Cms/Test/Mftf/Test/StoreViewLanguageCorrectSwitchTest.xml"
-  module: "Cms"
-  tests:
-    - testname: "StoreViewLanguageCorrectSwitchTest"
-      title: "Check that Store View(language) switches correct"
-      description: "Check that Store View(language) switches correct"
- 
-- filename: "AdminAddWidgetToWYSIWYGWithCatalogProductLinkTypeTest.xml"
-  repo: "https://github.com/magento/magento2/blob/2.3/app/code/Magento/Cms/Test/Mftf/Test/AdminAddWidgetToWYSIWYGWithCatalogProductLinkTypeTest.xml"
-  module: "Cms"
-  tests:
-    - testname: "AdminAddWidgetToWYSIWYGWithCatalogProductLinkTypeTest"
-      title: "Admin should be able to create a CMS page with widget type: Catalog product link"
-      description: "Admin should be able to create a CMS page with widget type: Catalog product link"
- 
-- filename: "AdminCreateCmsPageTest.xml"
-  repo: "https://github.com/magento/magento2/blob/2.3/app/code/Magento/Cms/Test/Mftf/Test/AdminCreateCmsPageTest.xml"
-  module: "Cms"
-  tests:
-    - testname: "AdminCreateCmsPageTest"
-      title: "Admin should be able to create a CMS Page"
-      description: "Admin should be able to create a CMS Page"
-
-    - testname: "AdminConfigDefaultCMSPageLayoutFromConfigurationSettingTest"
-      title: "Admin should be able to configure the default layout for CMS Page from System Configuration"
-      description: "Admin should be able to configure the default layout for CMS Page from System Configuration"
-
-    - testname: "AdminCreateDuplicatedCmsPageTest"
-      title: "Admin should be able to duplicate a CMS Page"
-      description: "Admin should be able to duplicate a CMS Page"
- 
-- filename: "AdminContentBlocksNavigateMenuTest.xml"
-  repo: "https://github.com/magento/magento2/blob/2.3/app/code/Magento/Cms/Test/Mftf/Test/AdminContentBlocksNavigateMenuTest.xml"
-  module: "Cms"
-  tests:
-    - testname: "AdminContentBlocksNavigateMenuTest"
-      title: "Admin content blocks navigate menu test"
-      description: "Admin should be able to navigate to Content &gt; Blocks"
- 
-- filename: "VerifyTinyMCEv4IsNativeWYSIWYGOnBlockTest.xml"
-  repo: "https://github.com/magento/magento2/blob/2.3/app/code/Magento/Cms/Test/Mftf/Test/VerifyTinyMCEv4IsNativeWYSIWYGOnBlockTest.xml"
-  module: "Cms"
-  tests:
-    - testname: "VerifyTinyMCEv4IsNativeWYSIWYGOnBlockTest"
-      title: "Admin should see TinyMCEv4.6 is the native WYSIWYG on Block"
-      description: "Admin should see TinyMCEv4.6 is the native WYSIWYG on Block"
- 
-- filename: "AdminMediaGalleryPopupUploadImagesWithoutErrorTest.xml"
-  repo: "https://github.com/magento/magento2/blob/2.3/app/code/Magento/Cms/Test/Mftf/Test/AdminMediaGalleryPopupUploadImagesWithoutErrorTest.xml"
-  module: "Cms"
-  tests:
-    - testname: "AdminMediaGalleryPopupUploadImagesWithoutErrorTest"
-      title: "Media Gallery popup upload images without error"
-      description: "Media Gallery popup upload images without error"
- 
-- filename: "AdminCreateCmsBlockTest.xml"
-  repo: "https://github.com/magento/magento2/blob/2.3/app/code/Magento/Cms/Test/Mftf/Test/AdminCreateCmsBlockTest.xml"
-  module: "Cms"
-  tests:
-    - testname: "AdminCreateDuplicatedCmsBlockTest"
-      title: "Admin should be able to duplicate a CMS block"
-      description: "Admin should be able to duplicate a CMS block"
- 
-- filename: "VerifyTinyMCEv4IsNativeWYSIWYGOnCMSPageTest.xml"
-  repo: "https://github.com/magento/magento2/blob/2.3/app/code/Magento/Cms/Test/Mftf/Test/VerifyTinyMCEv4IsNativeWYSIWYGOnCMSPageTest.xml"
-  module: "Cms"
-  tests:
-    - testname: "VerifyTinyMCEv4IsNativeWYSIWYGOnCMSPageTest"
-      title: "Admin should see TinyMCEv4.6 is the native WYSIWYG on CMS Page"
-      description: "Admin should see TinyMCEv4.6 is the native WYSIWYG on CMS Page"
- 
-- filename: "AdminContentPagesNavigateMenuTest.xml"
-  repo: "https://github.com/magento/magento2/blob/2.3/app/code/Magento/Cms/Test/Mftf/Test/AdminContentPagesNavigateMenuTest.xml"
-  module: "Cms"
-  tests:
-    - testname: "AdminContentPagesNavigateMenuTest"
-      title: "Admin content pages navigate menu test"
-      description: "Admin should be able to navigate to Content &gt; Pages"
- 
-- filename: "AdminAddImageToWYSIWYGCMSTest.xml"
-  repo: "https://github.com/magento/magento2/blob/2.3/app/code/Magento/Cms/Test/Mftf/Test/AdminAddImageToWYSIWYGCMSTest.xml"
-  module: "Cms"
-  tests:
-    - testname: "AdminAddImageToWYSIWYGCMSTest"
-      title: "Admin should be able to add image to WYSIWYG content of CMS Page"
-      description: "Admin should be able to add image to WYSIWYG content of CMS Page"
- 
-- filename: "AdminAddWidgetToWYSIWYGWithCMSPageLinkTypeTest.xml"
-  repo: "https://github.com/magento/magento2/blob/2.3/app/code/Magento/Cms/Test/Mftf/Test/AdminAddWidgetToWYSIWYGWithCMSPageLinkTypeTest.xml"
-  module: "Cms"
-  tests:
-    - testname: "AdminAddWidgetToWYSIWYGWithCMSPageLinkTypeTest"
-      title: "Admin should be able to create a CMS page with widget type: CMS page link"
-      description: "Admin should be able to create a CMS page with widget type: CMS page link"
- 
-- filename: "AdminAddImageToCMSPageTinyMCE3Test.xml"
-  repo: "https://github.com/magento/magento2/blob/2.3/app/code/Magento/Cms/Test/Mftf/Test/AdminAddImageToCMSPageTinyMCE3Test.xml"
-  module: "Cms"
-  tests:
-    - testname: "AdminAddImageToCMSPageTinyMCE3Test"
-      title: "Verify that admin is able to upload image to a CMS Page with TinyMCE3 enabled"
-      description: "Verify that admin is able to upload image to CMS Page with TinyMCE3 enabled"
- 
-- filename: "AdminAddWidgetToWYSIWYGBlockTest.xml"
-  repo: "https://github.com/magento/magento2/blob/2.3/app/code/Magento/Cms/Test/Mftf/Test/AdminAddWidgetToWYSIWYGBlockTest.xml"
-  module: "Cms"
-  tests:
-    - testname: "AdminAddWidgetToWYSIWYGBlockTest"
-      title: "Admin should be able to add widget to WYSIWYG content of Block"
-      description: "Admin should be able to add widget to WYSIWYG content Block"
- 
-- filename: "AdminAddWidgetToWYSIWYGWithRecentlyComparedProductsTypeTest.xml"
-  repo: "https://github.com/magento/magento2/blob/2.3/app/code/Magento/Cms/Test/Mftf/Test/AdminAddWidgetToWYSIWYGWithRecentlyComparedProductsTypeTest.xml"
-  module: "Cms"
-  tests:
-    - testname: "AdminAddWidgetToWYSIWYGWithRecentlyComparedProductsTypeTest"
-      title: "Admin should be able to create a CMS page with widget type: Recently Compared Products"
-      description: "Admin should be able to create a CMS page with widget type: Recently Compared Products"
- 
-- filename: "AdminAddWidgetToWYSIWYGWithCatalogCategoryLinkTypeTest.xml"
-  repo: "https://github.com/magento/magento2/blob/2.3/app/code/Magento/Cms/Test/Mftf/Test/AdminAddWidgetToWYSIWYGWithCatalogCategoryLinkTypeTest.xml"
-  module: "Cms"
-  tests:
-    - testname: "AdminAddWidgetToWYSIWYGWithCatalogCategoryLinkTypeTest"
-      title: "Admin should be able to create a CMS page with widget type: Catalog category link"
-      description: "Admin should be able to create a CMS page with widget type: Catalog category link"
- 
-- filename: "AdminAddWidgetToWYSIWYGWithRecentlyViewedProductsTypeTest.xml"
-  repo: "https://github.com/magento/magento2/blob/2.3/app/code/Magento/Cms/Test/Mftf/Test/AdminAddWidgetToWYSIWYGWithRecentlyViewedProductsTypeTest.xml"
-  module: "Cms"
-  tests:
-    - testname: "AdminAddWidgetToWYSIWYGWithRecentlyViewedProductsTypeTest"
-      title: "Admin should be able to create a CMS page with widget type: Recently Viewed Products"
-      description: "Admin should be able to create a CMS page with widget type: Recently Viewed Products"
- 
-- filename: "CheckStaticBlocksTest.xml"
-  repo: "https://github.com/magento/magento2/blob/2.3/app/code/Magento/Cms/Test/Mftf/Test/CheckStaticBlocksTest.xml"
-  module: "Cms"
-  tests:
-    - testname: "CheckStaticBlocksTest"
-      title: "Check static blocks: ID should be unique per Store View"
-      description: "Check static blocks: ID should be unique per Store View"
- 
-- filename: "AdminAddWidgetToWYSIWYGWithCMSStaticBlockTypeTest.xml"
-  repo: "https://github.com/magento/magento2/blob/2.3/app/code/Magento/Cms/Test/Mftf/Test/AdminAddWidgetToWYSIWYGWithCMSStaticBlockTypeTest.xml"
-  module: "Cms"
-  tests:
-    - testname: "AdminAddWidgetToWYSIWYGWithCMSStaticBlockTypeTest"
-      title: "Admin should be able to create a CMS page with widget type: CMS Static Block"
-      description: "Admin should be able to create a CMS page with widget type: CMS Static Block"
- 
-- filename: "AdminAddVariableToWYSIWYGBlockTest.xml"
-  repo: "https://github.com/magento/magento2/blob/2.3/app/code/Magento/Cms/Test/Mftf/Test/AdminAddVariableToWYSIWYGBlockTest.xml"
-  module: "Cms"
-  tests:
-    - testname: "AdminAddVariableToWYSIWYGBlockTest"
-      title: "Admin should be able to add variable to WYSIWYG content of Block"
-      description: "You should be able to add variable to WYSIWYG content Block"
- 
-- filename: "AdminCmsPageMassActionTest.xml"
-  repo: "https://github.com/magento/magento2/blob/2.3/app/code/Magento/Cms/Test/Mftf/Test/AdminCmsPageMassActionTest.xml"
-  module: "Cms"
-  tests:
-    - testname: "AdminCmsPageMassActionTest"
-      title: "Create two CMS Pages and perform mass disable action"
-      description: "Admin should be able to perform mass actions to CMS pages"
- 
-- filename: "AdminAddImageToWYSIWYGBlockTest.xml"
-  repo: "https://github.com/magento/magento2/blob/2.3/app/code/Magento/Cms/Test/Mftf/Test/AdminAddImageToWYSIWYGBlockTest.xml"
-  module: "Cms"
-  tests:
-    - testname: "AdminAddImageToWYSIWYGBlockTest"
-      title: "Admin should be able to add image to WYSIWYG content of Block"
-      description: "Admin should be able to add image to WYSIWYG content of Block"
- 
-- filename: "AdminAddVariableToWYSIWYGCMSTest.xml"
-  repo: "https://github.com/magento/magento2/blob/2.3/app/code/Magento/Cms/Test/Mftf/Test/AdminAddVariableToWYSIWYGCMSTest.xml"
-  module: "Cms"
-  tests:
-    - testname: "AdminAddVariableToWYSIWYGCMSTest"
-      title: "Admin should be able to insert the default Magento variable into content of WYSIWYG on CMS Pages"
-      description: "Admin should be able to insert the default Magento variable into content of WYSIWYG on CMS Pages"
- 
-- filename: "AdminAddWidgetToWYSIWYGWithCatalogProductListTypeTest.xml"
-  repo: "https://github.com/magento/magento2/blob/2.3/app/code/Magento/Cms/Test/Mftf/Test/AdminAddWidgetToWYSIWYGWithCatalogProductListTypeTest.xml"
-  module: "Cms"
-  tests:
-    - testname: "AdminAddWidgetToWYSIWYGWithCatalogProductListTypeTest"
-      title: "Admin should be able to create a CMS page with widget type: Catalog product list"
-      description: "Admin should be able to create a CMS page with widget type: Catalog product list"
- 
-- filename: "CheckOrderOfProdsInWidgetOnCMSPageTest.xml"
-  repo: "https://github.com/magento/magento2/blob/2.3/app/code/Magento/Cms/Test/Mftf/Test/CheckOrderOfProdsInWidgetOnCMSPageTest.xml"
-  module: "Cms"
-  tests:
-    - testname: "CheckOrderOfProdsInWidgetOnCMSPageTest"
-      title: "Checking order of products in a widget on a CMS page - SKU condition"
-      description: "Checking order of products in a widget on a CMS page - SKU condition"
- 
-- filename: "AdminDesignConfigMediaGalleryImageUploadTest.xml"
-  repo: "https://github.com/magento/magento2/blob/2.3/app/code/Magento/Theme/Test/Mftf/Test/AdminDesignConfigMediaGalleryImageUploadTest.xml"
-  module: "Theme"
-  tests:
-    - testname: "AdminDesignConfigMediaGalleryImageUploadTest"
-      title: "MC-5784: Image fields using imageUploader UIComponent cannot use gallery image"
-      description: "Admin should be able to use Image Uploader to add Gallery Images"
- 
-- filename: "AdminWatermarkUploadTest.xml"
-  repo: "https://github.com/magento/magento2/blob/2.3/app/code/Magento/Theme/Test/Mftf/Test/AdminWatermarkUploadTest.xml"
-  module: "Theme"
-  tests:
-    - testname: "AdminWatermarkUploadTest"
-      title: "MAGETWO-95934: Can't upload Watermark Image"
-      description: "Watermark images should be able to be uploaded in the admin"
- 
-- filename: "AdminContentThemesNavigateMenuTest.xml"
-  repo: "https://github.com/magento/magento2/blob/2.3/app/code/Magento/Theme/Test/Mftf/Test/AdminContentThemesNavigateMenuTest.xml"
-  module: "Theme"
-  tests:
-    - testname: "AdminContentThemesNavigateMenuTest"
-      title: "Admin content themes navigate menu test"
-      description: "Admin should be able to navigate to Content &gt; Themes"
- 
-- filename: "ThemeTest.xml"
-  repo: "https://github.com/magento/magento2/blob/2.3/app/code/Magento/Theme/Test/Mftf/Test/ThemeTest.xml"
-  module: "Theme"
-  tests:
-    - testname: "ThemeTest"
-      title: "Magento Rush theme should not be available in Themes grid"
-      description: "Magento Rush theme should not be available in Themes grid"
- 
-- filename: "AdminCreateProductUrLRewriteAndAddPermanentRedirectTest.xml"
-  repo: "https://github.com/magento/magento2/blob/2.3/app/code/Magento/UrlRewrite/Test/Mftf/Test/AdminCreateProductUrLRewriteAndAddPermanentRedirectTest.xml"
-  module: "UrlRewrite"
-  tests:
-    - testname: "AdminCreateProductUrLRewriteAndAddPermanentRedirectTest"
-      title: "Create product URL rewrite, with permanent redirect"
-      description: "Login as admin, create product UrlRewrite and add Permanent redirect"
- 
-- filename: "AdminMarketingUrlRewritesNavigateMenuTest.xml"
-  repo: "https://github.com/magento/magento2/blob/2.3/app/code/Magento/UrlRewrite/Test/Mftf/Test/AdminMarketingUrlRewritesNavigateMenuTest.xml"
-  module: "UrlRewrite"
-  tests:
-    - testname: "AdminMarketingUrlRewritesNavigateMenuTest"
-      title: "Admin marketing url rewrites navigate menu test"
-      description: "Admin should be able to navigate to Marketing &gt; URL Rewrites"
- 
-- filename: "AdminGenerateUrlRewritesForProductInCategoriesSwitchOffTest.xml"
-  repo: "https://github.com/magento/magento2/blob/2.3/app/code/Magento/UrlRewrite/Test/Mftf/Test/AdminGenerateUrlRewritesForProductInCategoriesSwitchOffTest.xml"
-  module: "UrlRewrite"
-  tests:
-    - testname: "AdminGenerateUrlRewritesForProductInCategoriesSwitchOffTest"
-      title: "Clear Url Rewrites after configuration turned off"
-      description: "Check Url Rewrites for product in categories is correctly cleared after configuration turned off"
- 
-- filename: "AdminUpdateCustomURLRewritesTemporaryTest.xml"
-  repo: "https://github.com/magento/magento2/blob/2.3/app/code/Magento/UrlRewrite/Test/Mftf/Test/AdminUpdateCustomURLRewritesTemporaryTest.xml"
-  module: "UrlRewrite"
-  tests:
-    - testname: "AdminUpdateCustomURLRewritesTemporaryTest"
-      title: "Update Custom URL Rewrites, temporary"
-      description: "Test log in to URL Rewrites and Update Custom URL Rewrites, temporary"
- 
-- filename: "AdminCreateCategoryUrlRewriteAndAddNoRedirectTest.xml"
-  repo: "https://github.com/magento/magento2/blob/2.3/app/code/Magento/UrlRewrite/Test/Mftf/Test/AdminCreateCategoryUrlRewriteAndAddNoRedirectTest.xml"
-  module: "UrlRewrite"
-  tests:
-    - testname: "AdminCreateCategoryUrlRewriteAndAddNoRedirectTest"
-      title: "Create category URL rewrite, with no redirect"
-      description: "Login as admin and create category UrlRewrite with No redirect"
- 
-- filename: "AdminUpdateProductUrlRewriteAndAddTemporaryRedirectTest.xml"
-  repo: "https://github.com/magento/magento2/blob/2.3/app/code/Magento/UrlRewrite/Test/Mftf/Test/AdminUpdateProductUrlRewriteAndAddTemporaryRedirectTest.xml"
-  module: "UrlRewrite"
-  tests:
-    - testname: "AdminUpdateProductUrlRewriteAndAddTemporaryRedirectTest"
-      title: "Update Product URL Rewrites"
-      description: "Login as Admin and update product UrlRewrite and add Temporary redirect type "
- 
-- filename: "AdminCreateCustomCMSPageUrlRewriteAndAddPermanentRedirectTest.xml"
-  repo: "https://github.com/magento/magento2/blob/2.3/app/code/Magento/UrlRewrite/Test/Mftf/Test/AdminCreateCustomCMSPageUrlRewriteAndAddPermanentRedirectTest.xml"
-  module: "UrlRewrite"
-  tests:
-    - testname: "AdminCreateCustomCMSPageUrlRewriteAndAddPermanentRedirectTest"
-      title: "Create custom URL rewrite, CMS permanent"
-      description: "Login as Admin and create custom CMS page UrlRewrite and add Permanent redirect type "
- 
-- filename: "AdminUpdateCustomURLRewritesPermanentTest.xml"
-  repo: "https://github.com/magento/magento2/blob/2.3/app/code/Magento/UrlRewrite/Test/Mftf/Test/AdminUpdateCustomURLRewritesPermanentTest.xml"
-  module: "UrlRewrite"
-  tests:
-    - testname: "AdminUpdateCustomURLRewritesPermanentTest"
-      title: "Update Custom URL Rewrites, permanent"
-      description: "Test log in to URL Rewrites and Update Custom URL Rewrites, permanent"
- 
-- filename: "AdminCheckUrlRewritesCorrectlyGeneratedForMultipleStoreviewsDuringProductImportTest.xml"
-  repo: "https://github.com/magento/magento2/blob/2.3/app/code/Magento/UrlRewrite/Test/Mftf/Test/AdminCheckUrlRewritesCorrectlyGeneratedForMultipleStoreviewsDuringProductImportTest.xml"
-  module: "UrlRewrite"
-  tests:
-    - testname: "AdminCheckUrlRewritesCorrectlyGeneratedForMultipleStoreviewsDuringProductImportTest"
-      title: "Url Rewrites Correctly Generated for Multiple Storeviews During Product Import"
-      description: "Check Url Rewrites Correctly Generated for Multiple Storeviews During Product Import."
-
-    - testname: "AdminCheckUrlRewritesCorrectlyGeneratedForMultipleStoreviewsDuringProductImportTestWithConfigurationTurnedOff"
-      title: "Url Rewrites Correctly Generated for Multiple Storeviews During Product Import With Configuration Turned Off"
-      description: "Check Url Rewrites Correctly Generated for Multiple Storeviews During Product Import."
- 
-- filename: "AdminUpdateCategoryUrlRewriteAndAddTemporaryRedirectTest.xml"
-  repo: "https://github.com/magento/magento2/blob/2.3/app/code/Magento/UrlRewrite/Test/Mftf/Test/AdminUpdateCategoryUrlRewriteAndAddTemporaryRedirectTest.xml"
-  module: "UrlRewrite"
-  tests:
-    - testname: "AdminUpdateCategoryUrlRewriteAndAddTemporaryRedirectTest"
-      title: "Update Category URL Rewrites, Temporary redirect type"
-      description: "Login as Admin and update category UrlRewrite and add Temporary redirect type"
- 
-- filename: "AdminUpdateCategoryUrlRewriteAndAddNoRedirectTest.xml"
-  repo: "https://github.com/magento/magento2/blob/2.3/app/code/Magento/UrlRewrite/Test/Mftf/Test/AdminUpdateCategoryUrlRewriteAndAddNoRedirectTest.xml"
-  module: "UrlRewrite"
-  tests:
-    - testname: "AdminUpdateCategoryUrlRewriteAndAddNoRedirectTest"
-      title: "Update Category URL Rewrites, no redirect type"
-      description: "Login as Admin and update category Url Rewrite and add redirect type No"
- 
-- filename: "AdminAutoUpdateURLRewriteWhenCategoryIsDeletedTest.xml"
-  repo: "https://github.com/magento/magento2/blob/2.3/app/code/Magento/UrlRewrite/Test/Mftf/Test/AdminAutoUpdateURLRewriteWhenCategoryIsDeletedTest.xml"
-  module: "UrlRewrite"
-  tests:
-    - testname: "AdminAutoUpdateURLRewriteWhenCategoryIsDeletedTest"
-      title: "Create product URL rewrite, autoupdate if subcategory deleted"
-      description: "Login as admin,verify UrlRewrite auto update when subcategory is deleted  "
- 
-- filename: "AdminCreateCategoryUrlRewriteAndAddTemporaryRedirectTest.xml"
-  repo: "https://github.com/magento/magento2/blob/2.3/app/code/Magento/UrlRewrite/Test/Mftf/Test/AdminCreateCategoryUrlRewriteAndAddTemporaryRedirectTest.xml"
-  module: "UrlRewrite"
-  tests:
-    - testname: "AdminCreateCategoryUrlRewriteAndAddTemporaryRedirectTest"
-      title: "Create category URL rewrite, with temporary redirect"
-      description: "Login as admin and create category UrlRewrite with Temporary redirect"
- 
-- filename: "AdminCreateCustomCMSPageUrlRewriteAndAddTemporaryRedirectTest.xml"
-  repo: "https://github.com/magento/magento2/blob/2.3/app/code/Magento/UrlRewrite/Test/Mftf/Test/AdminCreateCustomCMSPageUrlRewriteAndAddTemporaryRedirectTest.xml"
-  module: "UrlRewrite"
-  tests:
-    - testname: "AdminCreateCustomCMSPageUrlRewriteAndAddTemporaryRedirectTest"
-      title: "Create custom URL rewrite, CMS temporary"
-      description: "Login as Admin and create custom CMS page UrlRewrite and add Temporary redirect type "
- 
-- filename: "AdminCreateProductURLRewriteAndAddNoRedirectTest.xml"
-  repo: "https://github.com/magento/magento2/blob/2.3/app/code/Magento/UrlRewrite/Test/Mftf/Test/AdminCreateProductURLRewriteAndAddNoRedirectTest.xml"
-  module: "UrlRewrite"
-  tests:
-    - testname: "AdminCreateProductUrLRewriteAndAddNoRedirectTest"
-      title: "Create product URL rewrite, with no redirect"
-      description: "Login as admin, create product UrlRewrite and add No redirect  "
- 
-- filename: "AdminUpdateCategoryUrlRewriteAndAddAspxRequestPathTest.xml"
-  repo: "https://github.com/magento/magento2/blob/2.3/app/code/Magento/UrlRewrite/Test/Mftf/Test/AdminUpdateCategoryUrlRewriteAndAddAspxRequestPathTest.xml"
-  module: "UrlRewrite"
-  tests:
-    - testname: "AdminUpdateCategoryUrlRewriteAndAddAspxRequestPathTest"
-      title: "Update Category URL Rewrites, aspx request path"
-      description: "Login as Admin, update category UrlRewrite, add aspx request path and Temporary redirect type "
- 
-- filename: "AdminUrlRewritesForProductInAnchorCategoriesTest.xml"
-  repo: "https://github.com/magento/magento2/blob/2.3/app/code/Magento/UrlRewrite/Test/Mftf/Test/AdminUrlRewritesForProductInAnchorCategoriesTest.xml"
-  module: "UrlRewrite"
-  tests:
-    - testname: "AdminUrlRewritesForProductInAnchorCategoriesTest"
-      title: "Url-rewrites for product in anchor categories"
-      description: "For a product with category that has parent anchor categories, the rewrites is created when the category/product is saved."
-
-    - testname: "AdminUrlRewritesForProductInAnchorCategoriesTestWithConfigurationTurnedOff"
-      title: "Url-rewrites for product in anchor categories with configuration turned off"
-      description: "For a product with category that has parent anchor categories, the rewrites is created when the category/product is saved."
-
-    - testname: "AdminUrlRewritesForProductInAnchorCategoriesTestAllStoreView"
-      title: "Url-rewrites for product in anchor categories for all store views"
-      description: "Verify that Saving category do not delete UrlRewrites for subcategories and all products in them."
-
-    - testname: "AdminUrlRewritesForProductInAnchorCategoriesTestAllStoreViewWithConfigurationTurnedOff"
-      title: "Url-rewrites for product in anchor categories for all store views with configuration turned off"
-      description: "Url-rewrites for product in anchor categories for all store views with configuration turned off"
-
-    - testname: "AdminUrlRewritesForProductsWithConfigurationTurnedOff"
-      title: "No auto generated of request path for simple product when assigned to subCategory"
-      description: "No auto generated of request path when SEO configuration to Generate url rewrite for Generate 'category/product' URL Rewrites is set to No"
- 
-- filename: "AdminCreateProductURLRewriteWithCategoryAndAddTemporaryRedirectTest.xml"
-  repo: "https://github.com/magento/magento2/blob/2.3/app/code/Magento/UrlRewrite/Test/Mftf/Test/AdminCreateProductURLRewriteWithCategoryAndAddTemporaryRedirectTest.xml"
-  module: "UrlRewrite"
-  tests:
-    - testname: "AdminCreateProductURLRewriteWithCategoryAndAddTemporaryRedirectTest"
-      title: "Create product URL rewrite, add temporary redirect for product"
-      description: "Login as admin, create product with category and UrlRewrite and add temporary redirect  "
- 
-- filename: "AdminCreateCustomCategoryUrlRewriteAndAddPermanentRedirectTest.xml"
-  repo: "https://github.com/magento/magento2/blob/2.3/app/code/Magento/UrlRewrite/Test/Mftf/Test/AdminCreateCustomCategoryUrlRewriteAndAddPermanentRedirectTest.xml"
-  module: "UrlRewrite"
-  tests:
-    - testname: "AdminCreateCustomCategoryUrlRewriteAndAddPermanentRedirectTest"
-      title: "Create custom URL rewrite, permanent"
-      description: "Login as Admin and create custom UrlRewrite and add redirect type permenent"
- 
-- filename: "AdminCreateProductWithSeveralWebsitesAndCheckURLRewritesTest.xml"
-  repo: "https://github.com/magento/magento2/blob/2.3/app/code/Magento/UrlRewrite/Test/Mftf/Test/AdminCreateProductWithSeveralWebsitesAndCheckURLRewritesTest.xml"
-  module: "UrlRewrite"
-  tests:
-    - testname: "AdminCreateProductWithSeveralWebsitesAndCheckURLRewritesTest"
-      title: "Create product with several websites and check URL Rewrites"
-      description: "Test log in to Create product and Create product with several websites and check URL Rewrites"
- 
-- filename: "AdminDeleteCustomUrlRewriteTest.xml"
-  repo: "https://github.com/magento/magento2/blob/2.3/app/code/Magento/UrlRewrite/Test/Mftf/Test/AdminDeleteCustomUrlRewriteTest.xml"
-  module: "UrlRewrite"
-  tests:
-    - testname: "AdminDeleteCustomUrlRewriteTest"
-      title: "Delete custom URL rewrite"
-      description: "Test log in to URL rewrite and Delete custom URL rewrite"
- 
-- filename: "AdminCreateProductUrLRewriteAndAddTemporaryRedirectTest.xml"
-  repo: "https://github.com/magento/magento2/blob/2.3/app/code/Magento/UrlRewrite/Test/Mftf/Test/AdminCreateProductUrLRewriteAndAddTemporaryRedirectTest.xml"
-  module: "UrlRewrite"
-  tests:
-    - testname: "AdminCreateProductUrLRewriteAndAddTemporaryRedirectTest"
-      title: "Create product URL rewrite, with temporary redirect"
-      description: "Login as admin, create product UrlRewrite and add Temporary redirect"
- 
-- filename: "AdminUrlRewritesForProductAfterImportTest.xml"
-  repo: "https://github.com/magento/magento2/blob/2.3/app/code/Magento/UrlRewrite/Test/Mftf/Test/AdminUrlRewritesForProductAfterImportTest.xml"
-  module: "UrlRewrite"
-  tests:
-    - testname: "AdminUrlRewritesForProductAfterImportTest"
-      title: "Verify the number of URL rewrites when edit or import product"
-      description: "After importing products to admin verify the number of URL including categories matches"
- 
-- filename: "AdminCreateCategoryUrlRewriteAndAddPermanentRedirectTest.xml"
-  repo: "https://github.com/magento/magento2/blob/2.3/app/code/Magento/UrlRewrite/Test/Mftf/Test/AdminCreateCategoryUrlRewriteAndAddPermanentRedirectTest.xml"
-  module: "UrlRewrite"
-  tests:
-    - testname: "AdminCreateCategoryUrlRewriteAndAddPermanentRedirectTest"
-      title: "Create category URL rewrite, add permanent redirect for category"
-      description: "Login as admin and create category UrlRewrite with Permanent redirect"
- 
-- filename: "AdminUpdateCategoryUrlRewriteAndAddPermanentRedirectTest.xml"
-  repo: "https://github.com/magento/magento2/blob/2.3/app/code/Magento/UrlRewrite/Test/Mftf/Test/AdminUpdateCategoryUrlRewriteAndAddPermanentRedirectTest.xml"
-  module: "UrlRewrite"
-  tests:
-    - testname: "AdminUpdateCategoryUrlRewriteAndAddPermanentRedirectTest"
-      title: "Update Category URL Rewrites, permanent"
-      description: "Login as Admin and update category UrlRewrite and add Permanent redirect type"
- 
-- filename: "AdminCreateCustomProductUrlRewriteAndAddTemporaryRedirectTest.xml"
-  repo: "https://github.com/magento/magento2/blob/2.3/app/code/Magento/UrlRewrite/Test/Mftf/Test/AdminCreateCustomProductUrlRewriteAndAddTemporaryRedirectTest.xml"
-  module: "UrlRewrite"
-  tests:
-    - testname: "AdminCreateCustomProductUrlRewriteAndAddTemporaryRedirectTest"
-      title: "Create custom URL rewrite, temporary"
-      description: "Login as Admin and create custom product UrlRewrite and add Temporary redirect type "
- 
-- filename: "AdminProductCreateUrlRewriteForCustomStoreViewTest.xml"
-  repo: "https://github.com/magento/magento2/blob/2.3/app/code/Magento/UrlRewrite/Test/Mftf/Test/AdminProductCreateUrlRewriteForCustomStoreViewTest.xml"
-  module: "UrlRewrite"
-  tests:
-    - testname: "AdminProductCreateUrlRewriteForCustomStoreViewTest"
-      title: "Product custom URL Key is preserved when assigned to a Category"
-      description: "Verify Product custom URL Key (for custom Store View) is preserved when assigned to a Category (with custom URL Key) alongside with another Product without custom URL Key"
- 
-- filename: "AdminCheckUrlRewritesInCatalogCategoriesAfterChangingUrlKeyForStoreViewAndMovingCategoryTest.xml"
-  repo: "https://github.com/magento/magento2/blob/2.3/app/code/Magento/UrlRewrite/Test/Mftf/Test/AdminCheckUrlRewritesInCatalogCategoriesAfterChangingUrlKeyForStoreViewAndMovingCategoryTest.xml"
-  module: "UrlRewrite"
-  tests:
-    - testname: "AdminCheckUrlRewritesInCatalogCategoriesAfterChangingUrlKeyForStoreViewAndMovingCategoryTest"
-      title: "Check url rewrites in catalog categories after changing url key"
-      description: "Check url rewrites in catalog categories after changing url key for store view and moving category"
- 
-- filename: "StorefrontCheckCreditButtonConfigurationTest.xml"
-  repo: "https://github.com/magento/magento2/blob/2.3/app/code/Magento/Paypal/Test/Mftf/Test/StorefrontCheckCreditButtonConfigurationTest.xml"
-  module: "Paypal"
-  tests:
-    - testname: "StorefrontCheckCreditButtonConfigurationTest"
-      title: "Check Credit Button Configuration"
-      description: "Admin is able to customize Credit button"
- 
-- filename: "AdminSalesBillingAgreementsNavigateMenuTest.xml"
-  repo: "https://github.com/magento/magento2/blob/2.3/app/code/Magento/Paypal/Test/Mftf/Test/AdminSalesBillingAgreementsNavigateMenuTest.xml"
-  module: "Paypal"
-  tests:
-    - testname: "AdminSalesBillingAgreementsNavigateMenuTest"
-      title: "Admin sales billing agreements navigate menu test"
-      description: "Admin should be able to navigate to Sales &gt; Billing Agreements"
- 
-- filename: "StorefrontVerifySecureURLRedirectPaypalTest.xml"
-  repo: "https://github.com/magento/magento2/blob/2.3/app/code/Magento/Paypal/Test/Mftf/Test/StorefrontVerifySecureURLRedirectPaypalTest.xml"
-  module: "Paypal"
-  tests:
-    - testname: "StorefrontVerifySecureURLRedirectPaypal"
-      title: "Verify Secure URLs For Storefront Paypal Pages"
-      description: "Verify that the Secure URL configuration applies to the Paypal pages on the Storefront"
- 
-- filename: "AdminCheckDefaultValueOfPayPalCustomizeButtonTest.xml"
-  repo: "https://github.com/magento/magento2/blob/2.3/app/code/Magento/Paypal/Test/Mftf/Test/AdminCheckDefaultValueOfPayPalCustomizeButtonTest.xml"
-  module: "Paypal"
-  tests:
-    - testname: "AdminCheckDefaultValueOfPayPalCustomizeButtonTest"
-      title: "Check Default Value Of Paypal Customize Button"
-      description: "Default value of Paypal Customize Button should be NO"
- 
-- filename: "StorefrontPaypalSmartButtonInCheckoutPageTest.xml"
-  repo: "https://github.com/magento/magento2/blob/2.3/app/code/Magento/Paypal/Test/Mftf/Test/StorefrontPaypalSmartButtonInCheckoutPageTest.xml"
-  module: "Paypal"
-  tests:
-    - testname: "StorefrontPaypalSmartButtonInCheckoutPageTest"
-      title: "Mainflow of Paypal Smart Button"
-      description: "Users are able to place order using Paypal Smart Button"
- 
-- filename: "AdminOnePayPalSolutionsEnabledAtTheSameTimeTest.xml"
-  repo: "https://github.com/magento/magento2/blob/2.3/app/code/Magento/Paypal/Test/Mftf/Test/AdminOnePayPalSolutionsEnabledAtTheSameTimeTest.xml"
-  module: "Paypal"
-  tests:
-    - testname: "AdminOnePayPalSolutionsEnabledAtTheSameTimeTest"
-      title: "Only one PayPal solution enabled at the same time"
-      description: "Verify that only one PayPal solution can be enabled"
- 
-- filename: "AdminReportsPayPalSettlementNavigateMenuTest.xml"
-  repo: "https://github.com/magento/magento2/blob/2.3/app/code/Magento/Paypal/Test/Mftf/Test/AdminReportsPayPalSettlementNavigateMenuTest.xml"
-  module: "Paypal"
-  tests:
-    - testname: "AdminReportsPayPalSettlementNavigateMenuTest"
-      title: "Admin reports paypal settlement navigate menu test"
-      description: "Admin should be able to navigate to Reports &gt; PayPal Settlement"
- 
-- filename: "AdminVerifyNewRatingFormSingleStoreModeYesTest.xml"
-  repo: "https://github.com/magento/magento2/blob/2.3/app/code/Magento/Review/Test/Mftf/Test/AdminVerifyNewRatingFormSingleStoreModeYesTest.xml"
-  module: "Review"
-  tests:
-    - testname: "AdminVerifyNewRatingFormSingleStoreModeYesTest"
-      title: "Verify New Rating Form if single store mode is Yes"
-      description: "New Rating Form should not have Default store view field if single store mode is Yes"
- 
-- filename: "AdminVerifyNewRatingFormSingleStoreModeNoTest.xml"
-  repo: "https://github.com/magento/magento2/blob/2.3/app/code/Magento/Review/Test/Mftf/Test/AdminVerifyNewRatingFormSingleStoreModeNoTest.xml"
-  module: "Review"
-  tests:
-    - testname: "AdminVerifyNewRatingFormSingleStoreModeNoTest"
-      title: "Verify New Rating Form if single store mode is No"
-      description: "New Rating Form should have Default store view field if single store mode is No"
- 
-- filename: "AdminMarketingReviewsNavigateMenuTest.xml"
-  repo: "https://github.com/magento/magento2/blob/2.3/app/code/Magento/Review/Test/Mftf/Test/AdminMarketingReviewsNavigateMenuTest.xml"
-  module: "Review"
-  tests:
-    - testname: "AdminMarketingReviewsNavigateMenuTest"
-      title: "Admin marketing reviews navigate menu test"
-      description: "Admin should be able to navigate to Marketing &gt; Reviews"
- 
-- filename: "StorefrontVerifySecureURLRedirectReviewTest.xml"
-  repo: "https://github.com/magento/magento2/blob/2.3/app/code/Magento/Review/Test/Mftf/Test/StorefrontVerifySecureURLRedirectReviewTest.xml"
-  module: "Review"
-  tests:
-    - testname: "StorefrontVerifySecureURLRedirectReview"
-      title: "Verify Secure URLs For Storefront Review Pages"
-      description: "Verify that the Secure URL configuration applies to the Review pages on the Storefront"
- 
-- filename: "AdminReportsByProductsNavigateMenuTest.xml"
-  repo: "https://github.com/magento/magento2/blob/2.3/app/code/Magento/Review/Test/Mftf/Test/AdminReportsByProductsNavigateMenuTest.xml"
-  module: "Review"
-  tests:
-    - testname: "AdminReportsByProductsNavigateMenuTest"
-      title: "Admin reports by products navigate menu test"
-      description: "Admin should be able to navigate to Reports &gt; By Products"
- 
-- filename: "AdminStoresRatingNavigateMenuTest.xml"
-  repo: "https://github.com/magento/magento2/blob/2.3/app/code/Magento/Review/Test/Mftf/Test/AdminStoresRatingNavigateMenuTest.xml"
-  module: "Review"
-  tests:
-    - testname: "AdminStoresRatingNavigateMenuTest"
-      title: "Admin stores rating navigate menu test"
-      description: "Admin should be able to navigate to Stores &gt; Rating"
- 
-- filename: "AdminReportsByCustomersNavigateMenuTest.xml"
-  repo: "https://github.com/magento/magento2/blob/2.3/app/code/Magento/Review/Test/Mftf/Test/AdminReportsByCustomersNavigateMenuTest.xml"
-  module: "Review"
-  tests:
-    - testname: "AdminReportsByCustomersNavigateMenuTest"
-      title: "Admin reports by customers navigate menu test"
-      description: "Admin should be able to navigate to Reports &gt; By Customers"
- 
-- filename: "StorefrontFilterByTextSwatchTest.xml"
-  repo: "https://github.com/magento/magento2/blob/2.3/app/code/Magento/Swatches/Test/Mftf/Test/StorefrontFilterByTextSwatchTest.xml"
-  module: "Swatches"
-  tests:
-    - testname: "StorefrontFilterByTextSwatchTest"
-      title: "Customers can filter products using text swatches"
-      description: "Customers can filter products using text swatches"
- 
-- filename: "StorefrontSwatchProductWithFileCustomOptionTest.xml"
-  repo: "https://github.com/magento/magento2/blob/2.3/app/code/Magento/Swatches/Test/Mftf/Test/StorefrontSwatchProductWithFileCustomOptionTest.xml"
-  module: "Swatches"
-  tests:
-    - testname: "StorefrontSwatchProductWithFileCustomOptionTest"
-      title: "Configurable product with swatch option and file custom option"
-      description: "Configurable product with swatch option and file custom option. When adding to cart with an invalid filetype, the correct error message is shown, and options remain selected."
- 
-- filename: "StorefrontSeeProductImagesMatchingProductSwatchesTest.xml"
-  repo: "https://github.com/magento/magento2/blob/2.3/app/code/Magento/Swatches/Test/Mftf/Test/StorefrontSeeProductImagesMatchingProductSwatchesTest.xml"
-  module: "Swatches"
-  tests:
-    - testname: "StorefrontSeeProductImagesMatchingProductSwatchesTest"
-      title: "Customer can see product images matching product swatches"
-      description: "Customer can see product images matching product swatches"
- 
-- filename: "StorefrontSwatchAttributesDisplayInWidgetCMSTest.xml"
-  repo: "https://github.com/magento/magento2/blob/2.3/app/code/Magento/Swatches/Test/Mftf/Test/StorefrontSwatchAttributesDisplayInWidgetCMSTest.xml"
-  module: "Swatches"
-  tests:
-    - testname: "StorefrontSwatchAttributesDisplayInWidgetCMSTest"
-      title: "Swatch Attribute is not displayed in the Widget CMS"
-      description: "Swatch Attribute is not displayed in the Widget CMS"
- 
-- filename: "StorefrontFilterByImageSwatchTest.xml"
-  repo: "https://github.com/magento/magento2/blob/2.3/app/code/Magento/Swatches/Test/Mftf/Test/StorefrontFilterByImageSwatchTest.xml"
-  module: "Swatches"
-  tests:
-    - testname: "StorefrontFilterByImageSwatchTest"
-      title: "Customers can filter products using image swatches"
-      description: "Customers can filter products using image swatches"
- 
-- filename: "StorefrontConfigurableProductSwatchMinimumPriceTest.xml"
-  repo: "https://github.com/magento/magento2/blob/2.3/app/code/Magento/Swatches/Test/Mftf/Test/StorefrontConfigurableProductSwatchMinimumPriceTest.xml"
-  module: "Swatches"
-  tests:
-    - testname: "StorefrontConfigurableProductSwatchMinimumPriceProductPageTest"
-      title: "Swatch option should show the lowest price possible on product page"
-      description: "Swatch option should show the lowest price possible on product page"
-
-    - testname: "StorefrontConfigurableProductSwatchMinimumPriceCategoryPageTest"
-      title: "Swatch option should show the lowest price possible on category page"
-      description: "Swatch option should show the lowest price possible on category page"
- 
-- filename: "AdminCreateVisualSwatchTest.xml"
-  repo: "https://github.com/magento/magento2/blob/2.3/app/code/Magento/Swatches/Test/Mftf/Test/AdminCreateVisualSwatchTest.xml"
-  module: "Swatches"
-  tests:
-    - testname: "AdminCreateVisualSwatchTest"
-      title: "Admin can create product attribute with picked color swatch"
-      description: "Admin can create product attribute with picked color swatch"
- 
-- filename: "AdminCreateVisualSwatchWithNonValidOptionsTest.xml"
-  repo: "https://github.com/magento/magento2/blob/2.3/app/code/Magento/Swatches/Test/Mftf/Test/AdminCreateVisualSwatchWithNonValidOptionsTest.xml"
-  module: "Swatches"
-  tests:
-    - testname: "AdminCreateVisualSwatchWithNonValidOptionsTest"
-      title: "Admin should be able to create swatch product attribute"
-      description: "Admin should be able to create swatch product attribute"
- 
-- filename: "AdminCreateImageSwatchTest.xml"
-  repo: "https://github.com/magento/magento2/blob/2.3/app/code/Magento/Swatches/Test/Mftf/Test/AdminCreateImageSwatchTest.xml"
-  module: "Swatches"
-  tests:
-    - testname: "AdminCreateImageSwatchTest"
-      title: "Admin can create product attribute with image swatch"
-      description: "Admin can create product attribute with image swatch"
- 
-- filename: "AdminSaveConfigurableProductWithAttributesImagesAndSwatchesTest.xml"
-  repo: "https://github.com/magento/magento2/blob/2.3/app/code/Magento/Swatches/Test/Mftf/Test/AdminSaveConfigurableProductWithAttributesImagesAndSwatchesTest.xml"
-  module: "Swatches"
-  tests:
-    - testname: "AdminSaveConfigurableProductWithAttributesImagesAndSwatchesTest"
-      title: "Saving configurable product with custom product attribute (images as swatches)"
-      description: "Saving configurable product with custom product attribute (images as swatches)"
- 
-- filename: "AdminSetUpWatermarkForSwatchImageTest.xml"
-  repo: "https://github.com/magento/magento2/blob/2.3/app/code/Magento/Swatches/Test/Mftf/Test/AdminSetUpWatermarkForSwatchImageTest.xml"
-  module: "Swatches"
-  tests:
-    - testname: "AdminSetUpWatermarkForSwatchImageTest"
-      title: "Possibility to set up watermark for a swatch image type"
-      description: "Possibility to set up watermark for a swatch image type"
- 
-- filename: "AdminCreateTextSwatchTest.xml"
-  repo: "https://github.com/magento/magento2/blob/2.3/app/code/Magento/Swatches/Test/Mftf/Test/AdminCreateTextSwatchTest.xml"
-  module: "Swatches"
-  tests:
-    - testname: "AdminCreateTextSwatchTest"
-      title: "Admin can create product attribute with text swatch"
-      description: "Admin can create product attribute with text swatch"
- 
-- filename: "StorefrontImageColorWhenFilterByColorFilterTest.xml"
-  repo: "https://github.com/magento/magento2/blob/2.3/app/code/Magento/Swatches/Test/Mftf/Test/StorefrontImageColorWhenFilterByColorFilterTest.xml"
-  module: "Swatches"
-  tests:
-    - testname: "StorefrontImageColorWhenFilterByColorFilterTest"
-      title: "Image color when filtering by color filter on the Storefront"
-      description: "Image color when filtering by color filter on the Storefront"
- 
-- filename: "StorefrontDisplayAllCharactersOnTextSwatchTest.xml"
-  repo: "https://github.com/magento/magento2/blob/2.3/app/code/Magento/Swatches/Test/Mftf/Test/StorefrontDisplayAllCharactersOnTextSwatchTest.xml"
-  module: "Swatches"
-  tests:
-    - testname: "StorefrontDisplayAllCharactersOnTextSwatchTest"
-      title: "Admin can create product attribute with text swatch and view the display characters  in full"
-      description: "Admin can create product attribute with text swatch and check the display characters in full"
- 
-- filename: "StorefrontCustomerCanChangeProductOptionsUsingSwatchesTest.xml"
-  repo: "https://github.com/magento/magento2/blob/2.3/app/code/Magento/Swatches/Test/Mftf/Test/StorefrontCustomerCanChangeProductOptionsUsingSwatchesTest.xml"
-  module: "Swatches"
-  tests:
-    - testname: "StorefrontCustomerCanChangeProductOptionsUsingSwatchesTest"
-      title: "Customer can change product options using swatches"
-      description: "Customer can change product options using swatches"
- 
-- filename: "AdminDisablingSwatchTooltipsTest.xml"
-  repo: "https://github.com/magento/magento2/blob/2.3/app/code/Magento/Swatches/Test/Mftf/Test/AdminDisablingSwatchTooltipsTest.xml"
-  module: "Swatches"
-  tests:
-    - testname: "AdminDisablingSwatchTooltipsTest"
-      title: "Admin disabling swatch tooltips test."
-      description: "Verify possibility to disable/enable swatch tooltips."
- 
-- filename: "StorefrontFilterByVisualSwatchTest.xml"
-  repo: "https://github.com/magento/magento2/blob/2.3/app/code/Magento/Swatches/Test/Mftf/Test/StorefrontFilterByVisualSwatchTest.xml"
-  module: "Swatches"
-  tests:
-    - testname: "StorefrontFilterByVisualSwatchTest"
-      title: "Customers can filter products using visual swatches"
-      description: "Customers can filter products using visual swatches "
- 
-- filename: "AssociatedProductToConfigurableOutOfStockTest.xml"
-  repo: "https://github.com/magento/magento2/blob/2.3/app/code/Magento/CatalogInventory/Test/Mftf/Test/AssociatedProductToConfigurableOutOfStockTest.xml"
-  module: "CatalogInventory"
-  tests:
-    - testname: "AssociatedProductToConfigurableOutOfStockTest"
-      title: "Out of stock associated products to configurable are not full page cache cleaned "
-      description: "After last configurable product was ordered it becomes out of stock"
- 
-- filename: "AdminCreateProductWithZeroMaximumQtyAllowedInShoppingCartTest.xml"
-  repo: "https://github.com/magento/magento2/blob/2.3/app/code/Magento/CatalogInventory/Test/Mftf/Test/AdminCreateProductWithZeroMaximumQtyAllowedInShoppingCartTest.xml"
-  module: "CatalogInventory"
-  tests:
-    - testname: "AdminCreateProductWithZeroMaximumQtyAllowedInShoppingCartTest"
-      title: "Verify that product maximum qty allowed in shopping cart can't be set to zero or less"
-      description: "Verify that product maximum qty allowed in shopping cart can't be set to zero or less"
- 
-- filename: "ApplyCatalogRuleForSimpleAndConfigurableProductTest.xml"
-  repo: "https://github.com/magento/magento2/blob/2.3/app/code/Magento/CatalogRule/Test/Mftf/Test/ApplyCatalogRuleForSimpleAndConfigurableProductTest.xml"
-  module: "CatalogRule"
-  tests:
-    - testname: "ApplyCatalogPriceRuleForSimpleProductAndConfigurableProductTest"
-      title: "Admin should be able to apply the catalog price rule for simple product and configurable product"
-      description: "Admin should be able to apply the catalog price rule for simple product and configurable product"
- 
-- filename: "ApplyCatalogRuleForSimpleProductForNewCustomerGroupTest.xml"
-  repo: "https://github.com/magento/magento2/blob/2.3/app/code/Magento/CatalogRule/Test/Mftf/Test/ApplyCatalogRuleForSimpleProductForNewCustomerGroupTest.xml"
-  module: "CatalogRule"
-  tests:
-    - testname: "ApplyCatalogRuleForSimpleProductForNewCustomerGroupTest"
-      title: "Admin should be able to apply the catalog price rule for simple product for new customer group"
-      description: "Admin should be able to apply the catalog price rule for simple product for new customer group"
- 
-- filename: "AdminCreateInactiveCatalogPriceRuleTest.xml"
-  repo: "https://github.com/magento/magento2/blob/2.3/app/code/Magento/CatalogRule/Test/Mftf/Test/AdminCreateInactiveCatalogPriceRuleTest.xml"
-  module: "CatalogRule"
-  tests:
-    - testname: "AdminCreateInactiveCatalogPriceRuleTest"
-      title: "Create Inactive Catalog Price Rule"
-      description: "Login as admin and create inactive catalog price Rule"
- 
-- filename: "StorefrontInactiveCatalogRuleTest.xml"
-  repo: "https://github.com/magento/magento2/blob/2.3/app/code/Magento/CatalogRule/Test/Mftf/Test/StorefrontInactiveCatalogRuleTest.xml"
-  module: "CatalogRule"
-  tests:
-    - testname: "StorefrontInactiveCatalogRuleTest"
-      title: "Customer should not see the catalog price rule promotion if status is inactive"
-      description: "Customer should not see the catalog price rule promotion if status is inactive"
- 
-- filename: "AdminDeleteCatalogPriceRuleTest.xml"
-  repo: "https://github.com/magento/magento2/blob/2.3/app/code/Magento/CatalogRule/Test/Mftf/Test/AdminDeleteCatalogPriceRuleTest.xml"
-  module: "CatalogRule"
-  tests:
-    - testname: "AdminDeleteCatalogPriceRuleTest"
-      title: "Admin should be able to delete catalog price rule"
-      description: "Admin should be able to delete catalog price rule"
- 
-- filename: "AdminMarketingCatalogPriceRuleNavigateMenuTest.xml"
-  repo: "https://github.com/magento/magento2/blob/2.3/app/code/Magento/CatalogRule/Test/Mftf/Test/AdminMarketingCatalogPriceRuleNavigateMenuTest.xml"
-  module: "CatalogRule"
-  tests:
-    - testname: "AdminMarketingCatalogPriceRuleNavigateMenuTest"
-      title: "Admin marketing catalog price rule navigate menu test"
-      description: "Admin should be able to navigate to Marketing &gt; Catalog Price Rule"
- 
-- filename: "AdminEnableAttributeIsUndefinedCatalogPriceRuleTest.xml"
-  repo: "https://github.com/magento/magento2/blob/2.3/app/code/Magento/CatalogRule/Test/Mftf/Test/AdminEnableAttributeIsUndefinedCatalogPriceRuleTest.xml"
-  module: "CatalogRule"
-  tests:
-    - testname: "AdminEnableAttributeIsUndefinedCatalogPriceRuleTest"
-      title: "Enable 'is undefined' condition to Scope Catalog Price rules by custom product attribute"
-      description: "Enable 'is undefined' condition to Scope Catalog Price rules by custom product attribute"
- 
-- filename: "AdminDeleteCatalogPriceRuleEntityTest.xml"
-  repo: "https://github.com/magento/magento2/blob/2.3/app/code/Magento/CatalogRule/Test/Mftf/Test/AdminDeleteCatalogPriceRuleEntityTest.xml"
-  module: "CatalogRule"
-  tests:
-    - testname: "AdminDeleteCatalogPriceRuleEntityFromSimpleProductTest"
-      title: "Delete Catalog Price Rule for Simple Product"
-      description: "Assert that Catalog Price Rule is not applied for simple product."
-
-    - testname: "AdminDeleteCatalogPriceRuleEntityFromConfigurableProductTest"
-      title: "Delete Catalog Price Rule for Configurable Product"
-      description: "Assert that Catalog Price Rule is not applied for configurable product"
- 
-- filename: "ApplyCatalogRuleForSimpleProductAndFixedMethodTest.xml"
-  repo: "https://github.com/magento/magento2/blob/2.3/app/code/Magento/CatalogRule/Test/Mftf/Test/ApplyCatalogRuleForSimpleProductAndFixedMethodTest.xml"
-  module: "CatalogRule"
-  tests:
-    - testname: "ApplyCatalogRuleForSimpleProductAndFixedMethodTest"
-      title: "Admin should be able to apply the catalog price rule for simple product with custom options"
-      description: "Admin should be able to apply the catalog price rule for simple product with custom options"
- 
-- filename: "CatalogPriceRuleAndCustomerGroupMembershipArePersistedUnderLongTermCookieTest.xml"
-  repo: "https://github.com/magento/magento2/blob/2.3/app/code/Magento/CatalogRule/Test/Mftf/Test/CatalogPriceRuleAndCustomerGroupMembershipArePersistedUnderLongTermCookieTest.xml"
-  module: "CatalogRule"
-  tests:
-    - testname: "CatalogPriceRuleAndCustomerGroupMembershipArePersistedUnderLongTermCookieTest"
-      title: "Verify that Catalog Price Rule and Customer Group Membership are persisted under long-term cookie"
-      description: "Verify that Catalog Price Rule and Customer Group Membership are persisted under long-term cookie"
- 
-- filename: "ApplyCatalogPriceRuleByProductAttributeTest.xml"
-  repo: "https://github.com/magento/magento2/blob/2.3/app/code/Magento/CatalogRule/Test/Mftf/Test/ApplyCatalogPriceRuleByProductAttributeTest.xml"
-  module: "CatalogRule"
-  tests:
-    - testname: "ApplyCatalogPriceRuleByProductAttributeTest"
-      title: "Admin should be able to apply the catalog price rule by product attribute"
-      description: "Admin should be able to apply the catalog price rule by product attribute"
- 
-- filename: "AdminApplyCatalogRuleForConfigurableProductWithSpecialPricesTest.xml"
-  repo: "https://github.com/magento/magento2/blob/2.3/app/code/Magento/CatalogRule/Test/Mftf/Test/AdminApplyCatalogRuleForConfigurableProductWithSpecialPricesTest.xml"
-  module: "CatalogRule"
-  tests:
-    - testname: "AdminApplyCatalogRuleForConfigurableProductWithSpecialPricesTest"
-      title: "Admin should be able to apply the catalog price rule for configurable product with special prices"
-      description: "Admin should be able to apply the catalog price rule for configurable product with special prices"
- 
-- filename: "AdminCreateCatalogPriceRuleTest.xml"
-  repo: "https://github.com/magento/magento2/blob/2.3/app/code/Magento/CatalogRule/Test/Mftf/Test/AdminCreateCatalogPriceRuleTest.xml"
-  module: "CatalogRule"
-  tests:
-    - testname: "AdminCreateCatalogPriceRuleByPercentTest"
-      title: "Admin should be able to create a catalog price rule applied as a percentage of original (for simple product)"
-      description: "Admin should be able to create a catalog price rule applied as a percentage of original (for simple product)"
-
-    - testname: "AdminCreateCatalogPriceRuleByFixedTest"
-      title: "Admin should be able to create a catalog price rule applied as a fixed amount (for simple product)"
-      description: "Admin should be able to create a catalog price rule applied as a fixed amount (for simple product)"
-
-    - testname: "AdminCreateCatalogPriceRuleToPercentTest"
-      title: "Admin should be able to create a catalog price rule adjust final price to this percentage (for simple product)"
-      description: "Admin should be able to create a catalog price rule adjust final price to this percentage (for simple product)"
-
-    - testname: "AdminCreateCatalogPriceRuleToFixedTest"
-      title: "Admin should be able to create a catalog price rule adjust final price to discount value (for simple product)"
-      description: "Admin should be able to create a catalog price rule adjust final price to discount value (for simple product)"
-
-    - testname: "AdminCreateCatalogPriceRuleForCustomerGroupTest"
-      title: "Admin should be able to apply the catalog rule by customer group"
-      description: "Admin should be able to apply the catalog rule by customer group"
- 
-- filename: "DeleteCustomerGroupTest.xml"
-  repo: "https://github.com/magento/magento2/blob/2.3/app/code/Magento/CatalogRule/Test/Mftf/Test/DeleteCustomerGroupTest.xml"
-  module: "CatalogRule"
-  tests:
-    - testname: "DeleteCustomerGroupTest"
-      title: ""
-      description: ""
- 
-- filename: "AdminApplyCatalogRuleByCategoryTest.xml"
-  repo: "https://github.com/magento/magento2/blob/2.3/app/code/Magento/CatalogRule/Test/Mftf/Test/AdminApplyCatalogRuleByCategoryTest.xml"
-  module: "CatalogRule"
-  tests:
-    - testname: "AdminApplyCatalogRuleByCategoryTest"
-      title: "Admin should be able to apply the catalog rule by category"
-      description: "Admin should be able to apply the catalog rule by category"
- 
-- filename: "ApplyCatalogRuleForSimpleProductWithCustomOptionsTest.xml"
-  repo: "https://github.com/magento/magento2/blob/2.3/app/code/Magento/CatalogRule/Test/Mftf/Test/ApplyCatalogRuleForSimpleProductWithCustomOptionsTest.xml"
-  module: "CatalogRule"
-  tests:
-    - testname: "ApplyCatalogRuleForSimpleProductWithCustomOptionsTest"
-      title: "Admin should be able to apply the catalog price rule for simple product with custom options"
-      description: "Admin should be able to apply the catalog price rule for simple product with custom options"
- 
-- filename: "AdminCheckInputFieldsDisabledAfterAppConfigDumpTest.xml"
-  repo: "https://github.com/magento/magento2/blob/2.3/app/code/Magento/Dhl/Test/Mftf/Test/AdminCheckInputFieldsDisabledAfterAppConfigDumpTest.xml"
-  module: "Dhl"
-  tests:
-    - testname: "AdminCheckInputFieldsDisabledAfterAppConfigDumpTest"
-      title: ""
-      description: ""
- 
-- filename: "AdminAddVariableToWYSIWYGNewsletterTest.xml"
-  repo: "https://github.com/magento/magento2/blob/2.3/app/code/Magento/Newsletter/Test/Mftf/Test/AdminAddVariableToWYSIWYGNewsletterTest.xml"
-  module: "Newsletter"
-  tests:
-    - testname: "AdminAddVariableToWYSIWYGNewsletterTest"
-      title: "Admin should be able to add variable to WYSIWYG Editor of Newsletter"
-      description: "Admin should be able to add variable to WYSIWYG Editor Newsletter"
- 
-- filename: "AdminAddWidgetToWYSIWYGNewsletterTest.xml"
-  repo: "https://github.com/magento/magento2/blob/2.3/app/code/Magento/Newsletter/Test/Mftf/Test/AdminAddWidgetToWYSIWYGNewsletterTest.xml"
-  module: "Newsletter"
-  tests:
-    - testname: "AdminAddWidgetToWYSIWYGNewsletterTest"
-      title: "Admin should be able to add widget to WYSIWYG Editor of Newsletter"
-      description: "Admin should be able to add widget to WYSIWYG Editor Newsletter"
- 
-- filename: "AdminMarketingNewsletterTemplateNavigateMenuTest.xml"
-  repo: "https://github.com/magento/magento2/blob/2.3/app/code/Magento/Newsletter/Test/Mftf/Test/AdminMarketingNewsletterTemplateNavigateMenuTest.xml"
-  module: "Newsletter"
-  tests:
-    - testname: "AdminMarketingNewsletterTemplateNavigateMenuTest"
-      title: "Admin marketing newsletter template navigate menu test"
-      description: "Admin should be able to navigate to Marketing &gt; Newsletter Template"
- 
-- filename: "AdminReportsNewsletterProblemReportsNavigateMenuTest.xml"
-  repo: "https://github.com/magento/magento2/blob/2.3/app/code/Magento/Newsletter/Test/Mftf/Test/AdminReportsNewsletterProblemReportsNavigateMenuTest.xml"
-  module: "Newsletter"
-  tests:
-    - testname: "AdminReportsNewsletterProblemReportsNavigateMenuTest"
-      title: "Admin reports newsletter problem reports navigate menu test"
-      description: "Admin should be able to navigate to Reports &gt; Newsletter Problem Reports"
- 
-- filename: "AdminAddImageToWYSIWYGNewsletterTest.xml"
-  repo: "https://github.com/magento/magento2/blob/2.3/app/code/Magento/Newsletter/Test/Mftf/Test/AdminAddImageToWYSIWYGNewsletterTest.xml"
-  module: "Newsletter"
-  tests:
-    - testname: "AdminAddImageToWYSIWYGNewsletterTest"
-      title: "Admin should be able to add image to WYSIWYG content of Newsletter"
-      description: "Admin should be able to add image to WYSIWYG content Newsletter"
- 
-- filename: "VerifyTinyMCEv4IsNativeWYSIWYGOnNewsletterTest.xml"
-  repo: "https://github.com/magento/magento2/blob/2.3/app/code/Magento/Newsletter/Test/Mftf/Test/VerifyTinyMCEv4IsNativeWYSIWYGOnNewsletterTest.xml"
-  module: "Newsletter"
-  tests:
-    - testname: "VerifyTinyMCEv4IsNativeWYSIWYGOnNewsletterTest"
-      title: "Admin should see TinyMCEv4.6 is the native WYSIWYG on Newsletter"
-      description: "Admin should see TinyMCEv4.6 is the native WYSIWYG on Newsletter"
- 
-- filename: "StorefrontVerifySecureURLRedirectNewsletterTest.xml"
-  repo: "https://github.com/magento/magento2/blob/2.3/app/code/Magento/Newsletter/Test/Mftf/Test/StorefrontVerifySecureURLRedirectNewsletterTest.xml"
-  module: "Newsletter"
-  tests:
-    - testname: "StorefrontVerifySecureURLRedirectNewsletter"
-      title: "Verify Secure URLs For Storefront Newsletter Pages"
-      description: "Verify that the Secure URL configuration applies to the Newsletter pages on the Storefront"
- 
-- filename: "VerifySubscribedNewsletterDisplayedTest.xml"
-  repo: "https://github.com/magento/magento2/blob/2.3/app/code/Magento/Newsletter/Test/Mftf/Test/VerifySubscribedNewsletterDisplayedTest.xml"
-  module: "Newsletter"
-  tests:
-    - testname: "VerifySubscribedNewsletterDisplayedTest"
-      title: "Newsletter subscription when user is registered on 2 stores"
-      description: "Newsletter subscription when user is registered on 2 stores"
- 
-- filename: "AdminMarketingNewsletterQueueNavigateMenuTest.xml"
-  repo: "https://github.com/magento/magento2/blob/2.3/app/code/Magento/Newsletter/Test/Mftf/Test/AdminMarketingNewsletterQueueNavigateMenuTest.xml"
-  module: "Newsletter"
-  tests:
-    - testname: "AdminMarketingNewsletterQueueNavigateMenuTest"
-      title: "Admin marketing newsletter queue navigate menu test"
-      description: "Admin should be able to navigate to Marketing &gt; Newsletter Queue"
- 
-- filename: "AdminMarketingNewsletterSubscribersNavigateMenuTest.xml"
-  repo: "https://github.com/magento/magento2/blob/2.3/app/code/Magento/Newsletter/Test/Mftf/Test/AdminMarketingNewsletterSubscribersNavigateMenuTest.xml"
-  module: "Newsletter"
-  tests:
-    - testname: "AdminMarketingNewsletterSubscribersNavigateMenuTest"
-      title: "Admin marketing newsletter subscribers navigate menu test"
-      description: "Admin should be able to navigate to Marketing &gt; Newsletter Subscribers"
- 
-- filename: "AdminCreateConfigurableProductWithCreatingCategoryAndAttributeTest.xml"
-  repo: "https://github.com/magento/magento2/blob/2.3/app/code/Magento/ConfigurableProduct/Test/Mftf/Test/AdminCreateConfigurableProductWithCreatingCategoryAndAttributeTest.xml"
-  module: "ConfigurableProduct"
-  tests:
-    - testname: "AdminCreateConfigurableProductWithCreatingCategoryAndAttributeTest"
-      title: "Create configurable product with creating new category and new attribute (required fields only)"
-      description: "Admin should be able to create configurable product with creating new category and new attribute (required fields only)"
- 
-- filename: "AdminAddingNewOptionsWithImagesAndPricesToConfigurableProductTest.xml"
-  repo: "https://github.com/magento/magento2/blob/2.3/app/code/Magento/ConfigurableProduct/Test/Mftf/Test/AdminAddingNewOptionsWithImagesAndPricesToConfigurableProductTest.xml"
-  module: "ConfigurableProduct"
-  tests:
-    - testname: "AdminAddingNewOptionsWithImagesAndPricesToConfigurableProductTest"
-      title: "Adding new options with images and prices to Configurable Product"
-      description: "Test case verifies possibility to add new options for configurable attribute for existing configurable product."
- 
-- filename: "AdminCreateConfigurableProductWithTierPriceForOneItemTest.xml"
-  repo: "https://github.com/magento/magento2/blob/2.3/app/code/Magento/ConfigurableProduct/Test/Mftf/Test/AdminCreateConfigurableProductWithTierPriceForOneItemTest.xml"
-  module: "ConfigurableProduct"
-  tests:
-    - testname: "AdminCreateConfigurableProductWithTierPriceForOneItemTest"
-      title: "Create configurable product with tier price for one item"
-      description: "Admin should be able to create configurable product with tier price for one item"
- 
-- filename: "AdminCreateAndEditConfigurableProductSettingsTest.xml"
-  repo: "https://github.com/magento/magento2/blob/2.3/app/code/Magento/ConfigurableProduct/Test/Mftf/Test/AdminCreateAndEditConfigurableProductSettingsTest.xml"
-  module: "ConfigurableProduct"
-  tests:
-    - testname: "AdminCreateAndEditConfigurableProductSettingsTest"
-      title: "Admin should be able to set/edit other product information when creating/editing a configurable product"
-      description: "Admin should be able to set/edit other product information when creating/editing a configurable product"
- 
-- filename: "AdminConfigurableProductCreateTest.xml"
-  repo: "https://github.com/magento/magento2/blob/2.3/app/code/Magento/ConfigurableProduct/Test/Mftf/Test/AdminConfigurableProductCreateTest.xml"
-  module: "ConfigurableProduct"
-  tests:
-    - testname: "AdminConfigurableProductCreateTest"
-      title: "admin should be able to create a configurable product with attributes"
-      description: "admin should be able to create a configurable product with attributes"
-
-    - testname: "AdminCreateConfigurableProductAfterGettingIncorrectSKUMessageTest"
-      title: "admin should be able to create a configurable product after incorrect sku"
-      description: "admin should be able to create a configurable product after incorrect sku"
- 
-- filename: "ConfigurableProductAttributeNameDesignTest.xml"
-  repo: "https://github.com/magento/magento2/blob/2.3/app/code/Magento/ConfigurableProduct/Test/Mftf/Test/ConfigurableProductAttributeNameDesignTest.xml"
-  module: "ConfigurableProduct"
-  tests:
-    - testname: "ConfigurableProductAttributeNameDesignTest"
-      title: "Generation of configurable products with an attribute named 'design'"
-      description: "Generation of configurable products with an attribute named 'design'"
- 
-- filename: "AdminProductTypeSwitchingOnEditingTest.xml"
-  repo: "https://github.com/magento/magento2/blob/2.3/app/code/Magento/ConfigurableProduct/Test/Mftf/Test/AdminProductTypeSwitchingOnEditingTest.xml"
-  module: "ConfigurableProduct"
-  tests:
-    - testname: "AdminSimpleProductTypeSwitchingToConfigurableProductTest"
-      title: "Simple product type switching on editing to configurable product"
-      description: "Simple product type switching on editing to configurable product"
-
-    - testname: "AdminConfigurableProductTypeSwitchingToVirtualProductTest"
-      title: "Configurable product type switching on editing to virtual product"
-      description: "Configurable product type switching on editing to virtual product"
-
-    - testname: "AdminVirtualProductTypeSwitchingToConfigurableProductTest"
-      title: "Virtual product type switching on editing to configurable product"
-      description: "Virtual product type switching on editing to configurable product"
- 
-- filename: "AdminCheckResultsOfColorAndOtherFiltersTest.xml"
-  repo: "https://github.com/magento/magento2/blob/2.3/app/code/Magento/ConfigurableProduct/Test/Mftf/Test/AdminCheckResultsOfColorAndOtherFiltersTest.xml"
-  module: "ConfigurableProduct"
-  tests:
-    - testname: "AdminCheckResultsOfColorAndOtherFiltersTest"
-      title: "Checking results of color and other filters"
-      description: "Checking results of filters: color and other filters"
- 
-- filename: "AdminConfigurableProductOutOfStockTest.xml"
-  repo: "https://github.com/magento/magento2/blob/2.3/app/code/Magento/ConfigurableProduct/Test/Mftf/Test/AdminConfigurableProductOutOfStockTest.xml"
-  module: "ConfigurableProduct"
-  tests:
-    - testname: "AdminConfigurableProductChildrenOutOfStockTest"
-      title: "Configurable Product goes 'Out of Stock' if all associated Simple Products are 'Out of Stock'"
-      description: "Configurable Product goes 'Out of Stock' if all associated Simple Products are 'Out of Stock'"
-
-    - testname: "AdminConfigurableProductOutOfStockTestDeleteChildren"
-      title: "Configurable Product goes 'Out of Stock' if all associated Simple Products are deleted"
-      description: "Configurable Product goes 'Out of Stock' if all associated Simple Products are deleted"
-
-    - testname: "AdminConfigurableProductOutOfStockAndDeleteCombinationTest"
-      title: "Configurable Product goes 'Out of Stock' if all associated Simple Products are a combination of 'Out of Stock' and deleted"
-      description: "Configurable Product goes 'Out of Stock' if all associated Simple Products are a combination of 'Out of Stock' and deleted"
- 
-- filename: "ProductsQtyReturnAfterOrderCancelTest.xml"
-  repo: "https://github.com/magento/magento2/blob/2.3/app/code/Magento/ConfigurableProduct/Test/Mftf/Test/ProductsQtyReturnAfterOrderCancelTest.xml"
-  module: "ConfigurableProduct"
-  tests:
-    - testname: "ProductsQtyReturnAfterOrderCancel"
-      title: "Product qunatity return after order cancel"
-      description: "Check Product qunatity return after order cancel"
- 
-- filename: "AdminConfigurableProductLongSkuTest.xml"
-  repo: "https://github.com/magento/magento2/blob/2.3/app/code/Magento/ConfigurableProduct/Test/Mftf/Test/AdminConfigurableProductLongSkuTest.xml"
-  module: "ConfigurableProduct"
-  tests:
-    - testname: "AdminConfigurableProductLongSkuTest"
-      title: "Admin is able to create an product with a long sku below that is below the character limit"
-      description: "Try to create a product with sku slightly less than char limit. Get client side SKU length error for child products. Correct SKUs and save product succeeds."
- 
-- filename: "StorefrontVerifyConfigurableProductLayeredNavigationTest.xml"
-  repo: "https://github.com/magento/magento2/blob/2.3/app/code/Magento/ConfigurableProduct/Test/Mftf/Test/StorefrontVerifyConfigurableProductLayeredNavigationTest.xml"
-  module: "ConfigurableProduct"
-  tests:
-    - testname: "StorefrontVerifyConfigurableProductLayeredNavigationTest"
-      title: "Out of stock configurable attribute option doesn't show in Layered Navigation"
-      description: " Login as admin and verify out of stock configurable attribute option doesn't show in Layered Navigation"
- 
-- filename: "EndToEndB2CGuestUserTest.xml"
-  repo: "https://github.com/magento/magento2/blob/2.3/app/code/Magento/ConfigurableProduct/Test/Mftf/Test/EndToEndB2CGuestUserTest.xml"
-  module: "ConfigurableProduct"
-  tests:
-    - testname: "EndToEndB2CGuestUserTest"
-      title: ""
-      description: ""
-
-    - testname: "EndToEndB2CGuestUserMysqlTest"
-      title: ""
-      description: ""
- 
-- filename: "AdminCreateConfigurableProductWithImagesTest.xml"
-  repo: "https://github.com/magento/magento2/blob/2.3/app/code/Magento/ConfigurableProduct/Test/Mftf/Test/AdminCreateConfigurableProductWithImagesTest.xml"
-  module: "ConfigurableProduct"
-  tests:
-    - testname: "AdminCreateConfigurableProductWithImagesTest"
-      title: "Create configurable product with images"
-      description: "Admin should be able to create configurable product with images"
- 
-- filename: "AdminCreateConfigurableProductWithTwoOptionsWithoutAssignedToCategoryTest.xml"
-  repo: "https://github.com/magento/magento2/blob/2.3/app/code/Magento/ConfigurableProduct/Test/Mftf/Test/AdminCreateConfigurableProductWithTwoOptionsWithoutAssignedToCategoryTest.xml"
-  module: "ConfigurableProduct"
-  tests:
-    - testname: "AdminCreateConfigurableProductWithTwoOptionsWithoutAssignedToCategoryTest"
-      title: "Create configurable product with two new options without assigned to category with not visible child products"
-      description: "Admin should be able to create configurable product with two options without assigned to category, child products are not visible individually"
- 
-- filename: "AdminConfigurableProductUpdateAttributeTest.xml"
-  repo: "https://github.com/magento/magento2/blob/2.3/app/code/Magento/ConfigurableProduct/Test/Mftf/Test/AdminConfigurableProductUpdateAttributeTest.xml"
-  module: "ConfigurableProduct"
-  tests:
-    - testname: "AdminConfigurableProductUpdateAttributeTest"
-      title: "Admin should be able to update existing attributes of a configurable product"
-      description: "Admin should be able to update existing attributes of a configurable product"
-
-    - testname: "AdminConfigurableProductUpdateChildAttributeTest"
-      title: "Admin should be able to update existing attributes of child products of a configurable product"
-      description: "Admin should be able to update existing attributes of child products of a configurable product"
- 
-- filename: "AdminRemoveDefaultImageConfigurableTest.xml"
-  repo: "https://github.com/magento/magento2/blob/2.3/app/code/Magento/ConfigurableProduct/Test/Mftf/Test/AdminRemoveDefaultImageConfigurableTest.xml"
-  module: "ConfigurableProduct"
-  tests:
-    - testname: "AdminRemoveDefaultImageConfigurableTest"
-      title: "Admin should be able to remove default images from a Configurable Product"
-      description: "Admin should be able to remove default images from a Configurable Product"
- 
-- filename: "NewProductsListWidgetConfigurableProductTest.xml"
-  repo: "https://github.com/magento/magento2/blob/2.3/app/code/Magento/ConfigurableProduct/Test/Mftf/Test/NewProductsListWidgetConfigurableProductTest.xml"
-  module: "ConfigurableProduct"
-  tests:
-    - testname: "NewProductsListWidgetConfigurableProductTest"
-      title: "Admin should be able to set Configurable Product as new so that it shows up in the Catalog New Products List Widget"
-      description: "Admin should be able to set Configurable Product as new so that it shows up in the Catalog New Products List Widget"
- 
-- filename: "AdminCreateConfigurableProductWithThreeProductDontDisplayOutOfStockProductsTest.xml"
-  repo: "https://github.com/magento/magento2/blob/2.3/app/code/Magento/ConfigurableProduct/Test/Mftf/Test/AdminCreateConfigurableProductWithThreeProductDontDisplayOutOfStockProductsTest.xml"
-  module: "ConfigurableProduct"
-  tests:
-    - testname: "AdminCreateConfigurableProductWithThreeProductDontDisplayOutOfStockProductsTest"
-      title: "Create Configurable Product with three product, don't display out of stock products"
-      description: "Admin should be able to create Configurable Product with one out of stock and several in stock options, don't display out of stock products"
- 
-- filename: "AdminCheckValidatorConfigurableProductTest.xml"
-  repo: "https://github.com/magento/magento2/blob/2.3/app/code/Magento/ConfigurableProduct/Test/Mftf/Test/AdminCheckValidatorConfigurableProductTest.xml"
-  module: "ConfigurableProduct"
-  tests:
-    - testname: "AdminCheckValidatorConfigurableProductTest"
-      title: "Check that validator works correctly when creating Configurations for Configurable Products"
-      description: "Verify validator works correctly for Configurable Products"
- 
-- filename: "AdminAddDefaultImageConfigurableTest.xml"
-  repo: "https://github.com/magento/magento2/blob/2.3/app/code/Magento/ConfigurableProduct/Test/Mftf/Test/AdminAddDefaultImageConfigurableTest.xml"
-  module: "ConfigurableProduct"
-  tests:
-    - testname: "AdminAddDefaultImageConfigurableTest"
-      title: "Admin should be able to add default images for a Configurable Product"
-      description: "Admin should be able to add default images for a Configurable Product"
- 
-- filename: "StorefrontConfigurableProductCategoryViewChildOnlyTest.xml"
-  repo: "https://github.com/magento/magento2/blob/2.3/app/code/Magento/ConfigurableProduct/Test/Mftf/Test/StorefrontConfigurableProductCategoryViewChildOnlyTest.xml"
-  module: "ConfigurableProduct"
-  tests:
-    - testname: "StorefrontConfigurableProductCategoryViewChildOnlyTest"
-      title: "It should be possible to only view the child product of a configurable product"
-      description: "Create configurable product, add to category such that only child variation is visible in category"
- 
-- filename: "AdminCreateConfigurableProductBasedOnParentSkuTest.xml"
-  repo: "https://github.com/magento/magento2/blob/2.3/app/code/Magento/ConfigurableProduct/Test/Mftf/Test/AdminCreateConfigurableProductBasedOnParentSkuTest.xml"
-  module: "ConfigurableProduct"
-  tests:
-    - testname: "AdminCreateConfigurableProductBasedOnParentSkuTest"
-      title: "Configurable product variation's sku should be based on parent SKU"
-      description: "Admin should be able to create configurable product with two new options based on parent SKU, without assigned to category and attribute set"
- 
-- filename: "EndToEndB2CAdminTest.xml"
-  repo: "https://github.com/magento/magento2/blob/2.3/app/code/Magento/ConfigurableProduct/Test/Mftf/Test/EndToEndB2CAdminTest.xml"
-  module: "ConfigurableProduct"
-  tests:
-    - testname: "EndToEndB2CAdminTest"
-      title: ""
-      description: ""
- 
-- filename: "ConfigurableProductPriceAdditionalStoreViewTest.xml"
-  repo: "https://github.com/magento/magento2/blob/2.3/app/code/Magento/ConfigurableProduct/Test/Mftf/Test/ConfigurableProductPriceAdditionalStoreViewTest.xml"
-  module: "ConfigurableProduct"
-  tests:
-    - testname: "ConfigurableProductPriceAdditionalStoreViewTest"
-      title: "Configurable product prices should not disappear on storefront for additional store"
-      description: "Configurable product price should not disappear for additional stores on frontEnd if disabled for default store"
- 
-- filename: "AdminCreateConfigurableProductWithThreeProductDisplayOutOfStockProductsTest.xml"
-  repo: "https://github.com/magento/magento2/blob/2.3/app/code/Magento/ConfigurableProduct/Test/Mftf/Test/AdminCreateConfigurableProductWithThreeProductDisplayOutOfStockProductsTest.xml"
-  module: "ConfigurableProduct"
-  tests:
-    - testname: "AdminCreateConfigurableProductWithThreeProductDisplayOutOfStockProductsTest"
-      title: "Create Configurable Product with three product, display out of stock products"
-      description: "Admin should be able to create Configurable Product with one out of stock and several in stock options, display out of stock products"
- 
-- filename: "AdminConfigurableProductSetEditContentTest.xml"
-  repo: "https://github.com/magento/magento2/blob/2.3/app/code/Magento/ConfigurableProduct/Test/Mftf/Test/AdminConfigurableProductSetEditContentTest.xml"
-  module: "ConfigurableProduct"
-  tests:
-    - testname: "AdminConfigurableProductSetEditContentTest"
-      title: "Admin should be able to set/edit product Content when editing a configurable product"
-      description: "Admin should be able to set/edit product Content when editing a configurable product"
- 
-- filename: "AdminCreateConfigurableProductWithTwoOptionsAssignedToCategoryTest.xml"
-  repo: "https://github.com/magento/magento2/blob/2.3/app/code/Magento/ConfigurableProduct/Test/Mftf/Test/AdminCreateConfigurableProductWithTwoOptionsAssignedToCategoryTest.xml"
-  module: "ConfigurableProduct"
-  tests:
-    - testname: "AdminCreateConfigurableProductWithTwoOptionsAssignedToCategoryTest"
-      title: "Create configurable product with two new options assigned to category with not visible child products"
-      description: "Admin should be able to create configurable product with two new options, assigned to category, child products are not visible individually"
- 
-- filename: "AdminConfigurableSetEditRelatedProductsTest.xml"
-  repo: "https://github.com/magento/magento2/blob/2.3/app/code/Magento/ConfigurableProduct/Test/Mftf/Test/AdminConfigurableSetEditRelatedProductsTest.xml"
-  module: "ConfigurableProduct"
-  tests:
-    - testname: "AdminConfigurableSetEditRelatedProductsTest"
-      title: "Admin should be able to set/edit Related Products information when editing a configurable product"
-      description: "Admin should be able to set/edit Related Products information when editing a configurable product"
- 
-- filename: "AdminConfigurableProductDeleteTest.xml"
-  repo: "https://github.com/magento/magento2/blob/2.3/app/code/Magento/ConfigurableProduct/Test/Mftf/Test/AdminConfigurableProductDeleteTest.xml"
-  module: "ConfigurableProduct"
-  tests:
-    - testname: "AdminConfigurableProductDeleteTest"
-      title: "admin should be able to delete a configurable product"
-      description: "admin should be able to delete a configurable product"
-
-    - testname: "AdminConfigurableProductBulkDeleteTest"
-      title: "admin should be able to mass delete configurable products"
-      description: "admin should be able to mass delete configurable products"
- 
-- filename: "NoOptionAvailableToConfigureDisabledProductTest.xml"
-  repo: "https://github.com/magento/magento2/blob/2.3/app/code/Magento/ConfigurableProduct/Test/Mftf/Test/NoOptionAvailableToConfigureDisabledProductTest.xml"
-  module: "ConfigurableProduct"
-  tests:
-    - testname: "NoOptionAvailableToConfigureDisabledProductTest"
-      title: "Disabled variation of configurable product can't be added to shopping cart via admin"
-      description: "Disabled variation of configurable product can't be added to shopping cart via admin"
- 
-- filename: "StorefrontConfigurableProductDetailsTest.xml"
-  repo: "https://github.com/magento/magento2/blob/2.3/app/code/Magento/ConfigurableProduct/Test/Mftf/Test/StorefrontConfigurableProductDetailsTest.xml"
-  module: "ConfigurableProduct"
-  tests:
-    - testname: "StorefrontConfigurableProductBasicInfoTest"
-      title: "Guest customer should see basic Configurable Product details"
-      description: "Guest customer should see basic Configurable Product details"
-
-    - testname: "StorefrontConfigurableProductOptionsTest"
-      title: "Guest customer should be able to see product configuration options"
-      description: "Guest customer should be able to see product configuration options"
-
-    - testname: "StorefrontConfigurableProductCanAddToCartTest"
-      title: "Guest customer should be able to successfully add the product to the cart"
-      description: "Guest customer should be able to successfully add the product to the cart"
-
-    - testname: "StorefrontConfigurableProductCantAddToCartTest"
-      title: "Guest customer should not be able to add the product to the cart if options are not selected"
-      description: "Guest customer should not be able to add the product to the cart if options are not selected"
- 
-- filename: "StorefrontConfigurableProductViewTest.xml"
-  repo: "https://github.com/magento/magento2/blob/2.3/app/code/Magento/ConfigurableProduct/Test/Mftf/Test/StorefrontConfigurableProductViewTest.xml"
-  module: "ConfigurableProduct"
-  tests:
-    - testname: "StorefrontConfigurableProductGridViewTest"
-      title: "customer should see the configurable product in the category grid"
-      description: "customer should see the configurable product in the category grid"
-
-    - testname: "StorefrontConfigurableProductListViewTest"
-      title: "customer should see the configurable product in the category list"
-      description: "customer should see the configurable product in the category list"
-
-    - testname: "StorefrontConfigurableProductAddToCartTest"
-      title: "customer should be taken to the product details page when clicking add to cart"
-      description: "customer should be taken to the product details page when clicking add to cart"
- 
-- filename: "AdminConfigurableProductSearchTest.xml"
-  repo: "https://github.com/magento/magento2/blob/2.3/app/code/Magento/ConfigurableProduct/Test/Mftf/Test/AdminConfigurableProductSearchTest.xml"
-  module: "ConfigurableProduct"
-  tests:
-    - testname: "AdminConfigurableProductSearchTest"
-      title: "admin should be able to search for a configurable product"
-      description: "admin should be able to search for a configurable product"
-
-    - testname: "AdminConfigurableProductFilterByTypeTest"
-      title: "admin should be able to filter by type configurable product"
-      description: "admin should be able to filter by type configurable product"
- 
-- filename: "StorefrontSortingByPriceForConfigurableWithCatalogRuleAppliedTest.xml"
-  repo: "https://github.com/magento/magento2/blob/2.3/app/code/Magento/ConfigurableProduct/Test/Mftf/Test/StorefrontSortingByPriceForConfigurableWithCatalogRuleAppliedTest.xml"
-  module: "ConfigurableProduct"
-  tests:
-    - testname: "StorefrontSortingByPriceForConfigurableProductWithCatalogRuleAppliedTest"
-      title: "Sorting by price for Configurable with Catalog Rule applied"
-      description: "Sort by price should be correct if the apply Catalog Rule to child product of configurable product"
- 
-- filename: "AdminRelatedProductsTest.xml"
-  repo: "https://github.com/magento/magento2/blob/2.3/app/code/Magento/ConfigurableProduct/Test/Mftf/Test/AdminRelatedProductsTest.xml"
-  module: "ConfigurableProduct"
-  tests:
-    - testname: "AdminRelatedProductsTest"
-      title: "Admin should be able to promote products as related"
-      description: "Admin should be able to promote products as related"
- 
-- filename: "StorefrontVisibilityOfDuplicateProductTest.xml"
-  repo: "https://github.com/magento/magento2/blob/2.3/app/code/Magento/ConfigurableProduct/Test/Mftf/Test/StorefrontVisibilityOfDuplicateProductTest.xml"
-  module: "ConfigurableProduct"
-  tests:
-    - testname: "StorefrontVisibilityOfDuplicateProductTest"
-      title: "Visibility of duplicate product on the Storefront"
-      description: "Check visibility of duplicate product on the Storefront"
- 
-- filename: "AdminCreateConfigurableProductWithDisabledChildrenProductsTest.xml"
-  repo: "https://github.com/magento/magento2/blob/2.3/app/code/Magento/ConfigurableProduct/Test/Mftf/Test/AdminCreateConfigurableProductWithDisabledChildrenProductsTest.xml"
-  module: "ConfigurableProduct"
-  tests:
-    - testname: "AdminCreateConfigurableProductWithDisabledChildrenProductsTest"
-      title: "Create configurable product with disabled children products"
-      description: "Admin should be able to create configurable product with disabled children products, assigned to category"
- 
-- filename: "AdminDeleteConfigurableProductTest.xml"
-  repo: "https://github.com/magento/magento2/blob/2.3/app/code/Magento/ConfigurableProduct/Test/Mftf/Test/AdminDeleteConfigurableProductTest.xml"
-  module: "ConfigurableProduct"
-  tests:
-    - testname: "AdminDeleteConfigurableProductTest"
-      title: "Delete configurable product test"
-      description: "Admin should be able to delete a configurable product"
- 
-- filename: "AdvanceCatalogSearchConfigurableTest.xml"
-  repo: "https://github.com/magento/magento2/blob/2.3/app/code/Magento/ConfigurableProduct/Test/Mftf/Test/AdvanceCatalogSearchConfigurableTest.xml"
-  module: "ConfigurableProduct"
-  tests:
-    - testname: "AdvanceCatalogSearchConfigurableByNameTest"
-      title: "Guest customer should be able to advance search configurable product with product name"
-      description: "Guest customer should be able to advance search configurable product with product name"
-
-    - testname: "AdvanceCatalogSearchConfigurableBySkuTest"
-      title: "Guest customer should be able to advance search configurable product with product sku"
-      description: "Guest customer should be able to advance search configurable product with product sku"
-
-    - testname: "AdvanceCatalogSearchConfigurableByDescriptionTest"
-      title: "Guest customer should be able to advance search configurable product with product description"
-      description: "Guest customer should be able to advance search configurable product with product description"
-
-    - testname: "AdvanceCatalogSearchConfigurableByShortDescriptionTest"
-      title: "Guest customer should be able to advance search configurable product with product short description"
-      description: "Guest customer should be able to advance search configurable product with product short description"
- 
-- filename: "StorefrontConfigurableProductChildSearchTest.xml"
-  repo: "https://github.com/magento/magento2/blob/2.3/app/code/Magento/ConfigurableProduct/Test/Mftf/Test/StorefrontConfigurableProductChildSearchTest.xml"
-  module: "ConfigurableProduct"
-  tests:
-    - testname: "StorefrontConfigurableProductChildSearchTest"
-      title: "Guest customer should be able to search configurable product by attributes of child products"
-      description: "Guest customer should be able to search configurable product by attributes of child products"
- 
-- filename: "StorefrontConfigurableProductWithFileCustomOptionTest.xml"
-  repo: "https://github.com/magento/magento2/blob/2.3/app/code/Magento/ConfigurableProduct/Test/Mftf/Test/StorefrontConfigurableProductWithFileCustomOptionTest.xml"
-  module: "ConfigurableProduct"
-  tests:
-    - testname: "StorefrontConfigurableProductWithFileCustomOptionTest"
-      title: "Correct error message and redirect with invalid file option"
-      description: "Configurable product has file custom option. When adding to cart with an invalid filetype, the correct error message is shown, and options remain selected."
- 
-- filename: "AdminCheckConfigurableProductAttributeValueUniquenessTest.xml"
-  repo: "https://github.com/magento/magento2/blob/2.3/app/code/Magento/ConfigurableProduct/Test/Mftf/Test/AdminCheckConfigurableProductAttributeValueUniquenessTest.xml"
-  module: "ConfigurableProduct"
-  tests:
-    - testname: "AdminCheckConfigurableProductAttributeValueUniquenessTest"
-      title: "Attribute value validation (check for uniqueness) in configurable products"
-      description: "Attribute value validation (check for uniqueness) in configurable products"
- 
-- filename: "AdminConfigurableProductUpdateTest.xml"
-  repo: "https://github.com/magento/magento2/blob/2.3/app/code/Magento/ConfigurableProduct/Test/Mftf/Test/AdminConfigurableProductUpdateTest.xml"
-  module: "ConfigurableProduct"
-  tests:
-    - testname: "AdminConfigurableProductBulkUpdateTest"
-      title: "admin should be able to bulk update attributes of configurable products"
-      description: "admin should be able to bulk update attributes of configurable products"
-
-    - testname: "AdminConfigurableProductRemoveAnOptionTest"
-      title: "Admin should be able to remove a product configuration"
-      description: "Admin should be able to remove a product configuration"
-
-    - testname: "AdminConfigurableProductDisableAnOptionTest"
-      title: "Admin should be able to disable a product configuration"
-      description: "Admin should be able to disable a product configuration"
-
-    - testname: "AdminConfigurableProductRemoveConfigurationTest"
-      title: "Admin should be able to remove a configuration from a Configurable Product"
-      description: "Admin should be able to remove a configuration from a Configurable Product"
-
-    - testname: "AdminConfigurableProductAddConfigurationTest"
-      title: "Admin should be able to edit configuration to add a value to an existing attribute"
-      description: "Admin should be able to edit configuration to add a value to an existing attribute"
- 
-- filename: "EndToEndB2CLoggedInUserTest.xml"
-  repo: "https://github.com/magento/magento2/blob/2.3/app/code/Magento/ConfigurableProduct/Test/Mftf/Test/EndToEndB2CLoggedInUserTest.xml"
-  module: "ConfigurableProduct"
-  tests:
-    - testname: "EndToEndB2CLoggedInUserTest"
-      title: ""
-      description: ""
- 
-- filename: "StorefrontAdvanceCatalogSearchConfigurableBySkuWithHyphenTest.xml"
-  repo: "https://github.com/magento/magento2/blob/2.3/app/code/Magento/ConfigurableProduct/Test/Mftf/Test/StorefrontAdvanceCatalogSearchConfigurableBySkuWithHyphenTest.xml"
-  module: "ConfigurableProduct"
-  tests:
-    - testname: "StorefrontAdvanceCatalogSearchConfigurableBySkuWithHyphenTest"
-      title: "Guest customer should be able to advance search configurable product with product sku that contains hyphen"
-      description: "Guest customer should be able to advance search configurable product with product sku that contains hyphen"
- 
-- filename: "AdminAssertNoticeThatExistingSkuAutomaticallyChangedWhenSavingProductWithSameSkuTest.xml"
-  repo: "https://github.com/magento/magento2/blob/2.3/app/code/Magento/ConfigurableProduct/Test/Mftf/Test/AdminAssertNoticeThatExistingSkuAutomaticallyChangedWhenSavingProductWithSameSkuTest.xml"
-  module: "ConfigurableProduct"
-  tests:
-    - testname: "AdminAssertNoticeThatExistingSkuAutomaticallyChangedWhenSavingProductWithSameSkuTest"
-      title: "Assert notice that existing sku automatically changed when saving product with same sku"
-      description: "Admin should not be able to create configurable product and two new options with the same sku"
- 
-- filename: "AdminCreateAndDeleteBackupsTest.xml"
-  repo: "https://github.com/magento/magento2/blob/2.3/app/code/Magento/Backup/Test/Mftf/Test/AdminCreateAndDeleteBackupsTest.xml"
-  module: "Backup"
-  tests:
-    - testname: "AdminCreateAndDeleteBackupsTest"
-      title: "Create and delete backups"
-      description: "An admin user can create a backup of each type and delete each backup."
- 
-- filename: "CatalogProductListWidgetOrderTest.xml"
-  repo: "https://github.com/magento/magento2/blob/2.3/app/code/Magento/CatalogWidget/Test/Mftf/Test/CatalogProductListWidgetOrderTest.xml"
-  module: "CatalogWidget"
-  tests:
-    - testname: "CatalogProductListWidgetOrderTest"
-      title: "Checking order of products in the 'catalog Products List' widget"
-      description: "Check that products are ordered with recently added products first"
- 
-- filename: "CatalogProductListWidgetOperatorsTest.xml"
-  repo: "https://github.com/magento/magento2/blob/2.3/app/code/Magento/CatalogWidget/Test/Mftf/Test/CatalogProductListWidgetOperatorsTest.xml"
-  module: "CatalogWidget"
-  tests:
-    - testname: "CatalogProductListWidgetOperatorsTest"
-      title: "Checking operator more/less in the 'catalog Products List' widget"
-      description: "Check 'less than', 'equals or greater than', 'equals or less than' operators"
- 
-- filename: "AdminSystemIndexManagementNavigateMenuTest.xml"
-  repo: "https://github.com/magento/magento2/blob/2.3/app/code/Magento/Indexer/Test/Mftf/Test/AdminSystemIndexManagementNavigateMenuTest.xml"
-  module: "Indexer"
-  tests:
-    - testname: "AdminSystemIndexManagementNavigateMenuTest"
-      title: "Admin system index management navigate menu test"
-      description: "Admin should be able to navigate to System &gt; Index Management"
- 
-- filename: "StorefrontProductQuickSearchUsingElasticSearch6Test.xml"
-  repo: "https://github.com/magento/magento2/blob/2.3/app/code/Magento/Elasticsearch/Test/Mftf/Test/StorefrontProductQuickSearchUsingElasticSearch6Test.xml"
-  module: "Elasticsearch"
-  tests:
-    - testname: "StorefrontProductQuickSearchUsingElasticSearch6Test"
-      title: "Product quick search doesn't throw exception after ES is chosen as search engine with different amount per page"
-      description: "Verify no elastic search exception is thrown when searching for products, when displayed products per page are greater or equal the size of available products."
-
-    - testname: "StorefrontProductQuickSearchUsingElasticSearch6WithNotAvailablePageTest"
-      title: "Product quick search doesn't throw exception after ES is chosen as search engine with selected page out of range"
-      description: "Verify no elastic search exception is thrown when try to get page with selected page out of range."
- 
-- filename: "ProductQuickSearchUsingElasticSearchTest.xml"
-  repo: "https://github.com/magento/magento2/blob/2.3/app/code/Magento/Elasticsearch/Test/Mftf/Test/ProductQuickSearchUsingElasticSearchTest.xml"
-  module: "Elasticsearch"
-  tests:
-    - testname: "ProductQuickSearchUsingElasticSearchTest"
-      title: "Product quick search doesn't throw exception after ES is chosen as search engine"
-      description: "Verify no elastic search exception is thrown when searching for product before catalogsearch reindexing"
- 
-- filename: "TrackingScriptTest.xml"
-  repo: "https://github.com/magento/magento2/blob/2.3/app/code/Magento/AdminAnalytics/Test/Mftf/Test/TrackingScriptTest.xml"
-  module: "AdminAnalytics"
-  tests:
-    - testname: "TrackingScriptTest"
-      title: "Checks to see if the tracking script is in the dom of admin and if setting is turned to no it checks if the tracking script in the dom was removed"
-      description: "Checks to see if the tracking script is in the dom of admin and if setting is turned to no it checks if the tracking script in the dom was removed"
- 
-- filename: "AdminMarketingEmailTemplatesNavigateMenuTest.xml"
-  repo: "https://github.com/magento/magento2/blob/2.3/app/code/Magento/Email/Test/Mftf/Test/AdminMarketingEmailTemplatesNavigateMenuTest.xml"
-  module: "Email"
-  tests:
-    - testname: "AdminMarketingEmailTemplatesNavigateMenuTest"
-      title: "Admin marketing email templates navigate menu test"
-      description: "Admin should be able to navigate to Marketing &gt; Email Templates"
- 
-- filename: "AdminEmailTemplatePreviewTest.xml"
-  repo: "https://github.com/magento/magento2/blob/2.3/app/code/Magento/Email/Test/Mftf/Test/AdminEmailTemplatePreviewTest.xml"
-  module: "Email"
-  tests:
-    - testname: "AdminEmailTemplatePreviewTest"
-      title: "Check email template preview"
-      description: "Check if email template preview works correctly"
-
-    - testname: "AdminEmailTemplatePreviewWithDirectivesTest"
-      title: "Check email template preview with directives"
-      description: "Check if email template preview works correctly with directives"
-
-    - testname: "AdminEmailTemplatePreviewAsDraftWithDirectivesTest"
-      title: "Check email template preview with directives and preview as draft"
-      description: "Check if email template preview works correctly with directives in draft mode"
- 
-- filename: "TransactionalEmailsLogoUploadTest.xml"
-  repo: "https://github.com/magento/magento2/blob/2.3/app/code/Magento/Email/Test/Mftf/Test/TransactionalEmailsLogoUploadTest.xml"
-  module: "Email"
-  tests:
-    - testname: "TransactionalEmailsLogoUploadTest"
-      title: "MC-13908: Uploading a Transactional Emails logo"
-      description: "Transactional Emails Logo should be able to be uploaded in the admin and previewed"
- 
-- filename: "AdminSystemNotificationNavigateMenuTest.xml"
-  repo: "https://github.com/magento/magento2/blob/2.3/app/code/Magento/AdminNotification/Test/Mftf/Test/AdminSystemNotificationNavigateMenuTest.xml"
-  module: "AdminNotification"
-  tests:
-    - testname: "AdminSystemNotificationNavigateMenuTest"
-      title: "Admin system notification navigate menu test"
-      description: "Admin should be able to navigate to System &gt; Notifications"
- 
-- filename: "AdminSearchCustomerAddressByKeywordTest.xml"
-  repo: "https://github.com/magento/magento2/blob/2.3/app/code/Magento/Customer/Test/Mftf/Test/AdminSearchCustomerAddressByKeywordTest.xml"
-  module: "Customer"
-  tests:
-    - testname: "AdminSearchCustomerAddressByKeywordTest"
-      title: "Admin search customer address by keyword"
-      description: "Admin search customer address by keyword"
- 
-- filename: "AdminCreateCustomerRetailerWithoutAddressTest.xml"
-  repo: "https://github.com/magento/magento2/blob/2.3/app/code/Magento/Customer/Test/Mftf/Test/AdminCreateCustomerRetailerWithoutAddressTest.xml"
-  module: "Customer"
-  tests:
-    - testname: "AdminCreateCustomerRetailerWithoutAddressTest"
-      title: "Create customer, retailer without address"
-      description: "Login as admin and create customer retailer without address"
- 
-- filename: "ChangeCustomerGroupTest.xml"
-  repo: "https://github.com/magento/magento2/blob/2.3/app/code/Magento/Customer/Test/Mftf/Test/ChangeCustomerGroupTest.xml"
-  module: "Customer"
-  tests:
-    - testname: "ChangingSingleCustomerGroupViaGrid"
-      title: "Change a single customer group via grid"
-      description: "From the selection of All Customers select a single customer to change their group"
-
-    - testname: "ChangingAllCustomerGroupViaGrid"
-      title: "Change all customers' group via grid"
-      description: "Select All customers to change their group"
- 
-- filename: "AdminCreateNewCustomerOnStorefrontTest.xml"
-  repo: "https://github.com/magento/magento2/blob/2.3/app/code/Magento/Customer/Test/Mftf/Test/AdminCreateNewCustomerOnStorefrontTest.xml"
-  module: "Customer"
-  tests:
-    - testname: "AdminCreateNewCustomerOnStorefrontTest"
-      title: "Create New Customer on Storefront"
-      description: "Test log in to Create New Customer and Create New Customer on Storefront"
- 
-- filename: "AdminCreateCustomerWithoutAddressTest.xml"
-  repo: "https://github.com/magento/magento2/blob/2.3/app/code/Magento/Customer/Test/Mftf/Test/AdminCreateCustomerWithoutAddressTest.xml"
-  module: "Customer"
-  tests:
-    - testname: "AdminCreateCustomerWithoutAddressTest"
-      title: "Create customer, without address"
-      description: "Login as admin and create a customer without address"
- 
-- filename: "StorefrontCreateCustomerTest.xml"
-  repo: "https://github.com/magento/magento2/blob/2.3/app/code/Magento/Customer/Test/Mftf/Test/StorefrontCreateCustomerTest.xml"
-  module: "Customer"
-  tests:
-    - testname: "StorefrontCreateCustomerTest"
-      title: "Admin should be able to create a customer via the storefront"
-      description: "Admin should be able to create a customer via the storefront"
- 
-- filename: "StorefrontUpdateCustomerPasswordTest.xml"
-  repo: "https://github.com/magento/magento2/blob/2.3/app/code/Magento/Customer/Test/Mftf/Test/StorefrontUpdateCustomerPasswordTest.xml"
-  module: "Customer"
-  tests:
-    - testname: "StorefrontUpdateCustomerPasswordValidCurrentPasswordTest"
-      title: "Update Customer Password on Storefront, Valid Current Password"
-      description: "Update Customer Password on Storefront, Valid Current Password"
-
-    - testname: "StorefrontUpdateCustomerPasswordInvalidCurrentPasswordTest"
-      title: "Update Customer Password on Storefront, Invalid Current Password"
-      description: "Update Customer Password on Storefront, Invalid Current Password"
-
-    - testname: "StorefrontUpdateCustomerPasswordInvalidConfirmationPasswordTest"
-      title: "Update Customer Password on Storefront, Invalid Confirmation Password"
-      description: "Update Customer Password on Storefront, Invalid Confirmation Password"
- 
-- filename: "StorefrontLockCustomerOnLoginPageTest.xml"
-  repo: "https://github.com/magento/magento2/blob/2.3/app/code/Magento/Customer/Test/Mftf/Test/StorefrontLockCustomerOnLoginPageTest.xml"
-  module: "Customer"
-  tests:
-    - testname: "StorefrontLockCustomerOnLoginPageTest"
-      title: "Lock customer on Storefront with after many attempts to log in with incorrect credentials"
-      description: "Lock customer on Storefront with after many attempts to log in with incorrect credentials"
- 
-- filename: "AdminDeleteDefaultBillingCustomerAddressTest.xml"
-  repo: "https://github.com/magento/magento2/blob/2.3/app/code/Magento/Customer/Test/Mftf/Test/AdminDeleteDefaultBillingCustomerAddressTest.xml"
-  module: "Customer"
-  tests:
-    - testname: "AdminDeleteDefaultBillingCustomerAddressTest"
-      title: "Admin delete default billing customer address"
-      description: "Admin delete default billing customer address"
- 
-- filename: "StorefrontCreateExistingCustomerTest.xml"
-  repo: "https://github.com/magento/magento2/blob/2.3/app/code/Magento/Customer/Test/Mftf/Test/StorefrontCreateExistingCustomerTest.xml"
-  module: "Customer"
-  tests:
-    - testname: "StorefrontCreateExistingCustomerTest"
-      title: "Attempt to register customer on storefront with existing email"
-      description: "Attempt to register customer on storefront with existing email"
- 
-- filename: "AdminVerifyCustomerAddressStateContainValuesOnceTest.xml"
-  repo: "https://github.com/magento/magento2/blob/2.3/app/code/Magento/Customer/Test/Mftf/Test/AdminVerifyCustomerAddressStateContainValuesOnceTest.xml"
-  module: "Customer"
-  tests:
-    - testname: "AdminVerifyCustomerAddressStateContainValuesOnceTest"
-      title: "State/Province dropdown contain values once"
-      description: "When editing a customer in the backend from the Magento Admin Panel the State/Province should only be listed once"
- 
-- filename: "AdminCreateNewCustomerOnStorefrontSignupNewsletterTest.xml"
-  repo: "https://github.com/magento/magento2/blob/2.3/app/code/Magento/Customer/Test/Mftf/Test/AdminCreateNewCustomerOnStorefrontSignupNewsletterTest.xml"
-  module: "Customer"
-  tests:
-    - testname: "AdminCreateNewCustomerOnStorefrontSignupNewsletterTest"
-      title: "Create New Customer on Storefront, Sign-up Newsletter"
-      description: "Test log in to Create New Customer and Create New Customer on Storefront, Sign-up Newsletter"
- 
-- filename: "SearchByEmailInCustomerGridTest.xml"
-  repo: "https://github.com/magento/magento2/blob/2.3/app/code/Magento/Customer/Test/Mftf/Test/SearchByEmailInCustomerGridTest.xml"
-  module: "Customer"
-  tests:
-    - testname: "SearchByEmailInCustomerGridTest"
-      title: "Admin customer grid email searching"
-      description: "Admin customer grid searching by email in keyword"
- 
-- filename: "StorefrontUpdateCustomerAddressChinaTest.xml"
-  repo: "https://github.com/magento/magento2/blob/2.3/app/code/Magento/Customer/Test/Mftf/Test/StorefrontUpdateCustomerAddressChinaTest.xml"
-  module: "Customer"
-  tests:
-    - testname: "StorefrontUpdateCustomerAddressChinaTest"
-      title: "Update customer address on storefront with china address"
-      description: "Update customer address on storefront with china address and verify you can select a region"
- 
-- filename: "StorefrontResetCustomerPasswordFailedTest.xml"
-  repo: "https://github.com/magento/magento2/blob/2.3/app/code/Magento/Customer/Test/Mftf/Test/StorefrontResetCustomerPasswordFailedTest.xml"
-  module: "Customer"
-  tests:
-    - testname: "StorefrontResetCustomerPasswordFailedTest"
-      title: "Customer tries to reset password several times"
-      description: "Customer tries to reset password several times"
- 
-- filename: "AdminExactMatchSearchInCustomerGridTest.xml"
-  repo: "https://github.com/magento/magento2/blob/2.3/app/code/Magento/Customer/Test/Mftf/Test/AdminExactMatchSearchInCustomerGridTest.xml"
-  module: "Customer"
-  tests:
-    - testname: "AdminExactMatchSearchInCustomerGridTest"
-      title: "Admin customer grid exact match searching"
-      description: "Admin customer grid exact match searching with quotes in keyword"
- 
-- filename: "AdminCreateRetailCustomerGroupTest.xml"
-  repo: "https://github.com/magento/magento2/blob/2.3/app/code/Magento/Customer/Test/Mftf/Test/AdminCreateRetailCustomerGroupTest.xml"
-  module: "Customer"
-  tests:
-    - testname: "AdminCreateRetailCustomerGroupTest"
-      title: "Create retail customer group"
-      description: "Create retail customer group"
- 
-- filename: "AdminCustomersCustomerGroupsNavigateMenuTest.xml"
-  repo: "https://github.com/magento/magento2/blob/2.3/app/code/Magento/Customer/Test/Mftf/Test/AdminCustomersCustomerGroupsNavigateMenuTest.xml"
-  module: "Customer"
-  tests:
-    - testname: "AdminCustomersCustomerGroupsNavigateMenuTest"
-      title: "Admin customers customer groups navigate menu test"
-      description: "Admin should be able to navigate to Customers &gt; Customer Groups"
- 
-- filename: "AdminDeleteCustomerAddressesFromTheGridTest.xml"
-  repo: "https://github.com/magento/magento2/blob/2.3/app/code/Magento/Customer/Test/Mftf/Test/AdminDeleteCustomerAddressesFromTheGridTest.xml"
-  module: "Customer"
-  tests:
-    - testname: "AdminDeleteCustomerAddressesFromTheGridTest"
-      title: "Admin delete customer addresses from the grid"
-      description: "Admin delete customer addresses from the grid"
- 
-- filename: "AddingProductWithExpiredSessionTest.xml"
-  repo: "https://github.com/magento/magento2/blob/2.3/app/code/Magento/Customer/Test/Mftf/Test/AddingProductWithExpiredSessionTest.xml"
-  module: "Customer"
-  tests:
-    - testname: "AddingProductWithExpiredSessionTest"
-      title: "Adding a product to cart from category page with an expired session"
-      description: "Adding a product to cart from category page with an expired session"
- 
-- filename: "AdminAddNewDefaultBillingShippingCustomerAddressTest.xml"
-  repo: "https://github.com/magento/magento2/blob/2.3/app/code/Magento/Customer/Test/Mftf/Test/AdminAddNewDefaultBillingShippingCustomerAddressTest.xml"
-  module: "Customer"
-  tests:
-    - testname: "AdminAddNewDefaultBillingShippingCustomerAddressTest"
-      title: "Add new default billing/shipping customer address"
-      description: "Add new default billing/shipping customer address on customer addresses tab"
- 
-- filename: "StorefrontDeleteCustomerAddressTest.xml"
-  repo: "https://github.com/magento/magento2/blob/2.3/app/code/Magento/Customer/Test/Mftf/Test/StorefrontDeleteCustomerAddressTest.xml"
-  module: "Customer"
-  tests:
-    - testname: "StorefrontDeleteCustomerAddressTest"
-      title: "User should be able to delete Customer address successfully from storefront"
-      description: "User should be able to delete Customer address successfully from storefront"
- 
-- filename: "AdminCreateCustomerWithCustomGroupTest.xml"
-  repo: "https://github.com/magento/magento2/blob/2.3/app/code/Magento/Customer/Test/Mftf/Test/AdminCreateCustomerWithCustomGroupTest.xml"
-  module: "Customer"
-  tests:
-    - testname: "AdminCreateCustomerWithCustomGroupTest"
-      title: "Create customer, with custom group"
-      description: "Login as admin and create customer with custom group"
- 
-- filename: "AdminSetCustomerDefaultBillingAddressTest.xml"
-  repo: "https://github.com/magento/magento2/blob/2.3/app/code/Magento/Customer/Test/Mftf/Test/AdminSetCustomerDefaultBillingAddressTest.xml"
-  module: "Customer"
-  tests:
-    - testname: "AdminSetCustomerDefaultBillingAddressTest"
-      title: "Admin should be able to set customer default billing address"
-      description: "Admin should be able to set customer default billing address from customer addresses grid row actions"
- 
-- filename: "AllowedCountriesRestrictionApplyOnBackendTest.xml"
-  repo: "https://github.com/magento/magento2/blob/2.3/app/code/Magento/Customer/Test/Mftf/Test/AllowedCountriesRestrictionApplyOnBackendTest.xml"
-  module: "Customer"
-  tests:
-    - testname: "AllowedCountriesRestrictionApplyOnBackendTest"
-      title: "Country filter on Customers page when allowed countries restriction for a default website is applied"
-      description: "Country filter on Customers page when allowed countries restriction for a default website is applied"
- 
-- filename: "AdminCreateCustomerGroupAlreadyExistsTest.xml"
-  repo: "https://github.com/magento/magento2/blob/2.3/app/code/Magento/Customer/Test/Mftf/Test/AdminCreateCustomerGroupAlreadyExistsTest.xml"
-  module: "Customer"
-  tests:
-    - testname: "AdminCreateCustomerGroupAlreadyExistsTest"
-      title: "Create customer group already exists"
-      description: "Create customer group already exists"
- 
-- filename: "AdminCreateCustomerWithCountryPolandTest.xml"
-  repo: "https://github.com/magento/magento2/blob/2.3/app/code/Magento/Customer/Test/Mftf/Test/AdminCreateCustomerWithCountryPolandTest.xml"
-  module: "Customer"
-  tests:
-    - testname: "AdminCreateCustomerWithCountryPolandTest"
-      title: "Create customer, from Poland"
-      description: "Login as admin and create customer with Poland address"
- 
-- filename: "AdminCreateCustomerWithCountryUSATest.xml"
-  repo: "https://github.com/magento/magento2/blob/2.3/app/code/Magento/Customer/Test/Mftf/Test/AdminCreateCustomerWithCountryUSATest.xml"
-  module: "Customer"
-  tests:
-    - testname: "AdminCreateCustomerWithCountryUSATest"
-      title: "Create customer, from USA"
-      description: "Login as admin and create customer with USA address"
- 
-- filename: "StorefrontUpdateCustomerAddressTest.xml"
-  repo: "https://github.com/magento/magento2/blob/2.3/app/code/Magento/Customer/Test/Mftf/Test/StorefrontUpdateCustomerAddressTest.xml"
-  module: "Customer"
-  tests:
-    - testname: "StorefrontUpdateCustomerDefaultBillingAddressFromBlockTest"
-      title: "Add default customer address via the Storefront6"
-      description: "Storefront user should be able to create a new default address via the storefront"
-
-    - testname: "StorefrontUpdateCustomerDefaultShippingAddressFromBlockTest"
-      title: "Add default customer address via the Storefront611"
-      description: "Storefront user should be able to create a new default address via the storefront"
-
-    - testname: "StorefrontUpdateCustomerAddressFromGridTest"
-      title: "Add default customer address via the Storefront7"
-      description: "Storefront user should be able to create a new default address via the storefront2"
- 
-- filename: "AdminDeleteCustomerAddressesFromTheGridViaMassActionsTest.xml"
-  repo: "https://github.com/magento/magento2/blob/2.3/app/code/Magento/Customer/Test/Mftf/Test/AdminDeleteCustomerAddressesFromTheGridViaMassActionsTest.xml"
-  module: "Customer"
-  tests:
-    - testname: "AdminDeleteCustomerAddressesFromTheGridViaMassActionsTest"
-      title: "Admin delete customer addresses from the grid via mass actions"
-      description: "Admin delete customer addresses from the grid via mass actions"
- 
-- filename: "AdminResetCustomerPasswordTest.xml"
-  repo: "https://github.com/magento/magento2/blob/2.3/app/code/Magento/Customer/Test/Mftf/Test/AdminResetCustomerPasswordTest.xml"
-  module: "Customer"
-  tests:
-    - testname: "AdminResetCustomerPasswordTest"
-      title: "Admin should be able to reset customer password"
-      description: "Admin should be able to reset customer password"
- 
-- filename: "AdminVerifyCustomerAddressRequiredFieldsTest.xml"
-  repo: "https://github.com/magento/magento2/blob/2.3/app/code/Magento/Customer/Test/Mftf/Test/AdminVerifyCustomerAddressRequiredFieldsTest.xml"
-  module: "Customer"
-  tests:
-    - testname: "AdminVerifyCustomerAddressRequiredFieldsTest"
-      title: "Create customer, verify required fields on Addresses tab"
-      description: "Login as admin and verify required fields on Address tab"
- 
-- filename: "AdminCreateTaxClassCustomerGroupTest.xml"
-  repo: "https://github.com/magento/magento2/blob/2.3/app/code/Magento/Customer/Test/Mftf/Test/AdminCreateTaxClassCustomerGroupTest.xml"
-  module: "Customer"
-  tests:
-    - testname: "AdminCreateTaxClassCustomerGroupTest"
-      title: "Create tax class customer group"
-      description: "Create tax class customer group"
- 
-- filename: "AdminCheckDefaultValueDisableAutoGroupChangeIsYesTest.xml"
-  repo: "https://github.com/magento/magento2/blob/2.3/app/code/Magento/Customer/Test/Mftf/Test/AdminCheckDefaultValueDisableAutoGroupChangeIsYesTest.xml"
-  module: "Customer"
-  tests:
-    - testname: "AdminCheckDefaultValueDisableAutoGroupChangeIsYesTest"
-      title: "Check settings Default Value for Disable Automatic Group Changes Based on VAT ID is Yes"
-      description: "Check settings Default Value for Disable Automatic Group Changes Based on VAT ID is Yes"
- 
-- filename: "AdminUpdateCustomerTest.xml"
-  repo: "https://github.com/magento/magento2/blob/2.3/app/code/Magento/Customer/Test/Mftf/Test/AdminUpdateCustomerTest.xml"
-  module: "Customer"
-  tests:
-    - testname: "AdminUpdateCustomerInfoFromDefaultToNonDefaultTest"
-      title: "Update Customer Info from Default to Non-Default in Admin"
-      description: "Update Customer Info from Default to Non-Default in Admin"
-
-    - testname: "AdminUpdateCustomerAddressNoZipNoStateTest"
-      title: "Update Customer Address, without zip/state required, default billing/shipping checked in Admin"
-      description: "Update Customer Address, without zip/state required, default billing/shipping checked in Admin"
-
-    - testname: "AdminUpdateCustomerAddressNoBillingNoShippingTest"
-      title: "Update Customer Address, default billing/shipping unchecked in Admin"
-      description: "Update Customer Address, default billing/shipping unchecked in Admin"
-
-    - testname: "AdminDeleteCustomerAddressTest"
-      title: "Delete Customer Address in Admin"
-      description: "Delete Customer Address in Admin"
- 
-- filename: "StorefrontVerifySecureURLRedirectCustomerTest.xml"
-  repo: "https://github.com/magento/magento2/blob/2.3/app/code/Magento/Customer/Test/Mftf/Test/StorefrontVerifySecureURLRedirectCustomerTest.xml"
-  module: "Customer"
-  tests:
-    - testname: "StorefrontVerifySecureURLRedirectCustomer"
-      title: "Verify Secure URLs For Storefront Customer Pages"
-      description: "Verify that the Secure URL configuration applies to the Customer pages on the Storefront"
- 
-- filename: "StorefrontAddCustomerAddressTest.xml"
-  repo: "https://github.com/magento/magento2/blob/2.3/app/code/Magento/Customer/Test/Mftf/Test/StorefrontAddCustomerAddressTest.xml"
-  module: "Customer"
-  tests:
-    - testname: "StorefrontAddNewCustomerAddressTest"
-      title: "Storefront - My account - Address Book - add new address"
-      description: "Storefront user should be able to create a new address via the storefront"
-
-    - testname: "StorefrontAddCustomerDefaultAddressTest"
-      title: "Storefront - My account - Address Book - add new default billing/shipping address"
-      description: "Storefront user should be able to create a new default address via the storefront"
-
-    - testname: "StorefrontAddCustomerNonDefaultAddressTest"
-      title: "Storefront - My account - Address Book - add new non default billing/shipping address"
-      description: "Storefront user should be able to create a new non default address via the storefront"
- 
-- filename: "AdminCustomersNowOnlineNavigateMenuTest.xml"
-  repo: "https://github.com/magento/magento2/blob/2.3/app/code/Magento/Customer/Test/Mftf/Test/AdminCustomersNowOnlineNavigateMenuTest.xml"
-  module: "Customer"
-  tests:
-    - testname: "AdminCustomersNowOnlineNavigateMenuTest"
-      title: "Admin customers now online navigate menu test"
-      description: "Admin should be able to navigate to Customers &gt; Now Online"
- 
-- filename: "PasswordAutocompleteOffTest.xml"
-  repo: "https://github.com/magento/magento2/blob/2.3/app/code/Magento/Customer/Test/Mftf/Test/PasswordAutocompleteOffTest.xml"
-  module: "Customer"
-  tests:
-    - testname: "PasswordAutocompleteOffTest"
-      title: "[Security] Autocomplete attribute with off value is added to password input"
-      description: "[Security] Autocomplete attribute with off value is added to password input"
- 
-- filename: "StorefrontCheckTaxAddingValidVATIdTest.xml"
-  repo: "https://github.com/magento/magento2/blob/2.3/app/code/Magento/Customer/Test/Mftf/Test/StorefrontCheckTaxAddingValidVATIdTest.xml"
-  module: "Customer"
-  tests:
-    - testname: "StorefrontCheckTaxAddingValidVATIdTest"
-      title: "Check tax adding when it's changed to 'Valid VAT ID - Intra-Union'"
-      description: "Tax should be applied"
- 
-- filename: "StorefrontClearAllCompareProductsTest.xml"
-  repo: "https://github.com/magento/magento2/blob/2.3/app/code/Magento/Customer/Test/Mftf/Test/StorefrontClearAllCompareProductsTest.xml"
-  module: "Customer"
-  tests:
-    - testname: "StorefrontClearAllCompareProductsTest"
-      title: "Clear all products from the 'Compare Products' list"
-      description: "You should be able to remove all Products in the 'Compare Products' list."
- 
-- filename: "AdminCustomersAllCustomersNavigateMenuTest.xml"
-  repo: "https://github.com/magento/magento2/blob/2.3/app/code/Magento/Customer/Test/Mftf/Test/AdminCustomersAllCustomersNavigateMenuTest.xml"
-  module: "Customer"
-  tests:
-    - testname: "AdminCustomersAllCustomersNavigateMenuTest"
-      title: "Admin customers all customers navigate menu test"
-      description: "Admin should be able to navigate to Customers &gt; All Customers"
- 
-- filename: "StorefrontPersistedCustomerLoginTest.xml"
-  repo: "https://github.com/magento/magento2/blob/2.3/app/code/Magento/Customer/Test/Mftf/Test/StorefrontPersistedCustomerLoginTest.xml"
-  module: "Customer"
-  tests:
-    - testname: "StorefrontPersistedCustomerLoginTest"
-      title: "Persisted customer should be able to login from storefront"
-      description: "Persisted customer should be able to login from storefront"
- 
-- filename: "AdminPanelIsFrozenIfStorefrontIsOpenedViaCustomerViewTest.xml"
-  repo: "https://github.com/magento/magento2/blob/2.3/app/code/Magento/Customer/Test/Mftf/Test/AdminPanelIsFrozenIfStorefrontIsOpenedViaCustomerViewTest.xml"
-  module: "Customer"
-  tests:
-    - testname: "AdminPanelIsFrozenIfStorefrontIsOpenedViaCustomerViewTest"
-      title: "Place an order and click print"
-      description: "Admin panel is not frozen if Storefront is opened via Customer View"
- 
-- filename: "AdminVerifyCreateCustomerRequiredFieldsTest.xml"
-  repo: "https://github.com/magento/magento2/blob/2.3/app/code/Magento/Customer/Test/Mftf/Test/AdminVerifyCreateCustomerRequiredFieldsTest.xml"
-  module: "Customer"
-  tests:
-    - testname: "AdminVerifyCreateCustomerRequiredFieldsTest"
-      title: "Create customer, verify required fields on Account Information tab"
-      description: "Login as admin and verify required fields on account information section"
- 
-- filename: "AdminCreateNewCustomerTest.xml"
-  repo: "https://github.com/magento/magento2/blob/2.3/app/code/Magento/Customer/Test/Mftf/Test/AdminCreateNewCustomerTest.xml"
-  module: "Customer"
-  tests:
-    - testname: "AdminCreateNewCustomerTest"
-      title: "Create customer, new via backend"
-      description: "Login as admin and create a new customer"
- 
-- filename: "StorefrontLoginWithIncorrectCredentialsTest.xml"
-  repo: "https://github.com/magento/magento2/blob/2.3/app/code/Magento/Customer/Test/Mftf/Test/StorefrontLoginWithIncorrectCredentialsTest.xml"
-  module: "Customer"
-  tests:
-    - testname: "StorefrontLoginWithIncorrectCredentialsTest"
-      title: "Customer Login on Storefront with Incorrect Credentials"
-      description: "Customer Login on Storefront with Incorrect Credentials"
- 
-- filename: "AdminEditDefaultBillingShippingCustomerAddressTest.xml"
-  repo: "https://github.com/magento/magento2/blob/2.3/app/code/Magento/Customer/Test/Mftf/Test/AdminEditDefaultBillingShippingCustomerAddressTest.xml"
-  module: "Customer"
-  tests:
-    - testname: "AdminEditDefaultBillingShippingCustomerAddressTest"
-      title: "Edit default billing/shipping customer address"
-      description: "Edit default billing/shipping customer address on customer addresses tab"
- 
-- filename: "AdminSetCustomerDefaultShippingAddressTest.xml"
-  repo: "https://github.com/magento/magento2/blob/2.3/app/code/Magento/Customer/Test/Mftf/Test/AdminSetCustomerDefaultShippingAddressTest.xml"
-  module: "Customer"
-  tests:
-    - testname: "AdminSetCustomerDefaultShippingAddressTest"
-      title: "Admin should be able to set customer default shipping address"
-      description: "Admin should be able to set customer default shipping address from customer addresses grid row actions"
- 
-- filename: "AdminCheckDefaultValueDisableAutoGroupChangeIsNoTest.xml"
-  repo: "https://github.com/magento/magento2/blob/2.3/app/code/Magento/Customer/Test/Mftf/Test/AdminCheckDefaultValueDisableAutoGroupChangeIsNoTest.xml"
-  module: "Customer"
-  tests:
-    - testname: "AdminCheckDefaultValueDisableAutoGroupChangeIsNoTest"
-      title: "Check settings Default Value for Disable Automatic Group Changes Based on VAT ID is No"
-      description: "Check settings Default Value for Disable Automatic Group Changes Based on VAT ID is No"
- 
-- filename: "StorefrontUpdateCustomerAddressBelgiumTest.xml"
-  repo: "https://github.com/magento/magento2/blob/2.3/app/code/Magento/Customer/Test/Mftf/Test/StorefrontUpdateCustomerAddressBelgiumTest.xml"
-  module: "Customer"
-  tests:
-    - testname: "StorefrontUpdateCustomerAddressBelgiumTest"
-      title: "Update customer address on storefront with Belgium address"
-      description: "Update customer address on storefront with Belgium address and verify you can select a region"
- 
-- filename: "StorefrontVerifyNoXssInjectionOnUpdateCustomerInformationAddAddressTest.xml"
-  repo: "https://github.com/magento/magento2/blob/2.3/app/code/Magento/Customer/Test/Mftf/Test/StorefrontVerifyNoXssInjectionOnUpdateCustomerInformationAddAddressTest.xml"
-  module: "Customer"
-  tests:
-    - testname: "StorefrontVerifyNoXssInjectionOnUpdateCustomerInformationAddAddressTest"
-      title: "[Security] Verify No XSS Injection on Update Customer Information Add Address"
-      description: "Test log in to Storefront and Verify No XSS Injection on Update Customer Information Add Address"
- 
-- filename: "DeleteCustomerGroupTest.xml"
-  repo: "https://github.com/magento/magento2/blob/2.3/app/code/Magento/Customer/Test/Mftf/Test/DeleteCustomerGroupTest.xml"
-  module: "Customer"
-  tests:
-    - testname: "DeleteCustomerGroupTest"
-      title: "Delete Customer Group in Admin Panel"
-      description: "Admin should be able to delete a Customer Group"
- 
-- filename: "StorefrontUpdateCustomerAddressUKTest.xml"
-  repo: "https://github.com/magento/magento2/blob/2.3/app/code/Magento/Customer/Test/Mftf/Test/StorefrontUpdateCustomerAddressUKTest.xml"
-  module: "Customer"
-  tests:
-    - testname: "StorefrontUpdateCustomerAddressUKTest"
-      title: "Update Customer Address (UK) in Storefront"
-      description: "Test log in to Storefront and Update Customer Address (UK) in Storefront"
- 
-- filename: "StorefrontForgotPasswordTest.xml"
-  repo: "https://github.com/magento/magento2/blob/2.3/app/code/Magento/Customer/Test/Mftf/Test/StorefrontForgotPasswordTest.xml"
-  module: "Customer"
-  tests:
-    - testname: "StorefrontCustomerForgotPasswordTest"
-      title: "Forgot Password on Storefront validates customer email input"
-      description: "Forgot Password on Storefront validates customer email input"
- 
-- filename: "VerifyDisabledCustomerGroupFieldTest.xml"
-  repo: "https://github.com/magento/magento2/blob/2.3/app/code/Magento/Customer/Test/Mftf/Test/VerifyDisabledCustomerGroupFieldTest.xml"
-  module: "Customer"
-  tests:
-    - testname: "VerifyDisabledCustomerGroupFieldTest"
-      title: "Check that field is disabled in system Customer Group"
-      description: "Checks that customer_group_code field is disabled in NOT LOGGED IN Customer Group"
- 
-- filename: "AdminCreateCustomerTest.xml"
-  repo: "https://github.com/magento/magento2/blob/2.3/app/code/Magento/Customer/Test/Mftf/Test/AdminCreateCustomerTest.xml"
-  module: "Customer"
-  tests:
-    - testname: "AdminCreateCustomerTest"
-      title: "Admin should be able to create a customer"
-      description: "Admin should be able to create a customer"
- 
-- filename: "EndToEndB2CLoggedInUserTest.xml"
-  repo: "https://github.com/magento/magento2/blob/2.3/app/code/Magento/Customer/Test/Mftf/Test/EndToEndB2CLoggedInUserTest.xml"
-  module: "Customer"
-  tests:
-    - testname: "EndToEndB2CLoggedInUserTest"
-      title: "You should be able to pass End to End B2C Logged In User scenario"
-      description: "New user signup and browses catalog, searches for product, adds product to cart, adds product to wishlist, compares products, uses coupon code and checks out."
- 
-- filename: "AdminDeleteCustomerTest.xml"
-  repo: "https://github.com/magento/magento2/blob/2.3/app/code/Magento/Customer/Test/Mftf/Test/AdminDeleteCustomerTest.xml"
-  module: "Customer"
-  tests:
-    - testname: "AdminDeleteCustomerTest"
-      title: "DeleteCustomerBackendEntityTestVariation1"
-      description: "Login as admin and delete the customer"
- 
-- filename: "AdminCreateCustomerWithPrefixTest.xml"
-  repo: "https://github.com/magento/magento2/blob/2.3/app/code/Magento/Customer/Test/Mftf/Test/AdminCreateCustomerWithPrefixTest.xml"
-  module: "Customer"
-  tests:
-    - testname: "AdminCreateCustomerWithPrefixTest"
-      title: "Create customer, with prefix"
-      description: "Login as admin and create a customer with name prefix and suffix"
- 
-- filename: "StorefrontUpdateCustomerAddressFranceTest.xml"
-  repo: "https://github.com/magento/magento2/blob/2.3/app/code/Magento/Customer/Test/Mftf/Test/StorefrontUpdateCustomerAddressFranceTest.xml"
-  module: "Customer"
-  tests:
-    - testname: "StorefrontUpdateCustomerAddressFranceTest"
-      title: "Update Customer Address (France) in Storefront"
-      description: "Test log in to Storefront and Update Customer Address (France) in Storefront"
- 
-- filename: "StorefrontVerifySecureURLRedirectVaultTest.xml"
-  repo: "https://github.com/magento/magento2/blob/2.3/app/code/Magento/Vault/Test/Mftf/Test/StorefrontVerifySecureURLRedirectVaultTest.xml"
-  module: "Vault"
-  tests:
-    - testname: "StorefrontVerifySecureURLRedirectVault"
-      title: "Verify Secure URLs For Storefront Vault Pages"
-      description: "Verify that the Secure URL configuration applies to the Vault pages on the Storefront"
- 
-- filename: "StorefrontRemoveProductsFromWishlistUsingSidebarTest.xml"
-  repo: "https://github.com/magento/magento2/blob/2.3/app/code/Magento/Wishlist/Test/Mftf/Test/StorefrontRemoveProductsFromWishlistUsingSidebarTest.xml"
-  module: "Wishlist"
-  tests:
-    - testname: "StorefrontRemoveProductsFromWishlistUsingSidebarTest"
-      title: "Remove products from the wishlist using the sidebar."
-      description: "Products removed from wishlist and a customer remains on the same page."
- 
-- filename: "StorefrontVerifySecureURLRedirectWishlistTest.xml"
-  repo: "https://github.com/magento/magento2/blob/2.3/app/code/Magento/Wishlist/Test/Mftf/Test/StorefrontVerifySecureURLRedirectWishlistTest.xml"
-  module: "Wishlist"
-  tests:
-    - testname: "StorefrontVerifySecureURLRedirectWishlist"
-      title: "Verify Secure URLs For Storefront Wishlist Pages"
-      description: "Verify that the Secure URL configuration applies to the Wishlist pages on the Storefront"
- 
-- filename: "StorefrontDeleteBundleDynamicProductFromWishlistTest.xml"
-  repo: "https://github.com/magento/magento2/blob/2.3/app/code/Magento/Wishlist/Test/Mftf/Test/StorefrontDeleteBundleDynamicProductFromWishlistTest.xml"
-  module: "Wishlist"
-  tests:
-    - testname: "StorefrontDeleteBundleDynamicProductFromWishlistTest"
-      title: "Delete Dynamic Bundle Product from Wishlist on Frontend"
-      description: "Delete Dynamic Bundle Product from Wishlist on Frontend"
- 
-- filename: "StorefrontDeleteBundleFixedProductFromWishlistTest.xml"
-  repo: "https://github.com/magento/magento2/blob/2.3/app/code/Magento/Wishlist/Test/Mftf/Test/StorefrontDeleteBundleFixedProductFromWishlistTest.xml"
-  module: "Wishlist"
-  tests:
-    - testname: "StorefrontDeleteBundleFixedProductFromWishlistTest"
-      title: "Delete Fixed Bundle Product from Wishlist on Frontend"
-      description: "Delete Fixed Bundle Product from Wishlist on Frontend"
- 
-- filename: "StorefrontAddMultipleStoreProductsToWishlistTest.xml"
-  repo: "https://github.com/magento/magento2/blob/2.3/app/code/Magento/Wishlist/Test/Mftf/Test/StorefrontAddMultipleStoreProductsToWishlistTest.xml"
-  module: "Wishlist"
-  tests:
-    - testname: "StorefrontAddMultipleStoreProductsToWishlistTest"
-      title: "Customer should be able to add products to wishlist from different stores"
-      description: "All products added to wishlist should be visible on any store. Even if product visibility was set to 'Not Visible Individually' for this store"
- 
-- filename: "StorefrontAddProductsToCartFromWishlistUsingSidebarTest.xml"
-  repo: "https://github.com/magento/magento2/blob/2.3/app/code/Magento/Wishlist/Test/Mftf/Test/StorefrontAddProductsToCartFromWishlistUsingSidebarTest.xml"
-  module: "Wishlist"
-  tests:
-    - testname: "StorefrontAddProductsToCartFromWishlistUsingSidebarTest"
-      title: "Add products from the wishlist to the cart using the sidebar."
-      description: "Products added to the cart from wishlist and a customer remains on the same page."
- 
-- filename: "StorefrontDeletePersistedWishlistTest.xml"
-  repo: "https://github.com/magento/magento2/blob/2.3/app/code/Magento/Wishlist/Test/Mftf/Test/StorefrontDeletePersistedWishlistTest.xml"
-  module: "Wishlist"
-  tests:
-    - testname: "StorefrontDeletePersistedWishlistTest"
-      title: "Customer should be able to delete a persistent wishlist"
-      description: "Customer should be able to delete a persistent wishlist"
- 
-- filename: "StorefrontDeleteConfigurableProductFromWishlistTest.xml"
-  repo: "https://github.com/magento/magento2/blob/2.3/app/code/Magento/Wishlist/Test/Mftf/Test/StorefrontDeleteConfigurableProductFromWishlistTest.xml"
-  module: "Wishlist"
-  tests:
-    - testname: "StorefrontDeleteConfigurableProductFromWishlistTest"
-      title: "Delete Configurable Product from Wishlist on Frontend"
-      description: "Delete Configurable Product from Wishlist on Frontend"
- 
-- filename: "ConfProdAddToCartWishListWithUnselectedAttrTest.xml"
-  repo: "https://github.com/magento/magento2/blob/2.3/app/code/Magento/Wishlist/Test/Mftf/Test/ConfProdAddToCartWishListWithUnselectedAttrTest.xml"
-  module: "Wishlist"
-  tests:
-    - testname: "ConfProdAddToCartWishListWithUnselectedAttrTest"
-      title: "Adding configurable product to Cart from Wish List with unselected attributes"
-      description: "Verify adding configurable product to Cart from Wish List when attributes is unselected"
- 
-- filename: "ConfigurableProductChildImageShouldBeShownOnWishListTest.xml"
-  repo: "https://github.com/magento/magento2/blob/2.3/app/code/Magento/Wishlist/Test/Mftf/Test/ConfigurableProductChildImageShouldBeShownOnWishListTest.xml"
-  module: "Wishlist"
-  tests:
-    - testname: "ConfigurableProductChildImageShouldBeShownOnWishListTest"
-      title: "When user add Configurable child product to WIshlist then child product image should be shown in Wishlist"
-      description: "When user add Configurable child product to WIshlist then child product image should be shown in Wishlist"
- 
-- filename: "AdminCustomerWishListShareOptionsInputValidationTest.xml"
-  repo: "https://github.com/magento/magento2/blob/2.3/app/code/Magento/Wishlist/Test/Mftf/Test/AdminCustomerWishListShareOptionsInputValidationTest.xml"
-  module: "Wishlist"
-  tests:
-    - testname: "AdminCustomerWishListShareOptionsInputValidationTest"
-      title: "When user tries to set the Email Text Length Limit higher then 10,000 then validation message occurs"
-      description: "When user tries to set the Email Text Length Limit higher then 10,000 then validation message occurs"
- 
-- filename: "StorefrontShareWishlistEntityTest.xml"
-  repo: "https://github.com/magento/magento2/blob/2.3/app/code/Magento/Wishlist/Test/Mftf/Test/StorefrontShareWishlistEntityTest.xml"
-  module: "Wishlist"
-  tests:
-    - testname: "StorefrontShareWishlistEntityTest"
-      title: "Customer should be able to share a persistent wishlist"
-      description: "Customer should be able to share a persistent wishlist"
- 
-- filename: "StorefrontUpdateWishlistTest.xml"
-  repo: "https://github.com/magento/magento2/blob/2.3/app/code/Magento/Wishlist/Test/Mftf/Test/StorefrontUpdateWishlistTest.xml"
-  module: "Wishlist"
-  tests:
-    - testname: "StorefrontUpdateWishlistTest"
-      title: "Displaying of message after Wish List update"
-      description: "Displaying of message after Wish List update"
- 
-- filename: "EndToEndB2CLoggedInUserTest.xml"
-  repo: "https://github.com/magento/magento2/blob/2.3/app/code/Magento/Wishlist/Test/Mftf/Test/EndToEndB2CLoggedInUserTest.xml"
-  module: "Wishlist"
-  tests:
-    - testname: "EndToEndB2CLoggedInUserTest"
-      title: ""
-      description: ""
- 
-- filename: "WishListWithDisabledProductTest.xml"
-  repo: "https://github.com/magento/magento2/blob/2.3/app/code/Magento/Wishlist/Test/Mftf/Test/WishListWithDisabledProductTest.xml"
-  module: "Wishlist"
-  tests:
-    - testname: "WishListWithDisabledProductTest"
-      title: "Wish List should not include disabled products"
-      description: "Wish List should not include disabled products and pager should be absent"
- 
-- filename: "AdminConfigurationEnableDisableAnalyticsTest.xml"
-  repo: "https://github.com/magento/magento2/blob/2.3/app/code/Magento/Analytics/Test/Mftf/Test/AdminConfigurationEnableDisableAnalyticsTest.xml"
-  module: "Analytics"
-  tests:
-    - testname: "AdminConfigurationEnableDisableAnalyticsTest"
-      title: "Enable Disable Advanced Reporting"
-      description: "An admin user can enable/disable Advanced Reporting."
- 
-- filename: "AdminConfigurationBlankIndustryTest.xml"
-  repo: "https://github.com/magento/magento2/blob/2.3/app/code/Magento/Analytics/Test/Mftf/Test/AdminConfigurationBlankIndustryTest.xml"
-  module: "Analytics"
-  tests:
-    - testname: "AdminConfigurationBlankIndustryTest"
-      title: "Try to save empty Magento Advanced Reporting vertical"
-      description: "An admin user cannot save a blank industry setting on the Advanced Reporting configuration page."
- 
-- filename: "AdminAdvancedReportingButtonTest.xml"
-  repo: "https://github.com/magento/magento2/blob/2.3/app/code/Magento/Analytics/Test/Mftf/Test/AdminAdvancedReportingButtonTest.xml"
-  module: "Analytics"
-  tests:
-    - testname: "AdminAdvancedReportingButtonTest"
-      title: "AdvancedReportingButtonTest"
-      description: "Test log in to AdvancedReporting and tests AdvancedReportingButtonTest"
- 
-- filename: "AdminConfigurationPermissionTest.xml"
-  repo: "https://github.com/magento/magento2/blob/2.3/app/code/Magento/Analytics/Test/Mftf/Test/AdminConfigurationPermissionTest.xml"
-  module: "Analytics"
-  tests:
-    - testname: "AdminConfigurationPermissionTest"
-      title: "Advanced Reporting configuration permission"
-      description: "An admin user without Analytics permissions should not be able to see the Advanced Reporting configuration page."
- 
-- filename: "AdminConfigurationTimeToSendDataTest.xml"
-  repo: "https://github.com/magento/magento2/blob/2.3/app/code/Magento/Analytics/Test/Mftf/Test/AdminConfigurationTimeToSendDataTest.xml"
-  module: "Analytics"
-  tests:
-    - testname: "AdminConfigurationTimeToSendDataTest"
-      title: "Time of the day to collect data"
-      description: "An admin user can change the time of the day to collect data setting on the Advanced Reporting configuration page."
- 
-- filename: "AdminConfigurationIndustryTest.xml"
-  repo: "https://github.com/magento/magento2/blob/2.3/app/code/Magento/Analytics/Test/Mftf/Test/AdminConfigurationIndustryTest.xml"
-  module: "Analytics"
-  tests:
-    - testname: "AdminConfigurationIndustryTest"
-      title: "Set Magento Advanced reporting industry"
-      description: "An admin user can change the industry setting on the Advanced Reporting configuration page."
- 
-- filename: "AdminAdvancedReportingNavigateMenuTest.xml"
-  repo: "https://github.com/magento/magento2/blob/2.3/app/code/Magento/Analytics/Test/Mftf/Test/AdminAdvancedReportingNavigateMenuTest.xml"
-  module: "Analytics"
-  tests:
-    - testname: "AdminAdvancedReportingNavigateMenuTest"
-      title: "Admin advanced reporting navigate menu test"
-      description: "Admin should be able to navigate through advanced reporting admin menu to BI reports page"
- 
-- filename: "AdminReportsAbandonedCartsNavigateMenuTest.xml"
-  repo: "https://github.com/magento/magento2/blob/2.3/app/code/Magento/Reports/Test/Mftf/Test/AdminReportsAbandonedCartsNavigateMenuTest.xml"
-  module: "Reports"
-  tests:
-    - testname: "AdminReportsAbandonedCartsNavigateMenuTest"
-      title: "Admin reports abandoned carts navigate menu test"
-      description: "Admin should be able to navigate to Reports &gt; Abandoned Carts"
- 
-- filename: "AdminReportsLowStockNavigateMenuTest.xml"
-  repo: "https://github.com/magento/magento2/blob/2.3/app/code/Magento/Reports/Test/Mftf/Test/AdminReportsLowStockNavigateMenuTest.xml"
-  module: "Reports"
-  tests:
-    - testname: "AdminReportsLowStockNavigateMenuTest"
-      title: "Admin reports low stock navigate menu test"
-      description: "Admin should be able to navigate to Reports &gt; Low Stock"
- 
-- filename: "AdminReportsDownloadsNavigateMenuTest.xml"
-  repo: "https://github.com/magento/magento2/blob/2.3/app/code/Magento/Reports/Test/Mftf/Test/AdminReportsDownloadsNavigateMenuTest.xml"
-  module: "Reports"
-  tests:
-    - testname: "AdminReportsDownloadsNavigateMenuTest"
-      title: "Admin reports downloads navigate menu test"
-      description: "Admin should be able to navigate to Reports &gt; Downloads"
- 
-- filename: "CancelOrdersInOrderSalesReportTest.xml"
-  repo: "https://github.com/magento/magento2/blob/2.3/app/code/Magento/Reports/Test/Mftf/Test/CancelOrdersInOrderSalesReportTest.xml"
-  module: "Reports"
-  tests:
-    - testname: "CancelOrdersInOrderSalesReportTest"
-      title: "Canceled orders in order sales report"
-      description: "Verify canceling of orders in order sales report"
- 
-- filename: "AdminReportsNewNavigateMenuTest.xml"
-  repo: "https://github.com/magento/magento2/blob/2.3/app/code/Magento/Reports/Test/Mftf/Test/AdminReportsNewNavigateMenuTest.xml"
-  module: "Reports"
-  tests:
-    - testname: "AdminReportsNewNavigateMenuTest"
-      title: "Admin reports new navigate menu test"
-      description: "Admin should be able to navigate to Reports &gt; New"
- 
-- filename: "AdminReportsBestsellersNavigateMenuTest.xml"
-  repo: "https://github.com/magento/magento2/blob/2.3/app/code/Magento/Reports/Test/Mftf/Test/AdminReportsBestsellersNavigateMenuTest.xml"
-  module: "Reports"
-  tests:
-    - testname: "AdminReportsBestsellersNavigateMenuTest"
-      title: "Admin reports bestsellers navigate menu test"
-      description: "Admin should be able to navigate to Reports &gt; Bestsellers"
- 
-- filename: "AdminReportsProductsInCartNavigateMenuTest.xml"
-  repo: "https://github.com/magento/magento2/blob/2.3/app/code/Magento/Reports/Test/Mftf/Test/AdminReportsProductsInCartNavigateMenuTest.xml"
-  module: "Reports"
-  tests:
-    - testname: "AdminReportsProductsInCartNavigateMenuTest"
-      title: "Admin reports products in cart navigate menu test"
-      description: "Admin should be able to navigate to Reports &gt; Products in Cart"
- 
-- filename: "AdminReportsOrdersNavigateMenuTest.xml"
-  repo: "https://github.com/magento/magento2/blob/2.3/app/code/Magento/Reports/Test/Mftf/Test/AdminReportsOrdersNavigateMenuTest.xml"
-  module: "Reports"
-  tests:
-    - testname: "AdminReportsOrdersNavigateMenuTest"
-      title: "Admin reports orders navigate menu test"
-      description: "Admin should be able to navigate to Reports &gt; Orders"
- 
-- filename: "AdminReportsCouponsNavigateMenuTest.xml"
-  repo: "https://github.com/magento/magento2/blob/2.3/app/code/Magento/Reports/Test/Mftf/Test/AdminReportsCouponsNavigateMenuTest.xml"
-  module: "Reports"
-  tests:
-    - testname: "AdminReportsCouponsNavigateMenuTest"
-      title: "Admin reports coupons navigate menu test"
-      description: "Admin should be able to navigate to Reports &gt; Coupons"
- 
-- filename: "AdminReportsOrderedNavigateMenuTest.xml"
-  repo: "https://github.com/magento/magento2/blob/2.3/app/code/Magento/Reports/Test/Mftf/Test/AdminReportsOrderedNavigateMenuTest.xml"
-  module: "Reports"
-  tests:
-    - testname: "AdminReportsOrderedNavigateMenuTest"
-      title: "Admin reports ordered navigate menu test"
-      description: "Admin should be able to navigate to Reports &gt; Ordered"
- 
-- filename: "AdminReportsViewsNavigateMenuTest.xml"
-  repo: "https://github.com/magento/magento2/blob/2.3/app/code/Magento/Reports/Test/Mftf/Test/AdminReportsViewsNavigateMenuTest.xml"
-  module: "Reports"
-  tests:
-    - testname: "AdminReportsViewsNavigateMenuTest"
-      title: "Admin reports views navigate menu test"
-      description: "Admin should be able to navigate to Reports &gt; Views"
- 
-- filename: "AdminReportsOrderTotalNavigateMenuTest.xml"
-  repo: "https://github.com/magento/magento2/blob/2.3/app/code/Magento/Reports/Test/Mftf/Test/AdminReportsOrderTotalNavigateMenuTest.xml"
-  module: "Reports"
-  tests:
-    - testname: "AdminReportsOrderTotalNavigateMenuTest"
-      title: "Admin reports order total navigate menu test"
-      description: "Admin should be able to navigate to Reports &gt; Order Total"
- 
-- filename: "AdminReportsOrderCountNavigateMenuTest.xml"
-  repo: "https://github.com/magento/magento2/blob/2.3/app/code/Magento/Reports/Test/Mftf/Test/AdminReportsOrderCountNavigateMenuTest.xml"
-  module: "Reports"
-  tests:
-    - testname: "AdminReportsOrderCountNavigateMenuTest"
-      title: "Admin reports order count navigate menu test"
-      description: "Admin should be able to navigate to Reports &gt; Order Count"
- 
-- filename: "AdminReportsTaxNavigateMenuTest.xml"
-  repo: "https://github.com/magento/magento2/blob/2.3/app/code/Magento/Reports/Test/Mftf/Test/AdminReportsTaxNavigateMenuTest.xml"
-  module: "Reports"
-  tests:
-    - testname: "AdminReportsTaxNavigateMenuTest"
-      title: "Admin reports tax navigate menu test"
-      description: "Admin should be able to navigate to Reports &gt; Tax"
- 
-- filename: "AdminReportsRefreshStatisticsNavigateMenuTest.xml"
-  repo: "https://github.com/magento/magento2/blob/2.3/app/code/Magento/Reports/Test/Mftf/Test/AdminReportsRefreshStatisticsNavigateMenuTest.xml"
-  module: "Reports"
-  tests:
-    - testname: "AdminReportsRefreshStatisticsNavigateMenuTest"
-      title: "Admin reports refresh statistics navigate menu test"
-      description: "Admin should be able to navigate to Reports &gt; Refresh Statistics"
- 
-- filename: "AdminReportsInvoicedNavigateMenuTest.xml"
-  repo: "https://github.com/magento/magento2/blob/2.3/app/code/Magento/Reports/Test/Mftf/Test/AdminReportsInvoicedNavigateMenuTest.xml"
-  module: "Reports"
-  tests:
-    - testname: "AdminReportsInvoicedNavigateMenuTest"
-      title: "Admin reports invoiced navigate menu test"
-      description: "Admin should be able to navigate to Reports &gt; Invoiced"
- 
-- filename: "AdminCreateStoreGroupWithDefaultWebsiteAndDefaultCategoryTest.xml"
-  repo: "https://github.com/magento/magento2/blob/2.3/app/code/Magento/Store/Test/Mftf/Test/AdminCreateStoreGroupWithDefaultWebsiteAndDefaultCategoryTest.xml"
-  module: "Store"
-  tests:
-    - testname: "AdminCreateStoreGroupWithDefaultWebsiteAndDefaultCategoryTest"
-      title: "Create Store Group with Default Website and Default Category"
-      description: "Test log in to Stores and Create Store Group with Default Website and Default Category Test"
- 
-- filename: "AdminCreateCustomStoreViewStatusDisabledVerifyErrorSaveMessageTest.xml"
-  repo: "https://github.com/magento/magento2/blob/2.3/app/code/Magento/Store/Test/Mftf/Test/AdminCreateCustomStoreViewStatusDisabledVerifyErrorSaveMessageTest.xml"
-  module: "Store"
-  tests:
-    - testname: "AdminCreateCustomStoreViewStatusDisabledVerifyErrorSaveMessageTest"
-      title: "Create Custom Store View Status Disabled and Verify Error Save Message"
-      description: "Test log in to Stores and Create Custom Store View Status Enabled and Verify Error Save Message Test"
- 
-- filename: "AdminUpdateWebsiteTest.xml"
-  repo: "https://github.com/magento/magento2/blob/2.3/app/code/Magento/Store/Test/Mftf/Test/AdminUpdateWebsiteTest.xml"
-  module: "Store"
-  tests:
-    - testname: "AdminUpdateWebsiteTest"
-      title: "Update Website and Verify Store Form"
-      description: "Test log in to Stores and Update Website Test"
- 
-- filename: "AdminUpdateStoreGroupAndVerifyStoreViewFormTest.xml"
-  repo: "https://github.com/magento/magento2/blob/2.3/app/code/Magento/Store/Test/Mftf/Test/AdminUpdateStoreGroupAndVerifyStoreViewFormTest.xml"
-  module: "Store"
-  tests:
-    - testname: "AdminUpdateStoreGroupAndVerifyStoreViewFormTest"
-      title: "Update Store Group and Verify Store View Form"
-      description: "Test log in to Stores and Update Store Group Test"
- 
-- filename: "AdminCreateStoreViewStatusDisabledVerifyBackendAndFrontendTest.xml"
-  repo: "https://github.com/magento/magento2/blob/2.3/app/code/Magento/Store/Test/Mftf/Test/AdminCreateStoreViewStatusDisabledVerifyBackendAndFrontendTest.xml"
-  module: "Store"
-  tests:
-    - testname: "AdminCreateStoreViewStatusDisabledVerifyBackendAndFrontendTest"
-      title: "Create Store View Status Disabled and Verify Backend and Frontend"
-      description: "Test log in to Stores and Create Store View Status Disabled Test"
- 
-- filename: "AdminDeleteStoreViewTest.xml"
-  repo: "https://github.com/magento/magento2/blob/2.3/app/code/Magento/Store/Test/Mftf/Test/AdminDeleteStoreViewTest.xml"
-  module: "Store"
-  tests:
-    - testname: "AdminDeleteStoreViewTest"
-      title: "Delete Store View and Save Backup"
-      description: "Test log in to Stores and Delete Store View"
- 
-- filename: "AdminDeleteStoreGroupTest.xml"
-  repo: "https://github.com/magento/magento2/blob/2.3/app/code/Magento/Store/Test/Mftf/Test/AdminDeleteStoreGroupTest.xml"
-  module: "Store"
-  tests:
-    - testname: "AdminDeleteStoreGroupTest"
-      title: "Delete store group and save backup"
-      description: "Test log in to Stores and Delete Store Group Test"
- 
-- filename: "AdminCreateStoreGroupWithCustomWebsiteAndDefaultCategoryTest.xml"
-  repo: "https://github.com/magento/magento2/blob/2.3/app/code/Magento/Store/Test/Mftf/Test/AdminCreateStoreGroupWithCustomWebsiteAndDefaultCategoryTest.xml"
-  module: "Store"
-  tests:
-    - testname: "AdminCreateStoreGroupWithCustomWebsiteAndDefaultCategoryTest"
-      title: "Create Store Group with Custom Website and Default Category"
-      description: "Test log in to Stores and Create Store Group with Custom Website and Default Category Test"
- 
-- filename: "AdminCreateCustomStoreViewStatusEnabledVerifyBackendAndFrontendTest.xml"
-  repo: "https://github.com/magento/magento2/blob/2.3/app/code/Magento/Store/Test/Mftf/Test/AdminCreateCustomStoreViewStatusEnabledVerifyBackendAndFrontendTest.xml"
-  module: "Store"
-  tests:
-    - testname: "AdminCreateCustomStoreViewStatusEnabledVerifyBackendAndFrontendTest"
-      title: "Create Custom Store View Status Enabled and Verify Backend and Frontend"
-      description: "Test log in to Stores and Create Custom Store View Status Enabled and Verify Backend and Frontend Test"
- 
-- filename: "AdminCreateStoreViewTest.xml"
-  repo: "https://github.com/magento/magento2/blob/2.3/app/code/Magento/Store/Test/Mftf/Test/AdminCreateStoreViewTest.xml"
-  module: "Store"
-  tests:
-    - testname: "AdminCreateStoreViewTest"
-      title: "Admin shouldn't be able to create a Store View with the same code"
-      description: "Admin shouldn't be able to create a Store View with the same code"
- 
-- filename: "AdminCreateNewLocalizedStoreViewStatusEnabledTest.xml"
-  repo: "https://github.com/magento/magento2/blob/2.3/app/code/Magento/Store/Test/Mftf/Test/AdminCreateNewLocalizedStoreViewStatusEnabledTest.xml"
-  module: "Store"
-  tests:
-    - testname: "AdminCreateNewLocalizedStoreViewStatusEnabledTest"
-      title: "Create New Localized Store View Status Enabled and Verify Save Message"
-      description: "Test log in to Stores and Create New Localized Store View Status Enabled Test"
- 
-- filename: "AdminDeleteDefaultStoreViewTest.xml"
-  repo: "https://github.com/magento/magento2/blob/2.3/app/code/Magento/Store/Test/Mftf/Test/AdminDeleteDefaultStoreViewTest.xml"
-  module: "Store"
-  tests:
-    - testname: "AdminDeleteDefaultStoreViewTest"
-      title: "Delete Default Store View"
-      description: "Test another store view should be set as default when default store view is deleted"
- 
-- filename: "AdminMoveStoreToOtherGroupSameWebsiteTest.xml"
-  repo: "https://github.com/magento/magento2/blob/2.3/app/code/Magento/Store/Test/Mftf/Test/AdminMoveStoreToOtherGroupSameWebsiteTest.xml"
-  module: "Store"
-  tests:
-    - testname: "AdminMoveStoreToOtherGroupSameWebsiteTest"
-      title: "Move Store To Other Group Same Website and Verify Backend and Frontend"
-      description: "Test log in to Stores and Move Store To Other Group Same Website Test"
- 
-- filename: "AdminCreateStoreViewStatusEnabledVerifyBackendAndFrontendTest.xml"
-  repo: "https://github.com/magento/magento2/blob/2.3/app/code/Magento/Store/Test/Mftf/Test/AdminCreateStoreViewStatusEnabledVerifyBackendAndFrontendTest.xml"
-  module: "Store"
-  tests:
-    - testname: "AdminCreateStoreViewStatusEnabledVerifyBackendAndFrontendTest"
-      title: "Create Store View Status Enabled and Verify Backend and Frontend"
-      description: "Test log in to Stores and Create Store View Status Enabled Test"
- 
-- filename: "AdminUpdateStoreViewTest.xml"
-  repo: "https://github.com/magento/magento2/blob/2.3/app/code/Magento/Store/Test/Mftf/Test/AdminUpdateStoreViewTest.xml"
-  module: "Store"
-  tests:
-    - testname: "AdminUpdateStoreViewTest"
-      title: "Update Store View and Verify Backend and Frontend"
-      description: "Test log in to Stores and Update Store View Test"
- 
-- filename: "StorefrontAddStoreCodeInUrlTest.xml"
-  repo: "https://github.com/magento/magento2/blob/2.3/app/code/Magento/Store/Test/Mftf/Test/StorefrontAddStoreCodeInUrlTest.xml"
-  module: "Store"
-  tests:
-    - testname: "StorefrontAddStoreCodeInUrlTest"
-      title: "Store code should be added to storefront URL if the corresponding configuration is enabled"
-      description: "Store code should be added to storefront URL if the corresponding configuration is enabled"
- 
-- filename: "AdminUpdateStoreGroupAcceptAlertAndVerifyStoreViewFormTest.xml"
-  repo: "https://github.com/magento/magento2/blob/2.3/app/code/Magento/Store/Test/Mftf/Test/AdminUpdateStoreGroupAcceptAlertAndVerifyStoreViewFormTest.xml"
-  module: "Store"
-  tests:
-    - testname: "AdminUpdateStoreGroupAcceptAlertAndVerifyStoreViewFormTest"
-      title: "Update Store Group, Accept Alert and Verify Store View Form"
-      description: "Test log in to Stores and Update Store Group Test"
- 
-- filename: "AdminCreateCustomStoreViewStatusEnabledVerifyAbsenceOfDeleteButtonTest.xml"
-  repo: "https://github.com/magento/magento2/blob/2.3/app/code/Magento/Store/Test/Mftf/Test/AdminCreateCustomStoreViewStatusEnabledVerifyAbsenceOfDeleteButtonTest.xml"
-  module: "Store"
-  tests:
-    - testname: "AdminCreateCustomStoreViewStatusEnabledVerifyAbsenceOfDeleteButtonTest"
-      title: "Create Custom Store View Status Enabled and Verify Absence Of Delete Button"
-      description: "Test log in to Stores and Create Custom Store View Status Enabled and Verify Absence Of Delete Button Test"
- 
-- filename: "AdminCreateWebsiteTest.xml"
-  repo: "https://github.com/magento/magento2/blob/2.3/app/code/Magento/Store/Test/Mftf/Test/AdminCreateWebsiteTest.xml"
-  module: "Store"
-  tests:
-    - testname: "AdminCreateWebsiteTest"
-      title: "Create Website and Verify Store Form"
-      description: "Test log in to Stores and Create Website Test"
- 
-- filename: "AdminCreateStoreGroupWithCustomWebsiteAndRootCategoryTest.xml"
-  repo: "https://github.com/magento/magento2/blob/2.3/app/code/Magento/Store/Test/Mftf/Test/AdminCreateStoreGroupWithCustomWebsiteAndRootCategoryTest.xml"
-  module: "Store"
-  tests:
-    - testname: "AdminCreateStoreGroupWithCustomWebsiteAndRootCategoryTest"
-      title: "Create Store Group with Custom Website and Root Category"
-      description: "Test log in to Stores and Create Store Group with Custom Website and Root Category Test"
- 
-- filename: "StorefrontAutoGeneratedCouponCodeTest.xml"
-  repo: "https://github.com/magento/magento2/blob/2.3/app/code/Magento/SalesRule/Test/Mftf/Test/StorefrontAutoGeneratedCouponCodeTest.xml"
-  module: "SalesRule"
-  tests:
-    - testname: "StorefrontAutoGeneratedCouponCodeTest"
-      title: "[Cart Price Rule] Auto generated coupon code considers 'Uses per Coupon' and 'Uses per Customer' options"
-      description: "[Cart Price Rule] Auto generated coupon code considers 'Uses per Coupon' and 'Uses per Customer' options"
- 
-- filename: "AdminCreateCartPriceRuleForGeneratedCouponTest.xml"
-  repo: "https://github.com/magento/magento2/blob/2.3/app/code/Magento/SalesRule/Test/Mftf/Test/AdminCreateCartPriceRuleForGeneratedCouponTest.xml"
-  module: "SalesRule"
-  tests:
-    - testname: "AdminCreateCartPriceRuleForGeneratedCouponTest"
-      title: "Admin should be able to create a cart price rule for auto generated coupon codes"
-      description: "Admin should be able to create a cart price rule for auto generated coupon codes"
- 
-- filename: "AdminCartRulesAppliedForProductInCartTest.xml"
-  repo: "https://github.com/magento/magento2/blob/2.3/app/code/Magento/SalesRule/Test/Mftf/Test/AdminCartRulesAppliedForProductInCartTest.xml"
-  module: "SalesRule"
-  tests:
-    - testname: "AdminCartRulesAppliedForProductInCartTest"
-      title: "Check that cart rules applied for product in cart"
-      description: "Check that cart rules applied for product in cart"
- 
-- filename: "StorefrontCartRuleCouponForFreeShippingTest.xml"
-  repo: "https://github.com/magento/magento2/blob/2.3/app/code/Magento/SalesRule/Test/Mftf/Test/StorefrontCartRuleCouponForFreeShippingTest.xml"
-  module: "SalesRule"
-  tests:
-    - testname: "StorefrontCartRuleCouponForFreeShippingTest"
-      title: "Create Cart Price Rule for Free Shipping And Verify Coupon Code will shown in Order's totals"
-      description: "Test that Coupon Code of Cart Price Rule without discount for Product price but with Free shipping will shown in Order's totals"
- 
-- filename: "AdminCreateFixedAmountWholeCartDiscountTest.xml"
-  repo: "https://github.com/magento/magento2/blob/2.3/app/code/Magento/SalesRule/Test/Mftf/Test/AdminCreateFixedAmountWholeCartDiscountTest.xml"
-  module: "SalesRule"
-  tests:
-    - testname: "AdminCreateFixedAmountWholeCartDiscountTest"
-      title: "Admin should be able to create a cart price rule of type Fixed amount discount for whole cart"
-      description: "Admin should be able to create a cart price rule of type Fixed amount discount for whole cart"
- 
-- filename: "EndToEndB2CGuestUserTest.xml"
-  repo: "https://github.com/magento/magento2/blob/2.3/app/code/Magento/SalesRule/Test/Mftf/Test/EndToEndB2CGuestUserTest.xml"
-  module: "SalesRule"
-  tests:
-    - testname: "EndToEndB2CGuestUserTest"
-      title: ""
-      description: ""
-
-    - testname: "EndToEndB2CGuestUserMysqlTest"
-      title: ""
-      description: ""
- 
-- filename: "AdminCreateCartPriceRuleForMatchingSubtotalAndVerifyRuleConditionIsAppliedTest.xml"
-  repo: "https://github.com/magento/magento2/blob/2.3/app/code/Magento/SalesRule/Test/Mftf/Test/AdminCreateCartPriceRuleForMatchingSubtotalAndVerifyRuleConditionIsAppliedTest.xml"
-  module: "SalesRule"
-  tests:
-    - testname: "AdminCreateCartPriceRuleForMatchingSubtotalAndVerifyRuleConditionIsAppliedTest"
-      title: "Create Cart Price Rule For Matching Subtotal And Verify Rule Condition Is Applied"
-      description: "Test log in to Cart Price Rules and Create Cart Price Rule For Matching Subtotal And Verify Rule Condition Is Applied"
- 
-- filename: "CartPriceRuleForConfigurableProductTest.xml"
-  repo: "https://github.com/magento/magento2/blob/2.3/app/code/Magento/SalesRule/Test/Mftf/Test/CartPriceRuleForConfigurableProductTest.xml"
-  module: "SalesRule"
-  tests:
-    - testname: "CartPriceRuleForConfigurableProductTest"
-      title: "Checking Cart Price Rule for configurable products"
-      description: "Checking Cart Price Rule for configurable products"
- 
-- filename: "StorefrontCartTotalValueWithFullDiscountUsingCartRuleTest.xml"
-  repo: "https://github.com/magento/magento2/blob/2.3/app/code/Magento/SalesRule/Test/Mftf/Test/StorefrontCartTotalValueWithFullDiscountUsingCartRuleTest.xml"
-  module: "SalesRule"
-  tests:
-    - testname: "StorefrontCartTotalValueWithFullDiscountUsingCartRuleTest"
-      title: "Cart Total value when 100% discount applied through Cart Rule"
-      description: "Cart Total value when 100% discount applied through Cart Rule"
- 
-- filename: "AdminCreateCartPriceRuleWithMatchingCategoryAndVerifyRuleConditionIsAppliedTest.xml"
-  repo: "https://github.com/magento/magento2/blob/2.3/app/code/Magento/SalesRule/Test/Mftf/Test/AdminCreateCartPriceRuleWithMatchingCategoryAndVerifyRuleConditionIsAppliedTest.xml"
-  module: "SalesRule"
-  tests:
-    - testname: "AdminCreateCartPriceRuleWithMatchingCategoryAndVerifyRuleConditionIsAppliedTest"
-      title: "Create Cart Price Rule With Matching Category And Verify Rule Condition Is Applied"
-      description: "Test log in to Cart Price Rules and Create Cart Price Rule With Matching Category And Verify Rule Condition Is Applied"
- 
-- filename: "AdminCreateFixedAmountDiscountTest.xml"
-  repo: "https://github.com/magento/magento2/blob/2.3/app/code/Magento/SalesRule/Test/Mftf/Test/AdminCreateFixedAmountDiscountTest.xml"
-  module: "SalesRule"
-  tests:
-    - testname: "AdminCreateFixedAmountDiscountTest"
-      title: "Admin should be able to create a cart price rule of type Fixed amount discount"
-      description: "Admin should be able to create a cart price rule of type Fixed amount discount"
- 
-- filename: "AdminCreateCartPriceRuleWithMatchingTotalWeightAndVerifyRuleConditionIsAppliedTest.xml"
-  repo: "https://github.com/magento/magento2/blob/2.3/app/code/Magento/SalesRule/Test/Mftf/Test/AdminCreateCartPriceRuleWithMatchingTotalWeightAndVerifyRuleConditionIsAppliedTest.xml"
-  module: "SalesRule"
-  tests:
-    - testname: "AdminCreateCartPriceRuleWithMatchingTotalWeightAndVerifyRuleConditionIsAppliedTest"
-      title: "Create Cart Price Rule With Matching Total Weight And Verify Rule Condition Is Applied"
-      description: "Test log in to Cart Price Rules and Create Cart Price Rule With Matching Total Weight And Verify Rule Condition Is Applied"
- 
-- filename: "AdminCreateCartPriceRuleForCouponCodeTest.xml"
-  repo: "https://github.com/magento/magento2/blob/2.3/app/code/Magento/SalesRule/Test/Mftf/Test/AdminCreateCartPriceRuleForCouponCodeTest.xml"
-  module: "SalesRule"
-  tests:
-    - testname: "AdminCreateCartPriceRuleForCouponCodeTest"
-      title: "Admin should be able to create a cart price rule for a specific coupon code"
-      description: "Admin should be able to create a cart price rule for a specific coupon code"
- 
-- filename: "AdminCreateCartPriceRuleAndVerifyRuleConditionAndFreeShippingIsAppliedTest.xml"
-  repo: "https://github.com/magento/magento2/blob/2.3/app/code/Magento/SalesRule/Test/Mftf/Test/AdminCreateCartPriceRuleAndVerifyRuleConditionAndFreeShippingIsAppliedTest.xml"
-  module: "SalesRule"
-  tests:
-    - testname: "AdminCreateCartPriceRuleAndVerifyRuleConditionAndFreeShippingIsAppliedTest"
-      title: "Create Cart Price Rule And Verify Rule Condition And Free Shipping Is Applied"
-      description: "Test log in to Cart Price Rules and Create Cart Price Rule And Verify Rule Condition And Free Shipping Is Applied"
- 
-- filename: "AdminDeleteActiveSalesRuleWithPercentPriceAndVerifyDeleteMessageTest.xml"
-  repo: "https://github.com/magento/magento2/blob/2.3/app/code/Magento/SalesRule/Test/Mftf/Test/AdminDeleteActiveSalesRuleWithPercentPriceAndVerifyDeleteMessageTest.xml"
-  module: "SalesRule"
-  tests:
-    - testname: "AdminDeleteActiveSalesRuleWithPercentPriceAndVerifyDeleteMessageTest"
-      title: "Delete Active Sales Rule With Percent Price And Verify Delete Message"
-      description: "Test log in to Cart Price Rule and Delete Active Sales Rule Test"
- 
-- filename: "AdminCreatePercentOfProductPriceTest.xml"
-  repo: "https://github.com/magento/magento2/blob/2.3/app/code/Magento/SalesRule/Test/Mftf/Test/AdminCreatePercentOfProductPriceTest.xml"
-  module: "SalesRule"
-  tests:
-    - testname: "AdminCreatePercentOfProductPriceTest"
-      title: "Admin should be able to create a cart price rule of type Percent of product price discount"
-      description: "Admin should be able to create a cart price rule of type Percent of product price discount"
- 
-- filename: "AdminMarketingCartPriceRulesNavigateMenuTest.xml"
-  repo: "https://github.com/magento/magento2/blob/2.3/app/code/Magento/SalesRule/Test/Mftf/Test/AdminMarketingCartPriceRulesNavigateMenuTest.xml"
-  module: "SalesRule"
-  tests:
-    - testname: "AdminMarketingCartPriceRulesNavigateMenuTest"
-      title: "Admin marketing cart price rules navigate menu test"
-      description: "Admin should be able to navigate to Marketing &gt; Cart Price Rules"
- 
-- filename: "AdminCreateCartPriceRuleEmptyFromDateTest.xml"
-  repo: "https://github.com/magento/magento2/blob/2.3/app/code/Magento/SalesRule/Test/Mftf/Test/AdminCreateCartPriceRuleEmptyFromDateTest.xml"
-  module: "SalesRule"
-  tests:
-    - testname: "AdminCreateCartPriceRuleEmptyFromDateTest"
-      title: "Admin should be able to create a cart price rule with no starting date"
-      description: "Admin should be able to create a cart price rule without specifying the from_date and it should be set with the current date"
- 
-- filename: "StorefrontCategoryRulesShouldApplyToComplexProductsTest.xml"
-  repo: "https://github.com/magento/magento2/blob/2.3/app/code/Magento/SalesRule/Test/Mftf/Test/StorefrontCategoryRulesShouldApplyToComplexProductsTest.xml"
-  module: "SalesRule"
-  tests:
-    - testname: "StorefrontCategoryRulesShouldApplyToComplexProductsTest"
-      title: "Category rules should apply to complex products"
-      description: "Sales rules filtering on category should apply to all products, including complex products."
- 
-- filename: "PriceRuleCategoryNestingTest.xml"
-  repo: "https://github.com/magento/magento2/blob/2.3/app/code/Magento/SalesRule/Test/Mftf/Test/PriceRuleCategoryNestingTest.xml"
-  module: "SalesRule"
-  tests:
-    - testname: "PriceRuleCategoryNestingTest"
-      title: "Category nesting level must be the same as were created in categories."
-      description: "Category nesting level must be the same as were created in categories."
- 
-- filename: "AdminDeleteInactiveSalesRuleAndVerifyDeleteMessageTest.xml"
-  repo: "https://github.com/magento/magento2/blob/2.3/app/code/Magento/SalesRule/Test/Mftf/Test/AdminDeleteInactiveSalesRuleAndVerifyDeleteMessageTest.xml"
-  module: "SalesRule"
-  tests:
-    - testname: "AdminDeleteInactiveSalesRuleAndVerifyDeleteMessageTest"
-      title: "Delete Inactive Sales Rule And Verify Delete Message"
-      description: "Test log in to Cart Price Rule and Delete Inactive Sales Rule Test"
- 
-- filename: "DeleteCustomerGroupTest.xml"
-  repo: "https://github.com/magento/magento2/blob/2.3/app/code/Magento/SalesRule/Test/Mftf/Test/DeleteCustomerGroupTest.xml"
-  module: "SalesRule"
-  tests:
-    - testname: "DeleteCustomerGroupTest"
-      title: ""
-      description: ""
- 
-- filename: "AdminCreateBuyXGetYFreeTest.xml"
-  repo: "https://github.com/magento/magento2/blob/2.3/app/code/Magento/SalesRule/Test/Mftf/Test/AdminCreateBuyXGetYFreeTest.xml"
-  module: "SalesRule"
-  tests:
-    - testname: "AdminCreateBuyXGetYFreeTest"
-      title: "Admin should be able to create a cart price rule of type Buy X get Y free"
-      description: "Admin should be able to create a cart price rule of type Buy X get Y free"
- 
-- filename: "AdminCreateCartPriceRuleAndVerifyRuleConditionIsNotAppliedTest.xml"
-  repo: "https://github.com/magento/magento2/blob/2.3/app/code/Magento/SalesRule/Test/Mftf/Test/AdminCreateCartPriceRuleAndVerifyRuleConditionIsNotAppliedTest.xml"
-  module: "SalesRule"
-  tests:
-    - testname: "AdminCreateCartPriceRuleAndVerifyRuleConditionIsNotAppliedTest"
-      title: "Create Cart Price Rule And Verify Rule Condition Is Not Applied"
-      description: "Test log in to Cart Price Rules and Create Cart Price Rule And Verify Rule Condition Is Not Applied"
- 
-- filename: "EndToEndB2CLoggedInUserTest.xml"
-  repo: "https://github.com/magento/magento2/blob/2.3/app/code/Magento/SalesRule/Test/Mftf/Test/EndToEndB2CLoggedInUserTest.xml"
-  module: "SalesRule"
-  tests:
-    - testname: "EndToEndB2CLoggedInUserTest"
-      title: ""
-      description: ""
- 
-- filename: "AdminDeleteActiveSalesRuleWithComplexConditionsAndVerifyDeleteMessageTest.xml"
-  repo: "https://github.com/magento/magento2/blob/2.3/app/code/Magento/SalesRule/Test/Mftf/Test/AdminDeleteActiveSalesRuleWithComplexConditionsAndVerifyDeleteMessageTest.xml"
-  module: "SalesRule"
-  tests:
-    - testname: "AdminDeleteActiveSalesRuleWithComplexConditionsAndVerifyDeleteMessageTest"
-      title: "Delete Active Sales Rule With Complex Conditions And Verify Delete Message"
-      description: "Test log in to Cart Price Rule and Delete Active Sales Rule With Complex Conditions Test"
- 
-- filename: "StorefrontCategoryRulesShouldApplyToGroupedProductWithInvisibleIndividualProductTest.xml"
-  repo: "https://github.com/magento/magento2/blob/2.3/app/code/Magento/SalesRule/Test/Mftf/Test/StorefrontCategoryRulesShouldApplyToGroupedProductWithInvisibleIndividualProductTest.xml"
-  module: "SalesRule"
-  tests:
-    - testname: "StorefrontCategoryRulesShouldApplyToGroupedProductWithInvisibleIndividualProductTest"
-      title: "Category rules should apply to grouped product with invisible individual products"
-      description: "Category rules should apply to grouped product with invisible individual products"
- 
-- filename: "AdminApplyCatalogRuleForConfigurableProductWithOptionsTest.xml"
-  repo: "https://github.com/magento/magento2/blob/2.3/app/code/Magento/CatalogRuleConfigurable/Test/Mftf/Test/AdminApplyCatalogRuleForConfigurableProductWithOptionsTest.xml"
-  module: "CatalogRuleConfigurable"
-  tests:
-    - testname: "AdminApplyCatalogRuleForConfigurableProductWithOptionsTest"
-      title: "Apply catalog price rule for configurable product with options"
-      description: "Admin should be able to apply the catalog rule for configurable product with options"
- 
-- filename: "AdminApplyCatalogRuleForConfigurableProductWithAssignedSimpleProductsTest.xml"
-  repo: "https://github.com/magento/magento2/blob/2.3/app/code/Magento/CatalogRuleConfigurable/Test/Mftf/Test/AdminApplyCatalogRuleForConfigurableProductWithAssignedSimpleProductsTest.xml"
-  module: "CatalogRuleConfigurable"
-  tests:
-    - testname: "AdminApplyCatalogRuleForConfigurableProductWithAssignedSimpleProductsTest"
-      title: "Apply catalog rule for configurable product with assigned simple products"
-      description: "Admin should be able to apply catalog rule for configurable product with assigned simple products"
+    - testname: "StorefrontAdvancedSearchByPartialSkuTest"
+      title: "Search product in advanced search by partial sku"
+      description: "Search product in advanced search by partial sku"
+- filename: "StorefrontAdvancedSearchByPriceToTest.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/CatalogSearch/Test/Mftf/Test/StorefrontAdvancedSearchByPriceToTest.xml"
+  module: "CatalogSearch"
+  tests:
+    - testname: "StorefrontAdvancedSearchByPriceToTest"
+      title: "Search product in advanced search by price to"
+      description: "Search product in advanced search by price to"
+- filename: "StorefrontAdvancedSearchByPartialShortDescriptionTest.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/CatalogSearch/Test/Mftf/Test/StorefrontAdvancedSearchByPartialShortDescriptionTest.xml"
+  module: "CatalogSearch"
+  tests:
+    - testname: "StorefrontAdvancedSearchByPartialShortDescriptionTest"
+      title: "Search product in advanced search by partial short description"
+      description: "Search product in advanced search by partial short description"
+- filename: "AdminReportsSearchTermsNavigateMenuTest.xml"
+  repo: "https://github.com/magento/magento2/blob/2.3.5/app/code/Magento/CatalogSearch/Test/Mftf/Test/AdminReportsSearchTermsNavigateMenuTest.xml"
+  module: "CatalogSearch"
+  tests:
+    - testname: "AdminReportsSearchTermsNavigateMenuTest"
+      title: "Admin reports search terms navigate menu test"
+      description: "Admin should be able to navigate to Reports &gt; Search Terms"


### PR DESCRIPTION
## Purpose of this pull request

This pull request (PR) updates MFTF reference data after 2.3.5 release. The data is generated from MFTF tests defined in XML files of the corresponding modules at the magento2 codebase.

whatsnew
Updated [MFTF functional test reference](https://devdocs.magento.com/guides/v2.3/reference/mftf/functional-tests.html) and [MFTF action group reference](https://devdocs.magento.com/guides/v2.3/reference/mftf/action-groups.html).