### PR TITLE
Add Elasticsearch container config option to Magento Cloud Docker

### DIFF
--- a/src/cloud/docker/docker-containers-service.md
+++ b/src/cloud/docker/docker-containers-service.md
@@ -7,7 +7,6 @@ functional_areas:
   - Configuration
 ---
 
-
 The following containers provide the services required to build, deploy and run {{site.data.var.ee}} sites.
 
 {:.bs-callout-info}
@@ -62,6 +61,14 @@ See [Manage the database] for details about using the database.
 **Ports exposed**: `9200`, `9300`<br/>
 
 The Elasticsearch container for {{site.data.var.mcd-prod}} is a standard Elasticsearch container with required plugins and configurations for {{site.data.var.ee}}.
+
+You can customize the Elasticsearch container using the `--es-env-var` option when you generate the Docker Compose configuration file. You can set Elasticsearch options and specify the environment variables to apply when the container starts, such as the heap size for JVM.
+
+```bash
+php vendor/bin/ece-docker build:compose --es-env-var=ES_JAVA_OPTS="-Xms512m -Xmx512m" --es-env-var=node.store.allow_mmapfs=false
+```
+
+See [Important Elasticsearch configuration][] for information about available settings.
 
 ### Troubleshooting
 
@@ -246,3 +253,4 @@ To mount the custom index.php file using volumes:
 [varnish]: https://hub.docker.com/r/magento/magento-cloud-docker-varnish
 [PHP extensions]: {{site.baseurl}}/cloud/project/project-conf-files_magento-app.html#php-extensions
 [Docker override file]: https://docs.docker.com/compose/extends/
+[Important Elasticsearch configuration]: https://www.elastic.co/guide/en/elasticsearch/reference/6.5/important-settings.html

--- a/src/cloud/docker/docker-containers.md
+++ b/src/cloud/docker/docker-containers.md
@@ -31,14 +31,14 @@ See [Docker CLI containers] for details.
 | Name       | Service   | Key  | Available Versions | Notes
 | ------------- | ---------- | ---------- | ------------------ |------------------
 | [db] | MariaDB     | `--db` | 10.0, 10.1, 10.2 |  Standard database container
-| [elasticsearch] | Elasticsearch | `--es` | 1.7, 2.4, 5.2, 6.5 |
-| [FPM][fpm-container] | PHP FPM | `--php` | 7.0, 7.1, 7.2, 7.3 |  Used for all incoming requests
+| [elasticsearch] | Elasticsearch | `--es`<br>`--es-env-var` | 1.7, 2.4, 5.2, 6.5, 6.8, 7.5, 7.6 |
+| [FPM][fpm-container] | PHP FPM | `--php` | 7.0, 7.1, 7.2, 7.3, 7.4 |  Used for all incoming requests
 | [node][node-container] | Node | `--node` | 6, 8, 10, 11 |  Used gulp or other NPM based commands
 | [rabbitmq][rabbitmq-container]| RabbitMQ | `--rmq` | 3.5, 3.7, 3.8 |
 | [redis][redis-container] | Redis     | `--redis` | 3.2, 4.0, 5.0 |   Standard redis container
 | [selenium][selenium-container]| Selenium | `--with-selenium`<br>`--selenium-version`<br>`--selenium-image`| Any | Enables Magento application testing using the Magento Functional Testing Framework (MFTF)
 | [tls][tls-container] | SSL Endpoint |  |   |  Terminates SSL, can be configured to pass to varnish or nginx
-| [varnish][varnish-container] | Varnish | `--varnish` | 4, 6 |
+| [varnish][varnish-container] | Varnish | `--no-varnish` | 4, 6.2 |
 | [web][web-container] | NGINX | `--nginx` | 1.9, latest |
 
 The `ece-docker build:compose` command runs in interactive mode and verifies the configured service versions. To skip interactive mode, use the `-n, --no-interaction` option.

--- a/src/cloud/docker/docker-quick-reference.md
+++ b/src/cloud/docker/docker-quick-reference.md
@@ -27,7 +27,7 @@ List containers and ports | `docker-compose ps` or `docker ps`
 
 ### Override configuration
 
-Because the `ece-docker build:compose` command in the `{{site.data.var.ct}}` package overwrites the base configuration, we recommend saving your customizations in an override configuration file. You can use this method to merge multiple custom configurations. See [Docker Docs: Multiple Compose files](https://docs.docker.com/compose/extends/#multiple-compose-files).
+Because the `ece-docker build:compose` command overwrites the base configuration, we recommend saving your customizations in an override configuration file. You can use this method to merge multiple custom configurations. See [Docker Docs: Multiple Compose files][].
 
 The `docker-compose up` command considers the base `docker-compose.yml` configuration by default. If the `docker-compose.override.yml` file is present, then the override configuration merges with the base configuration.
 
@@ -41,11 +41,11 @@ docker-compose -f docker-compose.yml -f docker-compose-custom.yml [-f more-custo
 
 | Option       | Key              | Available values
 | ------------ | ---------------- | ------------------
-| [Mode]({{site.baseurl}}/cloud/docker/docker-config.html#set-the-launch-mode)         | `--mode`, `-m`   | production, developer
-| [File synchronization engine]({{site.baseurl}}/cloud/docker/docker-syncing-data.html) | `--sync-engine` | native (default), docker-sync, mutagen
+| [Mode][]         | `--mode`, `-m`   | production, developer
+| [File synchronization engine][] | `--sync-engine` | native (default), docker-sync, mutagen
 
 {:.bs-callout-info}
-See [Service versions] for a list of the options to configure the software service version when building your {{site.data.var.mcd-prod}} environment.
+See [Service versions] for a list of the options to configure and customize software service versions and other options when building your {{site.data.var.mcd-prod}} environment.
 
 ## bin/magento-docker
 
@@ -84,5 +84,10 @@ Restart containers | `./bin/magento-docker restart`
 Destroy containers | `./bin/magento-docker down`
 Destroy, re-create, and start containers | `./bin/magento-docker up`
 
-[Service versions]: {{site.baseurl}}/cloud/docker/docker-containers.html#service-containers
-[Configure Docker]: {{site.baseurl}}/cloud/docker/docker-config.html
+<!--Link definitions-->
+
+[Docker Docs: Multiple Compose files]: https://docs.docker.com/compose/extends/#multiple-compose-files
+[Mode]: {{site.baseurl}}/cloud/docker/docker-config.html#set-the-launch-mode
+[File synchronization engine]: {{ site.baseurl }}/cloud/docker/docker-syncing-data.html
+[Service versions]: {{ site.baseurl }}/cloud/docker/docker-containers.html#service-containers
+[Configure Docker]: {{ site.baseurl }}/cloud/docker/docker-config.html

--- a/src/cloud/release-notes/mcd-release-notes.md
+++ b/src/cloud/release-notes/mcd-release-notes.md
@@ -20,17 +20,15 @@ The release notes include:
 
 -  {:.new}**Container updates**–
 
-   -  {:.new}**PHP-FPM container updates**–
+   -  {:.new}**PHP-FPM**—Fixed an issue in the Docker entrypoint script (docker-entrypoint.sh) that caused errors when connecting to the PHP container.<!--MAGECLOUD-5142-->
 
-      -  {:.new}Fixed an issue in the Docker entrypoint script (docker-entrypoint.sh) that caused errors when connecting to the PHP container.<!--MAGECLOUD-5142-->
-
-   -  {:.new}**Varnish container**–
-
-      -  {:.new}The Varnish service is now provisioned by default when you deploy a Magento Cloud Docker environment using a supported version of the Magento Cloud application template.<!--MAGECLOUD-3598-->
+   -  {:.new}**Varnish**—The Varnish service is now provisioned by default when you deploy a Magento Cloud Docker environment using a supported version of the Magento Cloud application template.<!--MAGECLOUD-2634-->
 
 -  {:.new}**Command changes**–
 
-   -  {:.new}Added the `--no-varnish` option to the `ece-tools build:compose` command to skip Varnish service installation when you generate the configuration for a Magento Cloud Docker environment.<!--MAGECLOUD-3598-->
+   -  {:.new}Added the `--no-varnish` option to the `ece-tools build:compose` command to skip Varnish service installation when you generate the configuration for a Magento Cloud Docker environment.<!--MCLOUD-2634-->
+
+   -  {:.new}Added the `--es-env-var` option to the `ece-tools build:compose` command to customize the [Elasticsearch container configuration]({{ site.baseurl }}/cloud/docker/docker-containers-service.html#elasticsearch-container) when you generate the configuration for a Magento Cloud Docker environment.<!--MCLOUD-3059-->
 
 ## v1.0.0
 *Release date: Nov 14, 2019*<br/>


### PR DESCRIPTION
## Purpose of this pull request

Documented the new `es-en-var` option to customize the Elasticsearch container configuration when building the Docker Compose file for a Magento Cloud Docker environment.

## Affected DevDocs pages

- https://devdocs.magento.com/cloud/docker/docker-containers-service.html
- https://devdocs.magento.com/cloud/docker/docker-containers.html
- https://devdocs.magento.com/cloud/docker/docker-quick-reference.html
- https://devdocs.magento.com/cloud/release-notes/mcd-release-notes.html

## Links to Magento source code

https://github.com/magento/magento-cloud-docker/pull/174

whatsnew
Documented the new `es-en-var` option to customize the Elasticsearch container configuration when building the Docker Compose file for a Magento Cloud Docker environment. See [Elasticsearch container](https://devdocs.magento.com/cloud/docker/docker-containers-service.html#elasticsearch-container).
