### PR TITLE
Update Module Reference Guide (2.3.5 release)

### DIFF
--- a/src/_data/codebase/v2_3/mrg/b2b/B2b.yaml
+++ b/src/_data/codebase/v2_3/mrg/b2b/B2b.yaml
@@ -1,7 +1,7 @@
 ---
 title: Magento_B2b
 source_repo: magento2b2b
-release: 1.1.4
+release: 1.1.5
 github_path: app/code/Magento/B2b/README.md
 last_modified_at: '2017-02-15 17:02:23 +0300'
 content: "## Overview\n\nThe Magento_b2b module is the base module for B2B. It must

--- a/src/_data/codebase/v2_3/mrg/b2b/BundleNegotiableQuote.yaml
+++ b/src/_data/codebase/v2_3/mrg/b2b/BundleNegotiableQuote.yaml
@@ -1,7 +1,7 @@
 ---
 title: Magento_BundleNegotiableQuote
 source_repo: magento2b2b
-release: 1.1.4
+release: 1.1.5
 github_path: app/code/Magento/BundleNegotiableQuote/README.md
 last_modified_at: '2017-04-10 10:33:01 +0300'
 content: "## Overview\n\nThe Magento_BundleNegotiableQuote module enables bundle products

--- a/src/_data/codebase/v2_3/mrg/b2b/BundleRequisitionList.yaml
+++ b/src/_data/codebase/v2_3/mrg/b2b/BundleRequisitionList.yaml
@@ -1,7 +1,7 @@
 ---
 title: Magento_BundleRequisitionList
 source_repo: magento2b2b
-release: 1.1.4
+release: 1.1.5
 github_path: app/code/Magento/BundleRequisitionList/README.md
 last_modified_at: '2017-04-10 10:33:01 +0300'
 content: "## Overview\n\nThe Magento_BundleRequisitionList module enables bundle products

--- a/src/_data/codebase/v2_3/mrg/b2b/BundleSharedCatalog.yaml
+++ b/src/_data/codebase/v2_3/mrg/b2b/BundleSharedCatalog.yaml
@@ -1,7 +1,7 @@
 ---
 title: Magento_BundleSharedCatalog
 source_repo: magento2b2b
-release: 1.1.4
+release: 1.1.5
 github_path: app/code/Magento/BundleSharedCatalog/README.md
 last_modified_at: '2017-02-15 17:02:23 +0300'
 content: "## Overview\n\nThe Magento_BundleSharedCatalog module enables bundle products

--- a/src/_data/codebase/v2_3/mrg/b2b/CheckoutAddressSearchNegotiableQuote.yaml
+++ b/src/_data/codebase/v2_3/mrg/b2b/CheckoutAddressSearchNegotiableQuote.yaml
@@ -1,7 +1,7 @@
 ---
 title: Magento_CheckoutAddressSearchNegotiableQuote
 source_repo: magento2b2b
-release: 1.1.4
+release: 1.1.5
 github_path: app/code/Magento/CheckoutAddressSearchNegotiableQuote/README.md
 last_modified_at: '2019-04-10 17:47:51 -0500'
 content: |

--- a/src/_data/codebase/v2_3/mrg/b2b/CheckoutAgreementsNegotiableQuote.yaml
+++ b/src/_data/codebase/v2_3/mrg/b2b/CheckoutAgreementsNegotiableQuote.yaml
@@ -1,7 +1,7 @@
 ---
 title: Magento_CheckoutAgreementsNegotiableQuote
 source_repo: magento2b2b
-release: 1.1.4
+release: 1.1.5
 github_path: app/code/Magento/CheckoutAgreementsNegotiableQuote/README.md
 last_modified_at: '2019-08-16 15:20:08 -0500'
 content: |

--- a/src/_data/codebase/v2_3/mrg/b2b/Company.yaml
+++ b/src/_data/codebase/v2_3/mrg/b2b/Company.yaml
@@ -1,7 +1,7 @@
 ---
 title: Magento_Company
 source_repo: magento2b2b
-release: 1.1.4
+release: 1.1.5
 github_path: app/code/Magento/Company/README.md
 last_modified_at: '2017-02-15 17:02:23 +0300'
 content: "## Overview\n\nThe Magento_Company module allows a merchant to create a

--- a/src/_data/codebase/v2_3/mrg/b2b/CompanyCredit.yaml
+++ b/src/_data/codebase/v2_3/mrg/b2b/CompanyCredit.yaml
@@ -1,7 +1,7 @@
 ---
 title: Magento_CompanyCredit
 source_repo: magento2b2b
-release: 1.1.4
+release: 1.1.5
 github_path: app/code/Magento/CompanyCredit/README.md
 last_modified_at: '2017-02-15 17:02:23 +0300'
 content: "## Overview\n\nThe Magento_CompanyCredit module adds the \"Payment on Account\"

--- a/src/_data/codebase/v2_3/mrg/b2b/CompanyPayment.yaml
+++ b/src/_data/codebase/v2_3/mrg/b2b/CompanyPayment.yaml
@@ -1,7 +1,7 @@
 ---
 title: Magento_CompanyPayment
 source_repo: magento2b2b
-release: 1.1.4
+release: 1.1.5
 github_path: app/code/Magento/CompanyPayment/README.md
 last_modified_at: '2017-02-15 17:02:23 +0300'
 content: "## Overview\n\nThe Magento_CompanyPayment module allows a merchant to configure

--- a/src/_data/codebase/v2_3/mrg/b2b/ConfigurableNegotiableQuote.yaml
+++ b/src/_data/codebase/v2_3/mrg/b2b/ConfigurableNegotiableQuote.yaml
@@ -1,7 +1,7 @@
 ---
 title: Magento_ConfigurableNegotiableQuote
 source_repo: magento2b2b
-release: 1.1.4
+release: 1.1.5
 github_path: app/code/Magento/ConfigurableNegotiableQuote/README.md
 last_modified_at: '2017-04-10 10:33:01 +0300'
 content: "## Overview\n\nThe Magento_ConfigurableNegotiableQuote module enables configurable

--- a/src/_data/codebase/v2_3/mrg/b2b/ConfigurableRequisitionList.yaml
+++ b/src/_data/codebase/v2_3/mrg/b2b/ConfigurableRequisitionList.yaml
@@ -1,7 +1,7 @@
 ---
 title: Magento_ConfigurableRequisitionList
 source_repo: magento2b2b
-release: 1.1.4
+release: 1.1.5
 github_path: app/code/Magento/ConfigurableRequisitionList/README.md
 last_modified_at: '2017-04-10 10:33:01 +0300'
 content: "## Overview\n\nThe Magento_ConfigurableRequisitionList module enables configurable

--- a/src/_data/codebase/v2_3/mrg/b2b/ConfigurableSharedCatalog.yaml
+++ b/src/_data/codebase/v2_3/mrg/b2b/ConfigurableSharedCatalog.yaml
@@ -1,7 +1,7 @@
 ---
 title: Magento_ConfigurableSharedCatalog
 source_repo: magento2b2b
-release: 1.1.4
+release: 1.1.5
 github_path: app/code/Magento/ConfigurableSharedCatalog/README.md
 last_modified_at: '2017-02-15 17:02:23 +0300'
 content: "## Overview\n\nThe Magento_ConfigurableSharedCatalog module enables configurable

--- a/src/_data/codebase/v2_3/mrg/b2b/GiftCardNegotiableQuote.yaml
+++ b/src/_data/codebase/v2_3/mrg/b2b/GiftCardNegotiableQuote.yaml
@@ -1,7 +1,7 @@
 ---
 title: Magento_GiftCardNegotiableQuote
 source_repo: magento2b2b
-release: 1.1.4
+release: 1.1.5
 github_path: app/code/Magento/GiftCardNegotiableQuote/README.md
 last_modified_at: '2017-04-10 10:33:01 +0300'
 content: |

--- a/src/_data/codebase/v2_3/mrg/b2b/GiftCardRequisitionList.yaml
+++ b/src/_data/codebase/v2_3/mrg/b2b/GiftCardRequisitionList.yaml
@@ -1,7 +1,7 @@
 ---
 title: Magento_GiftCardRequisitionList
 source_repo: magento2b2b
-release: 1.1.4
+release: 1.1.5
 github_path: app/code/Magento/GiftCardRequisitionList/README.md
 last_modified_at: '2017-04-10 10:33:01 +0300'
 content: "## Overview\n\nThe Magento_GiftCardRequisitionList module enables gift cards

--- a/src/_data/codebase/v2_3/mrg/b2b/GiftCardSharedCatalog.yaml
+++ b/src/_data/codebase/v2_3/mrg/b2b/GiftCardSharedCatalog.yaml
@@ -1,7 +1,7 @@
 ---
 title: Magento_GiftCardSharedCatalog
 source_repo: magento2b2b
-release: 1.1.4
+release: 1.1.5
 github_path: app/code/Magento/GiftCardSharedCatalog/README.md
 last_modified_at: '2017-02-15 17:02:23 +0300'
 content: "## Overview\n\nThe Magento_GiftCardSharedCatalog module enables gift cards

--- a/src/_data/codebase/v2_3/mrg/b2b/GroupedRequisitionList.yaml
+++ b/src/_data/codebase/v2_3/mrg/b2b/GroupedRequisitionList.yaml
@@ -1,7 +1,7 @@
 ---
 title: Magento_GroupedRequisitionList
 source_repo: magento2b2b
-release: 1.1.4
+release: 1.1.5
 github_path: app/code/Magento/GroupedRequisitionList/README.md
 last_modified_at: '2017-04-10 10:33:01 +0300'
 content: "## Overview\n\nThe Magento_GroupedRequisitionList module enables grouped

--- a/src/_data/codebase/v2_3/mrg/b2b/GroupedSharedCatalog.yaml
+++ b/src/_data/codebase/v2_3/mrg/b2b/GroupedSharedCatalog.yaml
@@ -1,7 +1,7 @@
 ---
 title: Magento_GroupedSharedCatalog
 source_repo: magento2b2b
-release: 1.1.4
+release: 1.1.5
 github_path: app/code/Magento/GroupedSharedCatalog/README.md
 last_modified_at: '2017-02-15 17:02:23 +0300'
 content: "## Overview\n\nThe Magento_GroupedSharedCatalog module enables grouped products

--- a/src/_data/codebase/v2_3/mrg/b2b/NegotiableQuote.yaml
+++ b/src/_data/codebase/v2_3/mrg/b2b/NegotiableQuote.yaml
@@ -1,7 +1,7 @@
 ---
 title: Magento_NegotiableQuote
 source_repo: magento2b2b
-release: 1.1.4
+release: 1.1.5
 github_path: app/code/Magento/NegotiableQuote/README.md
 last_modified_at: '2017-02-15 17:02:23 +0300'
 content: "## Overview\n\nThe Magento_NegotiableQuote module allows a customer and

--- a/src/_data/codebase/v2_3/mrg/b2b/NegotiableQuoteSharedCatalog.yaml
+++ b/src/_data/codebase/v2_3/mrg/b2b/NegotiableQuoteSharedCatalog.yaml
@@ -1,7 +1,7 @@
 ---
 title: Magento_NegotiableQuoteSharedCatalog
 source_repo: magento2b2b
-release: 1.1.4
+release: 1.1.5
 github_path: app/code/Magento/NegotiableQuoteSharedCatalog/README.md
 last_modified_at: '2017-02-17 11:38:50 +0300'
 content: "## Overview\n\nThe Magento_NegotiableQuoteSharedCatalog module enables the

--- a/src/_data/codebase/v2_3/mrg/b2b/QuickOrder.yaml
+++ b/src/_data/codebase/v2_3/mrg/b2b/QuickOrder.yaml
@@ -1,7 +1,7 @@
 ---
 title: Magento_QuickOrder
 source_repo: magento2b2b
-release: 1.1.4
+release: 1.1.5
 github_path: app/code/Magento/QuickOrder/README.md
 last_modified_at: '2017-02-15 17:02:23 +0300'
 content: "## Overview\n\nThe Magento_QuickOrder module allows customers to improve

--- a/src/_data/codebase/v2_3/mrg/b2b/RequisitionList.yaml
+++ b/src/_data/codebase/v2_3/mrg/b2b/RequisitionList.yaml
@@ -1,7 +1,7 @@
 ---
 title: Magento_RequisitionList
 source_repo: magento2b2b
-release: 1.1.4
+release: 1.1.5
 github_path: app/code/Magento/RequisitionList/README.md
 last_modified_at: '2017-02-15 17:02:23 +0300'
 content: "## Overview\n\nThe Magento_RequisitionList module allows a customer to create

--- a/src/_data/codebase/v2_3/mrg/b2b/SharedCatalog.yaml
+++ b/src/_data/codebase/v2_3/mrg/b2b/SharedCatalog.yaml
@@ -1,7 +1,7 @@
 ---
 title: Magento_SharedCatalog
 source_repo: magento2b2b
-release: 1.1.4
+release: 1.1.5
 github_path: app/code/Magento/SharedCatalog/README.md
 last_modified_at: '2019-09-24 19:57:14 -0500'
 content: "## Overview\n\nThe Magento_SharedCatalog modules defines the visibility

--- a/src/_data/codebase/v2_3/mrg/ce/AdminAnalytics.yaml
+++ b/src/_data/codebase/v2_3/mrg/ce/AdminAnalytics.yaml
@@ -1,7 +1,7 @@
 ---
 title: Magento_AdminAnalytics
 source_repo: magento2ce
-release: 2.3.4
+release: 2.3.5
 github_path: app/code/Magento/AdminAnalytics/README.md
 last_modified_at: '2019-08-08 11:00:49 -0500'
 content: The Magento\AdminAnalytics module gathers information about the features

--- a/src/_data/codebase/v2_3/mrg/ce/AdminNotification.yaml
+++ b/src/_data/codebase/v2_3/mrg/ce/AdminNotification.yaml
@@ -1,7 +1,7 @@
 ---
 title: Magento_AdminNotification
 source_repo: magento2ce
-release: 2.3.4
+release: 2.3.5
 github_path: app/code/Magento/AdminNotification/README.md
 last_modified_at: '2019-08-19 00:16:18 +0100'
 content: |

--- a/src/_data/codebase/v2_3/mrg/ce/AdvancedPricingImportExport.yaml
+++ b/src/_data/codebase/v2_3/mrg/ce/AdvancedPricingImportExport.yaml
@@ -1,7 +1,7 @@
 ---
 title: Magento_AdvancedPricingImportExport
 source_repo: magento2ce
-release: 2.3.4
+release: 2.3.5
 github_path: app/code/Magento/AdvancedPricingImportExport/README.md
 last_modified_at: '2019-08-18 23:54:55 +0100'
 content: |-

--- a/src/_data/codebase/v2_3/mrg/ce/AdvancedSearch.yaml
+++ b/src/_data/codebase/v2_3/mrg/ce/AdvancedSearch.yaml
@@ -1,7 +1,7 @@
 ---
 title: Magento_AdvancedSearch
 source_repo: magento2ce
-release: 2.3.4
+release: 2.3.5
 github_path: app/code/Magento/AdvancedSearch/README.md
 last_modified_at: '2019-08-20 00:08:51 +0100'
 content: "The Magento_AdvancedSearch module introduces advanced search functionality

--- a/src/_data/codebase/v2_3/mrg/ce/Amqp.yaml
+++ b/src/_data/codebase/v2_3/mrg/ce/Amqp.yaml
@@ -1,7 +1,7 @@
 ---
 title: Magento_Amqp
 source_repo: magento2ce
-release: 2.3.4
+release: 2.3.5
 github_path: app/code/Magento/Amqp/README.md
 last_modified_at: '2019-08-19 00:22:19 +0100'
 content: |-

--- a/src/_data/codebase/v2_3/mrg/ce/AmqpStore.yaml
+++ b/src/_data/codebase/v2_3/mrg/ce/AmqpStore.yaml
@@ -1,7 +1,7 @@
 ---
 title: Magento_AmqpStore
 source_repo: magento2ce
-release: 2.3.4
+release: 2.3.5
 github_path: app/code/Magento/AmqpStore/README.md
 last_modified_at: '2019-08-27 01:59:34 +0100'
 content: |

--- a/src/_data/codebase/v2_3/mrg/ce/Analytics.yaml
+++ b/src/_data/codebase/v2_3/mrg/ce/Analytics.yaml
@@ -1,7 +1,7 @@
 ---
 title: Magento_Analytics
 source_repo: magento2ce
-release: 2.3.4
+release: 2.3.5
 github_path: app/code/Magento/Analytics/README.md
 last_modified_at: '2019-09-15 22:49:37 +0100'
 content: |

--- a/src/_data/codebase/v2_3/mrg/ce/AsynchronousOperations.yaml
+++ b/src/_data/codebase/v2_3/mrg/ce/AsynchronousOperations.yaml
@@ -1,7 +1,7 @@
 ---
 title: Magento_AsynchronousOperations
 source_repo: magento2ce
-release: 2.3.4
+release: 2.3.5
 github_path: app/code/Magento/AsynchronousOperations/README.md
 last_modified_at: '2019-08-27 01:56:24 +0100'
 content: "This component is designed to provide a response for a client that launched

--- a/src/_data/codebase/v2_3/mrg/ce/Authorization.yaml
+++ b/src/_data/codebase/v2_3/mrg/ce/Authorization.yaml
@@ -1,7 +1,7 @@
 ---
 title: Magento_Authorization
 source_repo: magento2ce
-release: 2.3.4
+release: 2.3.5
 github_path: app/code/Magento/Authorization/README.md
 last_modified_at: '2019-08-25 07:43:56 +0100'
 content: |

--- a/src/_data/codebase/v2_3/mrg/ce/Authorizenet.yaml
+++ b/src/_data/codebase/v2_3/mrg/ce/Authorizenet.yaml
@@ -1,7 +1,7 @@
 ---
 title: Magento_Authorizenet
 source_repo: magento2ce
-release: 2.3.4
+release: 2.3.5
 github_path: app/code/Magento/Authorizenet/README.md
 last_modified_at: '2019-08-28 14:50:53 +0100'
 content: "The Magento_Authorizenet module implements the integration with the Authorize.Net

--- a/src/_data/codebase/v2_3/mrg/ce/AuthorizenetAcceptjs.yaml
+++ b/src/_data/codebase/v2_3/mrg/ce/AuthorizenetAcceptjs.yaml
@@ -1,7 +1,7 @@
 ---
 title: Magento_AuthorizenetAcceptjs
 source_repo: magento2ce
-release: 2.3.4
+release: 2.3.5
 github_path: app/code/Magento/AuthorizenetAcceptjs/README.md
 last_modified_at: '2019-08-28 00:26:17 +0100'
 content: |

--- a/src/_data/codebase/v2_3/mrg/ce/AuthorizenetCardinal.yaml
+++ b/src/_data/codebase/v2_3/mrg/ce/AuthorizenetCardinal.yaml
@@ -1,7 +1,7 @@
 ---
 title: Magento_AuthorizenetCardinal
 source_repo: magento2ce
-release: 2.3.4
+release: 2.3.5
 github_path: app/code/Magento/AuthorizenetCardinal/README.md
 last_modified_at: '2019-08-28 14:16:34 +0100'
 content: "Use the Magento_AuthorizenetCardinal module to enable 3D Secure 2.0 support

--- a/src/_data/codebase/v2_3/mrg/ce/AuthorizenetGraphQl.yaml
+++ b/src/_data/codebase/v2_3/mrg/ce/AuthorizenetGraphQl.yaml
@@ -1,7 +1,7 @@
 ---
 title: Magento_AuthorizenetGraphQl
 source_repo: magento2ce
-release: 2.3.4
+release: 2.3.5
 github_path: app/code/Magento/AuthorizenetGraphQl/README.md
 last_modified_at: '2019-08-28 00:38:47 +0100'
 content: |

--- a/src/_data/codebase/v2_3/mrg/ce/Backend.yaml
+++ b/src/_data/codebase/v2_3/mrg/ce/Backend.yaml
@@ -1,7 +1,7 @@
 ---
 title: Magento_Backend
 source_repo: magento2ce
-release: 2.3.4
+release: 2.3.5
 github_path: app/code/Magento/Backend/README.md
 last_modified_at: '2019-09-15 23:59:05 +0100'
 content: |

--- a/src/_data/codebase/v2_3/mrg/ce/Backup.yaml
+++ b/src/_data/codebase/v2_3/mrg/ce/Backup.yaml
@@ -1,7 +1,7 @@
 ---
 title: Magento_Backup
 source_repo: magento2ce
-release: 2.3.4
+release: 2.3.5
 github_path: app/code/Magento/Backup/README.md
 last_modified_at: '2019-09-16 12:24:25 -0300'
 content: "The Magento_Backup module allows administrators to perform backups and rollbacks.

--- a/src/_data/codebase/v2_3/mrg/ce/Braintree.yaml
+++ b/src/_data/codebase/v2_3/mrg/ce/Braintree.yaml
@@ -1,7 +1,7 @@
 ---
 title: Magento_Braintree
 source_repo: magento2ce
-release: 2.3.4
+release: 2.3.5
 github_path: app/code/Magento/Braintree/README.md
 last_modified_at: '2019-09-23 14:26:40 -0500'
 content: |

--- a/src/_data/codebase/v2_3/mrg/ce/BraintreeGraphQl.yaml
+++ b/src/_data/codebase/v2_3/mrg/ce/BraintreeGraphQl.yaml
@@ -1,7 +1,7 @@
 ---
 title: Magento_BraintreeGraphQl
 source_repo: magento2ce
-release: 2.3.4
+release: 2.3.5
 github_path: app/code/Magento/BraintreeGraphQl/README.md
 last_modified_at: '2019-09-30 15:26:35 +0100'
 content: |

--- a/src/_data/codebase/v2_3/mrg/ce/Bundle.yaml
+++ b/src/_data/codebase/v2_3/mrg/ce/Bundle.yaml
@@ -1,7 +1,7 @@
 ---
 title: Magento_Bundle
 source_repo: magento2ce
-release: 2.3.4
+release: 2.3.5
 github_path: app/code/Magento/Bundle/README.md
 last_modified_at: '2014-12-12 12:14:06 -0800'
 content: |

--- a/src/_data/codebase/v2_3/mrg/ce/BundleGraphQl.yaml
+++ b/src/_data/codebase/v2_3/mrg/ce/BundleGraphQl.yaml
@@ -1,7 +1,7 @@
 ---
 title: Magento_BundleGraphQl
 source_repo: magento2ce
-release: 2.3.4
+release: 2.3.5
 github_path: app/code/Magento/BundleGraphQl/README.md
 last_modified_at: '2018-01-24 11:57:46 -0600'
 content: |

--- a/src/_data/codebase/v2_3/mrg/ce/BundleImportExport.yaml
+++ b/src/_data/codebase/v2_3/mrg/ce/BundleImportExport.yaml
@@ -1,7 +1,7 @@
 ---
 title: Magento_BundleImportExport
 source_repo: magento2ce
-release: 2.3.4
+release: 2.3.5
 github_path: app/code/Magento/BundleImportExport/README.md
 last_modified_at: '2015-05-28 02:24:13 +0300'
 content: |

--- a/src/_data/codebase/v2_3/mrg/ce/CacheInvalidate.yaml
+++ b/src/_data/codebase/v2_3/mrg/ce/CacheInvalidate.yaml
@@ -1,7 +1,7 @@
 ---
 title: Magento_CacheInvalidate
 source_repo: magento2ce
-release: 2.3.4
+release: 2.3.5
 github_path: app/code/Magento/CacheInvalidate/README.md
 last_modified_at: '2015-04-13 17:31:45 -0500'
 content: |-

--- a/src/_data/codebase/v2_3/mrg/ce/Captcha.yaml
+++ b/src/_data/codebase/v2_3/mrg/ce/Captcha.yaml
@@ -1,7 +1,7 @@
 ---
 title: Magento_Captcha
 source_repo: magento2ce
-release: 2.3.4
+release: 2.3.5
 github_path: app/code/Magento/Captcha/README.md
 last_modified_at: '2014-07-11 11:30:21 -0700'
 content: The Captcha module allows applying Turing test in the process of user authentication

--- a/src/_data/codebase/v2_3/mrg/ce/CardinalCommerce.yaml
+++ b/src/_data/codebase/v2_3/mrg/ce/CardinalCommerce.yaml
@@ -1,7 +1,7 @@
 ---
 title: Magento_CardinalCommerce
 source_repo: magento2ce
-release: 2.3.4
+release: 2.3.5
 github_path: app/code/Magento/CardinalCommerce/README.md
 last_modified_at: '2019-06-11 13:12:54 -0500'
 content: The CardinalCommerce module provides a possibility to enable 3-D Secure 2.0

--- a/src/_data/codebase/v2_3/mrg/ce/Catalog.yaml
+++ b/src/_data/codebase/v2_3/mrg/ce/Catalog.yaml
@@ -1,7 +1,7 @@
 ---
 title: Magento_Catalog
 source_repo: magento2ce
-release: 2.3.4
+release: 2.3.5
 github_path: app/code/Magento/Catalog/README.md
 last_modified_at: '2014-12-12 12:14:06 -0800'
 content: |

--- a/src/_data/codebase/v2_3/mrg/ce/CatalogAnalytics.yaml
+++ b/src/_data/codebase/v2_3/mrg/ce/CatalogAnalytics.yaml
@@ -1,7 +1,7 @@
 ---
 title: Magento_CatalogAnalytics
 source_repo: magento2ce
-release: 2.3.4
+release: 2.3.5
 github_path: app/code/Magento/CatalogAnalytics/README.md
 last_modified_at: '2019-08-06 14:40:28 -0500'
 content: 'The Magento_CatalogAnalytics module configures data definitions for a data

--- a/src/_data/codebase/v2_3/mrg/ce/CatalogCmsGraphQl.yaml
+++ b/src/_data/codebase/v2_3/mrg/ce/CatalogCmsGraphQl.yaml
@@ -1,7 +1,7 @@
 ---
 title: Magento_CatalogCmsGraphQl
 source_repo: magento2ce
-release: 2.3.4
+release: 2.3.5
 github_path: app/code/Magento/CatalogCmsGraphQl/README.md
 last_modified_at: '2019-10-11 12:20:01 -0500'
 content: "**CatalogCmsGraphQl** provides type and resolver information for GraphQL

--- a/src/_data/codebase/v2_3/mrg/ce/CatalogCustomerGraphQl.yaml
+++ b/src/_data/codebase/v2_3/mrg/ce/CatalogCustomerGraphQl.yaml
@@ -1,7 +1,7 @@
 ---
 title: Magento_CatalogCustomerGraphQl
 source_repo: magento2ce
-release: 2.3.4
+release: 2.3.5
 github_path: app/code/Magento/CatalogCustomerGraphQl/README.md
 last_modified_at: '2019-09-19 13:05:37 -0500'
 content: "**CatalogCustomerGraphQl** provides type and resolver information for GraphQL

--- a/src/_data/codebase/v2_3/mrg/ce/CatalogGraphQl.yaml
+++ b/src/_data/codebase/v2_3/mrg/ce/CatalogGraphQl.yaml
@@ -1,7 +1,7 @@
 ---
 title: Magento_CatalogGraphQl
 source_repo: magento2ce
-release: 2.3.4
+release: 2.3.5
 github_path: app/code/Magento/CatalogGraphQl/README.md
 last_modified_at: '2018-01-16 13:17:37 -0600'
 content: |

--- a/src/_data/codebase/v2_3/mrg/ce/CatalogInventory.yaml
+++ b/src/_data/codebase/v2_3/mrg/ce/CatalogInventory.yaml
@@ -1,7 +1,7 @@
 ---
 title: Magento_CatalogInventory
 source_repo: magento2ce
-release: 2.3.4
+release: 2.3.5
 github_path: app/code/Magento/CatalogInventory/README.md
 last_modified_at: '2014-12-12 12:14:06 -0800'
 content: 'Magento_CatalogInventory module allows retrieve and update stock attributes,

--- a/src/_data/codebase/v2_3/mrg/ce/CatalogInventoryGraphQl.yaml
+++ b/src/_data/codebase/v2_3/mrg/ce/CatalogInventoryGraphQl.yaml
@@ -1,7 +1,7 @@
 ---
 title: Magento_CatalogInventoryGraphQl
 source_repo: magento2ce
-release: 2.3.4
+release: 2.3.5
 github_path: app/code/Magento/CatalogInventoryGraphQl/README.md
 last_modified_at: '2018-07-18 16:40:53 +0200'
 content: |

--- a/src/_data/codebase/v2_3/mrg/ce/CatalogRule.yaml
+++ b/src/_data/codebase/v2_3/mrg/ce/CatalogRule.yaml
@@ -1,7 +1,7 @@
 ---
 title: Magento_CatalogRule
 source_repo: magento2ce
-release: 2.3.4
+release: 2.3.5
 github_path: app/code/Magento/CatalogRule/README.md
 last_modified_at: '2014-12-12 12:14:06 -0800'
 content: 'Magento_CatalogRule module is responsible for one of the types of price

--- a/src/_data/codebase/v2_3/mrg/ce/CatalogRuleConfigurable.yaml
+++ b/src/_data/codebase/v2_3/mrg/ce/CatalogRuleConfigurable.yaml
@@ -1,7 +1,7 @@
 ---
 title: Magento_CatalogRuleConfigurable
 source_repo: magento2ce
-release: 2.3.4
+release: 2.3.5
 github_path: app/code/Magento/CatalogRuleConfigurable/README.md
 last_modified_at: '2015-09-07 17:18:34 +0300'
 content: 'Magento_CatalogRuleConfigurable module is an extension of Magento_CatalogRule

--- a/src/_data/codebase/v2_3/mrg/ce/CatalogSearch.yaml
+++ b/src/_data/codebase/v2_3/mrg/ce/CatalogSearch.yaml
@@ -1,7 +1,7 @@
 ---
 title: Magento_CatalogSearch
 source_repo: magento2ce
-release: 2.3.4
+release: 2.3.5
 github_path: app/code/Magento/CatalogSearch/README.md
 last_modified_at: '2014-12-12 12:14:06 -0800'
 content: |

--- a/src/_data/codebase/v2_3/mrg/ce/CatalogUrlRewriteGraphQl.yaml
+++ b/src/_data/codebase/v2_3/mrg/ce/CatalogUrlRewriteGraphQl.yaml
@@ -1,7 +1,7 @@
 ---
 title: Magento_CatalogUrlRewriteGraphQl
 source_repo: magento2ce
-release: 2.3.4
+release: 2.3.5
 github_path: app/code/Magento/CatalogUrlRewriteGraphQl/README.md
 last_modified_at: '2018-01-16 16:07:17 -0600'
 content: |

--- a/src/_data/codebase/v2_3/mrg/ce/CatalogWidget.yaml
+++ b/src/_data/codebase/v2_3/mrg/ce/CatalogWidget.yaml
@@ -1,7 +1,7 @@
 ---
 title: Magento_CatalogWidget
 source_repo: magento2ce
-release: 2.3.4
+release: 2.3.5
 github_path: app/code/Magento/CatalogWidget/README.md
 last_modified_at: '2014-12-12 12:14:06 -0800'
 content: |

--- a/src/_data/codebase/v2_3/mrg/ce/Checkout.yaml
+++ b/src/_data/codebase/v2_3/mrg/ce/Checkout.yaml
@@ -1,7 +1,7 @@
 ---
 title: Magento_Checkout
 source_repo: magento2ce
-release: 2.3.4
+release: 2.3.5
 github_path: app/code/Magento/Checkout/README.md
 last_modified_at: '2014-10-24 14:51:44 -0700'
 content: |-

--- a/src/_data/codebase/v2_3/mrg/ce/CheckoutAgreements.yaml
+++ b/src/_data/codebase/v2_3/mrg/ce/CheckoutAgreements.yaml
@@ -1,7 +1,7 @@
 ---
 title: Magento_CheckoutAgreements
 source_repo: magento2ce
-release: 2.3.4
+release: 2.3.5
 github_path: app/code/Magento/CheckoutAgreements/README.md
 last_modified_at: '2014-10-24 14:51:44 -0700'
 content: |-

--- a/src/_data/codebase/v2_3/mrg/ce/CheckoutAgreementsGraphQl.yaml
+++ b/src/_data/codebase/v2_3/mrg/ce/CheckoutAgreementsGraphQl.yaml
@@ -1,7 +1,7 @@
 ---
 title: Magento_CheckoutAgreementsGraphQl
 source_repo: magento2ce
-release: 2.3.4
+release: 2.3.5
 github_path: app/code/Magento/CheckoutAgreementsGraphQl/README.md
 last_modified_at: '2019-03-20 17:00:47 +0200'
 content: |

--- a/src/_data/codebase/v2_3/mrg/ce/Cms.yaml
+++ b/src/_data/codebase/v2_3/mrg/ce/Cms.yaml
@@ -1,7 +1,7 @@
 ---
 title: Magento_Cms
 source_repo: magento2ce
-release: 2.3.4
+release: 2.3.5
 github_path: app/code/Magento/Cms/README.md
 last_modified_at: '2017-12-12 09:36:23 -0600'
 content: |-

--- a/src/_data/codebase/v2_3/mrg/ce/CmsGraphQl.yaml
+++ b/src/_data/codebase/v2_3/mrg/ce/CmsGraphQl.yaml
@@ -1,7 +1,7 @@
 ---
 title: Magento_CmsGraphQl
 source_repo: magento2ce
-release: 2.3.4
+release: 2.3.5
 github_path: app/code/Magento/CmsGraphQl/README.md
 last_modified_at: '2018-06-30 14:36:35 +0300'
 content: |

--- a/src/_data/codebase/v2_3/mrg/ce/CmsUrlRewrite.yaml
+++ b/src/_data/codebase/v2_3/mrg/ce/CmsUrlRewrite.yaml
@@ -1,7 +1,7 @@
 ---
 title: Magento_CmsUrlRewrite
 source_repo: magento2ce
-release: 2.3.4
+release: 2.3.5
 github_path: app/code/Magento/CmsUrlRewrite/README.md
 last_modified_at: '2017-03-07 16:04:38 -0600'
 content: "## Overview\n \nThe Magento_CmsUrlRewrite module adds support for URL rewrite

--- a/src/_data/codebase/v2_3/mrg/ce/CmsUrlRewriteGraphQl.yaml
+++ b/src/_data/codebase/v2_3/mrg/ce/CmsUrlRewriteGraphQl.yaml
@@ -1,7 +1,7 @@
 ---
 title: Magento_CmsUrlRewriteGraphQl
 source_repo: magento2ce
-release: 2.3.4
+release: 2.3.5
 github_path: app/code/Magento/CmsUrlRewriteGraphQl/README.md
 last_modified_at: '2018-01-17 16:25:54 -0600'
 content: |

--- a/src/_data/codebase/v2_3/mrg/ce/Config.yaml
+++ b/src/_data/codebase/v2_3/mrg/ce/Config.yaml
@@ -1,7 +1,7 @@
 ---
 title: Magento_Config
 source_repo: magento2ce
-release: 2.3.4
+release: 2.3.5
 github_path: app/code/Magento/Config/README.md
 last_modified_at: '2019-09-03 18:23:54 +0300'
 content: |

--- a/src/_data/codebase/v2_3/mrg/ce/ConfigurableProduct.yaml
+++ b/src/_data/codebase/v2_3/mrg/ce/ConfigurableProduct.yaml
@@ -1,7 +1,7 @@
 ---
 title: Magento_ConfigurableProduct
 source_repo: magento2ce
-release: 2.3.4
+release: 2.3.5
 github_path: app/code/Magento/ConfigurableProduct/README.md
 last_modified_at: '2014-12-12 12:14:06 -0800'
 content: |

--- a/src/_data/codebase/v2_3/mrg/ce/ConfigurableProductGraphQl.yaml
+++ b/src/_data/codebase/v2_3/mrg/ce/ConfigurableProductGraphQl.yaml
@@ -1,7 +1,7 @@
 ---
 title: Magento_ConfigurableProductGraphQl
 source_repo: magento2ce
-release: 2.3.4
+release: 2.3.5
 github_path: app/code/Magento/ConfigurableProductGraphQl/README.md
 last_modified_at: '2018-01-16 13:17:37 -0600'
 content: |

--- a/src/_data/codebase/v2_3/mrg/ce/ConfigurableProductSales.yaml
+++ b/src/_data/codebase/v2_3/mrg/ce/ConfigurableProductSales.yaml
@@ -1,7 +1,7 @@
 ---
 title: Magento_ConfigurableProductSales
 source_repo: magento2ce
-release: 2.3.4
+release: 2.3.5
 github_path: app/code/Magento/ConfigurableProductSales/README.md
 last_modified_at: '2017-07-14 16:51:00 +0300'
 content: 'Catalog. Returns true if the previously ordered item configuration is still

--- a/src/_data/codebase/v2_3/mrg/ce/Contact.yaml
+++ b/src/_data/codebase/v2_3/mrg/ce/Contact.yaml
@@ -1,7 +1,7 @@
 ---
 title: Magento_Contact
 source_repo: magento2ce
-release: 2.3.4
+release: 2.3.5
 github_path: app/code/Magento/Contact/README.md
 last_modified_at: '2014-12-12 12:14:06 -0800'
 content: 'Magento_Contact module provides an implementation of "Contact Us" feature

--- a/src/_data/codebase/v2_3/mrg/ce/Cookie.yaml
+++ b/src/_data/codebase/v2_3/mrg/ce/Cookie.yaml
@@ -1,7 +1,7 @@
 ---
 title: Magento_Cookie
 source_repo: magento2ce
-release: 2.3.4
+release: 2.3.5
 github_path: app/code/Magento/Cookie/README.md
 last_modified_at: '2015-01-28 16:50:13 -0600'
 content: 'Magento_Cookie module allows enabling and configuring HTTP cookie related

--- a/src/_data/codebase/v2_3/mrg/ce/Cron.yaml
+++ b/src/_data/codebase/v2_3/mrg/ce/Cron.yaml
@@ -1,7 +1,7 @@
 ---
 title: Magento_Cron
 source_repo: magento2ce
-release: 2.3.4
+release: 2.3.5
 github_path: app/code/Magento/Cron/README.md
 last_modified_at: '2015-04-30 16:30:07 -0500'
 content: |-

--- a/src/_data/codebase/v2_3/mrg/ce/Csp.yaml
+++ b/src/_data/codebase/v2_3/mrg/ce/Csp.yaml
@@ -1,0 +1,9 @@
+---
+title: Magento_Csp
+source_repo: magento2ce
+release: 2.3.5
+github_path: app/code/Magento/Csp/README.md
+last_modified_at: '2019-11-14 16:21:59 -0600'
+content: |
+  Magento_Csp implements Content Security Policies for Magento. Allows CSP configuration for Merchants,
+  provides a way for extension and theme developers to configure CSP headers for their extensions.

--- a/src/_data/codebase/v2_3/mrg/ce/CurrencySymbol.yaml
+++ b/src/_data/codebase/v2_3/mrg/ce/CurrencySymbol.yaml
@@ -1,7 +1,7 @@
 ---
 title: Magento_CurrencySymbol
 source_repo: magento2ce
-release: 2.3.4
+release: 2.3.5
 github_path: app/code/Magento/CurrencySymbol/README.md
 last_modified_at: '2014-12-12 12:14:06 -0800'
 content: |+

--- a/src/_data/codebase/v2_3/mrg/ce/Customer.yaml
+++ b/src/_data/codebase/v2_3/mrg/ce/Customer.yaml
@@ -1,7 +1,7 @@
 ---
 title: Magento_Customer
 source_repo: magento2ce
-release: 2.3.4
+release: 2.3.5
 github_path: app/code/Magento/Customer/README.md
 last_modified_at: '2015-08-27 15:34:05 -0500'
 content: "The Magento_Customer module serves to handle the customer data (Customer,

--- a/src/_data/codebase/v2_3/mrg/ce/CustomerAnalytics.yaml
+++ b/src/_data/codebase/v2_3/mrg/ce/CustomerAnalytics.yaml
@@ -1,7 +1,7 @@
 ---
 title: Magento_CustomerAnalytics
 source_repo: magento2ce
-release: 2.3.4
+release: 2.3.5
 github_path: app/code/Magento/CustomerAnalytics/README.md
 last_modified_at: '2019-08-06 14:40:28 -0500'
 content: 'The Magento_CustomerAnalytics module configures data definitions for a data

--- a/src/_data/codebase/v2_3/mrg/ce/CustomerDownloadableGraphQl.yaml
+++ b/src/_data/codebase/v2_3/mrg/ce/CustomerDownloadableGraphQl.yaml
@@ -1,7 +1,7 @@
 ---
 title: Magento_CustomerDownloadableGraphQl
 source_repo: magento2ce
-release: 2.3.4
+release: 2.3.5
 github_path: app/code/Magento/CustomerDownloadableGraphQl/README.md
 last_modified_at: '2019-06-25 22:45:10 +0200'
 content: |

--- a/src/_data/codebase/v2_3/mrg/ce/CustomerGraphQl.yaml
+++ b/src/_data/codebase/v2_3/mrg/ce/CustomerGraphQl.yaml
@@ -1,7 +1,7 @@
 ---
 title: Magento_CustomerGraphQl
 source_repo: magento2ce
-release: 2.3.4
+release: 2.3.5
 github_path: app/code/Magento/CustomerGraphQl/README.md
 last_modified_at: '2018-01-16 13:17:37 -0600'
 content: |

--- a/src/_data/codebase/v2_3/mrg/ce/CustomerImportExport.yaml
+++ b/src/_data/codebase/v2_3/mrg/ce/CustomerImportExport.yaml
@@ -1,7 +1,7 @@
 ---
 title: Magento_CustomerImportExport
 source_repo: magento2ce
-release: 2.3.4
+release: 2.3.5
 github_path: app/code/Magento/CustomerImportExport/README.md
 last_modified_at: '2014-10-31 09:04:08 -0700'
 content: 'The Magento_CustomerImportExport module handles the import and export of

--- a/src/_data/codebase/v2_3/mrg/ce/Deploy.yaml
+++ b/src/_data/codebase/v2_3/mrg/ce/Deploy.yaml
@@ -1,7 +1,7 @@
 ---
 title: Magento_Deploy
 source_repo: magento2ce
-release: 2.3.4
+release: 2.3.5
 github_path: app/code/Magento/Deploy/README.md
 last_modified_at: '2019-07-16 21:19:40 +0100'
 content: "## Purpose of module\n\nDeploy is a module that holds collection of services

--- a/src/_data/codebase/v2_3/mrg/ce/Developer.yaml
+++ b/src/_data/codebase/v2_3/mrg/ce/Developer.yaml
@@ -1,7 +1,7 @@
 ---
 title: Magento_Developer
 source_repo: magento2ce
-release: 2.3.4
+release: 2.3.5
 github_path: app/code/Magento/Developer/README.md
 last_modified_at: '2015-01-15 14:33:14 -0600'
 content: 'The Magento_Developer module provides functionality to make it easier to

--- a/src/_data/codebase/v2_3/mrg/ce/Dhl.yaml
+++ b/src/_data/codebase/v2_3/mrg/ce/Dhl.yaml
@@ -1,7 +1,7 @@
 ---
 title: Magento_Dhl
 source_repo: magento2ce
-release: 2.3.4
+release: 2.3.5
 github_path: app/code/Magento/Dhl/README.md
 last_modified_at: '2014-10-31 09:04:08 -0700'
 content: |

--- a/src/_data/codebase/v2_3/mrg/ce/Directory.yaml
+++ b/src/_data/codebase/v2_3/mrg/ce/Directory.yaml
@@ -1,7 +1,7 @@
 ---
 title: Magento_Directory
 source_repo: magento2ce
-release: 2.3.4
+release: 2.3.5
 github_path: app/code/Magento/Directory/README.md
 last_modified_at: '2014-12-12 12:14:06 -0800'
 content: |

--- a/src/_data/codebase/v2_3/mrg/ce/DirectoryGraphQl.yaml
+++ b/src/_data/codebase/v2_3/mrg/ce/DirectoryGraphQl.yaml
@@ -1,7 +1,7 @@
 ---
 title: Magento_DirectoryGraphQl
 source_repo: magento2ce
-release: 2.3.4
+release: 2.3.5
 github_path: app/code/Magento/DirectoryGraphQl/README.md
 last_modified_at: '2019-01-31 09:12:38 -0500'
 content: |

--- a/src/_data/codebase/v2_3/mrg/ce/Downloadable.yaml
+++ b/src/_data/codebase/v2_3/mrg/ce/Downloadable.yaml
@@ -1,7 +1,7 @@
 ---
 title: Magento_Downloadable
 source_repo: magento2ce
-release: 2.3.4
+release: 2.3.5
 github_path: app/code/Magento/Downloadable/README.md
 last_modified_at: '2014-12-12 12:14:06 -0800'
 content: |

--- a/src/_data/codebase/v2_3/mrg/ce/DownloadableGraphQl.yaml
+++ b/src/_data/codebase/v2_3/mrg/ce/DownloadableGraphQl.yaml
@@ -1,7 +1,7 @@
 ---
 title: Magento_DownloadableGraphQl
 source_repo: magento2ce
-release: 2.3.4
+release: 2.3.5
 github_path: app/code/Magento/DownloadableGraphQl/README.md
 last_modified_at: '2018-01-24 15:58:51 -0600'
 content: |

--- a/src/_data/codebase/v2_3/mrg/ce/DownloadableImportExport.yaml
+++ b/src/_data/codebase/v2_3/mrg/ce/DownloadableImportExport.yaml
@@ -1,7 +1,7 @@
 ---
 title: Magento_DownloadableImportExport
 source_repo: magento2ce
-release: 2.3.4
+release: 2.3.5
 github_path: app/code/Magento/DownloadableImportExport/README.md
 last_modified_at: '2015-08-10 11:16:49 +0300'
 content: 'The Magento_DownloadableImportExport module handles the import and export

--- a/src/_data/codebase/v2_3/mrg/ce/Eav.yaml
+++ b/src/_data/codebase/v2_3/mrg/ce/Eav.yaml
@@ -1,7 +1,7 @@
 ---
 title: Magento_Eav
 source_repo: magento2ce
-release: 2.3.4
+release: 2.3.5
 github_path: app/code/Magento/Eav/README.md
 last_modified_at: '2014-10-24 14:51:44 -0700'
 content: |-

--- a/src/_data/codebase/v2_3/mrg/ce/EavGraphQl.yaml
+++ b/src/_data/codebase/v2_3/mrg/ce/EavGraphQl.yaml
@@ -1,7 +1,7 @@
 ---
 title: Magento_EavGraphQl
 source_repo: magento2ce
-release: 2.3.4
+release: 2.3.5
 github_path: app/code/Magento/EavGraphQl/README.md
 last_modified_at: '2018-01-16 13:17:37 -0600'
 content: "**EavGraphQl** primarily provides the GraphQl module information to generate

--- a/src/_data/codebase/v2_3/mrg/ce/Elasticsearch.yaml
+++ b/src/_data/codebase/v2_3/mrg/ce/Elasticsearch.yaml
@@ -1,7 +1,7 @@
 ---
 title: Magento_Elasticsearch
 source_repo: magento2ce
-release: 2.3.4
+release: 2.3.5
 github_path: app/code/Magento/Elasticsearch/README.md
 last_modified_at: '2018-03-09 17:43:18 -0600'
 content: |-

--- a/src/_data/codebase/v2_3/mrg/ce/Elasticsearch6.yaml
+++ b/src/_data/codebase/v2_3/mrg/ce/Elasticsearch6.yaml
@@ -1,7 +1,7 @@
 ---
 title: Magento_Elasticsearch6
 source_repo: magento2ce
-release: 2.3.4
+release: 2.3.5
 github_path: app/code/Magento/Elasticsearch6/README.md
 last_modified_at: '2019-03-01 10:53:19 -0600'
 content: |

--- a/src/_data/codebase/v2_3/mrg/ce/Elasticsearch7.yaml
+++ b/src/_data/codebase/v2_3/mrg/ce/Elasticsearch7.yaml
@@ -1,0 +1,9 @@
+---
+title: Magento_Elasticsearch7
+source_repo: magento2ce
+release: 2.3.5
+github_path: app/code/Magento/Elasticsearch7/README.md
+last_modified_at: '2020-01-31 16:12:43 -0600'
+content: |
+  Magento\Elasticsearch7 module allows to use Elastic search engine (v7) for product searching capabilities.
+  The module implements Magento\Search library interfaces.

--- a/src/_data/codebase/v2_3/mrg/ce/Email.yaml
+++ b/src/_data/codebase/v2_3/mrg/ce/Email.yaml
@@ -1,7 +1,7 @@
 ---
 title: Magento_Email
 source_repo: magento2ce
-release: 2.3.4
+release: 2.3.5
 github_path: app/code/Magento/Email/README.md
 last_modified_at: '2014-12-12 12:14:06 -0800'
 content: |

--- a/src/_data/codebase/v2_3/mrg/ce/EncryptionKey.yaml
+++ b/src/_data/codebase/v2_3/mrg/ce/EncryptionKey.yaml
@@ -1,7 +1,7 @@
 ---
 title: Magento_EncryptionKey
 source_repo: magento2ce
-release: 2.3.4
+release: 2.3.5
 github_path: app/code/Magento/EncryptionKey/README.md
 last_modified_at: '2015-08-27 15:34:05 -0500'
 content: 'The Magento_EncryptionKey module provides an advanced encryption model to

--- a/src/_data/codebase/v2_3/mrg/ce/Fedex.yaml
+++ b/src/_data/codebase/v2_3/mrg/ce/Fedex.yaml
@@ -1,7 +1,7 @@
 ---
 title: Magento_Fedex
 source_repo: magento2ce
-release: 2.3.4
+release: 2.3.5
 github_path: app/code/Magento/Fedex/README.md
 last_modified_at: '2014-10-31 09:04:08 -0700'
 content: 'The Magento_Fedex implements the integration with the FedEx shipping carrier.

--- a/src/_data/codebase/v2_3/mrg/ce/GiftMessage.yaml
+++ b/src/_data/codebase/v2_3/mrg/ce/GiftMessage.yaml
@@ -1,7 +1,7 @@
 ---
 title: Magento_GiftMessage
 source_repo: magento2ce
-release: 2.3.4
+release: 2.3.5
 github_path: app/code/Magento/GiftMessage/README.md
 last_modified_at: '2014-10-24 14:51:44 -0700'
 content: Magento\GiftMessage module allows to add a message to order or to each ordered

--- a/src/_data/codebase/v2_3/mrg/ce/GoogleAdwords.yaml
+++ b/src/_data/codebase/v2_3/mrg/ce/GoogleAdwords.yaml
@@ -1,7 +1,7 @@
 ---
 title: Magento_GoogleAdwords
 source_repo: magento2ce
-release: 2.3.4
+release: 2.3.5
 github_path: app/code/Magento/GoogleAdwords/README.md
 last_modified_at: '2014-12-12 12:14:06 -0800'
 content: 'GoogleAdwords is a module designed for integration of Google Adwords service.

--- a/src/_data/codebase/v2_3/mrg/ce/GoogleAnalytics.yaml
+++ b/src/_data/codebase/v2_3/mrg/ce/GoogleAnalytics.yaml
@@ -1,7 +1,7 @@
 ---
 title: Magento_GoogleAnalytics
 source_repo: magento2ce
-release: 2.3.4
+release: 2.3.5
 github_path: app/code/Magento/GoogleAnalytics/README.md
 last_modified_at: '2014-12-12 12:14:06 -0800'
 content: 'Magento_GoogleAnalytics is a module for integration with Google Analytics

--- a/src/_data/codebase/v2_3/mrg/ce/GoogleOptimizer.yaml
+++ b/src/_data/codebase/v2_3/mrg/ce/GoogleOptimizer.yaml
@@ -1,7 +1,7 @@
 ---
 title: Magento_GoogleOptimizer
 source_repo: magento2ce
-release: 2.3.4
+release: 2.3.5
 github_path: app/code/Magento/GoogleOptimizer/README.md
 last_modified_at: '2014-12-12 12:14:06 -0800'
 content: "Magento_GoogleOptimizer module implements functionality of Google Experiment

--- a/src/_data/codebase/v2_3/mrg/ce/GraphQl.yaml
+++ b/src/_data/codebase/v2_3/mrg/ce/GraphQl.yaml
@@ -1,7 +1,7 @@
 ---
 title: Magento_GraphQl
 source_repo: magento2ce
-release: 2.3.4
+release: 2.3.5
 github_path: app/code/Magento/GraphQl/README.md
 last_modified_at: '2017-10-25 11:14:11 -0500'
 content: "**GraphQl** provides the framework for the application to expose GraphQL

--- a/src/_data/codebase/v2_3/mrg/ce/GraphQlCache.yaml
+++ b/src/_data/codebase/v2_3/mrg/ce/GraphQlCache.yaml
@@ -1,7 +1,7 @@
 ---
 title: Magento_GraphQlCache
 source_repo: magento2ce
-release: 2.3.4
+release: 2.3.5
 github_path: app/code/Magento/GraphQlCache/README.md
 last_modified_at: '2019-04-08 11:49:04 -0500'
 content: "**GraphQL Cache** provides the ability to cache GraphQL queries.\nThis module

--- a/src/_data/codebase/v2_3/mrg/ce/GroupedCatalogInventory.yaml
+++ b/src/_data/codebase/v2_3/mrg/ce/GroupedCatalogInventory.yaml
@@ -1,7 +1,7 @@
 ---
 title: Magento_GroupedCatalogInventory
 source_repo: magento2ce
-release: 2.3.4
+release: 2.3.5
 github_path: app/code/Magento/GroupedCatalogInventory/README.md
 last_modified_at: '2018-11-27 16:04:57 -0600'
 content: 'Magento_GroupedCatalogInventory contains behavior related to the inventory

--- a/src/_data/codebase/v2_3/mrg/ce/GroupedProduct.yaml
+++ b/src/_data/codebase/v2_3/mrg/ce/GroupedProduct.yaml
@@ -1,7 +1,7 @@
 ---
 title: Magento_GroupedProduct
 source_repo: magento2ce
-release: 2.3.4
+release: 2.3.5
 github_path: app/code/Magento/GroupedProduct/README.md
 last_modified_at: '2014-12-12 12:14:06 -0800'
 content: |

--- a/src/_data/codebase/v2_3/mrg/ce/GroupedProductGraphQl.yaml
+++ b/src/_data/codebase/v2_3/mrg/ce/GroupedProductGraphQl.yaml
@@ -1,7 +1,7 @@
 ---
 title: Magento_GroupedProductGraphQl
 source_repo: magento2ce
-release: 2.3.4
+release: 2.3.5
 github_path: app/code/Magento/GroupedProductGraphQl/README.md
 last_modified_at: '2018-01-29 15:12:49 -0600'
 content: |

--- a/src/_data/codebase/v2_3/mrg/ce/ImportExport.yaml
+++ b/src/_data/codebase/v2_3/mrg/ce/ImportExport.yaml
@@ -1,7 +1,7 @@
 ---
 title: Magento_ImportExport
 source_repo: magento2ce
-release: 2.3.4
+release: 2.3.5
 github_path: app/code/Magento/ImportExport/README.md
 last_modified_at: '2014-12-12 12:14:06 -0800'
 content: |

--- a/src/_data/codebase/v2_3/mrg/ce/Indexer.yaml
+++ b/src/_data/codebase/v2_3/mrg/ce/Indexer.yaml
@@ -1,7 +1,7 @@
 ---
 title: Magento_Indexer
 source_repo: magento2ce
-release: 2.3.4
+release: 2.3.5
 github_path: app/code/Magento/Indexer/README.md
 last_modified_at: '2016-04-11 18:16:09 +0300'
 content: |-

--- a/src/_data/codebase/v2_3/mrg/ce/InstantPurchase.yaml
+++ b/src/_data/codebase/v2_3/mrg/ce/InstantPurchase.yaml
@@ -1,7 +1,7 @@
 ---
 title: Magento_InstantPurchase
 source_repo: magento2ce
-release: 2.3.4
+release: 2.3.5
 github_path: app/code/Magento/InstantPurchase/README.md
 last_modified_at: '2019-08-06 14:40:28 -0500'
 content: |

--- a/src/_data/codebase/v2_3/mrg/ce/Integration.yaml
+++ b/src/_data/codebase/v2_3/mrg/ce/Integration.yaml
@@ -1,7 +1,7 @@
 ---
 title: Magento_Integration
 source_repo: magento2ce
-release: 2.3.4
+release: 2.3.5
 github_path: app/code/Magento/Integration/README.md
 last_modified_at: '2014-12-12 12:14:06 -0800'
 content: |

--- a/src/_data/codebase/v2_3/mrg/ce/LayeredNavigation.yaml
+++ b/src/_data/codebase/v2_3/mrg/ce/LayeredNavigation.yaml
@@ -1,7 +1,7 @@
 ---
 title: Magento_LayeredNavigation
 source_repo: magento2ce
-release: 2.3.4
+release: 2.3.5
 github_path: app/code/Magento/LayeredNavigation/README.md
 last_modified_at: '2014-12-12 12:14:06 -0800'
 content: |

--- a/src/_data/codebase/v2_3/mrg/ce/Marketplace.yaml
+++ b/src/_data/codebase/v2_3/mrg/ce/Marketplace.yaml
@@ -1,7 +1,7 @@
 ---
 title: Magento_Marketplace
 source_repo: magento2ce
-release: 2.3.4
+release: 2.3.5
 github_path: app/code/Magento/Marketplace/README.md
 last_modified_at: '2015-10-02 13:02:03 +0300'
 content: The Magento_Marketplace module allows to display partners of Magento in the

--- a/src/_data/codebase/v2_3/mrg/ce/MediaGallery.yaml
+++ b/src/_data/codebase/v2_3/mrg/ce/MediaGallery.yaml
@@ -1,7 +1,7 @@
 ---
 title: Magento_MediaGallery
 source_repo: magento2ce
-release: 2.3.4
+release: 2.3.5
 github_path: app/code/Magento/MediaGallery/README.md
 last_modified_at: '2019-11-04 11:34:55 +0000'
 content: |

--- a/src/_data/codebase/v2_3/mrg/ce/MediaGalleryApi.yaml
+++ b/src/_data/codebase/v2_3/mrg/ce/MediaGalleryApi.yaml
@@ -1,7 +1,7 @@
 ---
 title: Magento_MediaGalleryApi
 source_repo: magento2ce
-release: 2.3.4
+release: 2.3.5
 github_path: app/code/Magento/MediaGalleryApi/README.md
 last_modified_at: '2019-11-04 11:34:55 +0000'
 content: |

--- a/src/_data/codebase/v2_3/mrg/ce/MediaStorage.yaml
+++ b/src/_data/codebase/v2_3/mrg/ce/MediaStorage.yaml
@@ -1,7 +1,7 @@
 ---
 title: Magento_MediaStorage
 source_repo: magento2ce
-release: 2.3.4
+release: 2.3.5
 github_path: app/code/Magento/MediaStorage/README.md
 last_modified_at: '2015-02-26 14:04:15 +0200'
 content: 'The Magento_MediaStorage module implements functionality related with upload

--- a/src/_data/codebase/v2_3/mrg/ce/MessageQueue.yaml
+++ b/src/_data/codebase/v2_3/mrg/ce/MessageQueue.yaml
@@ -1,7 +1,7 @@
 ---
 title: Magento_MessageQueue
 source_repo: magento2ce
-release: 2.3.4
+release: 2.3.5
 github_path: app/code/Magento/MessageQueue/README.md
 last_modified_at: '2018-02-21 14:27:13 +0200'
 content: "**MessageQueue** provides support of Advanced Message Queuing Protocol\n"

--- a/src/_data/codebase/v2_3/mrg/ce/MsrpConfigurableProduct.yaml
+++ b/src/_data/codebase/v2_3/mrg/ce/MsrpConfigurableProduct.yaml
@@ -1,7 +1,7 @@
 ---
 title: Magento_MsrpConfigurableProduct
 source_repo: magento2ce
-release: 2.3.4
+release: 2.3.5
 github_path: app/code/Magento/MsrpConfigurableProduct/README.md
 last_modified_at: '2019-03-02 19:21:49 -0600'
 content: "**MsrpConfigurableProduct** provides type and resolver information for the

--- a/src/_data/codebase/v2_3/mrg/ce/MsrpGroupedProduct.yaml
+++ b/src/_data/codebase/v2_3/mrg/ce/MsrpGroupedProduct.yaml
@@ -1,7 +1,7 @@
 ---
 title: Magento_MsrpGroupedProduct
 source_repo: magento2ce
-release: 2.3.4
+release: 2.3.5
 github_path: app/code/Magento/MsrpGroupedProduct/README.md
 last_modified_at: '2019-03-02 19:21:49 -0600'
 content: "**MsrpGroupedProduct** provides type and resolver information for the Msrp

--- a/src/_data/codebase/v2_3/mrg/ce/Multishipping.yaml
+++ b/src/_data/codebase/v2_3/mrg/ce/Multishipping.yaml
@@ -1,7 +1,7 @@
 ---
 title: Magento_Multishipping
 source_repo: magento2ce
-release: 2.3.4
+release: 2.3.5
 github_path: app/code/Magento/Multishipping/README.md
 last_modified_at: '2014-10-24 14:51:44 -0700'
 content: |-

--- a/src/_data/codebase/v2_3/mrg/ce/MysqlMq.yaml
+++ b/src/_data/codebase/v2_3/mrg/ce/MysqlMq.yaml
@@ -1,7 +1,7 @@
 ---
 title: Magento_MysqlMq
 source_repo: magento2ce
-release: 2.3.4
+release: 2.3.5
 github_path: app/code/Magento/MysqlMq/README.md
 last_modified_at: '2018-02-21 14:27:42 +0200'
 content: "**MysqlMq** provides message queue implementation based on MySQL.\n"

--- a/src/_data/codebase/v2_3/mrg/ce/NewRelicReporting.yaml
+++ b/src/_data/codebase/v2_3/mrg/ce/NewRelicReporting.yaml
@@ -1,7 +1,7 @@
 ---
 title: Magento_NewRelicReporting
 source_repo: magento2ce
-release: 2.3.4
+release: 2.3.5
 github_path: app/code/Magento/NewRelicReporting/README.md
 last_modified_at: '2015-10-01 16:15:45 +0300'
 content: "Module Magento\\NewRelicReporting implements integration New Relic APM and

--- a/src/_data/codebase/v2_3/mrg/ce/Newsletter.yaml
+++ b/src/_data/codebase/v2_3/mrg/ce/Newsletter.yaml
@@ -1,7 +1,7 @@
 ---
 title: Magento_Newsletter
 source_repo: magento2ce
-release: 2.3.4
+release: 2.3.5
 github_path: app/code/Magento/Newsletter/README.md
 last_modified_at: '2014-12-12 12:14:06 -0800'
 content: 'Magento_Newsletter module allows clients to subscribe for information about

--- a/src/_data/codebase/v2_3/mrg/ce/OfflinePayments.yaml
+++ b/src/_data/codebase/v2_3/mrg/ce/OfflinePayments.yaml
@@ -1,7 +1,7 @@
 ---
 title: Magento_OfflinePayments
 source_repo: magento2ce
-release: 2.3.4
+release: 2.3.5
 github_path: app/code/Magento/OfflinePayments/README.md
 last_modified_at: '2014-10-31 09:04:08 -0700'
 content: |

--- a/src/_data/codebase/v2_3/mrg/ce/OfflineShipping.yaml
+++ b/src/_data/codebase/v2_3/mrg/ce/OfflineShipping.yaml
@@ -1,7 +1,7 @@
 ---
 title: Magento_OfflineShipping
 source_repo: magento2ce
-release: 2.3.4
+release: 2.3.5
 github_path: app/code/Magento/OfflineShipping/README.md
 last_modified_at: '2014-10-31 09:04:08 -0700'
 content: |+

--- a/src/_data/codebase/v2_3/mrg/ce/PageCache.yaml
+++ b/src/_data/codebase/v2_3/mrg/ce/PageCache.yaml
@@ -1,7 +1,7 @@
 ---
 title: Magento_PageCache
 source_repo: magento2ce
-release: 2.3.4
+release: 2.3.5
 github_path: app/code/Magento/PageCache/README.md
 last_modified_at: '2014-10-24 14:51:44 -0700'
 content: |-

--- a/src/_data/codebase/v2_3/mrg/ce/Payment.yaml
+++ b/src/_data/codebase/v2_3/mrg/ce/Payment.yaml
@@ -1,7 +1,7 @@
 ---
 title: Magento_Payment
 source_repo: magento2ce
-release: 2.3.4
+release: 2.3.5
 github_path: app/code/Magento/Payment/README.md
 last_modified_at: '2014-10-31 09:04:08 -0700'
 content: |

--- a/src/_data/codebase/v2_3/mrg/ce/Paypal.yaml
+++ b/src/_data/codebase/v2_3/mrg/ce/Paypal.yaml
@@ -1,7 +1,7 @@
 ---
 title: Magento_Paypal
 source_repo: magento2ce
-release: 2.3.4
+release: 2.3.5
 github_path: app/code/Magento/Paypal/README.md
 last_modified_at: '2019-03-31 18:42:40 +0300'
 content: |

--- a/src/_data/codebase/v2_3/mrg/ce/PaypalCaptcha.yaml
+++ b/src/_data/codebase/v2_3/mrg/ce/PaypalCaptcha.yaml
@@ -1,7 +1,7 @@
 ---
 title: Magento_PaypalCaptcha
 source_repo: magento2ce
-release: 2.3.4
+release: 2.3.5
 github_path: app/code/Magento/PaypalCaptcha/README.md
 last_modified_at: '2019-03-21 15:00:40 -0500'
 content: The PayPal Captcha module provides a possibility to enable Captcha validation

--- a/src/_data/codebase/v2_3/mrg/ce/PaypalGraphQl.yaml
+++ b/src/_data/codebase/v2_3/mrg/ce/PaypalGraphQl.yaml
@@ -1,7 +1,7 @@
 ---
 title: Magento_PaypalGraphQl
 source_repo: magento2ce
-release: 2.3.4
+release: 2.3.5
 github_path: app/code/Magento/PaypalGraphQl/README.md
 last_modified_at: '2019-05-23 10:50:05 -0500'
 content: "**PaypalGraphQl** provides resolver information for using Paypal payment

--- a/src/_data/codebase/v2_3/mrg/ce/Persistent.yaml
+++ b/src/_data/codebase/v2_3/mrg/ce/Persistent.yaml
@@ -1,7 +1,7 @@
 ---
 title: Magento_Persistent
 source_repo: magento2ce
-release: 2.3.4
+release: 2.3.5
 github_path: app/code/Magento/Persistent/README.md
 last_modified_at: '2014-10-24 14:51:44 -0700'
 content: |

--- a/src/_data/codebase/v2_3/mrg/ce/ProductAlert.yaml
+++ b/src/_data/codebase/v2_3/mrg/ce/ProductAlert.yaml
@@ -1,7 +1,7 @@
 ---
 title: Magento_ProductAlert
 source_repo: magento2ce
-release: 2.3.4
+release: 2.3.5
 github_path: app/code/Magento/ProductAlert/README.md
 last_modified_at: '2014-10-31 09:04:08 -0700'
 content: 'The Magento_ProductAlert module enables product alerts, which allow customers

--- a/src/_data/codebase/v2_3/mrg/ce/ProductVideo.yaml
+++ b/src/_data/codebase/v2_3/mrg/ce/ProductVideo.yaml
@@ -1,7 +1,7 @@
 ---
 title: Magento_ProductVideo
 source_repo: magento2ce
-release: 2.3.4
+release: 2.3.5
 github_path: app/code/Magento/ProductVideo/README.md
 last_modified_at: '2015-09-11 16:19:20 +0300'
 content: 'The Magento_ProductVideo module implements functionality related with linking

--- a/src/_data/codebase/v2_3/mrg/ce/Quote.yaml
+++ b/src/_data/codebase/v2_3/mrg/ce/Quote.yaml
@@ -1,7 +1,7 @@
 ---
 title: Magento_Quote
 source_repo: magento2ce
-release: 2.3.4
+release: 2.3.5
 github_path: app/code/Magento/Quote/README.md
 last_modified_at: '2015-01-06 12:45:10 +0200'
 content: |

--- a/src/_data/codebase/v2_3/mrg/ce/QuoteAnalytics.yaml
+++ b/src/_data/codebase/v2_3/mrg/ce/QuoteAnalytics.yaml
@@ -1,7 +1,7 @@
 ---
 title: Magento_QuoteAnalytics
 source_repo: magento2ce
-release: 2.3.4
+release: 2.3.5
 github_path: app/code/Magento/QuoteAnalytics/README.md
 last_modified_at: '2019-08-06 14:40:28 -0500'
 content: 'The Magento_QuoteAnalytics module configures data definitions for a data

--- a/src/_data/codebase/v2_3/mrg/ce/QuoteGraphQl.yaml
+++ b/src/_data/codebase/v2_3/mrg/ce/QuoteGraphQl.yaml
@@ -1,7 +1,7 @@
 ---
 title: Magento_QuoteGraphQl
 source_repo: magento2ce
-release: 2.3.4
+release: 2.3.5
 github_path: app/code/Magento/QuoteGraphQl/README.md
 last_modified_at: '2018-07-31 14:11:47 +0200'
 content: |

--- a/src/_data/codebase/v2_3/mrg/ce/RelatedProductGraphQl.yaml
+++ b/src/_data/codebase/v2_3/mrg/ce/RelatedProductGraphQl.yaml
@@ -1,7 +1,7 @@
 ---
 title: Magento_RelatedProductGraphQl
 source_repo: magento2ce
-release: 2.3.4
+release: 2.3.5
 github_path: app/code/Magento/RelatedProductGraphQl/README.md
 last_modified_at: '2019-05-08 12:53:00 -0500'
 content: "**RelatedProductGraphQl** provides endpoints for getting  Cross Sell / Related/

--- a/src/_data/codebase/v2_3/mrg/ce/ReleaseNotification.yaml
+++ b/src/_data/codebase/v2_3/mrg/ce/ReleaseNotification.yaml
@@ -1,7 +1,7 @@
 ---
 title: Magento_ReleaseNotification
 source_repo: magento2ce
-release: 2.3.4
+release: 2.3.5
 github_path: app/code/Magento/ReleaseNotification/README.md
 last_modified_at: '2019-09-06 19:55:12 +0300'
 content: "The **Release Notification Module** serves to provide a notification delivery

--- a/src/_data/codebase/v2_3/mrg/ce/Reports.yaml
+++ b/src/_data/codebase/v2_3/mrg/ce/Reports.yaml
@@ -1,7 +1,7 @@
 ---
 title: Magento_Reports
 source_repo: magento2ce
-release: 2.3.4
+release: 2.3.5
 github_path: app/code/Magento/Reports/README.md
 last_modified_at: '2014-12-12 12:14:06 -0800'
 content: |

--- a/src/_data/codebase/v2_3/mrg/ce/RequireJs.yaml
+++ b/src/_data/codebase/v2_3/mrg/ce/RequireJs.yaml
@@ -1,7 +1,7 @@
 ---
 title: Magento_RequireJs
 source_repo: magento2ce
-release: 2.3.4
+release: 2.3.5
 github_path: app/code/Magento/RequireJs/README.md
 last_modified_at: '2014-11-28 11:40:11 -0800'
 content: |

--- a/src/_data/codebase/v2_3/mrg/ce/Review.yaml
+++ b/src/_data/codebase/v2_3/mrg/ce/Review.yaml
@@ -1,7 +1,7 @@
 ---
 title: Magento_Review
 source_repo: magento2ce
-release: 2.3.4
+release: 2.3.5
 github_path: app/code/Magento/Review/README.md
 last_modified_at: '2014-12-12 12:14:06 -0800'
 content: 'Magento_Review module functionality allows to write reviews for products.

--- a/src/_data/codebase/v2_3/mrg/ce/ReviewAnalytics.yaml
+++ b/src/_data/codebase/v2_3/mrg/ce/ReviewAnalytics.yaml
@@ -1,7 +1,7 @@
 ---
 title: Magento_ReviewAnalytics
 source_repo: magento2ce
-release: 2.3.4
+release: 2.3.5
 github_path: app/code/Magento/ReviewAnalytics/README.md
 last_modified_at: '2019-08-06 14:40:28 -0500'
 content: 'The Magento_ReviewAnalytics module configures data definitions for a data

--- a/src/_data/codebase/v2_3/mrg/ce/Robots.yaml
+++ b/src/_data/codebase/v2_3/mrg/ce/Robots.yaml
@@ -1,7 +1,7 @@
 ---
 title: Magento_Robots
 source_repo: magento2ce
-release: 2.3.4
+release: 2.3.5
 github_path: app/code/Magento/Robots/README.md
 last_modified_at: '2017-06-15 17:15:28 +0300'
 content: "The Robots module provides the following functionalities: \n* contains a

--- a/src/_data/codebase/v2_3/mrg/ce/Rss.yaml
+++ b/src/_data/codebase/v2_3/mrg/ce/Rss.yaml
@@ -1,7 +1,7 @@
 ---
 title: Magento_Rss
 source_repo: magento2ce
-release: 2.3.4
+release: 2.3.5
 github_path: app/code/Magento/Rss/README.md
 last_modified_at: '2014-12-12 12:14:06 -0800'
 content: 'Magento_Rss module is responsible for processing all RSS feeds of the application

--- a/src/_data/codebase/v2_3/mrg/ce/Rule.yaml
+++ b/src/_data/codebase/v2_3/mrg/ce/Rule.yaml
@@ -1,7 +1,7 @@
 ---
 title: Magento_Rule
 source_repo: magento2ce
-release: 2.3.4
+release: 2.3.5
 github_path: app/code/Magento/Rule/README.md
 last_modified_at: '2014-12-12 12:14:06 -0800'
 content: 'Magento_Rule module provides abstract implementation of rules and rule conditions

--- a/src/_data/codebase/v2_3/mrg/ce/Sales.yaml
+++ b/src/_data/codebase/v2_3/mrg/ce/Sales.yaml
@@ -1,7 +1,7 @@
 ---
 title: Magento_Sales
 source_repo: magento2ce
-release: 2.3.4
+release: 2.3.5
 github_path: app/code/Magento/Sales/README.md
 last_modified_at: '2014-10-24 14:51:44 -0700'
 content: |

--- a/src/_data/codebase/v2_3/mrg/ce/SalesAnalytics.yaml
+++ b/src/_data/codebase/v2_3/mrg/ce/SalesAnalytics.yaml
@@ -1,7 +1,7 @@
 ---
 title: Magento_SalesAnalytics
 source_repo: magento2ce
-release: 2.3.4
+release: 2.3.5
 github_path: app/code/Magento/SalesAnalytics/README.md
 last_modified_at: '2019-08-06 14:40:28 -0500'
 content: 'The Magento_SalesAnalytics module configures data definitions for a data

--- a/src/_data/codebase/v2_3/mrg/ce/SalesGraphQl.yaml
+++ b/src/_data/codebase/v2_3/mrg/ce/SalesGraphQl.yaml
@@ -1,7 +1,7 @@
 ---
 title: Magento_SalesGraphQl
 source_repo: magento2ce
-release: 2.3.4
+release: 2.3.5
 github_path: app/code/Magento/SalesGraphQl/README.md
 last_modified_at: '2018-10-15 19:46:32 +0300'
 content: |

--- a/src/_data/codebase/v2_3/mrg/ce/SalesInventory.yaml
+++ b/src/_data/codebase/v2_3/mrg/ce/SalesInventory.yaml
@@ -1,7 +1,7 @@
 ---
 title: Magento_SalesInventory
 source_repo: magento2ce
-release: 2.3.4
+release: 2.3.5
 github_path: app/code/Magento/SalesInventory/README.md
 last_modified_at: '2016-09-21 16:39:44 +0300'
 content: 'Magento_SalesInventory module allows retrieve and update stock attributes

--- a/src/_data/codebase/v2_3/mrg/ce/SalesRule.yaml
+++ b/src/_data/codebase/v2_3/mrg/ce/SalesRule.yaml
@@ -1,7 +1,7 @@
 ---
 title: Magento_SalesRule
 source_repo: magento2ce
-release: 2.3.4
+release: 2.3.5
 github_path: app/code/Magento/SalesRule/README.md
 last_modified_at: '2014-10-24 14:51:44 -0700'
 content: "SalesRule module is responsible for managing and processing Promotion Shopping

--- a/src/_data/codebase/v2_3/mrg/ce/SalesSequence.yaml
+++ b/src/_data/codebase/v2_3/mrg/ce/SalesSequence.yaml
@@ -1,7 +1,7 @@
 ---
 title: Magento_SalesSequence
 source_repo: magento2ce
-release: 2.3.4
+release: 2.3.5
 github_path: app/code/Magento/SalesSequence/README.md
 last_modified_at: '2015-03-20 16:50:43 +0200'
 content: |

--- a/src/_data/codebase/v2_3/mrg/ce/SampleData.yaml
+++ b/src/_data/codebase/v2_3/mrg/ce/SampleData.yaml
@@ -1,7 +1,7 @@
 ---
 title: Magento_SampleData
 source_repo: magento2ce
-release: 2.3.4
+release: 2.3.5
 github_path: app/code/Magento/SampleData/README.md
 last_modified_at: '2019-08-06 14:40:28 -0500'
 content: |

--- a/src/_data/codebase/v2_3/mrg/ce/Search.yaml
+++ b/src/_data/codebase/v2_3/mrg/ce/Search.yaml
@@ -1,7 +1,7 @@
 ---
 title: Magento_Search
 source_repo: magento2ce
-release: 2.3.4
+release: 2.3.5
 github_path: app/code/Magento/Search/README.md
 last_modified_at: '2014-12-12 12:14:06 -0800'
 content: 'Magento_Search module introduces basic search functionality and provides

--- a/src/_data/codebase/v2_3/mrg/ce/Security.yaml
+++ b/src/_data/codebase/v2_3/mrg/ce/Security.yaml
@@ -1,7 +1,7 @@
 ---
 title: Magento_Security
 source_repo: magento2ce
-release: 2.3.4
+release: 2.3.5
 github_path: app/code/Magento/Security/README.md
 last_modified_at: '2016-01-11 17:45:47 +0300'
 content: |

--- a/src/_data/codebase/v2_3/mrg/ce/SendFriend.yaml
+++ b/src/_data/codebase/v2_3/mrg/ce/SendFriend.yaml
@@ -1,7 +1,7 @@
 ---
 title: Magento_SendFriend
 source_repo: magento2ce
-release: 2.3.4
+release: 2.3.5
 github_path: app/code/Magento/SendFriend/README.md
 last_modified_at: '2015-06-02 12:45:34 +0300'
 content: 'The Magento_SendFriend implements the functionality behind the "Email to

--- a/src/_data/codebase/v2_3/mrg/ce/SendFriendGraphQl.yaml
+++ b/src/_data/codebase/v2_3/mrg/ce/SendFriendGraphQl.yaml
@@ -1,7 +1,7 @@
 ---
 title: Magento_SendFriendGraphQl
 source_repo: magento2ce
-release: 2.3.4
+release: 2.3.5
 github_path: app/code/Magento/SendFriendGraphQl/README.md
 last_modified_at: '2018-11-19 20:18:31 +0200'
 content: "**SendFriendGraphQl** provides support of GraphQL for SendFriend functionality.\n"

--- a/src/_data/codebase/v2_3/mrg/ce/Shipping.yaml
+++ b/src/_data/codebase/v2_3/mrg/ce/Shipping.yaml
@@ -1,7 +1,7 @@
 ---
 title: Magento_Shipping
 source_repo: magento2ce
-release: 2.3.4
+release: 2.3.5
 github_path: app/code/Magento/Shipping/README.md
 last_modified_at: '2014-10-31 09:04:08 -0700'
 content: |

--- a/src/_data/codebase/v2_3/mrg/ce/Signifyd.yaml
+++ b/src/_data/codebase/v2_3/mrg/ce/Signifyd.yaml
@@ -1,7 +1,7 @@
 ---
 title: Magento_Signifyd
 source_repo: magento2ce
-release: 2.3.4
+release: 2.3.5
 github_path: app/code/Magento/Signifyd/README.md
 last_modified_at: '2019-08-06 14:40:28 -0500'
 content: |

--- a/src/_data/codebase/v2_3/mrg/ce/Sitemap.yaml
+++ b/src/_data/codebase/v2_3/mrg/ce/Sitemap.yaml
@@ -1,7 +1,7 @@
 ---
 title: Magento_Sitemap
 source_repo: magento2ce
-release: 2.3.4
+release: 2.3.5
 github_path: app/code/Magento/Sitemap/README.md
 last_modified_at: '2014-07-11 11:30:21 -0700'
 content: |-

--- a/src/_data/codebase/v2_3/mrg/ce/Store.yaml
+++ b/src/_data/codebase/v2_3/mrg/ce/Store.yaml
@@ -1,7 +1,7 @@
 ---
 title: Magento_Store
 source_repo: magento2ce
-release: 2.3.4
+release: 2.3.5
 github_path: app/code/Magento/Store/README.md
 last_modified_at: '2014-10-24 14:51:44 -0700'
 content: |-

--- a/src/_data/codebase/v2_3/mrg/ce/StoreGraphQl.yaml
+++ b/src/_data/codebase/v2_3/mrg/ce/StoreGraphQl.yaml
@@ -1,7 +1,7 @@
 ---
 title: Magento_StoreGraphQl
 source_repo: magento2ce
-release: 2.3.4
+release: 2.3.5
 github_path: app/code/Magento/StoreGraphQl/README.md
 last_modified_at: '2018-04-09 17:36:37 -0500'
 content: |

--- a/src/_data/codebase/v2_3/mrg/ce/Swagger.yaml
+++ b/src/_data/codebase/v2_3/mrg/ce/Swagger.yaml
@@ -1,7 +1,7 @@
 ---
 title: Magento_Swagger
 source_repo: magento2ce
-release: 2.3.4
+release: 2.3.5
 github_path: app/code/Magento/Swagger/README.md
 last_modified_at: '2015-08-14 15:14:44 -0500'
 content: |

--- a/src/_data/codebase/v2_3/mrg/ce/SwaggerWebapi.yaml
+++ b/src/_data/codebase/v2_3/mrg/ce/SwaggerWebapi.yaml
@@ -1,7 +1,7 @@
 ---
 title: Magento_SwaggerWebapi
 source_repo: magento2ce
-release: 2.3.4
+release: 2.3.5
 github_path: app/code/Magento/SwaggerWebapi/README.md
 last_modified_at: '2018-03-23 17:48:45 +1300'
 content: The Magento_SwaggerWebapi module provides the implementation of the REST

--- a/src/_data/codebase/v2_3/mrg/ce/SwaggerWebapiAsync.yaml
+++ b/src/_data/codebase/v2_3/mrg/ce/SwaggerWebapiAsync.yaml
@@ -1,7 +1,7 @@
 ---
 title: Magento_SwaggerWebapiAsync
 source_repo: magento2ce
-release: 2.3.4
+release: 2.3.5
 github_path: app/code/Magento/SwaggerWebapiAsync/README.md
 last_modified_at: '2018-03-23 17:48:46 +1300'
 content: The Magento_SwaggerWebapiAsync module provides the implementation of the

--- a/src/_data/codebase/v2_3/mrg/ce/Swatches.yaml
+++ b/src/_data/codebase/v2_3/mrg/ce/Swatches.yaml
@@ -1,7 +1,7 @@
 ---
 title: Magento_Swatches
 source_repo: magento2ce
-release: 2.3.4
+release: 2.3.5
 github_path: app/code/Magento/Swatches/README.md
 last_modified_at: '2015-07-28 12:18:39 +0300'
 content: Magento_Swatches module is replacing default product attributes text values

--- a/src/_data/codebase/v2_3/mrg/ce/SwatchesGraphQl.yaml
+++ b/src/_data/codebase/v2_3/mrg/ce/SwatchesGraphQl.yaml
@@ -1,7 +1,7 @@
 ---
 title: Magento_SwatchesGraphQl
 source_repo: magento2ce
-release: 2.3.4
+release: 2.3.5
 github_path: app/code/Magento/SwatchesGraphQl/README.md
 last_modified_at: '2018-01-16 16:07:17 -0600'
 content: |

--- a/src/_data/codebase/v2_3/mrg/ce/SwatchesLayeredNavigation.yaml
+++ b/src/_data/codebase/v2_3/mrg/ce/SwatchesLayeredNavigation.yaml
@@ -1,7 +1,7 @@
 ---
 title: Magento_SwatchesLayeredNavigation
 source_repo: magento2ce
-release: 2.3.4
+release: 2.3.5
 github_path: app/code/Magento/SwatchesLayeredNavigation/README.md
 last_modified_at: '2016-03-10 13:38:33 +0200'
 content: |

--- a/src/_data/codebase/v2_3/mrg/ce/Tax.yaml
+++ b/src/_data/codebase/v2_3/mrg/ce/Tax.yaml
@@ -1,7 +1,7 @@
 ---
 title: Magento_Tax
 source_repo: magento2ce
-release: 2.3.4
+release: 2.3.5
 github_path: app/code/Magento/Tax/README.md
 last_modified_at: '2014-10-24 14:51:44 -0700'
 content: |-

--- a/src/_data/codebase/v2_3/mrg/ce/TaxGraphQl.yaml
+++ b/src/_data/codebase/v2_3/mrg/ce/TaxGraphQl.yaml
@@ -1,7 +1,7 @@
 ---
 title: Magento_TaxGraphQl
 source_repo: magento2ce
-release: 2.3.4
+release: 2.3.5
 github_path: app/code/Magento/TaxGraphQl/README.md
 last_modified_at: '2018-01-16 16:07:17 -0600'
 content: |

--- a/src/_data/codebase/v2_3/mrg/ce/Theme.yaml
+++ b/src/_data/codebase/v2_3/mrg/ce/Theme.yaml
@@ -1,7 +1,7 @@
 ---
 title: Magento_Theme
 source_repo: magento2ce
-release: 2.3.4
+release: 2.3.5
 github_path: app/code/Magento/Theme/README.md
 last_modified_at: '2014-07-11 11:30:21 -0700'
 content: The Theme module contains common infrastructure that provides an ability

--- a/src/_data/codebase/v2_3/mrg/ce/ThemeGraphQl.yaml
+++ b/src/_data/codebase/v2_3/mrg/ce/ThemeGraphQl.yaml
@@ -1,7 +1,7 @@
 ---
 title: Magento_ThemeGraphQl
 source_repo: magento2ce
-release: 2.3.4
+release: 2.3.5
 github_path: app/code/Magento/ThemeGraphQl/README.md
 last_modified_at: '2018-12-06 10:59:37 -0500'
 content: |

--- a/src/_data/codebase/v2_3/mrg/ce/Tinymce3.yaml
+++ b/src/_data/codebase/v2_3/mrg/ce/Tinymce3.yaml
@@ -1,7 +1,7 @@
 ---
 title: Magento_Tinymce3
 source_repo: magento2ce
-release: 2.3.4
+release: 2.3.5
 github_path: app/code/Magento/Tinymce3/README.md
 last_modified_at: '2018-05-14 17:18:09 -0500'
 content: We have updated the TinyMCE module to the latest available version, 4.6.4.

--- a/src/_data/codebase/v2_3/mrg/ce/Translation.yaml
+++ b/src/_data/codebase/v2_3/mrg/ce/Translation.yaml
@@ -1,7 +1,7 @@
 ---
 title: Magento_Translation
 source_repo: magento2ce
-release: 2.3.4
+release: 2.3.5
 github_path: app/code/Magento/Translation/README.md
 last_modified_at: '2014-12-12 12:14:06 -0800'
 content: |

--- a/src/_data/codebase/v2_3/mrg/ce/Ui.yaml
+++ b/src/_data/codebase/v2_3/mrg/ce/Ui.yaml
@@ -1,7 +1,7 @@
 ---
 title: Magento_Ui
 source_repo: magento2ce
-release: 2.3.4
+release: 2.3.5
 github_path: app/code/Magento/Ui/README.md
 last_modified_at: '2016-08-05 21:54:51 +1200'
 content: |

--- a/src/_data/codebase/v2_3/mrg/ce/Ups.yaml
+++ b/src/_data/codebase/v2_3/mrg/ce/Ups.yaml
@@ -1,7 +1,7 @@
 ---
 title: Magento_Ups
 source_repo: magento2ce
-release: 2.3.4
+release: 2.3.5
 github_path: app/code/Magento/Ups/README.md
 last_modified_at: '2014-10-31 09:04:08 -0700'
 content: 'The Magento_Ups module implements integration with the United Parcel Service

--- a/src/_data/codebase/v2_3/mrg/ce/UrlRewrite.yaml
+++ b/src/_data/codebase/v2_3/mrg/ce/UrlRewrite.yaml
@@ -1,7 +1,7 @@
 ---
 title: Magento_UrlRewrite
 source_repo: magento2ce
-release: 2.3.4
+release: 2.3.5
 github_path: app/code/Magento/UrlRewrite/README.md
 last_modified_at: '2014-12-12 12:14:06 -0800'
 content: 'Magento_UrlRewrite module provides ability to customize website URLs by

--- a/src/_data/codebase/v2_3/mrg/ce/UrlRewriteGraphQl.yaml
+++ b/src/_data/codebase/v2_3/mrg/ce/UrlRewriteGraphQl.yaml
@@ -1,7 +1,7 @@
 ---
 title: Magento_UrlRewriteGraphQl
 source_repo: magento2ce
-release: 2.3.4
+release: 2.3.5
 github_path: app/code/Magento/UrlRewriteGraphQl/README.md
 last_modified_at: '2018-01-17 11:18:15 -0600'
 content: |

--- a/src/_data/codebase/v2_3/mrg/ce/User.yaml
+++ b/src/_data/codebase/v2_3/mrg/ce/User.yaml
@@ -1,7 +1,7 @@
 ---
 title: Magento_User
 source_repo: magento2ce
-release: 2.3.4
+release: 2.3.5
 github_path: app/code/Magento/User/README.md
 last_modified_at: '2015-08-27 15:34:05 -0500'
 content: |

--- a/src/_data/codebase/v2_3/mrg/ce/Usps.yaml
+++ b/src/_data/codebase/v2_3/mrg/ce/Usps.yaml
@@ -1,7 +1,7 @@
 ---
 title: Magento_Usps
 source_repo: magento2ce
-release: 2.3.4
+release: 2.3.5
 github_path: app/code/Magento/Usps/README.md
 last_modified_at: '2014-10-31 09:04:08 -0700'
 content: 'The Magento_Usps module provides integration with the United States Postal

--- a/src/_data/codebase/v2_3/mrg/ce/Variable.yaml
+++ b/src/_data/codebase/v2_3/mrg/ce/Variable.yaml
@@ -1,7 +1,7 @@
 ---
 title: Magento_Variable
 source_repo: magento2ce
-release: 2.3.4
+release: 2.3.5
 github_path: app/code/Magento/Variable/README.md
 last_modified_at: '2015-02-10 10:11:24 -0600'
 content: 'Magento\Variable Allows to create custom variables and then use them in

--- a/src/_data/codebase/v2_3/mrg/ce/Vault.yaml
+++ b/src/_data/codebase/v2_3/mrg/ce/Vault.yaml
@@ -1,7 +1,7 @@
 ---
 title: Magento_Vault
 source_repo: magento2ce
-release: 2.3.4
+release: 2.3.5
 github_path: app/code/Magento/Vault/README.md
 last_modified_at: '2015-12-02 14:06:21 +0200'
 content: 'The Magento_Vault module implements the integration with the Vault payment

--- a/src/_data/codebase/v2_3/mrg/ce/VaultGraphQl.yaml
+++ b/src/_data/codebase/v2_3/mrg/ce/VaultGraphQl.yaml
@@ -1,7 +1,7 @@
 ---
 title: Magento_VaultGraphQl
 source_repo: magento2ce
-release: 2.3.4
+release: 2.3.5
 github_path: app/code/Magento/VaultGraphQl/README.md
 last_modified_at: '2019-01-22 15:13:27 -0500'
 content: |

--- a/src/_data/codebase/v2_3/mrg/ce/Version.yaml
+++ b/src/_data/codebase/v2_3/mrg/ce/Version.yaml
@@ -1,7 +1,7 @@
 ---
 title: Magento_Version
 source_repo: magento2ce
-release: 2.3.4
+release: 2.3.5
 github_path: app/code/Magento/Version/README.md
 last_modified_at: '2015-01-29 16:15:56 -0600'
 content: 'Magento\Version Allows to get Magento version and edition by HTTP GET request

--- a/src/_data/codebase/v2_3/mrg/ce/Webapi.yaml
+++ b/src/_data/codebase/v2_3/mrg/ce/Webapi.yaml
@@ -1,7 +1,7 @@
 ---
 title: Magento_Webapi
 source_repo: magento2ce
-release: 2.3.4
+release: 2.3.5
 github_path: app/code/Magento/Webapi/README.md
 last_modified_at: '2014-10-24 14:51:44 -0700'
 content: "**Webapi** provides the framework for the application to expose REST and

--- a/src/_data/codebase/v2_3/mrg/ce/WebapiAsync.yaml
+++ b/src/_data/codebase/v2_3/mrg/ce/WebapiAsync.yaml
@@ -1,7 +1,7 @@
 ---
 title: Magento_WebapiAsync
 source_repo: magento2ce
-release: 2.3.4
+release: 2.3.5
 github_path: app/code/Magento/WebapiAsync/README.md
 last_modified_at: '2018-03-20 12:57:53 +0200'
 content: "**WebapiAsync** Extends Webapi extension and provide functional to process

--- a/src/_data/codebase/v2_3/mrg/ce/WebapiSecurity.yaml
+++ b/src/_data/codebase/v2_3/mrg/ce/WebapiSecurity.yaml
@@ -1,7 +1,7 @@
 ---
 title: Magento_WebapiSecurity
 source_repo: magento2ce
-release: 2.3.4
+release: 2.3.5
 github_path: app/code/Magento/WebapiSecurity/README.md
 last_modified_at: '2016-03-22 15:38:49 -0500'
 content: |

--- a/src/_data/codebase/v2_3/mrg/ce/Weee.yaml
+++ b/src/_data/codebase/v2_3/mrg/ce/Weee.yaml
@@ -1,7 +1,7 @@
 ---
 title: Magento_Weee
 source_repo: magento2ce
-release: 2.3.4
+release: 2.3.5
 github_path: app/code/Magento/Weee/README.md
 last_modified_at: '2017-04-10 16:29:08 -0500'
 content: |

--- a/src/_data/codebase/v2_3/mrg/ce/WeeeGraphQl.yaml
+++ b/src/_data/codebase/v2_3/mrg/ce/WeeeGraphQl.yaml
@@ -1,7 +1,7 @@
 ---
 title: Magento_WeeeGraphQl
 source_repo: magento2ce
-release: 2.3.4
+release: 2.3.5
 github_path: app/code/Magento/WeeeGraphQl/README.md
 last_modified_at: '2018-01-17 17:11:48 -0600'
 content: |

--- a/src/_data/codebase/v2_3/mrg/ce/Widget.yaml
+++ b/src/_data/codebase/v2_3/mrg/ce/Widget.yaml
@@ -1,7 +1,7 @@
 ---
 title: Magento_Widget
 source_repo: magento2ce
-release: 2.3.4
+release: 2.3.5
 github_path: app/code/Magento/Widget/README.md
 last_modified_at: '2014-07-11 11:30:21 -0700'
 content: The Widget module allows Magento application to be extended with custom widget

--- a/src/_data/codebase/v2_3/mrg/ce/Wishlist.yaml
+++ b/src/_data/codebase/v2_3/mrg/ce/Wishlist.yaml
@@ -1,7 +1,7 @@
 ---
 title: Magento_Wishlist
 source_repo: magento2ce
-release: 2.3.4
+release: 2.3.5
 github_path: app/code/Magento/Wishlist/README.md
 last_modified_at: '2014-10-31 09:04:08 -0700'
 content: |

--- a/src/_data/codebase/v2_3/mrg/ce/WishlistAnalytics.yaml
+++ b/src/_data/codebase/v2_3/mrg/ce/WishlistAnalytics.yaml
@@ -1,7 +1,7 @@
 ---
 title: Magento_WishlistAnalytics
 source_repo: magento2ce
-release: 2.3.4
+release: 2.3.5
 github_path: app/code/Magento/WishlistAnalytics/README.md
 last_modified_at: '2019-08-06 14:40:28 -0500'
 content: 'The Magento_WishlistAnalytics module configures data definitions for a data

--- a/src/_data/codebase/v2_3/mrg/ce/WishlistGraphQl.yaml
+++ b/src/_data/codebase/v2_3/mrg/ce/WishlistGraphQl.yaml
@@ -1,7 +1,7 @@
 ---
 title: Magento_WishlistGraphQl
 source_repo: magento2ce
-release: 2.3.4
+release: 2.3.5
 github_path: app/code/Magento/WishlistGraphQl/README.md
 last_modified_at: '2018-10-26 12:42:07 +0200'
 content: |

--- a/src/_data/codebase/v2_3/mrg/ee/AdminGws.yaml
+++ b/src/_data/codebase/v2_3/mrg/ee/AdminGws.yaml
@@ -1,7 +1,7 @@
 ---
 title: Magento_AdminGws
 source_repo: magento2ee
-release: 2.3.4
+release: 2.3.5
 github_path: app/code/Magento/AdminGws/README.md
 last_modified_at: '2014-12-17 18:31:49 +0000'
 content: "**AdminGws** provides configuration management within the Global, Website,

--- a/src/_data/codebase/v2_3/mrg/ee/AdvancedCatalog.yaml
+++ b/src/_data/codebase/v2_3/mrg/ee/AdvancedCatalog.yaml
@@ -1,7 +1,7 @@
 ---
 title: Magento_AdvancedCatalog
 source_repo: magento2ee
-release: 2.3.4
+release: 2.3.5
 github_path: app/code/Magento/AdvancedCatalog/README.md
 last_modified_at: '2015-06-22 19:38:00 +0300'
 content: |

--- a/src/_data/codebase/v2_3/mrg/ee/AdvancedCheckout.yaml
+++ b/src/_data/codebase/v2_3/mrg/ee/AdvancedCheckout.yaml
@@ -1,7 +1,7 @@
 ---
 title: Magento_AdvancedCheckout
 source_repo: magento2ee
-release: 2.3.4
+release: 2.3.5
 github_path: app/code/Magento/AdvancedCheckout/README.md
 last_modified_at: '2014-12-17 18:31:49 +0000'
 content: |-

--- a/src/_data/codebase/v2_3/mrg/ee/AdvancedRule.yaml
+++ b/src/_data/codebase/v2_3/mrg/ee/AdvancedRule.yaml
@@ -1,7 +1,7 @@
 ---
 title: Magento_AdvancedRule
 source_repo: magento2ee
-release: 2.3.4
+release: 2.3.5
 github_path: app/code/Magento/AdvancedRule/README.md
 last_modified_at: '2015-11-20 12:14:51 -0600'
 content: "AdvancedRule module enhances the performance of rule processing.\n\n"

--- a/src/_data/codebase/v2_3/mrg/ee/AdvancedSalesRule.yaml
+++ b/src/_data/codebase/v2_3/mrg/ee/AdvancedSalesRule.yaml
@@ -1,7 +1,7 @@
 ---
 title: Magento_AdvancedSalesRule
 source_repo: magento2ee
-release: 2.3.4
+release: 2.3.5
 github_path: app/code/Magento/AdvancedSalesRule/README.md
 last_modified_at: '2015-11-20 12:14:51 -0600'
 content: "AdvancedSalesRule module enhances the performance of sale rule processing.\n\n"

--- a/src/_data/codebase/v2_3/mrg/ee/Banner.yaml
+++ b/src/_data/codebase/v2_3/mrg/ee/Banner.yaml
@@ -1,7 +1,7 @@
 ---
 title: Magento_Banner
 source_repo: magento2ee
-release: 2.3.4
+release: 2.3.5
 github_path: app/code/Magento/Banner/README.md
 last_modified_at: '2018-01-12 13:34:20 +0200'
 content: "The Banner module allows creating and managing dynamic blocks and widgets

--- a/src/_data/codebase/v2_3/mrg/ee/BannerCustomerSegment.yaml
+++ b/src/_data/codebase/v2_3/mrg/ee/BannerCustomerSegment.yaml
@@ -1,7 +1,7 @@
 ---
 title: Magento_BannerCustomerSegment
 source_repo: magento2ee
-release: 2.3.4
+release: 2.3.5
 github_path: app/code/Magento/BannerCustomerSegment/README.md
 last_modified_at: '2014-12-17 18:31:49 +0000'
 content: The Banner Customer Segment module allows creating and managing banners in

--- a/src/_data/codebase/v2_3/mrg/ee/BundleImportExportStaging.yaml
+++ b/src/_data/codebase/v2_3/mrg/ee/BundleImportExportStaging.yaml
@@ -1,7 +1,7 @@
 ---
 title: Magento_BundleImportExportStaging
 source_repo: magento2ee
-release: 2.3.4
+release: 2.3.5
 github_path: app/code/Magento/BundleImportExportStaging/README.md
 last_modified_at: '2017-05-26 18:23:26 +0300'
 content: |-

--- a/src/_data/codebase/v2_3/mrg/ee/BundleStaging.yaml
+++ b/src/_data/codebase/v2_3/mrg/ee/BundleStaging.yaml
@@ -1,7 +1,7 @@
 ---
 title: Magento_BundleStaging
 source_repo: magento2ee
-release: 2.3.4
+release: 2.3.5
 github_path: app/code/Magento/BundleStaging/README.md
 last_modified_at: '2016-04-12 17:33:21 +0300'
 content: |-

--- a/src/_data/codebase/v2_3/mrg/ee/CatalogEvent.yaml
+++ b/src/_data/codebase/v2_3/mrg/ee/CatalogEvent.yaml
@@ -1,7 +1,7 @@
 ---
 title: Magento_CatalogEvent
 source_repo: magento2ee
-release: 2.3.4
+release: 2.3.5
 github_path: app/code/Magento/CatalogEvent/README.md
 last_modified_at: '2014-12-17 18:31:49 +0000'
 content: |

--- a/src/_data/codebase/v2_3/mrg/ee/CatalogImportExportStaging.yaml
+++ b/src/_data/codebase/v2_3/mrg/ee/CatalogImportExportStaging.yaml
@@ -1,7 +1,7 @@
 ---
 title: Magento_CatalogImportExportStaging
 source_repo: magento2ee
-release: 2.3.4
+release: 2.3.5
 github_path: app/code/Magento/CatalogImportExportStaging/README.md
 last_modified_at: '2016-04-07 09:45:21 -0500'
 content: |

--- a/src/_data/codebase/v2_3/mrg/ee/CatalogInventoryStaging.yaml
+++ b/src/_data/codebase/v2_3/mrg/ee/CatalogInventoryStaging.yaml
@@ -1,7 +1,7 @@
 ---
 title: Magento_CatalogInventoryStaging
 source_repo: magento2ee
-release: 2.3.4
+release: 2.3.5
 github_path: app/code/Magento/CatalogInventoryStaging/README.md
 last_modified_at: '2016-07-04 18:13:15 +0300'
 content: "## Magento_CatalogInventoryStaging module\n\n## Overview\n\nThe Magento_CatalogInventoryStaging

--- a/src/_data/codebase/v2_3/mrg/ee/CatalogPermissions.yaml
+++ b/src/_data/codebase/v2_3/mrg/ee/CatalogPermissions.yaml
@@ -1,7 +1,7 @@
 ---
 title: Magento_CatalogPermissions
 source_repo: magento2ee
-release: 2.3.4
+release: 2.3.5
 github_path: app/code/Magento/CatalogPermissions/README.md
 last_modified_at: '2015-05-14 15:09:36 +0300'
 content: |

--- a/src/_data/codebase/v2_3/mrg/ee/CatalogRuleStaging.yaml
+++ b/src/_data/codebase/v2_3/mrg/ee/CatalogRuleStaging.yaml
@@ -1,7 +1,7 @@
 ---
 title: Magento_CatalogRuleStaging
 source_repo: magento2ee
-release: 2.3.4
+release: 2.3.5
 github_path: app/code/Magento/CatalogRuleStaging/README.md
 last_modified_at: '2016-08-03 10:46:30 +0300'
 content: |-

--- a/src/_data/codebase/v2_3/mrg/ee/CatalogStaging.yaml
+++ b/src/_data/codebase/v2_3/mrg/ee/CatalogStaging.yaml
@@ -1,7 +1,7 @@
 ---
 title: Magento_CatalogStaging
 source_repo: magento2ee
-release: 2.3.4
+release: 2.3.5
 github_path: app/code/Magento/CatalogStaging/README.md
 last_modified_at: '2016-07-13 17:35:04 -0500'
 content: |-

--- a/src/_data/codebase/v2_3/mrg/ee/CatalogStagingGraphQl.yaml
+++ b/src/_data/codebase/v2_3/mrg/ee/CatalogStagingGraphQl.yaml
@@ -1,0 +1,9 @@
+---
+title: Magento_CatalogStagingGraphQl
+source_repo: magento2ee
+release: 2.3.5
+github_path: app/code/Magento/CatalogStagingGraphQl/README.md
+last_modified_at: '2019-11-22 09:44:16 -0600'
+content: |
+  **CatalogStagingGraphQl** supports Staging functionality for Catalog in the scope of GraphQl.
+  This includes preview capabilities for catalog entities.

--- a/src/_data/codebase/v2_3/mrg/ee/CatalogUrlRewriteStaging.yaml
+++ b/src/_data/codebase/v2_3/mrg/ee/CatalogUrlRewriteStaging.yaml
@@ -1,7 +1,7 @@
 ---
 title: Magento_CatalogUrlRewriteStaging
 source_repo: magento2ee
-release: 2.3.4
+release: 2.3.5
 github_path: app/code/Magento/CatalogUrlRewriteStaging/README.md
 last_modified_at: '2016-07-04 18:13:15 +0300'
 content: |-

--- a/src/_data/codebase/v2_3/mrg/ee/CheckoutAddressSearch.yaml
+++ b/src/_data/codebase/v2_3/mrg/ee/CheckoutAddressSearch.yaml
@@ -1,7 +1,7 @@
 ---
 title: Magento_CheckoutAddressSearch
 source_repo: magento2ee
-release: 2.3.4
+release: 2.3.5
 github_path: app/code/Magento/CheckoutAddressSearch/README.md
 last_modified_at: '2019-04-10 17:47:51 -0500'
 content: |

--- a/src/_data/codebase/v2_3/mrg/ee/CheckoutAddressSearchGiftRegistry.yaml
+++ b/src/_data/codebase/v2_3/mrg/ee/CheckoutAddressSearchGiftRegistry.yaml
@@ -1,7 +1,7 @@
 ---
 title: Magento_CheckoutAddressSearchGiftRegistry
 source_repo: magento2ee
-release: 2.3.4
+release: 2.3.5
 github_path: app/code/Magento/CheckoutAddressSearchGiftRegistry/README.md
 last_modified_at: '2019-04-05 18:54:17 -0500'
 content: |

--- a/src/_data/codebase/v2_3/mrg/ee/CheckoutStaging.yaml
+++ b/src/_data/codebase/v2_3/mrg/ee/CheckoutStaging.yaml
@@ -1,7 +1,7 @@
 ---
 title: Magento_CheckoutStaging
 source_repo: magento2ee
-release: 2.3.4
+release: 2.3.5
 github_path: app/code/Magento/CheckoutStaging/README.md
 last_modified_at: '2016-07-04 12:55:14 +0000'
 content: |

--- a/src/_data/codebase/v2_3/mrg/ee/CmsStaging.yaml
+++ b/src/_data/codebase/v2_3/mrg/ee/CmsStaging.yaml
@@ -1,7 +1,7 @@
 ---
 title: Magento_CmsStaging
 source_repo: magento2ee
-release: 2.3.4
+release: 2.3.5
 github_path: app/code/Magento/CmsStaging/README.md
 last_modified_at: '2016-07-13 17:35:04 -0500'
 content: "## Magento_CmsStaging module\n\n## Overview\n\nThe Magento_CmsStaging module

--- a/src/_data/codebase/v2_3/mrg/ee/ConfigurableProductStaging.yaml
+++ b/src/_data/codebase/v2_3/mrg/ee/ConfigurableProductStaging.yaml
@@ -1,7 +1,7 @@
 ---
 title: Magento_ConfigurableProductStaging
 source_repo: magento2ee
-release: 2.3.4
+release: 2.3.5
 github_path: app/code/Magento/ConfigurableProductStaging/README.md
 last_modified_at: '2017-02-06 15:24:41 +0200'
 content: |

--- a/src/_data/codebase/v2_3/mrg/ee/CustomAttributeManagement.yaml
+++ b/src/_data/codebase/v2_3/mrg/ee/CustomAttributeManagement.yaml
@@ -1,7 +1,7 @@
 ---
 title: Magento_CustomAttributeManagement
 source_repo: magento2ee
-release: 2.3.4
+release: 2.3.5
 github_path: app/code/Magento/CustomAttributeManagement/README.md
 last_modified_at: '2014-12-17 18:31:49 +0000'
 content: |

--- a/src/_data/codebase/v2_3/mrg/ee/CustomerBalance.yaml
+++ b/src/_data/codebase/v2_3/mrg/ee/CustomerBalance.yaml
@@ -1,7 +1,7 @@
 ---
 title: Magento_CustomerBalance
 source_repo: magento2ee
-release: 2.3.4
+release: 2.3.5
 github_path: app/code/Magento/CustomerBalance/README.md
 last_modified_at: '2014-12-17 18:31:49 +0000'
 content: |

--- a/src/_data/codebase/v2_3/mrg/ee/CustomerBalanceGraphQl.yaml
+++ b/src/_data/codebase/v2_3/mrg/ee/CustomerBalanceGraphQl.yaml
@@ -1,7 +1,7 @@
 ---
 title: Magento_CustomerBalanceGraphQl
 source_repo: magento2ee
-release: 2.3.4
+release: 2.3.5
 github_path: app/code/Magento/CustomerBalanceGraphQl/README.md
 last_modified_at: '2019-07-16 10:30:00 -0500'
 content: |

--- a/src/_data/codebase/v2_3/mrg/ee/CustomerCustomAttributes.yaml
+++ b/src/_data/codebase/v2_3/mrg/ee/CustomerCustomAttributes.yaml
@@ -1,7 +1,7 @@
 ---
 title: Magento_CustomerCustomAttributes
 source_repo: magento2ee
-release: 2.3.4
+release: 2.3.5
 github_path: app/code/Magento/CustomerCustomAttributes/README.md
 last_modified_at: '2014-12-17 18:31:49 +0000'
 content: |

--- a/src/_data/codebase/v2_3/mrg/ee/CustomerFinance.yaml
+++ b/src/_data/codebase/v2_3/mrg/ee/CustomerFinance.yaml
@@ -1,7 +1,7 @@
 ---
 title: Magento_CustomerFinance
 source_repo: magento2ee
-release: 2.3.4
+release: 2.3.5
 github_path: app/code/Magento/CustomerFinance/README.md
 last_modified_at: '2014-12-17 18:31:49 +0000'
 content: |

--- a/src/_data/codebase/v2_3/mrg/ee/CustomerSegment.yaml
+++ b/src/_data/codebase/v2_3/mrg/ee/CustomerSegment.yaml
@@ -1,7 +1,7 @@
 ---
 title: Magento_CustomerSegment
 source_repo: magento2ee
-release: 2.3.4
+release: 2.3.5
 github_path: app/code/Magento/CustomerSegment/README.md
 last_modified_at: '2014-12-17 18:31:49 +0000'
 content: |

--- a/src/_data/codebase/v2_3/mrg/ee/Cybersource.yaml
+++ b/src/_data/codebase/v2_3/mrg/ee/Cybersource.yaml
@@ -1,7 +1,7 @@
 ---
 title: Magento_Cybersource
 source_repo: magento2ee
-release: 2.3.4
+release: 2.3.5
 github_path: app/code/Magento/Cybersource/README.md
 last_modified_at: '2015-06-19 14:49:00 +0300'
 content: 'The Magento_Cybersource module implements the integration with the Cybersource

--- a/src/_data/codebase/v2_3/mrg/ee/DownloadableStaging.yaml
+++ b/src/_data/codebase/v2_3/mrg/ee/DownloadableStaging.yaml
@@ -1,7 +1,7 @@
 ---
 title: Magento_DownloadableStaging
 source_repo: magento2ee
-release: 2.3.4
+release: 2.3.5
 github_path: app/code/Magento/DownloadableStaging/README.md
 last_modified_at: '2016-07-13 17:35:04 -0500'
 content: |-

--- a/src/_data/codebase/v2_3/mrg/ee/ElasticsearchCatalogPermissions.yaml
+++ b/src/_data/codebase/v2_3/mrg/ee/ElasticsearchCatalogPermissions.yaml
@@ -1,7 +1,7 @@
 ---
 title: Magento_ElasticsearchCatalogPermissions
 source_repo: magento2ee
-release: 2.3.4
+release: 2.3.5
 github_path: app/code/Magento/ElasticsearchCatalogPermissions/README.md
 last_modified_at: '2018-12-28 16:36:26 +0200'
 content: |-

--- a/src/_data/codebase/v2_3/mrg/ee/Enterprise.yaml
+++ b/src/_data/codebase/v2_3/mrg/ee/Enterprise.yaml
@@ -1,7 +1,7 @@
 ---
 title: Magento_Enterprise
 source_repo: magento2ee
-release: 2.3.4
+release: 2.3.5
 github_path: app/code/Magento/Enterprise/README.md
 last_modified_at: '2014-12-17 18:31:49 +0000'
 content: The Enterprise module switches the store to Enterprise edition by adding

--- a/src/_data/codebase/v2_3/mrg/ee/Eway.yaml
+++ b/src/_data/codebase/v2_3/mrg/ee/Eway.yaml
@@ -1,7 +1,7 @@
 ---
 title: Magento_Eway
 source_repo: magento2ee
-release: 2.3.4
+release: 2.3.5
 github_path: app/code/Magento/Eway/README.md
 last_modified_at: '2015-07-29 19:08:38 +0300'
 content: 'The Magento_Eway module implements the integration with the Eway payment

--- a/src/_data/codebase/v2_3/mrg/ee/GiftCard.yaml
+++ b/src/_data/codebase/v2_3/mrg/ee/GiftCard.yaml
@@ -1,7 +1,7 @@
 ---
 title: Magento_GiftCard
 source_repo: magento2ee
-release: 2.3.4
+release: 2.3.5
 github_path: app/code/Magento/GiftCard/README.md
 last_modified_at: '2014-12-17 18:31:49 +0000'
 content: "Magento_GiftCard module introduces new product type in the Magento application

--- a/src/_data/codebase/v2_3/mrg/ee/GiftCardAccount.yaml
+++ b/src/_data/codebase/v2_3/mrg/ee/GiftCardAccount.yaml
@@ -1,7 +1,7 @@
 ---
 title: Magento_GiftCardAccount
 source_repo: magento2ee
-release: 2.3.4
+release: 2.3.5
 github_path: app/code/Magento/GiftCardAccount/README.md
 last_modified_at: '2014-12-17 18:31:49 +0000'
 content: 'The Magento_GiftCardAccount module is responsible for gift card balances,

--- a/src/_data/codebase/v2_3/mrg/ee/GiftCardAccountGraphQl.yaml
+++ b/src/_data/codebase/v2_3/mrg/ee/GiftCardAccountGraphQl.yaml
@@ -1,7 +1,7 @@
 ---
 title: Magento_GiftCardAccountGraphQl
 source_repo: magento2ee
-release: 2.3.4
+release: 2.3.5
 github_path: app/code/Magento/GiftCardAccountGraphQl/README.md
 last_modified_at: '2019-05-30 10:55:23 -0500'
 content: |

--- a/src/_data/codebase/v2_3/mrg/ee/GiftCardGraphQl.yaml
+++ b/src/_data/codebase/v2_3/mrg/ee/GiftCardGraphQl.yaml
@@ -1,7 +1,7 @@
 ---
 title: Magento_GiftCardGraphQl
 source_repo: magento2ee
-release: 2.3.4
+release: 2.3.5
 github_path: app/code/Magento/GiftCardGraphQl/README.md
 last_modified_at: '2018-01-30 15:41:07 -0600'
 content: |

--- a/src/_data/codebase/v2_3/mrg/ee/GiftCardImportExport.yaml
+++ b/src/_data/codebase/v2_3/mrg/ee/GiftCardImportExport.yaml
@@ -1,7 +1,7 @@
 ---
 title: Magento_GiftCardImportExport
 source_repo: magento2ee
-release: 2.3.4
+release: 2.3.5
 github_path: app/code/Magento/GiftCardImportExport/README.md
 last_modified_at: '2015-08-18 15:10:06 +0300'
 content: |

--- a/src/_data/codebase/v2_3/mrg/ee/GiftCardStaging.yaml
+++ b/src/_data/codebase/v2_3/mrg/ee/GiftCardStaging.yaml
@@ -1,7 +1,7 @@
 ---
 title: Magento_GiftCardStaging
 source_repo: magento2ee
-release: 2.3.4
+release: 2.3.5
 github_path: app/code/Magento/GiftCardStaging/README.md
 last_modified_at: '2016-07-13 17:35:04 -0500'
 content: |

--- a/src/_data/codebase/v2_3/mrg/ee/GiftMessageStaging.yaml
+++ b/src/_data/codebase/v2_3/mrg/ee/GiftMessageStaging.yaml
@@ -1,7 +1,7 @@
 ---
 title: Magento_GiftMessageStaging
 source_repo: magento2ee
-release: 2.3.4
+release: 2.3.5
 github_path: app/code/Magento/GiftMessageStaging/README.md
 last_modified_at: '2016-07-04 18:13:15 +0300'
 content: |-

--- a/src/_data/codebase/v2_3/mrg/ee/GiftRegistry.yaml
+++ b/src/_data/codebase/v2_3/mrg/ee/GiftRegistry.yaml
@@ -1,7 +1,7 @@
 ---
 title: Magento_GiftRegistry
 source_repo: magento2ee
-release: 2.3.4
+release: 2.3.5
 github_path: app/code/Magento/GiftRegistry/README.md
 last_modified_at: '2014-12-17 18:31:49 +0000'
 content: |-

--- a/src/_data/codebase/v2_3/mrg/ee/GiftWrapping.yaml
+++ b/src/_data/codebase/v2_3/mrg/ee/GiftWrapping.yaml
@@ -1,7 +1,7 @@
 ---
 title: Magento_GiftWrapping
 source_repo: magento2ee
-release: 2.3.4
+release: 2.3.5
 github_path: app/code/Magento/GiftWrapping/README.md
 last_modified_at: '2014-12-17 18:31:49 +0000'
 content: |-

--- a/src/_data/codebase/v2_3/mrg/ee/GiftWrappingStaging.yaml
+++ b/src/_data/codebase/v2_3/mrg/ee/GiftWrappingStaging.yaml
@@ -1,7 +1,7 @@
 ---
 title: Magento_GiftWrappingStaging
 source_repo: magento2ee
-release: 2.3.4
+release: 2.3.5
 github_path: app/code/Magento/GiftWrappingStaging/README.md
 last_modified_at: '2016-07-04 18:13:15 +0300'
 content: |-

--- a/src/_data/codebase/v2_3/mrg/ee/GoogleOptimizerStaging.yaml
+++ b/src/_data/codebase/v2_3/mrg/ee/GoogleOptimizerStaging.yaml
@@ -1,7 +1,7 @@
 ---
 title: Magento_GoogleOptimizerStaging
 source_repo: magento2ee
-release: 2.3.4
+release: 2.3.5
 github_path: app/code/Magento/GoogleOptimizerStaging/README.md
 last_modified_at: '2016-07-04 18:13:15 +0300'
 content: |-

--- a/src/_data/codebase/v2_3/mrg/ee/GoogleTagManager.yaml
+++ b/src/_data/codebase/v2_3/mrg/ee/GoogleTagManager.yaml
@@ -1,7 +1,7 @@
 ---
 title: Magento_GoogleTagManager
 source_repo: magento2ee
-release: 2.3.4
+release: 2.3.5
 github_path: app/code/Magento/GoogleTagManager/README.md
 last_modified_at: '2015-06-22 19:55:26 +0300'
 content: 'Magento_GoogleTagManager is a module for integration with Google Tag Manager

--- a/src/_data/codebase/v2_3/mrg/ee/GroupedProductStaging.yaml
+++ b/src/_data/codebase/v2_3/mrg/ee/GroupedProductStaging.yaml
@@ -1,7 +1,7 @@
 ---
 title: Magento_GroupedProductStaging
 source_repo: magento2ee
-release: 2.3.4
+release: 2.3.5
 github_path: app/code/Magento/GroupedProductStaging/README.md
 last_modified_at: '2016-07-04 18:13:15 +0300'
 content: |-

--- a/src/_data/codebase/v2_3/mrg/ee/Invitation.yaml
+++ b/src/_data/codebase/v2_3/mrg/ee/Invitation.yaml
@@ -1,7 +1,7 @@
 ---
 title: Magento_Invitation
 source_repo: magento2ee
-release: 2.3.4
+release: 2.3.5
 github_path: app/code/Magento/Invitation/README.md
 last_modified_at: '2014-12-17 18:31:49 +0000'
 content: 'The Magento_Invitation module enables invitation sending, referral tracking

--- a/src/_data/codebase/v2_3/mrg/ee/LayeredNavigationStaging.yaml
+++ b/src/_data/codebase/v2_3/mrg/ee/LayeredNavigationStaging.yaml
@@ -1,7 +1,7 @@
 ---
 title: Magento_LayeredNavigationStaging
 source_repo: magento2ee
-release: 2.3.4
+release: 2.3.5
 github_path: app/code/Magento/LayeredNavigationStaging/README.md
 last_modified_at: '2016-07-04 12:55:14 +0000'
 content: |

--- a/src/_data/codebase/v2_3/mrg/ee/Logging.yaml
+++ b/src/_data/codebase/v2_3/mrg/ee/Logging.yaml
@@ -1,7 +1,7 @@
 ---
 title: Magento_Logging
 source_repo: magento2ee
-release: 2.3.4
+release: 2.3.5
 github_path: app/code/Magento/Logging/README.md
 last_modified_at: '2014-12-17 18:31:49 +0000'
 content: |-

--- a/src/_data/codebase/v2_3/mrg/ee/MsrpStaging.yaml
+++ b/src/_data/codebase/v2_3/mrg/ee/MsrpStaging.yaml
@@ -1,7 +1,7 @@
 ---
 title: Magento_MsrpStaging
 source_repo: magento2ee
-release: 2.3.4
+release: 2.3.5
 github_path: app/code/Magento/MsrpStaging/README.md
 last_modified_at: '2016-07-06 16:58:52 +0300'
 content: |-

--- a/src/_data/codebase/v2_3/mrg/ee/MultipleWishlist.yaml
+++ b/src/_data/codebase/v2_3/mrg/ee/MultipleWishlist.yaml
@@ -1,7 +1,7 @@
 ---
 title: Magento_MultipleWishlist
 source_repo: magento2ee
-release: 2.3.4
+release: 2.3.5
 github_path: app/code/Magento/MultipleWishlist/README.md
 last_modified_at: '2014-12-17 18:31:49 +0000'
 content: |

--- a/src/_data/codebase/v2_3/mrg/ee/PaymentStaging.yaml
+++ b/src/_data/codebase/v2_3/mrg/ee/PaymentStaging.yaml
@@ -1,7 +1,7 @@
 ---
 title: Magento_PaymentStaging
 source_repo: magento2ee
-release: 2.3.4
+release: 2.3.5
 github_path: app/code/Magento/PaymentStaging/README.md
 last_modified_at: '2016-07-04 12:55:14 +0000'
 content: |

--- a/src/_data/codebase/v2_3/mrg/ee/PersistentHistory.yaml
+++ b/src/_data/codebase/v2_3/mrg/ee/PersistentHistory.yaml
@@ -1,7 +1,7 @@
 ---
 title: Magento_PersistentHistory
 source_repo: magento2ee
-release: 2.3.4
+release: 2.3.5
 github_path: app/code/Magento/PersistentHistory/README.md
 last_modified_at: '2014-12-17 18:31:49 +0000'
 content: |-

--- a/src/_data/codebase/v2_3/mrg/ee/PricePermissions.yaml
+++ b/src/_data/codebase/v2_3/mrg/ee/PricePermissions.yaml
@@ -1,7 +1,7 @@
 ---
 title: Magento_PricePermissions
 source_repo: magento2ee
-release: 2.3.4
+release: 2.3.5
 github_path: app/code/Magento/PricePermissions/README.md
 last_modified_at: '2014-12-17 18:31:49 +0000'
 content: 'Magento_PricePermissions module allows to restrict such admin rights as

--- a/src/_data/codebase/v2_3/mrg/ee/ProductVideoStaging.yaml
+++ b/src/_data/codebase/v2_3/mrg/ee/ProductVideoStaging.yaml
@@ -1,7 +1,7 @@
 ---
 title: Magento_ProductVideoStaging
 source_repo: magento2ee
-release: 2.3.4
+release: 2.3.5
 github_path: app/code/Magento/ProductVideoStaging/README.md
 last_modified_at: '2016-07-04 18:13:15 +0300'
 content: |-

--- a/src/_data/codebase/v2_3/mrg/ee/PromotionPermissions.yaml
+++ b/src/_data/codebase/v2_3/mrg/ee/PromotionPermissions.yaml
@@ -1,7 +1,7 @@
 ---
 title: Magento_PromotionPermissions
 source_repo: magento2ee
-release: 2.3.4
+release: 2.3.5
 github_path: app/code/Magento/PromotionPermissions/README.md
 last_modified_at: '2014-12-17 18:31:49 +0000'
 content: |-

--- a/src/_data/codebase/v2_3/mrg/ee/Reminder.yaml
+++ b/src/_data/codebase/v2_3/mrg/ee/Reminder.yaml
@@ -1,7 +1,7 @@
 ---
 title: Magento_Reminder
 source_repo: magento2ee
-release: 2.3.4
+release: 2.3.5
 github_path: app/code/Magento/Reminder/README.md
 last_modified_at: '2014-12-17 18:31:49 +0000'
 content: 'Magento_Reminder module provides functionality for sending reminder emails

--- a/src/_data/codebase/v2_3/mrg/ee/ResourceConnections.yaml
+++ b/src/_data/codebase/v2_3/mrg/ee/ResourceConnections.yaml
@@ -1,7 +1,7 @@
 ---
 title: Magento_ResourceConnections
 source_repo: magento2ee
-release: 2.3.4
+release: 2.3.5
 github_path: app/code/Magento/ResourceConnections/README.md
 last_modified_at: '2015-08-25 12:44:48 +0300'
 content: "Magento\\ResourceConnections module adds a mechanism to segregate database

--- a/src/_data/codebase/v2_3/mrg/ee/ReviewStaging.yaml
+++ b/src/_data/codebase/v2_3/mrg/ee/ReviewStaging.yaml
@@ -1,7 +1,7 @@
 ---
 title: Magento_ReviewStaging
 source_repo: magento2ee
-release: 2.3.4
+release: 2.3.5
 github_path: app/code/Magento/ReviewStaging/README.md
 last_modified_at: '2016-07-04 18:13:15 +0300'
 content: "## Magento_ReviewStaging module\n\n## Overview\n\nThe Magento_ReviewStaging

--- a/src/_data/codebase/v2_3/mrg/ee/Reward.yaml
+++ b/src/_data/codebase/v2_3/mrg/ee/Reward.yaml
@@ -1,7 +1,7 @@
 ---
 title: Magento_Reward
 source_repo: magento2ee
-release: 2.3.4
+release: 2.3.5
 github_path: app/code/Magento/Reward/README.md
 last_modified_at: '2014-12-17 18:31:49 +0000'
 content: |-

--- a/src/_data/codebase/v2_3/mrg/ee/RewardGraphQl.yaml
+++ b/src/_data/codebase/v2_3/mrg/ee/RewardGraphQl.yaml
@@ -1,7 +1,7 @@
 ---
 title: Magento_RewardGraphQl
 source_repo: magento2ee
-release: 2.3.4
+release: 2.3.5
 github_path: app/code/Magento/RewardGraphQl/README.md
 last_modified_at: '2018-01-16 16:07:42 -0600'
 content: |

--- a/src/_data/codebase/v2_3/mrg/ee/RewardStaging.yaml
+++ b/src/_data/codebase/v2_3/mrg/ee/RewardStaging.yaml
@@ -1,7 +1,7 @@
 ---
 title: Magento_RewardStaging
 source_repo: magento2ee
-release: 2.3.4
+release: 2.3.5
 github_path: app/code/Magento/RewardStaging/README.md
 last_modified_at: '2017-06-02 13:06:13 +0300'
 content: |-

--- a/src/_data/codebase/v2_3/mrg/ee/Rma.yaml
+++ b/src/_data/codebase/v2_3/mrg/ee/Rma.yaml
@@ -1,7 +1,7 @@
 ---
 title: Magento_Rma
 source_repo: magento2ee
-release: 2.3.4
+release: 2.3.5
 github_path: app/code/Magento/Rma/README.md
 last_modified_at: '2016-04-08 15:30:29 +0300'
 content: Rma module is responsible for processing Return Merchandise Approvals.

--- a/src/_data/codebase/v2_3/mrg/ee/RmaGraphQl.yaml
+++ b/src/_data/codebase/v2_3/mrg/ee/RmaGraphQl.yaml
@@ -1,7 +1,7 @@
 ---
 title: Magento_RmaGraphQl
 source_repo: magento2ee
-release: 2.3.4
+release: 2.3.5
 github_path: app/code/Magento/RmaGraphQl/README.md
 last_modified_at: '2018-01-16 16:07:42 -0600'
 content: |

--- a/src/_data/codebase/v2_3/mrg/ee/RmaStaging.yaml
+++ b/src/_data/codebase/v2_3/mrg/ee/RmaStaging.yaml
@@ -1,7 +1,7 @@
 ---
 title: Magento_RmaStaging
 source_repo: magento2ee
-release: 2.3.4
+release: 2.3.5
 github_path: app/code/Magento/RmaStaging/README.md
 last_modified_at: '2016-07-06 16:58:52 +0300'
 content: |-

--- a/src/_data/codebase/v2_3/mrg/ee/SalesArchive.yaml
+++ b/src/_data/codebase/v2_3/mrg/ee/SalesArchive.yaml
@@ -1,7 +1,7 @@
 ---
 title: Magento_SalesArchive
 source_repo: magento2ee
-release: 2.3.4
+release: 2.3.5
 github_path: app/code/Magento/SalesArchive/README.md
 last_modified_at: '2014-12-17 18:31:49 +0000'
 content: |-

--- a/src/_data/codebase/v2_3/mrg/ee/SalesRuleStaging.yaml
+++ b/src/_data/codebase/v2_3/mrg/ee/SalesRuleStaging.yaml
@@ -1,7 +1,7 @@
 ---
 title: Magento_SalesRuleStaging
 source_repo: magento2ee
-release: 2.3.4
+release: 2.3.5
 github_path: app/code/Magento/SalesRuleStaging/README.md
 last_modified_at: '2016-07-13 17:35:04 -0500'
 content: "<h2>Magento_SalesRuleStaging module</h2>\n\n## Overview\n\nThe Magento_SalesRuleStaging

--- a/src/_data/codebase/v2_3/mrg/ee/ScalableCheckout.yaml
+++ b/src/_data/codebase/v2_3/mrg/ee/ScalableCheckout.yaml
@@ -1,7 +1,7 @@
 ---
 title: Magento_ScalableCheckout
 source_repo: magento2ee
-release: 2.3.4
+release: 2.3.5
 github_path: app/code/Magento/ScalableCheckout/README.md
 last_modified_at: '2015-02-04 13:08:45 +0200'
 content: |-

--- a/src/_data/codebase/v2_3/mrg/ee/ScalableInventory.yaml
+++ b/src/_data/codebase/v2_3/mrg/ee/ScalableInventory.yaml
@@ -1,7 +1,7 @@
 ---
 title: Magento_ScalableInventory
 source_repo: magento2ee
-release: 2.3.4
+release: 2.3.5
 github_path: app/code/Magento/ScalableInventory/README.md
 last_modified_at: '2015-09-01 17:12:45 +0300'
 content: |

--- a/src/_data/codebase/v2_3/mrg/ee/ScalableOms.yaml
+++ b/src/_data/codebase/v2_3/mrg/ee/ScalableOms.yaml
@@ -1,7 +1,7 @@
 ---
 title: Magento_ScalableOms
 source_repo: magento2ee
-release: 2.3.4
+release: 2.3.5
 github_path: app/code/Magento/ScalableOms/README.md
 last_modified_at: '2015-05-15 13:27:50 +0300'
 content: |-

--- a/src/_data/codebase/v2_3/mrg/ee/ScheduledImportExport.yaml
+++ b/src/_data/codebase/v2_3/mrg/ee/ScheduledImportExport.yaml
@@ -1,7 +1,7 @@
 ---
 title: Magento_ScheduledImportExport
 source_repo: magento2ee
-release: 2.3.4
+release: 2.3.5
 github_path: app/code/Magento/ScheduledImportExport/README.md
 last_modified_at: '2014-12-17 18:31:49 +0000'
 content: |

--- a/src/_data/codebase/v2_3/mrg/ee/SearchStaging.yaml
+++ b/src/_data/codebase/v2_3/mrg/ee/SearchStaging.yaml
@@ -1,7 +1,7 @@
 ---
 title: Magento_SearchStaging
 source_repo: magento2ee
-release: 2.3.4
+release: 2.3.5
 github_path: app/code/Magento/SearchStaging/README.md
 last_modified_at: '2016-07-04 12:55:14 +0000'
 content: |

--- a/src/_data/codebase/v2_3/mrg/ee/Staging.yaml
+++ b/src/_data/codebase/v2_3/mrg/ee/Staging.yaml
@@ -1,7 +1,7 @@
 ---
 title: Magento_Staging
 source_repo: magento2ee
-release: 2.3.4
+release: 2.3.5
 github_path: app/code/Magento/Staging/README.md
 last_modified_at: '2016-10-19 18:10:05 +0300'
 content: |

--- a/src/_data/codebase/v2_3/mrg/ee/StagingGraphQl.yaml
+++ b/src/_data/codebase/v2_3/mrg/ee/StagingGraphQl.yaml
@@ -1,0 +1,9 @@
+---
+title: Magento_StagingGraphQl
+source_repo: magento2ee
+release: 2.3.5
+github_path: app/code/Magento/StagingGraphQl/README.md
+last_modified_at: '2019-11-20 16:45:00 -0600'
+content: |
+  **StagingGraphQl** provides type information for the GraphQl module
+  to stage and preview entities.

--- a/src/_data/codebase/v2_3/mrg/ee/Support.yaml
+++ b/src/_data/codebase/v2_3/mrg/ee/Support.yaml
@@ -1,7 +1,7 @@
 ---
 title: Magento_Support
 source_repo: magento2ee
-release: 2.3.4
+release: 2.3.5
 github_path: app/code/Magento/Support/README.md
 last_modified_at: '2015-07-31 14:51:10 +0300'
 content: 'Magento_Support module is used for generation of system reports, which provide

--- a/src/_data/codebase/v2_3/mrg/ee/TargetRule.yaml
+++ b/src/_data/codebase/v2_3/mrg/ee/TargetRule.yaml
@@ -1,7 +1,7 @@
 ---
 title: Magento_TargetRule
 source_repo: magento2ee
-release: 2.3.4
+release: 2.3.5
 github_path: app/code/Magento/TargetRule/README.md
 last_modified_at: '2014-12-17 18:31:49 +0000'
 content: 'Magento_TargetRule module allows to configure the rules for showing related

--- a/src/_data/codebase/v2_3/mrg/ee/Tinymce3Banner.yaml
+++ b/src/_data/codebase/v2_3/mrg/ee/Tinymce3Banner.yaml
@@ -1,7 +1,7 @@
 ---
 title: Magento_Tinymce3Banner
 source_repo: magento2ee
-release: 2.3.4
+release: 2.3.5
 github_path: app/code/Magento/Tinymce3Banner/README.md
 last_modified_at: '2018-05-14 12:30:39 -0500'
 content: Tinymce3Banner module allows to update banner widget images on Wysiwyg. We

--- a/src/_data/codebase/v2_3/mrg/ee/VersionsCms.yaml
+++ b/src/_data/codebase/v2_3/mrg/ee/VersionsCms.yaml
@@ -1,7 +1,7 @@
 ---
 title: Magento_VersionsCms
 source_repo: magento2ee
-release: 2.3.4
+release: 2.3.5
 github_path: app/code/Magento/VersionsCms/README.md
 last_modified_at: '2017-04-14 11:20:03 -0500'
 content: |

--- a/src/_data/codebase/v2_3/mrg/ee/VersionsCmsUrlRewrite.yaml
+++ b/src/_data/codebase/v2_3/mrg/ee/VersionsCmsUrlRewrite.yaml
@@ -1,0 +1,10 @@
+---
+title: Magento_VersionsCmsUrlRewrite
+source_repo: magento2ee
+release: 2.3.5
+github_path: app/code/Magento/VersionsCmsUrlRewrite/README.md
+last_modified_at: '2020-01-20 12:07:09 +0200'
+content: "The Versions CMS Url Rewrite Module ties up the Store Switcher program with
+  implementation of the Hierarchy structure. See also Magento_UrlRewrite and Magento_VersionsCms
+  modules. \n\nExtends the Store Switcher program and makes it take into account nodes
+  from the Hierarchy structure.\n"

--- a/src/_data/codebase/v2_3/mrg/ee/VisualMerchandiser.yaml
+++ b/src/_data/codebase/v2_3/mrg/ee/VisualMerchandiser.yaml
@@ -1,7 +1,7 @@
 ---
 title: Magento_VisualMerchandiser
 source_repo: magento2ee
-release: 2.3.4
+release: 2.3.5
 github_path: app/code/Magento/VisualMerchandiser/README.md
 last_modified_at: '2015-06-03 11:17:57 +0000'
 content: |-

--- a/src/_data/codebase/v2_3/mrg/ee/WebsiteRestriction.yaml
+++ b/src/_data/codebase/v2_3/mrg/ee/WebsiteRestriction.yaml
@@ -1,7 +1,7 @@
 ---
 title: Magento_WebsiteRestriction
 source_repo: magento2ee
-release: 2.3.4
+release: 2.3.5
 github_path: app/code/Magento/WebsiteRestriction/README.md
 last_modified_at: '2014-12-17 18:31:49 +0000'
 content: |

--- a/src/_data/codebase/v2_3/mrg/ee/WeeeStaging.yaml
+++ b/src/_data/codebase/v2_3/mrg/ee/WeeeStaging.yaml
@@ -1,7 +1,7 @@
 ---
 title: Magento_WeeeStaging
 source_repo: magento2ee
-release: 2.3.4
+release: 2.3.5
 github_path: app/code/Magento/WeeeStaging/README.md
 last_modified_at: '2016-07-06 16:58:52 +0300'
 content: |-

--- a/src/_data/codebase/v2_3/mrg/ee/Worldpay.yaml
+++ b/src/_data/codebase/v2_3/mrg/ee/Worldpay.yaml
@@ -1,7 +1,7 @@
 ---
 title: Magento_Worldpay
 source_repo: magento2ee
-release: 2.3.4
+release: 2.3.5
 github_path: app/code/Magento/Worldpay/README.md
 last_modified_at: '2015-07-07 12:08:21 +0300'
 content: 'The Magento_Worldpay module implements the integration with the Worldpay

--- a/src/_data/codebase/v2_3/mrg/msi/Inventory.yaml
+++ b/src/_data/codebase/v2_3/mrg/msi/Inventory.yaml
@@ -1,8 +1,8 @@
 ---
 title: Magento_Inventory
 source_repo: inventory
-release: ''
-github_path: app/code/Magento/Inventory/README.md
+release: 1.1.5
+github_path: Inventory/README.md
 last_modified_at: '2018-11-09 00:12:40 +0200'
 content: "The `Inventory` module is part of the new inventory infrastructure,\nwhich
   replaces the legacy `CatalogInventory` module with new and expanded features and

--- a/src/_data/codebase/v2_3/mrg/msi/InventoryAdminUi.yaml
+++ b/src/_data/codebase/v2_3/mrg/msi/InventoryAdminUi.yaml
@@ -1,8 +1,8 @@
 ---
 title: Magento_InventoryAdminUi
 source_repo: inventory
-release: ''
-github_path: app/code/Magento/InventoryAdminUi/README.md
+release: 1.1.5
+github_path: InventoryAdminUi/README.md
 last_modified_at: '2018-11-09 00:12:40 +0200'
 content: |
   The `InventoryAdminUi` module extends the Magento Admin UI to add Inventory Management functionality.

--- a/src/_data/codebase/v2_3/mrg/msi/InventoryAdvancedCheckout.yaml
+++ b/src/_data/codebase/v2_3/mrg/msi/InventoryAdvancedCheckout.yaml
@@ -1,8 +1,8 @@
 ---
 title: Magento_InventoryAdvancedCheckout
 source_repo: inventory
-release: ''
-github_path: app/code/Magento/InventoryAdvancedCheckout/README.md
+release: 1.1.5
+github_path: InventoryAdvancedCheckout/README.md
 last_modified_at: '2019-08-02 00:04:37 -0500'
 content: |-
   ## Magento_InventoryAdvancedCheckout

--- a/src/_data/codebase/v2_3/mrg/msi/InventoryApi.yaml
+++ b/src/_data/codebase/v2_3/mrg/msi/InventoryApi.yaml
@@ -1,8 +1,8 @@
 ---
 title: Magento_InventoryApi
 source_repo: inventory
-release: ''
-github_path: app/code/Magento/InventoryApi/README.md
+release: 1.1.5
+github_path: InventoryApi/README.md
 last_modified_at: '2018-11-09 00:12:40 +0200'
 content: "The `InventoryApi` module provides Inventory Management service contracts.
   \n\nThis module is part of the new inventory infrastructure. The\n[Inventory Management

--- a/src/_data/codebase/v2_3/mrg/msi/InventoryBundleProduct.yaml
+++ b/src/_data/codebase/v2_3/mrg/msi/InventoryBundleProduct.yaml
@@ -1,8 +1,8 @@
 ---
 title: Magento_InventoryBundleProduct
 source_repo: inventory
-release: ''
-github_path: app/code/Magento/InventoryBundleProduct/README.md
+release: 1.1.5
+github_path: InventoryBundleProduct/README.md
 last_modified_at: '2018-11-09 00:12:40 +0200'
 content: |
   The `InventoryBundleProduct` module integrates inventory management business logic into Magento's bundle product logic.

--- a/src/_data/codebase/v2_3/mrg/msi/InventoryBundleProductAdminUi.yaml
+++ b/src/_data/codebase/v2_3/mrg/msi/InventoryBundleProductAdminUi.yaml
@@ -1,8 +1,8 @@
 ---
 title: Magento_InventoryBundleProductAdminUi
 source_repo: inventory
-release: ''
-github_path: app/code/Magento/InventoryBundleProductAdminUi/README.md
+release: 1.1.5
+github_path: InventoryBundleProductAdminUi/README.md
 last_modified_at: '2018-11-09 00:12:40 +0200'
 content: "The `InventoryBundleProductAdminUi`extends the Magento Admin UI to add MSI
   functionality.\n\nThis module is part of the new inventory infrastructure. The\n[Inventory

--- a/src/_data/codebase/v2_3/mrg/msi/InventoryCache.yaml
+++ b/src/_data/codebase/v2_3/mrg/msi/InventoryCache.yaml
@@ -1,8 +1,8 @@
 ---
 title: Magento_InventoryCache
 source_repo: inventory
-release: ''
-github_path: app/code/Magento/InventoryCache/README.md
+release: 1.1.5
+github_path: InventoryCache/README.md
 last_modified_at: '2018-11-09 00:12:40 +0200'
 content: |
   The `InventoryCache` module integrates inventory management business logic into Magento's cache logic.

--- a/src/_data/codebase/v2_3/mrg/msi/InventoryCatalog.yaml
+++ b/src/_data/codebase/v2_3/mrg/msi/InventoryCatalog.yaml
@@ -1,8 +1,8 @@
 ---
 title: Magento_InventoryCatalog
 source_repo: inventory
-release: ''
-github_path: app/code/Magento/InventoryCatalog/README.md
+release: 1.1.5
+github_path: InventoryCatalog/README.md
 last_modified_at: '2018-11-09 00:12:40 +0200'
 content: "The `InventoryCatalog` module integrates inventory management business logic
   into Magento's catalog logic.\n\nThis module is part of the new inventory infrastructure.

--- a/src/_data/codebase/v2_3/mrg/msi/InventoryCatalogAdminUi.yaml
+++ b/src/_data/codebase/v2_3/mrg/msi/InventoryCatalogAdminUi.yaml
@@ -1,8 +1,8 @@
 ---
 title: Magento_InventoryCatalogAdminUi
 source_repo: inventory
-release: ''
-github_path: app/code/Magento/InventoryCatalogAdminUi/README.md
+release: 1.1.5
+github_path: InventoryCatalogAdminUi/README.md
 last_modified_at: '2018-11-09 00:12:40 +0200'
 content: |
   The `InventoryCatalogAdminUi` module extends the Magento Admin UI to add MSI functionality.

--- a/src/_data/codebase/v2_3/mrg/msi/InventoryCatalogApi.yaml
+++ b/src/_data/codebase/v2_3/mrg/msi/InventoryCatalogApi.yaml
@@ -1,8 +1,8 @@
 ---
 title: Magento_InventoryCatalogApi
 source_repo: inventory
-release: ''
-github_path: app/code/Magento/InventoryCatalogApi/README.md
+release: 1.1.5
+github_path: InventoryCatalogApi/README.md
 last_modified_at: '2018-11-09 00:12:40 +0200'
 content: "The `InventoryCatalogApi` module provides service contracts for default
   source and stock providers as well as bulk operations. \n\nThis module is part of

--- a/src/_data/codebase/v2_3/mrg/msi/InventoryCatalogSearch.yaml
+++ b/src/_data/codebase/v2_3/mrg/msi/InventoryCatalogSearch.yaml
@@ -1,8 +1,8 @@
 ---
 title: Magento_InventoryCatalogSearch
 source_repo: inventory
-release: ''
-github_path: app/code/Magento/InventoryCatalogSearch/README.md
+release: 1.1.5
+github_path: InventoryCatalogSearch/README.md
 last_modified_at: '2018-11-09 00:12:40 +0200'
 content: |
   The `InventoryCatalogSearch` module integrates inventory management business logic into Magento's search logic.

--- a/src/_data/codebase/v2_3/mrg/msi/InventoryConfigurableProduct.yaml
+++ b/src/_data/codebase/v2_3/mrg/msi/InventoryConfigurableProduct.yaml
@@ -1,8 +1,8 @@
 ---
 title: Magento_InventoryConfigurableProduct
 source_repo: inventory
-release: ''
-github_path: app/code/Magento/InventoryConfigurableProduct/README.md
+release: 1.1.5
+github_path: InventoryConfigurableProduct/README.md
 last_modified_at: '2018-11-09 00:12:40 +0200'
 content: |
   ## InventoryConfigurableProduct module

--- a/src/_data/codebase/v2_3/mrg/msi/InventoryConfigurableProductAdminUi.yaml
+++ b/src/_data/codebase/v2_3/mrg/msi/InventoryConfigurableProductAdminUi.yaml
@@ -1,8 +1,8 @@
 ---
 title: Magento_InventoryConfigurableProductAdminUi
 source_repo: inventory
-release: ''
-github_path: app/code/Magento/InventoryConfigurableProductAdminUi/README.md
+release: 1.1.5
+github_path: InventoryConfigurableProductAdminUi/README.md
 last_modified_at: '2018-11-09 00:12:40 +0200'
 content: "The `InventoryConfigurableProductAdminUi`extends the Magento Admin UI to
   add inventory management functionality.\n\nThis module is part of the new inventory

--- a/src/_data/codebase/v2_3/mrg/msi/InventoryConfigurableProductIndexer.yaml
+++ b/src/_data/codebase/v2_3/mrg/msi/InventoryConfigurableProductIndexer.yaml
@@ -1,8 +1,8 @@
 ---
 title: Magento_InventoryConfigurableProductIndexer
 source_repo: inventory
-release: ''
-github_path: app/code/Magento/InventoryConfigurableProductIndexer/README.md
+release: 1.1.5
+github_path: InventoryConfigurableProductIndexer/README.md
 last_modified_at: '2018-11-09 00:12:40 +0200'
 content: |
   The `InventoryConfigurableProductIndexer` module integrates inventory management business logic into Magento's indexation logic for configurable products.

--- a/src/_data/codebase/v2_3/mrg/msi/InventoryConfiguration.yaml
+++ b/src/_data/codebase/v2_3/mrg/msi/InventoryConfiguration.yaml
@@ -1,8 +1,8 @@
 ---
 title: Magento_InventoryConfiguration
 source_repo: inventory
-release: ''
-github_path: app/code/Magento/InventoryConfiguration/README.md
+release: 1.1.5
+github_path: InventoryConfiguration/README.md
 last_modified_at: '2018-11-09 00:12:40 +0200'
 content: "The `InventoryConfiguration` module implements logic for inventory management
   configuration.\n\nThis module is part of the new inventory infrastructure. The\n[Inventory

--- a/src/_data/codebase/v2_3/mrg/msi/InventoryConfigurationApi.yaml
+++ b/src/_data/codebase/v2_3/mrg/msi/InventoryConfigurationApi.yaml
@@ -1,8 +1,8 @@
 ---
 title: Magento_InventoryConfigurationApi
 source_repo: inventory
-release: ''
-github_path: app/code/Magento/InventoryConfigurationApi/README.md
+release: 1.1.5
+github_path: InventoryConfigurationApi/README.md
 last_modified_at: '2018-11-09 00:12:40 +0200'
 content: |
   The `InventoryConfigurationApi` module provides service contracts for inventory management configuration.

--- a/src/_data/codebase/v2_3/mrg/msi/InventoryDistanceBasedSourceSelection.yaml
+++ b/src/_data/codebase/v2_3/mrg/msi/InventoryDistanceBasedSourceSelection.yaml
@@ -1,8 +1,8 @@
 ---
 title: Magento_InventoryDistanceBasedSourceSelection
 source_repo: inventory
-release: ''
-github_path: app/code/Magento/InventoryDistanceBasedSourceSelection/README.md
+release: 1.1.5
+github_path: InventoryDistanceBasedSourceSelection/README.md
 last_modified_at: '2018-12-28 10:54:19 +0100'
 content: "The `InventoryDistanceBasedSourceSelection` module implements logic for
   distance based source selection\n\nThis module is part of the new inventory infrastructure.

--- a/src/_data/codebase/v2_3/mrg/msi/InventoryDistanceBasedSourceSelectionAdminUi.yaml
+++ b/src/_data/codebase/v2_3/mrg/msi/InventoryDistanceBasedSourceSelectionAdminUi.yaml
@@ -1,8 +1,8 @@
 ---
 title: Magento_InventoryDistanceBasedSourceSelectionAdminUi
 source_repo: inventory
-release: ''
-github_path: app/code/Magento/InventoryDistanceBasedSourceSelectionAdminUi/README.md
+release: 1.1.5
+github_path: InventoryDistanceBasedSourceSelectionAdminUi/README.md
 last_modified_at: '2018-12-28 10:54:19 +0100'
 content: |
   The `InventoryDistanceBasedSourceSelectionAdminUi` module extends Magento's admin UI with source selection based on distance functionality.

--- a/src/_data/codebase/v2_3/mrg/msi/InventoryDistanceBasedSourceSelectionApi.yaml
+++ b/src/_data/codebase/v2_3/mrg/msi/InventoryDistanceBasedSourceSelectionApi.yaml
@@ -1,8 +1,8 @@
 ---
 title: Magento_InventoryDistanceBasedSourceSelectionApi
 source_repo: inventory
-release: ''
-github_path: app/code/Magento/InventoryDistanceBasedSourceSelectionApi/README.md
+release: 1.1.5
+github_path: InventoryDistanceBasedSourceSelectionApi/README.md
 last_modified_at: '2018-12-28 10:54:19 +0100'
 content: "The `InventoryDistanceBasedSourceSelectionApi` module provides service contracts
   for distance based source selection algorithm. \n\nThis module is part of the new

--- a/src/_data/codebase/v2_3/mrg/msi/InventoryElasticsearch.yaml
+++ b/src/_data/codebase/v2_3/mrg/msi/InventoryElasticsearch.yaml
@@ -1,8 +1,8 @@
 ---
 title: Magento_InventoryElasticsearch
 source_repo: inventory
-release: ''
-github_path: app/code/Magento/InventoryElasticsearch/README.md
+release: 1.1.5
+github_path: InventoryElasticsearch/README.md
 last_modified_at: '2018-12-21 16:08:11 +0200'
 content: |
   The `InventoryElasticsearch` module provides elastic search support for Inventory Management.

--- a/src/_data/codebase/v2_3/mrg/msi/InventoryExportStock.yaml
+++ b/src/_data/codebase/v2_3/mrg/msi/InventoryExportStock.yaml
@@ -1,8 +1,8 @@
 ---
 title: Magento_InventoryExportStock
 source_repo: inventory
-release: ''
-github_path: app/code/Magento/InventoryExportStock/README.md
+release: 1.1.5
+github_path: InventoryExportStock/README.md
 last_modified_at: '2019-04-23 22:46:43 +0300'
 content: |
   The `InventoryExportStock` module provides aggregated stock export functionality.

--- a/src/_data/codebase/v2_3/mrg/msi/InventoryExportStockApi.yaml
+++ b/src/_data/codebase/v2_3/mrg/msi/InventoryExportStockApi.yaml
@@ -1,8 +1,8 @@
 ---
 title: Magento_InventoryExportStockApi
 source_repo: inventory
-release: ''
-github_path: app/code/Magento/InventoryExportStockApi/README.md
+release: 1.1.5
+github_path: InventoryExportStockApi/README.md
 last_modified_at: '2019-04-23 22:46:43 +0300'
 content: |
   The `InventoryExportStockApi` module provides provides aggregated stock export functionality api.

--- a/src/_data/codebase/v2_3/mrg/msi/InventoryGraphQl.yaml
+++ b/src/_data/codebase/v2_3/mrg/msi/InventoryGraphQl.yaml
@@ -1,8 +1,8 @@
 ---
 title: Magento_InventoryGraphQl
 source_repo: inventory
-release: ''
-github_path: app/code/Magento/InventoryGraphQl/README.md
+release: 1.1.5
+github_path: InventoryGraphQl/README.md
 last_modified_at: '2019-03-30 16:15:21 +0100'
 content: |
   The `InventoryGraphQl` provides type information for the GraphQl module

--- a/src/_data/codebase/v2_3/mrg/msi/InventoryGroupedProduct.yaml
+++ b/src/_data/codebase/v2_3/mrg/msi/InventoryGroupedProduct.yaml
@@ -1,8 +1,8 @@
 ---
 title: Magento_InventoryGroupedProduct
 source_repo: inventory
-release: ''
-github_path: app/code/Magento/InventoryGroupedProduct/README.md
+release: 1.1.5
+github_path: InventoryGroupedProduct/README.md
 last_modified_at: '2018-11-09 00:12:40 +0200'
 content: "The `InventoryGroupedProduct` module integrates inventory management business
   logic into Magento's grouped product logic.\n\nThis module is part of the new inventory

--- a/src/_data/codebase/v2_3/mrg/msi/InventoryGroupedProductAdminUi.yaml
+++ b/src/_data/codebase/v2_3/mrg/msi/InventoryGroupedProductAdminUi.yaml
@@ -1,8 +1,8 @@
 ---
 title: Magento_InventoryGroupedProductAdminUi
 source_repo: inventory
-release: ''
-github_path: app/code/Magento/InventoryGroupedProductAdminUi/README.md
+release: 1.1.5
+github_path: InventoryGroupedProductAdminUi/README.md
 last_modified_at: '2018-11-09 00:12:40 +0200'
 content: |
   The `InventoryGroupedProductAdminUi` module extends Magento's admin UI with inventory management functionality.

--- a/src/_data/codebase/v2_3/mrg/msi/InventoryGroupedProductIndexer.yaml
+++ b/src/_data/codebase/v2_3/mrg/msi/InventoryGroupedProductIndexer.yaml
@@ -1,8 +1,8 @@
 ---
 title: Magento_InventoryGroupedProductIndexer
 source_repo: inventory
-release: ''
-github_path: app/code/Magento/InventoryGroupedProductIndexer/README.md
+release: 1.1.5
+github_path: InventoryGroupedProductIndexer/README.md
 last_modified_at: '2018-11-09 00:12:40 +0200'
 content: |
   The `InventoryGroupedProductIndexer` module integrates inventory management business logic into Magento's indexation logic for grouped products.

--- a/src/_data/codebase/v2_3/mrg/msi/InventoryImportExport.yaml
+++ b/src/_data/codebase/v2_3/mrg/msi/InventoryImportExport.yaml
@@ -1,8 +1,8 @@
 ---
 title: Magento_InventoryImportExport
 source_repo: inventory
-release: ''
-github_path: app/code/Magento/InventoryImportExport/README.md
+release: 1.1.5
+github_path: InventoryImportExport/README.md
 last_modified_at: '2018-11-09 00:12:40 +0200'
 content: "The `InventoryImportExport` module provides compatibility between Magento's
   flat file import/export logic and Inventory Management.\n\nThis module is part of

--- a/src/_data/codebase/v2_3/mrg/msi/InventoryIndexer.yaml
+++ b/src/_data/codebase/v2_3/mrg/msi/InventoryIndexer.yaml
@@ -1,8 +1,8 @@
 ---
 title: Magento_InventoryIndexer
 source_repo: inventory
-release: ''
-github_path: app/code/Magento/InventoryIndexer/README.md
+release: 1.1.5
+github_path: InventoryIndexer/README.md
 last_modified_at: '2018-11-09 00:12:40 +0200'
 content: |
   The `InventoryIndexer` module provides indexation logic for Inventory Management.

--- a/src/_data/codebase/v2_3/mrg/msi/InventoryLowQuantityNotification.yaml
+++ b/src/_data/codebase/v2_3/mrg/msi/InventoryLowQuantityNotification.yaml
@@ -1,8 +1,8 @@
 ---
 title: Magento_InventoryLowQuantityNotification
 source_repo: inventory
-release: ''
-github_path: app/code/Magento/InventoryLowQuantityNotification/README.md
+release: 1.1.5
+github_path: InventoryLowQuantityNotification/README.md
 last_modified_at: '2018-11-09 00:12:40 +0200'
 content: "The `InventoryLowQuantityNotification` module integrates Inventory Management
   business logic into Magento's low quantity notification logic.\n\nThis module is

--- a/src/_data/codebase/v2_3/mrg/msi/InventoryLowQuantityNotificationAdminUi.yaml
+++ b/src/_data/codebase/v2_3/mrg/msi/InventoryLowQuantityNotificationAdminUi.yaml
@@ -1,8 +1,8 @@
 ---
 title: Magento_InventoryLowQuantityNotificationAdminUi
 source_repo: inventory
-release: ''
-github_path: app/code/Magento/InventoryLowQuantityNotificationAdminUi/README.md
+release: 1.1.5
+github_path: InventoryLowQuantityNotificationAdminUi/README.md
 last_modified_at: '2018-11-09 00:12:40 +0200'
 content: |
   The `InventoryLowQuantityNotificationAdminUi` module extends Magento's admin UI with inventory management functionality.

--- a/src/_data/codebase/v2_3/mrg/msi/InventoryLowQuantityNotificationApi.yaml
+++ b/src/_data/codebase/v2_3/mrg/msi/InventoryLowQuantityNotificationApi.yaml
@@ -1,8 +1,8 @@
 ---
 title: Magento_InventoryLowQuantityNotificationApi
 source_repo: inventory
-release: ''
-github_path: app/code/Magento/InventoryLowQuantityNotificationApi/README.md
+release: 1.1.5
+github_path: InventoryLowQuantityNotificationApi/README.md
 last_modified_at: '2018-11-09 00:12:40 +0200'
 content: "The `InventoryLowQuantityNotificationApi` module provides service contracts
   for managing Inventory Management notifications. \n\nThis module is part of the

--- a/src/_data/codebase/v2_3/mrg/msi/InventoryMultiDimensionalIndexerApi.yaml
+++ b/src/_data/codebase/v2_3/mrg/msi/InventoryMultiDimensionalIndexerApi.yaml
@@ -1,8 +1,8 @@
 ---
 title: Magento_InventoryMultiDimensionalIndexerApi
 source_repo: inventory
-release: ''
-github_path: app/code/Magento/InventoryMultiDimensionalIndexerApi/README.md
+release: 1.1.5
+github_path: InventoryMultiDimensionalIndexerApi/README.md
 last_modified_at: '2018-11-09 00:12:40 +0200'
 content: "The `InventoryMultiDimensionalIndexerApi` module  provides functionality
   for creating and handling multi-dimension indexes.\n\nThis module is part of the

--- a/src/_data/codebase/v2_3/mrg/msi/InventoryProductAlert.yaml
+++ b/src/_data/codebase/v2_3/mrg/msi/InventoryProductAlert.yaml
@@ -1,8 +1,8 @@
 ---
 title: Magento_InventoryProductAlert
 source_repo: inventory
-release: ''
-github_path: app/code/Magento/InventoryProductAlert/README.md
+release: 1.1.5
+github_path: InventoryProductAlert/README.md
 last_modified_at: '2018-11-09 00:12:40 +0200'
 content: |+
   The `InventoryProductAlert` module integrates Inventory Management business logic into Magento's product alert logic.

--- a/src/_data/codebase/v2_3/mrg/msi/InventoryRequisitionList.yaml
+++ b/src/_data/codebase/v2_3/mrg/msi/InventoryRequisitionList.yaml
@@ -1,8 +1,8 @@
 ---
 title: Magento_InventoryRequisitionList
 source_repo: inventory
-release: ''
-github_path: app/code/Magento/InventoryRequisitionList/README.md
+release: 1.1.5
+github_path: InventoryRequisitionList/README.md
 last_modified_at: '2019-08-02 00:04:37 -0500'
 content: The Magento_InventoryRequisitionList allows the customer to use the new inventory
   management (MSI).

--- a/src/_data/codebase/v2_3/mrg/msi/InventoryReservationCli.yaml
+++ b/src/_data/codebase/v2_3/mrg/msi/InventoryReservationCli.yaml
@@ -1,8 +1,8 @@
 ---
 title: Magento_InventoryReservationCli
 source_repo: inventory
-release: ''
-github_path: app/code/Magento/InventoryReservationCli/README.md
+release: 1.1.5
+github_path: InventoryReservationCli/README.md
 last_modified_at: '2019-04-10 12:11:17 +0200'
 content: |
   The `InventoryReservationCli` module provide a cli command which helps the developer to discover inconsistencies on reservation.

--- a/src/_data/codebase/v2_3/mrg/msi/InventoryReservations.yaml
+++ b/src/_data/codebase/v2_3/mrg/msi/InventoryReservations.yaml
@@ -1,8 +1,8 @@
 ---
 title: Magento_InventoryReservations
 source_repo: inventory
-release: ''
-github_path: app/code/Magento/InventoryReservations/README.md
+release: 1.1.5
+github_path: InventoryReservations/README.md
 last_modified_at: '2018-11-09 00:12:40 +0200'
 content: "The `InventoryReservations` module provides logic for handling product reservations.\n\nThis
   module is part of the new inventory infrastructure. The\n[Inventory Management overview](https://devdocs.magento.com/guides/v2.3/inventory/index.html)\ndescribes

--- a/src/_data/codebase/v2_3/mrg/msi/InventoryReservationsApi.yaml
+++ b/src/_data/codebase/v2_3/mrg/msi/InventoryReservationsApi.yaml
@@ -1,8 +1,8 @@
 ---
 title: Magento_InventoryReservationsApi
 source_repo: inventory
-release: ''
-github_path: app/code/Magento/InventoryReservationsApi/README.md
+release: 1.1.5
+github_path: InventoryReservationsApi/README.md
 last_modified_at: '2018-11-09 00:12:40 +0200'
 content: |
   The `InventoryReservationsApi` module provides service contracts for Inventory Management reservations.

--- a/src/_data/codebase/v2_3/mrg/msi/InventorySales.yaml
+++ b/src/_data/codebase/v2_3/mrg/msi/InventorySales.yaml
@@ -1,8 +1,8 @@
 ---
 title: Magento_InventorySales
 source_repo: inventory
-release: ''
-github_path: app/code/Magento/InventorySales/README.md
+release: 1.1.5
+github_path: InventorySales/README.md
 last_modified_at: '2018-11-09 00:12:40 +0200'
 content: "The `InventorySales` module integrates Inventory Management business logic
   into Magento's sales logic.\n\nThis module is part of the new inventory infrastructure.

--- a/src/_data/codebase/v2_3/mrg/msi/InventorySalesAdminUi.yaml
+++ b/src/_data/codebase/v2_3/mrg/msi/InventorySalesAdminUi.yaml
@@ -1,8 +1,8 @@
 ---
 title: Magento_InventorySalesAdminUi
 source_repo: inventory
-release: ''
-github_path: app/code/Magento/InventorySalesAdminUi/README.md
+release: 1.1.5
+github_path: InventorySalesAdminUi/README.md
 last_modified_at: '2018-11-09 00:12:40 +0200'
 content: "The `InventorySalesAdminUi` module extends Magento's Admin UI with Inventory
   Management functionality.\n\nThis module is part of the new inventory infrastructure.

--- a/src/_data/codebase/v2_3/mrg/msi/InventorySalesApi.yaml
+++ b/src/_data/codebase/v2_3/mrg/msi/InventorySalesApi.yaml
@@ -1,8 +1,8 @@
 ---
 title: Magento_InventorySalesApi
 source_repo: inventory
-release: ''
-github_path: app/code/Magento/InventorySalesApi/README.md
+release: 1.1.5
+github_path: InventorySalesApi/README.md
 last_modified_at: '2018-11-09 00:12:40 +0200'
 content: "The `InventorySalesApi` module provides service contracts for inventory
   management. \n\nThis module is part of the new inventory infrastructure. The\n[Inventory

--- a/src/_data/codebase/v2_3/mrg/msi/InventorySalesFrontendUi.yaml
+++ b/src/_data/codebase/v2_3/mrg/msi/InventorySalesFrontendUi.yaml
@@ -1,8 +1,8 @@
 ---
 title: Magento_InventorySalesFrontendUi
 source_repo: inventory
-release: ''
-github_path: app/code/Magento/InventorySalesFrontendUi/README.md
+release: 1.1.5
+github_path: InventorySalesFrontendUi/README.md
 last_modified_at: '2018-11-09 00:12:40 +0200'
 content: "The `InventorySalesFrontendUi` module extends Magento's frontend UI with
   Inventory Management functionality. \n\nThis module is part of the new inventory

--- a/src/_data/codebase/v2_3/mrg/msi/InventorySetupFixtureGenerator.yaml
+++ b/src/_data/codebase/v2_3/mrg/msi/InventorySetupFixtureGenerator.yaml
@@ -1,8 +1,8 @@
 ---
 title: Magento_InventorySetupFixtureGenerator
 source_repo: inventory
-release: ''
-github_path: app/code/Magento/InventorySetupFixtureGenerator/README.md
+release: 1.1.5
+github_path: InventorySetupFixtureGenerator/README.md
 last_modified_at: '2018-12-24 14:41:45 +0200'
 content: "The `InventorySetupFixtureGenerator` module customizes the process of Inventory
   Data (Salable Quantity) Generation for [performance testing](https://devdocs.magento.com/guides/v2.3/config-guide/cli/config-cli-subcommands-perf-data.html).\n\nThis

--- a/src/_data/codebase/v2_3/mrg/msi/InventoryShipping.yaml
+++ b/src/_data/codebase/v2_3/mrg/msi/InventoryShipping.yaml
@@ -1,8 +1,8 @@
 ---
 title: Magento_InventoryShipping
 source_repo: inventory
-release: ''
-github_path: app/code/Magento/InventoryShipping/README.md
+release: 1.1.5
+github_path: InventoryShipping/README.md
 last_modified_at: '2018-11-09 00:12:40 +0200'
 content: "The `InventoryShipping` module integrates MSI business logic into Magento's
   shipping logic.\n\nThis module is part of the new inventory infrastructure. The\n[Inventory

--- a/src/_data/codebase/v2_3/mrg/msi/InventoryShippingAdminUi.yaml
+++ b/src/_data/codebase/v2_3/mrg/msi/InventoryShippingAdminUi.yaml
@@ -1,8 +1,8 @@
 ---
 title: Magento_InventoryShippingAdminUi
 source_repo: inventory
-release: ''
-github_path: app/code/Magento/InventoryShippingAdminUi/README.md
+release: 1.1.5
+github_path: InventoryShippingAdminUi/README.md
 last_modified_at: '2018-11-09 00:12:40 +0200'
 content: |
   The `InventoryShippingAdminUi` module extends Magento's Admin UI with Inventory Management functionality.

--- a/src/_data/codebase/v2_3/mrg/msi/InventorySourceDeductionApi.yaml
+++ b/src/_data/codebase/v2_3/mrg/msi/InventorySourceDeductionApi.yaml
@@ -1,8 +1,8 @@
 ---
 title: Magento_InventorySourceDeductionApi
 source_repo: inventory
-release: ''
-github_path: app/code/Magento/InventorySourceDeductionApi/README.md
+release: 1.1.5
+github_path: InventorySourceDeductionApi/README.md
 last_modified_at: '2018-11-09 00:12:40 +0200'
 content: "The `InventorySourceDeductionApi` module provides service contracts for
   managing source deductuions when products are sold. \n\nThis module is part of the

--- a/src/_data/codebase/v2_3/mrg/msi/InventorySourceSelection.yaml
+++ b/src/_data/codebase/v2_3/mrg/msi/InventorySourceSelection.yaml
@@ -1,8 +1,8 @@
 ---
 title: Magento_InventorySourceSelection
 source_repo: inventory
-release: ''
-github_path: app/code/Magento/InventorySourceSelection/README.md
+release: 1.1.5
+github_path: InventorySourceSelection/README.md
 last_modified_at: '2018-11-09 00:12:40 +0200'
 content: "The `InventorySourceSelection` module provides source selection logic for
   Inventory Management.\n\nThis module is part of the new inventory infrastructure.

--- a/src/_data/codebase/v2_3/mrg/msi/InventorySourceSelectionApi.yaml
+++ b/src/_data/codebase/v2_3/mrg/msi/InventorySourceSelectionApi.yaml
@@ -1,8 +1,8 @@
 ---
 title: Magento_InventorySourceSelectionApi
 source_repo: inventory
-release: ''
-github_path: app/code/Magento/InventorySourceSelectionApi/README.md
+release: 1.1.5
+github_path: InventorySourceSelectionApi/README.md
 last_modified_at: '2018-11-09 00:12:40 +0200'
 content: |
   The `InventorySourceSelectionApi` module provides service contracts for source selection algorithms (SSA).

--- a/src/_data/toc/module-reference-guide-2_3.yml
+++ b/src/_data/toc/module-reference-guide-2_3.yml
@@ -3,7 +3,8 @@ pages:
   - label: Introduction
     url: /mrg/intro.html
   
-  - label: Open Source (v2.3.4)
+  - label: Open Source (v2.3.5)
+    include_versions: ["2.3"]
     children:
     
       - label: AdminAnalytics
@@ -153,6 +154,9 @@ pages:
       - label: Cron
         url: /mrg/ce/Cron.html
     
+      - label: Csp
+        url: /mrg/ce/Csp.html
+    
       - label: CurrencySymbol
         url: /mrg/ce/CurrencySymbol.html
     
@@ -206,6 +210,9 @@ pages:
     
       - label: Elasticsearch6
         url: /mrg/ce/Elasticsearch6.html
+    
+      - label: Elasticsearch7
+        url: /mrg/ce/Elasticsearch7.html
     
       - label: Email
         url: /mrg/ce/Email.html
@@ -499,7 +506,8 @@ pages:
         url: /mrg/ce/WishlistGraphQl.html
     
   
-  - label: Commerce (v2.3.4)
+  - label: Commerce (v2.3.5)
+    include_versions: ["2.3"]
     children:
     
       - label: AdminGws
@@ -546,6 +554,9 @@ pages:
     
       - label: CatalogStaging
         url: /mrg/ee/CatalogStaging.html
+    
+      - label: CatalogStagingGraphQl
+        url: /mrg/ee/CatalogStagingGraphQl.html
     
       - label: CatalogUrlRewriteStaging
         url: /mrg/ee/CatalogUrlRewriteStaging.html
@@ -718,6 +729,9 @@ pages:
       - label: Staging
         url: /mrg/ee/Staging.html
     
+      - label: StagingGraphQl
+        url: /mrg/ee/StagingGraphQl.html
+    
       - label: Support
         url: /mrg/ee/Support.html
     
@@ -729,6 +743,9 @@ pages:
     
       - label: VersionsCms
         url: /mrg/ee/VersionsCms.html
+    
+      - label: VersionsCmsUrlRewrite
+        url: /mrg/ee/VersionsCmsUrlRewrite.html
     
       - label: VisualMerchandiser
         url: /mrg/ee/VisualMerchandiser.html
@@ -743,7 +760,8 @@ pages:
         url: /mrg/ee/Worldpay.html
     
   
-  - label: B2B (v1.1.4)
+  - label: B2B (v1.1.5)
+    include_versions: ["2.3"]
     children:
     
       - label: B2b
@@ -813,7 +831,8 @@ pages:
         url: /mrg/b2b/SharedCatalog.html
     
   
-  - label: Inventory Management (v1.1.4)
+  - label: Inventory Management (v1.1.5)
+    include_versions: ["2.3"]
     children:
     
       - label: Inventory


### PR DESCRIPTION
## Purpose of this pull request

This pull request (PR) introduces documentation updates generated from READMEs at _magento2ce_, _magento2ee_, _magento2b2b_, and _inventory_ repositories.

_Internal preview: 1733_

## Affected DevDocs pages

<!-- REQUIRED List the affected pages on devdocs.magento.com (URLs). Not needed for large numbers of files. -->

- https://devdocs.magento.com/guides/v2.3/mrg/ce/...
- https://devdocs.magento.com/guides/v2.3/mrg/ee/...
- https://devdocs.magento.com/guides/v2.3/mrg/b2b/...
- https://devdocs.magento.com/guides/v2.3/mrg/msi/...

## Links to Magento source code

<!--  OPTIONAL - REMOVE THIS SECTION IF NOT USED. If this pull request references a file in a Magento codebase repository, add it here. -->

-  modules' README.md files at _magento2ce_, _magento2ee_, _magento2b2b_, and _inventory_ repositories

-----

whatsnew
Updated all module topics according to codebase repositories at the Module Reference Guide.