### PR TITLE
Update composer.json link URL

### DIFF
--- a/src/guides/v2.3/extension-dev-guide/build/module-load-order.md
+++ b/src/guides/v2.3/extension-dev-guide/build/module-load-order.md
@@ -6,7 +6,7 @@ menu_title: Component load order
 menu_order: 7000
 ---
 
-You may need to specify your component's dependency on other components or files from other components using your component's [composer.json]({{ page.baseurl }}/extension-dev-guide/build/create_component.html#add-component-xml). Further, you can specify a load order in your component's `module.xml` file using the `<sequence>` tag to ensure that needed files from other components are already loaded when your component loads.
+You may need to specify your component's dependency on other components or files from other components using your component's [composer.json]({{ page.baseurl }}/extension-dev-guide/build/create_component.html#add-composer-json). Further, you can specify a load order in your component's `module.xml` file using the `<sequence>` tag to ensure that needed files from other components are already loaded when your component loads.
 
 `<sequence>` declares the list of components that must be loaded before the current component is loaded. It's used for loading different kind of files: configuration files, view files (including CSS, Less, and template files), or setup classes. Note that `<sequence>` does not affect the loading of regular classes (non-setup classes).
 *Setup* classes are classes in the component that create or update [database schema](https://glossary.magento.com/database-schema) or data.


### PR DESCRIPTION
## Purpose of this pull request
Fix the wrong link for document 

## Affected DevDocs pages
- https://devdocs.magento.com/guides/v2.3/extension-dev-guide/build/module-load-order.html
