### PR TITLE
Update fastly-vcl-bypass-to-origin.md

### DIFF
--- a/src/cloud/cdn/fastly-vcl-bypass-to-origin.md
+++ b/src/cloud/cdn/fastly-vcl-bypass-to-origin.md
@@ -70,6 +70,18 @@ To bypass Fastly and submit requests to the origin server:
  {:.bs-callout-info}
 Instead of manually uploading custom VCL snippets, you can add snippets to the `$MAGENTO_CLOUD_APP_DIR/var/vcl_snippets_custom` directory in your environment. Snippets in this directory upload automatically any time you click *upload VCL to Fastly* in the Admin UI. See [Automated custom VCL snippets deployment][] in the Fastly CDN module for Magento 2 documentation.
 
+### A large number of graphql interface requests will cause a 403 error
+
+Please bypass WAF for GraphQL requests:
+1. Create a new custom VCL snippet https://github.com/fastly/fastly-magento2/blob/master/Documentation/Guides/CUSTOM-VCL-SNIPPETS.md
+2. Set type: recv, priority: 15
+
+3. Configure VCL to bypass WAF processing:
+```
+if (req.url.path ~ "^/graphql") {
+    set req.http.bypasswaf = "1";
+}
+```
 <!-- Link definitions -->
 
 [Create Fastly Bypass VCL snippet]: {{ site.baseurl }}/common/images/cloud/cloud-fastly-create-bypass-snippet.png


### PR DESCRIPTION
Solve a lot of graphql requests fastly return 403 error

## Purpose of this pull request

This pull request (PR) ...

## Affected DevDocs pages
https://devdocs.magento.com/cloud/cdn/fastly-vcl-bypass-to-origin.html
<!-- REQUIRED List the affected pages on devdocs.magento.com (URLs). Not needed for large numbers of files. -->

-  ...

## Links to Magento source code

<!--  OPTIONAL - REMOVE THIS SECTION IF NOT USED. If this pull request references a file in a Magento codebase repository, add it here. -->

-  ...

<!--
If you are fixing a GitHub issue, note it using GitHub keyword format (https://help.github.com/en/articles/closing-issues-using-keywords#closing-an-issue-in-a-different-repository) to close the issue when this pull request is merged. Example: `Fixes #1234`

`master` is the default branch. Merged pull requests to `master` go live on the site automatically. Any requested changes to content on the `master` branch must be related to the released codebase. Any content related to future releases goes in the `develop` branch.

See Contribution guidelines (https://github.com/magento/devdocs/blob/master/.github/CONTRIBUTING.md) for more information.
-->
