### PR TITLE
Add section header for linking to Pro architecture

### DIFF
--- a/src/cloud/architecture/pro-architecture.md
+++ b/src/cloud/architecture/pro-architecture.md
@@ -65,6 +65,8 @@ The following table summarizes the differences between environments:
   </tbody>
 </table>
 
+## Pro environment architecture
+
 Your project is a single Git repository with three, main environment branches for Integration, Staging, and Production. The following diagram shows the hierarchical relationship of the environments:
 
 ![High-level view of Pro Environment architecture]({{ site.baseurl }}/common/images/cloud/cloud_pro-branch-architecture.png)


### PR DESCRIPTION
## Purpose of this pull request

Per reader feedback, provide a header to make it easier to provide link references to the Pro architecture diagram.

## Affected DevDocs pages

https://devdocs.magento.com/cloud/architecture/pro-architecture.html
