### PR TITLE
Add info about Composer dependency for upgrade plugin

### DIFF
--- a/src/guides/v2.3/comp-mgr/cli/upgrade-with-plugin.md
+++ b/src/guides/v2.3/comp-mgr/cli/upgrade-with-plugin.md
@@ -11,7 +11,7 @@ functional_areas:
 -->
 
 {:.bs-callout-warning}
-This plugin is currently in beta. Do not use it on production. It only works with Composer version 1.8.0 or earlier. It is currently incompatible with Magento 2.3.5 or later.
+This plugin is in beta. Do not use it on production. It only works with Composer version 1.8.0 or earlier. It is currently incompatible with Magento 2.3.5 or later.
 
 The [`magento/composer-root-update-plugin`][custom composer plugin] Composer plugin resolves changes that need to be made to the root project `composer.json` file before updating to a new Magento product requirement.
 

--- a/src/guides/v2.3/comp-mgr/cli/upgrade-with-plugin.md
+++ b/src/guides/v2.3/comp-mgr/cli/upgrade-with-plugin.md
@@ -11,8 +11,7 @@ functional_areas:
 -->
 
 {:.bs-callout-warning}
-This upgrading scenario is still under development and is published here to make it available for the Community to test.
-Do not use it on production.
+This plugin is currently in beta. Do not use it on production. It only works with Composer version 1.8.0 or earlier. It is currently incompatible with Magento 2.3.5 or later.
 
 The [`magento/composer-root-update-plugin`][custom composer plugin] Composer plugin resolves changes that need to be made to the root project `composer.json` file before updating to a new Magento product requirement.
 


### PR DESCRIPTION
## Purpose of this pull request

This pull request (PR) updates the note about the compatibility of the Composer plugin for upgrading Magento. It is not compatible with Magento 2.3.5.

## Affected DevDocs pages

-  https://devdocs.magento.com/guides/v2.3/comp-mgr/cli/upgrade-with-plugin.html

whatsnew
Added a [note](https://devdocs.magento.com/guides/v2.3/comp-mgr/cli/upgrade-with-plugin.html) about Composer upgrade plugin compatibility with Magento 2.3.5.