### PR TITLE
Add docs for REDIS_BACKEND deploy variable

### DIFF
--- a/src/cloud/env/variables-deploy.md
+++ b/src/cloud/env/variables-deploy.md
@@ -92,7 +92,7 @@ If the _REDIS_BACKEND_ variable specifies  `\Magento\Framework\Cache\Backend\Rem
 - **Default**—`Cm_Cache_Backend_Redis`
 - **Version**—Magento 2.3.5 and later
 
-Configuration the backend model for redis cache.
+Specifies the backend model configuration for the Redis cache.
 
 Magento version 2.3.5 and later includes the following backend models:
  - `Cm_Cache_Backend_Redis`

--- a/src/cloud/env/variables-deploy.md
+++ b/src/cloud/env/variables-deploy.md
@@ -99,6 +99,8 @@ Magento version 2.3.5 and later includes the following backend models:
  - `\Magento\Framework\Cache\Backend\Redis`
  - `\Magento\Framework\Cache\Backend\RemoteSynchronizedCache`
 
+{:.bs-callout-info}
+See [L2 caching in the Magento application]({{site.baseurl}}/guides/v2.3/config-guide/two-level-cache.html) for details on selecting the backend model for Redis caching.
 ### `CLEAN_STATIC_FILES`
 
 -  **Default**—`true`

--- a/src/cloud/env/variables-deploy.md
+++ b/src/cloud/env/variables-deploy.md
@@ -94,7 +94,7 @@ If the _REDIS_BACKEND_ variable specifies  `\Magento\Framework\Cache\Backend\Rem
 
 Configuration the backend model for redis cache.
 
-Since version 2.3.5 Magento supports the next backend models:
+Magento version 2.3.5 and later includes the following backend models:
  - `Cm_Cache_Backend_Redis`
  - `\Magento\Framework\Cache\Backend\Redis`
  - `\Magento\Framework\Cache\Backend\RemoteSynchronizedCache`

--- a/src/cloud/env/variables-deploy.md
+++ b/src/cloud/env/variables-deploy.md
@@ -54,7 +54,7 @@ stage:
             database: 11
 ```
 
-Be aware, if you use this `\Magento\Framework\Cache\Backend\RemoteSynchronizedCache` backend model then configuration structure will be the next:
+If the _REDIS_BACKEND_ variable specifies  `\Magento\Framework\Cache\Backend\RemoteSynchronizedCache`for the backend model, you must use the following configuration structure:
 
 ```php
 'cache' => [

--- a/src/cloud/env/variables-deploy.md
+++ b/src/cloud/env/variables-deploy.md
@@ -54,6 +54,51 @@ stage:
             database: 11
 ```
 
+Be aware, if you use this `\Magento\Framework\Cache\Backend\RemoteSynchronizedCache` backend model then configuration structure will be the next:
+
+```php
+'cache' => [
+    'frontend' => [
+        'default' => [
+             'backend' => '\\Magento\\Framework\\Cache\\Backend\\RemoteSynchronizedCache',
+             'backend_options' => [
+                 'remote_backend' => '\\Magento\\Framework\\Cache\\Backend\\Redis',
+                 'remote_backend_options' => [
+                     'persistent' => 0,
+                     'server' => 'localhost',
+                     'database' => '0',
+                     'port' => '6370',
+                     'password' => '',
+                     'compress_data' => '1',
+                 ],
+                 'local_backend' => 'Cm_Cache_Backend_File',
+                 'local_backend_options' => [
+                     'cache_dir' => '/dev/shm/'
+                 ]
+             ],
+             'frontend_options' => [
+                 'write_control' => false,
+             ],
+         ]
+    ],
+    'type' => [
+        'default' => ['frontend' => 'default'],
+    ],
+]
+```
+
+### `REDIS_BACKEND`
+
+- **Default**—`Cm_Cache_Backend_Redis`
+- **Version**—Magento 2.3.5 and later
+
+Configuration the backend model for redis cache.
+
+Since version 2.3.5 Magento supports the next backend models:
+ - `Cm_Cache_Backend_Redis`
+ - `\Magento\Framework\Cache\Backend\Redis`
+ - `\Magento\Framework\Cache\Backend\RemoteSynchronizedCache`
+
 ### `CLEAN_STATIC_FILES`
 
 -  **Default**—`true`


### PR DESCRIPTION
## Purpose of this pull request

Information about the new REDIS_BACKEND deployment variable to configure Redis backend mode.

## Affected DevDocs pages

https://devdocs.magento.com/cloud/env/variables-deploy.html

## Links to Magento source code

https://github.com/magento/ece-tools/pull/724

whatsnew
Added the REDIS_BACKEND environment variable to configure the Redis backend model for Redis cache.
