### PR TITLE
Fix logo parameter name so it is used by Logo block

### DIFF
--- a/src/guides/v2.3/frontend-dev-guide/themes/theme-create.md
+++ b/src/guides/v2.3/frontend-dev-guide/themes/theme-create.md
@@ -244,7 +244,7 @@ For example, if your logo file is `my_logo.png` sized 300x300px, you need to dec
     <body>
         <referenceBlock name="logo">
             <arguments>
-                <argument name="logo_src" xsi:type="string">images/my_logo.png</argument>
+                <argument name="logo_file" xsi:type="string">images/my_logo.png</argument>
                 <argument name="logo_width" xsi:type="number">300</argument>
                 <argument name="logo_height" xsi:type="number">300</argument>
                 <argument name="logo_alt" xsi:type="string">Logo name</argument>


### PR DESCRIPTION
## Purpose of this pull request
Fixes  #7276
This pull request corrects a parameter name to one that is used by Logo block to determine the image source.

## Affected DevDocs pages
- https://devdocs.magento.com/guides/v2.3/frontend-dev-guide/themes/theme-create.html

## Links to Magento source code

-  https://github.com/magento/magento2/blob/8d90d12c2e0573a5ff898d6695cf730cd5a5792c/app/code/Magento/Theme/Block/Html/Header/Logo.php#L138

<!--
If you are fixing a GitHub issue, note it using GitHub keyword format (https://help.github.com/en/articles/closing-issues-using-keywords#closing-an-issue-in-a-different-repository) to close the issue when this pull request is merged. Example: `Fixes #1234`

`master` is the default branch. Merged pull requests to `master` go live on the site automatically. Any requested changes to content on the `master` branch must be related to the released codebase. Any content related to future releases goes in the `develop` branch.

See Contribution guidelines (https://github.com/magento/devdocs/blob/master/.github/CONTRIBUTING.md) for more information.
-->
