### PR TITLE
Update css-themes.md

### DIFF
--- a/src/guides/v2.3/frontend-dev-guide/css-topics/css-themes.md
+++ b/src/guides/v2.3/frontend-dev-guide/css-topics/css-themes.md
@@ -79,7 +79,7 @@ For example, to include `<theme_dir>/web/css/custom.css`:
 ```xml
 <page xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="urn:magento:framework:View/Layout/etc/page_configuration.xsd">
     <head>
-        <css src="css/custom.css"  src_type="url" rel="stylesheet" type="text/css"  />
+        <css src="css/custom.css" rel="stylesheet" type="text/css"  />
     </head>
 </page>
 ```


### PR DESCRIPTION
"src_type="url" at line 82 was causing a request-blocking due to nosniff error on firefox and a 404 on chrome. Removing "src_type="url" makes it work properly again.

## Purpose of this pull request
In this exemple the custom.css doesnt come from a url, and was causing blocking errors on the browser.

## Affected DevDocs pages
https://devdocs.magento.com/guides/v2.3/frontend-dev-guide/css-topics/css-themes.html



