### PR TITLE
MC-34147: Prepare Composer update plugin docs for GA

### DIFF
--- a/src/guides/v2.3/comp-mgr/cli/upgrade-with-plugin.md
+++ b/src/guides/v2.3/comp-mgr/cli/upgrade-with-plugin.md
@@ -10,9 +10,6 @@ functional_areas:
 {% capture ee %}{{site.data.var.ee}}{% endcapture %}
 -->
 
-{:.bs-callout-warning}
-This plugin is in beta. Do not use it on production. It only works with Composer version 1.8.0 or earlier. It is currently incompatible with Magento 2.3.5 or later.
-
 The [`magento/composer-root-update-plugin`][custom composer plugin] Composer plugin resolves changes that need to be made to the root project `composer.json` file before updating to a new Magento product requirement.
 
 Basically, this section repeats the manual upgrade scenario with the only exclusion that you are guided to install the plugin to resolve the dependency conflicts instead of fixing them manually.
@@ -30,7 +27,7 @@ Backup the existing `composer.json` file in the Magento installation directory.
 ## Install the plugin
 
 ```bash
-composer require magento/composer-root-update-plugin ~0.1 --no-update
+composer require magento/composer-root-update-plugin ~1.0 --no-update
 ```
 
 Update the dependencies:

--- a/src/guides/v2.4/comp-mgr/cli/upgrade-with-plugin.md
+++ b/src/guides/v2.4/comp-mgr/cli/upgrade-with-plugin.md
@@ -10,10 +10,6 @@ functional_areas:
 {% capture ee %}{{site.data.var.ee}}{% endcapture %}
 -->
 
-{:.bs-callout-warning}
-This upgrading scenario is still under development and is published here to make it available for the Community to test.
-Do not use it on production.
-
 The [`magento/composer-root-update-plugin`][custom composer plugin] Composer plugin resolves changes that need to be made to the root project `composer.json` file before updating to a new Magento product requirement.
 
 Basically, this section repeats the manual upgrade scenario with the only exclusion that you are guided to install the plugin to resolve the dependency conflicts instead of fixing them manually.
@@ -31,7 +27,7 @@ Backup the existing `composer.json` file in the Magento installation directory.
 ## Install the plugin
 
 ```bash
-composer require magento/composer-root-update-plugin ~0.1 --no-update
+composer require magento/composer-root-update-plugin ~1.0 --no-update
 ```
 
 Update the dependencies:


### PR DESCRIPTION
## Purpose of this pull request

This pull request (PR) removes the beta note and Composer dependency for the `composer-root-update-plugin` tool. The tool's GA release will coincide with the 2.4.0 GA release.

## Affected DevDocs pages

-  https://devdocs.magento.com/guides/v2.3/comp-mgr/cli/upgrade-with-plugin.html

whatsnew
Removed beta information from the [Composer root update plugin](https://devdocs.magento.com/guides/v2.3/comp-mgr/cli/upgrade-with-plugin.html) topic to support the GA release of the tool.