### PR TITLE
 Adding new PHP extensions

### DIFF
--- a/src/cloud/docker/docker-extend.md
+++ b/src/cloud/docker/docker-extend.md
@@ -75,6 +75,63 @@ To add a new service version using a `Dockerfile`:
 
 1. Once the build succeeds, test the changes by specifying the [Docker build sources].
 
+## Add a new PHP extension
+
+In addition to built in extensions, you can add PHP extensions to the PHP container.
+
+{:.procedure}
+To add a new PHP extension:
+
+1. Clone the `{{site.data.var.mcd}}` project to your local environment if necessary.
+
+1. On the command line, navigate to the following directory
+   ```bash
+      cd magento-cloud-docker/src/Compose/Php
+   ```
+
+1. Open `ExtensionResolver.php` file, define the required extension inside the `getConfig` method by specifying the extension type and dependency.
+
+    For instance the following block adds the GNUPG extension:
+    ```PHP
+    'gnupg' => [
+      '>=7.0' => [
+      self::EXTENSION_TYPE => self::EXTENSION_TYPE_PECL,
+      self::EXTENSION_OS_DEPENDENCIES => ['libgpgme11-dev'],
+    ],],
+    ```
+1. The extension type can be either CORE or PECL which are defined by `EXTENSION_TYPE_PECL` or `EXTENSION_TYPE_CORE` respectively.
+
+1. Add any required `.ini` files to the PHP configuration:
+   -  Navigate to the following directory
+
+      ```bash
+       cd magento-cloud-docker/images/php/fpm
+      ```
+   -  Add the .ini files to the `etc` directory
+   -  Open the `Dockerfile` and add the following line:
+
+      ```conf
+        COPY etc/<filename>.ini /usr/local/etc/php/conf.d/<filename>.ini
+      ```
+   -  For CLI container, Navigate to the following directory
+
+      ```bash
+        cd magento-cloud-docker/images/php/cli
+      ```
+   -  Add the .ini files to the `etc` directory
+   -  Open `Dockerfile` and add the following line to it
+
+      ```conf
+      ADD etc/<file-name>.ini /usr/local/etc/php/conf.d/<filename>.ini
+      ```
+
+1. Run the following command to generate the `Dockerfile` for various php versions.
+
+    ```bash
+    bin/ece-docker image:generate:php
+   ```
+1. Test the extension by specifying the [Docker build sources].
+
 [multiple compose files]: https://docs.docker.com/compose/reference/overview/#specifying-multiple-compose-files
 [service versions]: https://devdocs.magento.com/cloud/docker/docker-containers.html#service-containers
 [Docker build sources]: https://devdocs.magento.com/cloud/docker/docker-extend.html#specify-docker-build-sources

--- a/src/cloud/docker/docker-extend.md
+++ b/src/cloud/docker/docker-extend.md
@@ -91,45 +91,60 @@ To add a new PHP extension:
 
 1. Open `ExtensionResolver.php` file, define the required extension inside the `getConfig` method by specifying the extension type and dependency.
 
-    For instance the following block adds the GNUPG extension:
-    ```PHP
-    'gnupg' => [
-      '>=7.0' => [
-      self::EXTENSION_TYPE => self::EXTENSION_TYPE_PECL,
-      self::EXTENSION_OS_DEPENDENCIES => ['libgpgme11-dev'],
-    ],],
-    ```
-1. The extension type can be either CORE or PECL which are defined by `EXTENSION_TYPE_PECL` or `EXTENSION_TYPE_CORE` respectively.
+   For instance the following block adds the GNUPG extension:
+    
+   ```php
+   'gnupg' => [
+     '>=7.0' => [
+     self::EXTENSION_TYPE => self::EXTENSION_TYPE_PECL,
+     self::EXTENSION_OS_DEPENDENCIES => ['libgpgme11-dev'],
+   ],],
+   ```
+   The extension type can be either CORE or PECL, which are defined as `EXTENSION_TYPE_PECL` or `EXTENSION_TYPE_CORE` respectively.
 
-1. Add any required `.ini` files to the PHP configuration:
-   -  Navigate to the following directory
+1. Add any required `.ini` files to the PHP FPM container configuration:
+
+   -  On the command line, navigate to FPM image directory.
 
       ```bash
-       cd magento-cloud-docker/images/php/fpm
+      cd magento-cloud-docker/images/php/fpm
       ```
-   -  Add the .ini files to the `etc` directory
-   -  Open the `Dockerfile` and add the following line:
+      
+   -  Add each required `.ini` file to the `etc` directory.
+   
+   -  For each `.ini` file that you added, add the following line to the `Dockerfile` (`magento-cloud-docker/images/php/fpm/Dockerfile`):
 
       ```conf
         COPY etc/<filename>.ini /usr/local/etc/php/conf.d/<filename>.ini
       ```
-   -  For CLI container, Navigate to the following directory
+      
+1. Add any required `.ini` files to the PHP CLI container configuration: 
+ 
+   -  On the command line, navigate to the CLI image directory.
 
       ```bash
-        cd magento-cloud-docker/images/php/cli
+      cd magento-cloud-docker/images/php/cli
       ```
-   -  Add the .ini files to the `etc` directory
-   -  Open `Dockerfile` and add the following line to it
+       
+   -  Add each required `.ini` file to the `etc` directory
+   
+   -  For each `.ini` file that you added, add the following line to the `Dockerfile` (`magento-cloud-docker/images/php/cli/Dockerfile`):
 
-      ```conf
-      ADD etc/<file-name>.ini /usr/local/etc/php/conf.d/<filename>.ini
-      ```
+       ```conf
+       ADD etc/<file-name>.ini /usr/local/etc/php/conf.d/<filename>.ini
+       ```
 
-1. Run the following command to generate the `Dockerfile` for various php versions.
+1. Generate an updated `Dockerfile` for all PHP image versions included in the {{site.data.var.mcd}} package.
 
-    ```bash
-    bin/ece-docker image:generate:php
+   ```bash
+   bin/ece-docker image:generate:php
    ```
+
+1. Test the extension by specifying the [Docker build sources].
+
+[multiple compose files]: https://docs.docker.com/compose/reference/overview/#specifying-multiple-compose-files
+[service versions]: https://devdocs.magento.com/cloud/docker/docker-containers.html#service-containers
+[Docker build sources]: https://devdocs.magento.com/cloud/docker/docker-extend.html#specify-docker-build-sources
 1. Test the extension by specifying the [Docker build sources].
 
 [multiple compose files]: https://docs.docker.com/compose/reference/overview/#specifying-multiple-compose-files

--- a/src/cloud/docker/docker-extend.md
+++ b/src/cloud/docker/docker-extend.md
@@ -92,7 +92,7 @@ To add a new PHP extension:
 1. Open `ExtensionResolver.php` file, define the required extension inside the `getConfig` method by specifying the extension type and dependency.
 
    For instance the following block adds the GNUPG extension:
-    
+
    ```php
    'gnupg' => [
      '>=7.0' => [
@@ -109,25 +109,25 @@ To add a new PHP extension:
       ```bash
       cd magento-cloud-docker/images/php/fpm
       ```
-      
+ 
    -  Add each required `.ini` file to the `etc` directory.
-   
+
    -  For each `.ini` file that you added, add the following line to the `Dockerfile` (`magento-cloud-docker/images/php/fpm/Dockerfile`):
 
       ```conf
         COPY etc/<filename>.ini /usr/local/etc/php/conf.d/<filename>.ini
       ```
-      
+
 1. Add any required `.ini` files to the PHP CLI container configuration: 
- 
+
    -  On the command line, navigate to the CLI image directory.
 
       ```bash
       cd magento-cloud-docker/images/php/cli
       ```
-       
+ 
    -  Add each required `.ini` file to the `etc` directory
-   
+
    -  For each `.ini` file that you added, add the following line to the `Dockerfile` (`magento-cloud-docker/images/php/cli/Dockerfile`):
 
        ```conf
@@ -145,8 +145,6 @@ To add a new PHP extension:
 [multiple compose files]: https://docs.docker.com/compose/reference/overview/#specifying-multiple-compose-files
 [service versions]: https://devdocs.magento.com/cloud/docker/docker-containers.html#service-containers
 [Docker build sources]: https://devdocs.magento.com/cloud/docker/docker-extend.html#specify-docker-build-sources
-1. Test the extension by specifying the [Docker build sources].
-
 [multiple compose files]: https://docs.docker.com/compose/reference/overview/#specifying-multiple-compose-files
 [service versions]: https://devdocs.magento.com/cloud/docker/docker-containers.html#service-containers
 [Docker build sources]: https://devdocs.magento.com/cloud/docker/docker-extend.html#specify-docker-build-sources


### PR DESCRIPTION
## Purpose of this pull request

This pull request covers the process of adding a new PHP extension to PHP images of Cloud Docker.
(https://github.com/magento/magento-cloud-docker/issues/155)

## Affected DevDocs pages

<!-- REQUIRED List the affected pages on devdocs.magento.com (URLs). Not needed for large numbers of files. -->

-  https://devdocs.magento.com/cloud/docker/docker-extend.html

whats new
Updated the [Extend Docker](https://devdocs.magento.com/cloud/docker/docker-extend.html)  topic to include instructions for adding a new PHP extension to the PHP container for Magento Cloud Docker.