### PR TITLE
Fix incorrect docker-compose command

### DIFF
--- a/src/cloud/docker/docker-containers.md
+++ b/src/cloud/docker/docker-containers.md
@@ -126,7 +126,7 @@ ERROR: Volume magento-sync declared as external, but could not be found. Please 
 All containers use the Docker logging method. You can view the logs using the `docker-compose` command. The following example uses the `-f` option to _follow_ the log output of the TLS container:
 
 ```bash
-docker-composer logs -f tls
+docker-compose logs -f tls
 ```
 
 Now you can see all requests that are passing through the TLS container and check for errors.


### PR DESCRIPTION
## Purpose of this pull request

Fixed error in `docker-compose` command for viewing logs in Magento Cloud Docker environment.  Error identified by customer feedback.

## Affected DevDocs pages

<!-- REQUIRED List the affected pages on devdocs.magento.com (URLs). Not needed for large numbers of files. -->

https://devdocs.magento.com/cloud/docker/docker-containers.html