### PR TITLE
Speeding up npm install --prefer-offline --no-audit --no-optional

### DIFF
--- a/src/cloud/project/project-conf-files_magento-app.md
+++ b/src/cloud/project/project-conf-files_magento-app.md
@@ -260,7 +260,7 @@ dependencies:
 hooks:
     build: |
         cd public/profiles/project_name/themes/custom/theme_name
-        npm install
+        npm install --prefer-offline --no-audit --no-optional
         grunt
         cd
         php ./vendor/bin/ece-tools build

--- a/src/compliance/privacy/__adobe-privacy-js-library.md
+++ b/src/compliance/privacy/__adobe-privacy-js-library.md
@@ -15,7 +15,7 @@ Use this library to retrieve and remove the data stored in the browser by these 
 
 Use one of the following methods to download the library file:
 
--  npm: `npm install @adobe/adobe-privacy`
+-  npm: `npm install --prefer-offline --no-audit --no-optional @adobe/adobe-privacy`
 -  GitHub: <https://github.com/Adobe-Marketing-Cloud/adobe-privacy>
 
 After you have the file, you will need to add it to a custom module or theme installed in your Magento instance.

--- a/src/guides/v2.3/frontend-dev-guide/css-topics/css_debug.md
+++ b/src/guides/v2.3/frontend-dev-guide/css-topics/css_debug.md
@@ -37,7 +37,7 @@ To compile `.less` files, add your theme to `module.exports` in the Grunt config
    ```
 
    ```bash
-   npm install
+   npm install --prefer-offline --no-audit --no-optional
    ```
 
    ```bash

--- a/src/guides/v2.3/frontend-dev-guide/css-topics/gulp-sass.md
+++ b/src/guides/v2.3/frontend-dev-guide/css-topics/gulp-sass.md
@@ -43,7 +43,7 @@ For details about adding a custom preprocessor, see [Add custom CSS preprocessor
 
 1. Add the gulp-sass package for the Sass preprocessor by running the following command:
 
-   `npm install gulp-sass`
+   `npm install --prefer-offline --no-audit --no-optional gulp-sass`
 
 ## Create a theme and add Sass styles
 

--- a/src/guides/v2.3/frontend-dev-guide/tools/using_grunt.md
+++ b/src/guides/v2.3/frontend-dev-guide/tools/using_grunt.md
@@ -41,7 +41,7 @@ Magento has built-in Grunt tasks configured, but there are still several steps y
    ```
 
    ```bash
-   npm install
+   npm install --prefer-offline --no-audit --no-optional
    ```
 
    ```bash

--- a/src/guides/v2.3/test/js/jasmine.md
+++ b/src/guides/v2.3/test/js/jasmine.md
@@ -21,7 +21,7 @@ Magento uses a custom [Grunt] task named `spec` to run Jasmine tests. The task c
 **Step 5.** In `<magento_root_dir>`, install all dependencies:
 
 ```bash
-npm install
+npm install --prefer-offline --no-audit --no-optional
 ```
 
 **Step 6.** In `<magento_root_dir>`, generate static view files in Magento that are going to be tested
@@ -248,7 +248,7 @@ Warning: Task "spec" not found. Use --force to continue.
 1. Remove `package.json`, `Gruntfile.js`.
 1. Copy `package.json`, `Gruntfile.js` from `package.json.sample`, `Gruntfile.js.sample`.
 1. Delete the `node_modules` directory.
-1. Run `npm install` in your terminal.
+1. Run `npm install --prefer-offline --no-audit --no-optional` in your terminal.
 
 ### Warning: Cannot read property 'pid' of undefined {#cannot-read-property-pid-warning}
 
@@ -271,7 +271,7 @@ cd <magento_root>/node_modules/grunt-contrib-jasmine
 ```
 
 ```bash
-npm install
+npm install --prefer-offline --no-audit --no-optional
 ```
 
 <!-- LINK DEFINITIONS -->


### PR DESCRIPTION
Speeding up npm install --prefer-offline --no-audit --no-optional

## Purpose of this pull request

Since we use npm in the project just to install the necessary packages to compile LESS using Grunt.

We must focus on speed and performance in our development environment, staging, uat, production, etc.

We do not need every new run of npm install:

1) Use the network, download the packages and install them again, if we have them in cache. By default, verifies packages against the registry after a minimum cache time to see if the package is still good, so prefering offline mode, no network requests will be done during install. So --prefer-offline should be used.

2) Receive during the installation of package audit, is anyone looking for these results? I think they can be suppressed. So --no-audit should be used.

3) Install package dependencies that we are not going to use. So --no-optional should be used.

Using the additional arguments with npm it will be 15% faster to install the packages. Faster than npm, it would be if we use pnpm, but it would be for another scope.


## Affected DevDocs pages

https://devdocs.magento.com/cloud/project/project-conf-files_magento-app.html

https://devdocs.magento.com/guides/v2.3/frontend-dev-guide/css-topics/css_debug.html

https://devdocs.magento.com/guides/v2.3/frontend-dev-guide/tools/using_grunt.html

https://devdocs.magento.com/page-builder/docs/getting-started/install-pagebuilder.html

https://devdocs.magento.com/guides/v2.3/test/js/jasmine.html

https://devdocs.magento.com/guides/v2.3/frontend-dev-guide/css-topics/gulp-sass.html

