### PR TITLE
magento/devdocs#: Editorial. Fix RWD CSS file names

### DIFF
--- a/src/guides/v2.3/frontend-dev-guide/responsive-web-design/rwd_css.md
+++ b/src/guides/v2.3/frontend-dev-guide/responsive-web-design/rwd_css.md
@@ -54,7 +54,7 @@ For Less styles rules to be compiled to `styles-m.css` without a media query so 
 
 ```less
 //
-//  Common (style-m.css)
+//  Common (styles-m.css)
 //  _____________________________________________
 & when (@media-common = true) {
     // your code
@@ -73,7 +73,7 @@ For grouping style rules in certain media queries the `.media-width()` mixin use
 
 ```less
 //
-//  Mobile (style-m.css)
+//  Mobile (styles-m.css)
 //  _____________________________________________
 
 .media-width(@extremum, @break) when (@extremum = 'max') and (@break = @screen__s) {


### PR DESCRIPTION


## Purpose of this pull request

This pull request (PR) fixes CSS file names in the [Media queries in Magento default themes](https://devdocs.magento.com/guides/v2.3/frontend-dev-guide/responsive-web-design/rwd_css.html#lib_rwd).

## Affected DevDocs pages

<!-- REQUIRED List the affected pages on devdocs.magento.com (URLs). Not needed for large numbers of files. -->

- https://devdocs.magento.com/guides/v2.3/frontend-dev-guide/responsive-web-design/rwd_css.html#lib_rwd

## Links to Magento source code

<!--  OPTIONAL - REMOVE THIS SECTION IF NOT USED. If this pull request references a file in a Magento codebase repository, add it here. -->

- [styles-m.css](https://github.com/magento/magento2/blob/2.4-develop/app/design/frontend/Magento/blank/Magento_Theme/layout/default_head_blocks.xml#L10)
- [styles-l.css](https://github.com/magento/magento2/blob/2.4-develop/app/design/frontend/Magento/blank/Magento_Theme/layout/default_head_blocks.xml#L11)

<!--
If you are fixing a GitHub issue, note it using GitHub keyword format (https://help.github.com/en/articles/closing-issues-using-keywords#closing-an-issue-in-a-different-repository) to close the issue when this pull request is merged. Example: `Fixes #1234`

`master` is the default branch. Merged pull requests to `master` go live on the site automatically. Any requested changes to content on the `master` branch must be related to the released codebase. Any content related to future releases goes in the `develop` branch.

See Contribution guidelines (https://github.com/magento/devdocs/blob/master/.github/CONTRIBUTING.md) for more information.
-->

Thank you!