### PR TITLE
Fix custom logo example

### DIFF
--- a/src/guides/v2.3/frontend-dev-guide/themes/theme-create.md
+++ b/src/guides/v2.3/frontend-dev-guide/themes/theme-create.md
@@ -244,7 +244,7 @@ For example, if your logo file is `my_logo.png` sized 300x300px, you need to dec
     <body>
         <referenceBlock name="logo">
             <arguments>
-                <argument name="logo_src" xsi:type="string">images/my_logo.png</argument>
+                <argument name="logo_file" xsi:type="string">images/my_logo.png</argument>
                 <argument name="logo_width" xsi:type="number">300</argument>
                 <argument name="logo_height" xsi:type="number">300</argument>
                 <argument name="logo_alt" xsi:type="string">Logo name</argument>


### PR DESCRIPTION
## Purpose of this pull request
Fixes #7276 
Fix the example for declaring a custom theme logo. If the argument `logo_src` is passed, this will directly inject the passed string into the images `src` attribute. This is not correct in the example and is unlikely to be correct in most cases.

The `logo_file` argument will use the correct, fully qualified, static versioned URL.

## Affected DevDocs pages

-  https://devdocs.magento.com/guides/v2.3/frontend-dev-guide/themes/theme-create.html

## Links to Magento source code

-  https://github.com/magento/magento2/blob/8d90d12c2e0573a5ff898d6695cf730cd5a5792c/app/code/Magento/Theme/Block/Html/Header/Logo.php#L138