### PR TITLE
Add contributors and maintainers link to home page

### DIFF
--- a/src/index.html
+++ b/src/index.html
@@ -60,6 +60,7 @@ guide_version: '2.3'
       <ul>
         <li><a href="{{ site.baseurl }}/community/resources/resources.html">Community Resources</a></li>
         <li><a href="{{ page.baseurl }}/contributor-guide/contributing.html">Contributor Guide</a></li>
+        <li><a href="{{ page.baseurl }}/contributor-guide/contributors.html">Contributors and Maintainers</a></li>
         <li><a href="{{ page.baseurl }}/contributor-guide/contributing_dod.html">Magento Definition of Done</a></li>
       </ul>
     </div>


### PR DESCRIPTION
## Purpose of this pull request

Added a [Contributors and Maintainers](https://devdocs.magento.com/guides/v2.3/contributor-guide/contributors.html#/individual-contributors) link to the Community section of the DevDocs home page per user feedback.

## Affected DevDocs pages

- https://devdocs.magento.com/