### PR TITLE
MCLOUD-5956: Cloud rewrite import notice

### DIFF
--- a/src/cloud/configure/import-url-rewrites.md
+++ b/src/cloud/configure/import-url-rewrites.md
@@ -12,7 +12,6 @@ You can easily migrate to the {{site.data.var.ece}} platform without losing SEO 
 {:.bs-callout-info}
 This module supports PHP versions 7.0.13 and later patch releases and all 7.1.x and 7.2.x patch releases. The module is available for Magento version 2.2.x and 2.3.x only.
 
-
 {:.procedure}
 To install the URL rewrite module:
 

--- a/src/cloud/configure/import-url-rewrites.md
+++ b/src/cloud/configure/import-url-rewrites.md
@@ -12,6 +12,7 @@ You can easily migrate to the {{site.data.var.ece}} platform without losing SEO 
 {:.bs-callout-info}
 This module supports PHP versions 7.0.13 and later patch releases and all 7.1.x and 7.2.x patch releases. The module is available for Magento version 2.2.x and 2.3.x only.
 
+
 {:.procedure}
 To install the URL rewrite module:
 
@@ -96,6 +97,9 @@ To import URL Rewrites:
    ![Successful URL rewrite]({{site.baseurl}}/common/images/cloud/cloud-urlrewrite-success.png)
 
 ## Troubleshooting the import
+
+{:.bs-callout-info}
+Large uploads can be limited by the `upload_max_filesize` directive in `php.ini`. If your URL file is bigger than the existing limit, see [Customize php.ini settings]({{ site.baseurl }}/cloud/project/project-conf-files_magento-app.html#customize-phpini-settings) to increase it.
 
 If the import is **not** successful, you receive an error message reporting the URL rewrite failed:
 


### PR DESCRIPTION
## Purpose of this pull request

This pull request (PR) updates the documentation for URL rewrite importing. It adds a notice that large file uploads can be limited by `php.ini`. The ini limit is more likely to be encountered after increasing the code-defined upload limit from 20 MiB to 100 MiB.

## Affected DevDocs pages

- https://devdocs.magento.com/cloud/configure/import-url-rewrites.html

## Links to Magento source code

- https://github.com/magento/module-url-rewrite-import-export/pull/4

<!--
If you are fixing a GitHub issue, note it using GitHub keyword format (https://help.github.com/en/articles/closing-issues-using-keywords#closing-an-issue-in-a-different-repository) to close the issue when this pull request is merged. Example: `Fixes #1234`

`master` is the default branch. Merged pull requests to `master` go live on the site automatically. Any requested changes to content on the `master` branch must be related to the released codebase. Any content related to future releases goes in the `develop` branch.

See Contribution guidelines (https://github.com/magento/devdocs/blob/master/.github/CONTRIBUTING.md) for more information.
-->
whatsnew
Updated the [Import URL Rewrites](https://devdocs.magento.com/cloud/configure/import-url-rewrites.html) topic with guidance about checking the PHP  file upload limit to prevent errors when uploading a large file for importing URL rewrites.