### PR TITLE
Add deployment error reference for ece-tools

### DIFF
--- a/src/_data/cloud-error-messages.yml
+++ b/src/_data/cloud-error-messages.yml
@@ -1,0 +1,86 @@
+# Error messages
+
+# Magento Cloud error labels and suggested solutions to include in Cloud error reference table
+
+# ENV_PHP_IS_NOT_WRITEABLE applies to errors 102 and 202
+
+ENV_PHP_IS_NOT_WRITABLE: "Deployment script can't make required changes to the `/app/etc/env.php` file. Check your filesystem permissions."
+
+# CONFIG_NOT_DEFINED applies to errors 103 and 203
+
+CONFIG_NOT_DEFINED: "Configuration isn't defined in the `./vendor/magento/ece-tools/config/schema.yaml` file. Check that the config variable name is correct and it's defined."
+
+# CONFIG_PARSE_FAILED applies to 4, 104, 204
+CONFIG_PARSE_FAILED: The `./.magento.env.yaml` file format is invalid. Format the file according to YAML standards.
+
+# CONFIG_UNABLE_TO_READ applies to 5, 105, 205
+CONFIG_UNABLE_TO_READ: Unable to read the `./.magento.env.yaml` file. Check file permissions.
+
+CONFIG_PHP_IS_NOT_WRITABLE: Deployment script can't make required changes to the `/app/etc/config.php` file. Check your filesystem permissions.
+
+CANT_READ_COMPOSER_JSON: Unable to read the `./composer.json` file. Check file permissions.
+
+COMPOSER_MISSED_REQUIRED_AUTOLOAD: Required `autoload` section is missing from the `composer.json` file. Compare the autoload section from the Magento `composer.json` file template, and add the missing configuration.
+
+WRONG_CONFIGURATION_MAGENTO_ENV_YAML: The `./.magento.env.yaml` file contains invalid configuration. Check the error log for detailed info.
+
+COMPOSER_DUMP_AUTOLOAD_FAILED: The `composer dump-autoload` command failed. Check the `cloud.log` for more information.
+
+BALER_NOT_FOUND: "Check the `SCD_USE_BALER` environment variable to verify that the Baler module is configured and enabled for JS bundling. If you don't want to use the Baler module, set `SCD_USE_BALER: false`."
+
+#The UTILITY_NOT_FOUND_ACTION applies to the following errors: 
+#  BUILD_UTILITY_NOT_FOUND = 18
+#  DEPLOY_UTILITY_NOT_FOUND = 118
+
+UTILITY_NOT_FOUND_ACTION: One of required utilities was not found on server. Check the `cloud.log` for more information and install required utility.
+
+# The CHECK_CLOUD_LOG_ACTION applies to the following errors:
+# SCD_COMPRESSION_FAILED = 20, 120
+# SCD_COPYING_FAILED = 21
+
+CHECK_CLOUD_LOG_ACTION: Check the `cloud.log` for more information.
+
+WRITABLE_DIRECTORY_COPYING_FAILED: Failed to copy writable directories into the `./init` folder. Check your filesystem permissions.
+
+CLEAN_INIT_PUB_STATIC_FAILED: Failed to clean `./init/pub/static` folder. Check your filesystem permissions.
+
+COMPOSER_PACKAGE_NOT_FOUND: If you installed the Magento application version directly from the Magento git repository, verify that the `DEPLOYED_MAGENTO_VERSION_FROM_GIT` environment variable is configured.
+
+WRONG_CACHE_CONFIGURATION: Cache configuration is missing required parameters `server` or `port`. Check the `cloud.log` for more information.
+
+REDIS_CACHE_CLEAN_FAILED: Failed to clean the Redis cache. Check that the Redis cache configuration is correct and that the Redis service is available. See [Setup Redis service]({{ site.baseurl}}/cloud/project/project-conf-files_services-redis.html).
+
+WRONG_CONFIGURATION_DB: Check that the the `DATABASE_CONFIGURATION` environment variable is configured correctly.
+
+WRONG_CONFIGURATION_SESSION: Check that the `SESSION_CONFIGURATION` environment variable is configured correctly. The configuration must contain at least the `save` parameter.
+
+WRONG_CONFIGURATION_SEARCH: Check that the `SEARCH_CONFIGURATION` environment variable is configured correctly.. The configuration must contain at least the `engine` parameter.
+
+WRONG_CONFIGURATION_RESOURCE: Check that the `RESOURCE_CONFIGURATION` environment variable is configured correctly. The configuration must contain at least `connection` parameter.
+
+ELASTIC_SUITE_WITHOUT_ES: ElasticSuite is installed, but the Elasticsearch service is not available. Check that the `SEARCH_CONFIGURATION` environment variable is configured correctly, and verify that the Elasticsearch service is available.
+
+ELASTIC_SUITE_WRONG_ENGINE: ElasticSuite is installed but another search engine is configured. Update the `SEARCH_CONFIGURATION` environment variable to enable Elasticsearch and verify the Elasticsearch service configuration in the `services.yaml` file.
+
+#The INSTALL_UPGRADE_ACTION applies to the following errors: 
+#  INSTALL_COMMAND_FAILED - 116
+#  UPGRADE_COMMAND_FAILED - 126
+
+INSTALL_UPGRADE_ACTION: "Check the `cloud.log` and `install_upgrade.log` for more information. Add `VERBOSE_COMMANDS: '-vvv'` into `.magento.env.yaml` for more detailed command output."
+
+SCD_UNABLE_UPDATE_VERSION: Cannot update `./pub/static/deployed_version.txt` file. Check your filesystem permissions.
+
+VIEW_PREPROCESSED_CLEAN_FAILED: Unable to clean the `./var/view_preprocessed` folder. Check your filesystem permissions.
+
+FILE_CREDENTIALS_EMAIL_NOT_WRITABLE: Failed to update the `/var/credentials_email.txt` file. Check your filesystem permissions.
+
+#The CLOUD_LOG_VERBOSE_ACTION applies to the following errors:
+
+#  MODULE_ENABLE_COMMAND_FAILED - 11
+#  SCD_FAILED - 19, 119, 
+#  MAINTENANCE_MODE_ENABLING_FAILED - 108,  
+#  CONFIG_IMPORT_COMMAND_FAILED- 117
+#  SPLIT_DB_COMMAND_FAILED - 123
+#  CACHE_FLUSH_COMMAND_FAILED - 127, 227
+
+CLOUD_LOG_VERBOSE_ACTION: "Check the `cloud.log` for more information. Add `VERBOSE_COMMANDS: '-vvv'` into `.magento.env.yaml` for more detailed command output."

--- a/src/_data/cloud-error-messages.yml
+++ b/src/_data/cloud-error-messages.yml
@@ -48,7 +48,7 @@ COMPOSER_PACKAGE_NOT_FOUND: If you installed the Magento application version dir
 
 WRONG_CACHE_CONFIGURATION: Cache configuration is missing required parameters `server` or `port`. Check the `cloud.log` for more information.
 
-REDIS_CACHE_CLEAN_FAILED: Failed to clean the Redis cache. Check that the Redis cache configuration is correct and that the Redis service is available. See [Setup Redis service]({{ site.baseurl }}/cloud/project/project-conf-files_services-redis.html).
+REDIS_CACHE_CLEAN_FAILED: Failed to clean the Redis cache. Check that the Redis cache configuration is correct and that the Redis service is available. See [Setup Redis service](https://devdocs.magento.com/cloud/project/project-conf-files_services-redis.html).
 
 WRONG_CONFIGURATION_DB: Check that the the `DATABASE_CONFIGURATION` environment variable is configured correctly.
 

--- a/src/_data/cloud-error-messages.yml
+++ b/src/_data/cloud-error-messages.yml
@@ -4,19 +4,19 @@
 
 # ENV_PHP_IS_NOT_WRITEABLE applies to errors 102 and 202
 
-ENV_PHP_IS_NOT_WRITABLE: "Deployment script can't make required changes to the `/app/etc/env.php` file. Check your filesystem permissions."
+ENV_PHP_IS_NOT_WRITABLE: "Deployment script cannot make required changes to the `/app/etc/env.php` file. Check your filesystem permissions."
 
 # CONFIG_NOT_DEFINED applies to errors 103 and 203
 
-CONFIG_NOT_DEFINED: "Configuration isn't defined in the `./vendor/magento/ece-tools/config/schema.yaml` file. Check that the config variable name is correct and it's defined."
+CONFIG_NOT_DEFINED: "Configuration isn't defined in the `./vendor/magento/ece-tools/config/schema.yaml` file. Check that the config variable name is correct, and that it defined."
 
 # CONFIG_PARSE_FAILED applies to 4, 104, 204
-CONFIG_PARSE_FAILED: The `./.magento.env.yaml` file format is invalid. Format the file according to YAML standards.
+CONFIG_PARSE_FAILED: The `./.magento.env.yaml` file format is invalid. Use a YAML parser to check the syntax and fix any errors.
 
 # CONFIG_UNABLE_TO_READ applies to 5, 105, 205
 CONFIG_UNABLE_TO_READ: Unable to read the `./.magento.env.yaml` file. Check file permissions.
 
-CONFIG_PHP_IS_NOT_WRITABLE: Deployment script can't make required changes to the `/app/etc/config.php` file. Check your filesystem permissions.
+CONFIG_PHP_IS_NOT_WRITABLE: Deployment script cannot make required changes to the `/app/etc/config.php` file. Check your filesystem permissions.
 
 CANT_READ_COMPOSER_JSON: Unable to read the `./composer.json` file. Check file permissions.
 
@@ -26,7 +26,7 @@ WRONG_CONFIGURATION_MAGENTO_ENV_YAML: The `./.magento.env.yaml` file contains in
 
 COMPOSER_DUMP_AUTOLOAD_FAILED: The `composer dump-autoload` command failed. Check the `cloud.log` for more information.
 
-BALER_NOT_FOUND: "Check the `SCD_USE_BALER` environment variable to verify that the Baler module is configured and enabled for JS bundling. If you don't want to use the Baler module, set `SCD_USE_BALER: false`."
+BALER_NOT_FOUND: "Check the `SCD_USE_BALER` environment variable to verify that the Baler module is configured and enabled for JS bundling. If you don't need the Baler module, set `SCD_USE_BALER: false`."
 
 #The UTILITY_NOT_FOUND_ACTION applies to the following errors: 
 #  BUILD_UTILITY_NOT_FOUND = 18
@@ -48,7 +48,7 @@ COMPOSER_PACKAGE_NOT_FOUND: If you installed the Magento application version dir
 
 WRONG_CACHE_CONFIGURATION: Cache configuration is missing required parameters `server` or `port`. Check the `cloud.log` for more information.
 
-REDIS_CACHE_CLEAN_FAILED: Failed to clean the Redis cache. Check that the Redis cache configuration is correct and that the Redis service is available. See [Setup Redis service]({{ site.baseurl}}/cloud/project/project-conf-files_services-redis.html).
+REDIS_CACHE_CLEAN_FAILED: Failed to clean the Redis cache. Check that the Redis cache configuration is correct and that the Redis service is available.
 
 WRONG_CONFIGURATION_DB: Check that the the `DATABASE_CONFIGURATION` environment variable is configured correctly.
 

--- a/src/_data/cloud-error-messages.yml
+++ b/src/_data/cloud-error-messages.yml
@@ -48,7 +48,7 @@ COMPOSER_PACKAGE_NOT_FOUND: If you installed the Magento application version dir
 
 WRONG_CACHE_CONFIGURATION: Cache configuration is missing required parameters `server` or `port`. Check the `cloud.log` for more information.
 
-REDIS_CACHE_CLEAN_FAILED: Failed to clean the Redis cache. Check that the Redis cache configuration is correct and that the Redis service is available.
+REDIS_CACHE_CLEAN_FAILED: Failed to clean the Redis cache. Check that the Redis cache configuration is correct and that the Redis service is available. See [Setup Redis service]({{ site.baseurl }}/cloud/project/project-conf-files_services-redis.html).
 
 WRONG_CONFIGURATION_DB: Check that the the `DATABASE_CONFIGURATION` environment variable is configured correctly.
 

--- a/src/_data/toc/cloud-guide.yml
+++ b/src/_data/toc/cloud-guide.yml
@@ -507,6 +507,11 @@ pages:
       url: /cloud/trouble/trouble.html
       versionless: true
       children:
+
+        - label: Deployment error reference
+          url: /cloud/trouble/error-codes.html
+          versionless: true
+
         - label: Troubleshoot deployment
           url: /cloud/trouble/troubleshoot-deployment.html
           versionless: true

--- a/src/cloud/deploy/static-content-deployment.md
+++ b/src/cloud/deploy/static-content-deployment.md
@@ -50,7 +50,7 @@ To install and configure Baler:
    ```
 
    {:.bs-callout-tip}
-   If you do not have a copy of the `config.php` file in your development branch, see [Recommended procedure to manage your settings]({{site.baseurl}}/cloud/live/sens-data-over.html#cloud-config-specific-recomm) to learn how to generate and use this file to manage Magento store configuration for Cloud projects.
+   If you do not have a copy of the `config.php` file in your development branch, see [Procedure to manage your settings]({{site.baseurl}}/cloud/live/sens-data-over.html#procedure-to-manage-your-settings) to learn how to generate and use this file to manage Magento store configuration for Cloud projects.
 
 1. Update your `.magento.env.yaml` environment configuration file to enable the `SCD_USE_BALER` option during the build process:
 

--- a/src/cloud/env/variables-deploy.md
+++ b/src/cloud/env/variables-deploy.md
@@ -101,7 +101,7 @@ Magento version 2.3.5 and later includes the following backend models:
 -  `\Magento\Framework\Cache\Backend\RemoteSynchronizedCache`
 
 {:.bs-callout-info}
-See [L2 caching in the Magento application]({{site.baseurl}}/guides/v2.3/config-guide/two-level-cache.html) for details on selecting the backend model for Redis caching.
+See [L2 caching in the Magento application]({{site.baseurl}}/guides/v2.3/config-guide/cache/two-level-cache.html) for details on selecting the backend model for Redis caching.
 
 ### `CLEAN_STATIC_FILES`
 

--- a/src/cloud/reference/discover-deploy.md
+++ b/src/cloud/reference/discover-deploy.md
@@ -23,7 +23,7 @@ You can track build and deploy actions in real-time using the terminal or the Pr
 If you are using external GitHub repositories, the log of operations does not display in the GitHub session. However, you can still follow activity in the interface for the external repository and the Project Web Interface. See [Integrations]({{ site.baseurl }}/cloud/integrations/cloud-integrations.html).
 
 {:.bs-callout-info}
-In Integration environments, you cannot view the deploy logs from the Project Web Interface. This feature is available only for Production and Staging environments. However, you can view logs for every phase of the deployment in any environment using the Magento [build and deploy]({{ site.baseurl }}/cloud/project/log-locations.html#build-and-deploy-logs) logs.
+In Integration environments, you cannot view the deploy logs from the Project Web Interface. This feature is available only for Production and Staging environments. However, you can view logs for every phase of the deployment in any environment using the Magento [build and deploy]({{ site.baseurl }}/cloud/project/log-locations.html#build-and-deploy-logs) logs. For troubleshooting information, see the [Deployment error reference]({{site.baseurl}}/cloud/trouble/error-codes.html).
 
 ## Project configuration {#cloud-deploy-conf}
 

--- a/src/cloud/trouble/error-codes.md
+++ b/src/cloud/trouble/error-codes.md
@@ -16,16 +16,10 @@ Error messages are categorized by deployment stage–build, deploy, and post-dep
 
 ## Build stage
 
-<style>
-table.my-special-table td:nth-child(1) {
-  width: 50px;
-}
-</style>
-
-{:.table.my-special-table}
+{: .error-table}
 | Error code | Build step | Error description | Suggested action |
-| --- | --- | --- | -- |
-| 2 | | File `./app/etc/env.php` is not writable | {{site.data.cloud-error-messages.ENV_PHP_IS_NOT_WRITABLE}}|
+| ---------- | ---------- | ----------------- | ---------------- |
+| 2 | | Cannot write to the `./app/etc/env.php` file | {{site.data.cloud-error-messages.ENV_PHP_IS_NOT_WRITABLE}}|
 | 3 | | Configuration isn't defined in the `schema.yaml` file | {{site.data.cloud-error-messages.CONFIG_NOT_DEFINED}}|
 | 4 | | Failed to parse the `.magento.env.yaml` file | {{site.data.cloud-error-messages.CONFIG_PARSE_FAILED}}|
 | 5 | | Unable to read the `.magento.env.yaml` file | {{site.data.cloud-error-messages.CONFIG_UNABLE_TO_READ}}|
@@ -52,6 +46,7 @@ table.my-special-table td:nth-child(1) {
 
 ## Deploy stage
 
+{: .error-table}
 | Error code | Deploy step | Error description | Suggested action |
 | --- | --- | --- | -- |
 | 101 | pre-deploy: cache | Incorrect cache configuration (missing port or host) | {{site.data.cloud-error-messages.WRONG_CACHE_CONFIGURATION}} |
@@ -83,11 +78,12 @@ REDIS_CACHE_CLEAN_FAILED}}. |
 | 125 | install-update: reset-password | Failed to update the `/var/credentials_email.txt` file | {{site.data.cloud-error-messages.FILE_CREDENTIALS_EMAIL_NOT_WRITABLE}} |
 | 126 | install-update: update | Command `/bin/magento setup:upgrade` failed | {{site.data.cloud-error-messages.INSTALL_UPGRADE_ACTION}} |
 | 127 | clean-cache | Command `/bin/magento cache:flush` failed | {{site.data.cloud-error-messages.CLOUD_LOG_VERBOSE_ACTION}} |
-| 128 | disable-maintenance-mode | Command `/bin/magento maintenance:disable` failed | |
+| 128 | disable-maintenance-mode | Command `/bin/magento maintenance:disable` failed | {{site.data.cloud-error-messages.CLOUD_LOG_VERBOSE_ACTION}} |
 | 129 | install-update: reset-password | Enable to read reset password template | |
 
 ## Post-deploy stage
 
+{: .error-table}
 | Error code | Post-deploy step | Error description | Suggested action |
 | --- | --- | --- | -- |
 | 201 | is-deploy-failed | Deploy stage failed | |
@@ -103,3 +99,17 @@ REDIS_CACHE_CLEAN_FAILED}}. |
 <!--Link definitions-->
 
 [Scenario-based deployment]: {{site.baseurl}}/cloud/deploy/scenario-based-deployment.html
+
+<!--Custom css-->
+
+<!--
+  This is a style declaration so that first column does not wrap
+-->
+
+<style>
+table.error-table td:nth-child(1) {
+  width: 125px;
+}
+table.error-table td:nth-child(2) {
+  width: 200px;
+}

--- a/src/cloud/trouble/error-codes.md
+++ b/src/cloud/trouble/error-codes.md
@@ -19,17 +19,17 @@ Error messages are categorized by deployment stage–build, deploy, and post-dep
 | Error code | Build step | Error description | Suggested action |
 | --- | --- | --- | -- |
 | 2 | | File `./app/etc/env.php` is not writable | {{site.data.cloud-error-messages.ENV_PHP_IS_NOT_WRITABLE}}|
-| 3 | | Configuration isn't defined in schema.yaml | {{site.data.cloud-error-messages.CONFIG_NOT_DEFINED}}|
-| 4 | | Failed to parse .magento.env.yaml | {{site.data.cloud-error-messages.CONFIG_PARSE_FAILED}}|
-| 5 | | Unable to read .magento.env.yaml | {{site.data.cloud-error-messages.CONFIG_UNABLE_TO_READ}}|
-| 6 | | Unable to read .schema.yaml | |
-| 7 | refresh-modules | File `./app/etc/config.php` is not writable |{{site.data.cloud-error-messages.CONFIG_PHP_IS_NOT_WRITABLE}} |
-| 8 | validate-config | Unable to read composer.json |{{site.data.cloud-error-messages.CANT_READ_COMPOSER_JSON}} |
-| 9 | validate-config | Composer.json missed required autoload section | {{site.data.cloud-error-messages.COMPOSER_MISSED_REQUIRED_AUTOLOAD}} |
+| 3 | | Configuration isn't defined in the `schema.yaml` file | {{site.data.cloud-error-messages.CONFIG_NOT_DEFINED}}|
+| 4 | | Failed to parse the `.magento.env.yaml` file | {{site.data.cloud-error-messages.CONFIG_PARSE_FAILED}}|
+| 5 | | Unable to read the `.magento.env.yaml` file | {{site.data.cloud-error-messages.CONFIG_UNABLE_TO_READ}}|
+| 6 | | Unable to read the `.schema.yaml` file | |
+| 7 | refresh-modules | Cannot write to the `./app/etc/config.php` file |{{site.data.cloud-error-messages.CONFIG_PHP_IS_NOT_WRITABLE}} |
+| 8 | validate-config | Cannot read the `composer.json` file |{{site.data.cloud-error-messages.CANT_READ_COMPOSER_JSON}} |
+| 9 | validate-config | Composer.json is missing required autoload section | {{site.data.cloud-error-messages.COMPOSER_MISSED_REQUIRED_AUTOLOAD}} |
 | 10 | validate-config | The file `.magento.env.yaml` contains an option which isn't declared in the schema, or has an invalid value or stage | {{site.data.cloud-error-messages.WRONG_CONFIGURATION_MAGENTO_ENV_YAML}}|
 | 11 | refresh-modules | Command `/bin/magento module:enable --all` failed | {{site.data.cloud-error-messages.CLOUD_LOG_VERBOSE_ACTION}} |
 | 12 | apply-patches | Failed to apply patch | |
-| 13 | set-report-dir-nesting-level | Can't write to the file `/pub/errors/local.xml` | |
+| 13 | set-report-dir-nesting-level | Cannot write to the file `/pub/errors/local.xml` | |
 | 14 | copy-sample-data | Failed to copy sample data files | |
 | 15 | compile-di | Command `/bin/magento setup:di:compile` failed | |
 | 16 | dump-autoload | Command `composer dump-autoload` failed | {{site.data.cloud-error-messages.COMPOSER_DUMP_AUTOLOAD_FAILED}} |
@@ -48,13 +48,14 @@ Error messages are categorized by deployment stage–build, deploy, and post-dep
 | Error code | Deploy step | Error description | Suggested action |
 | --- | --- | --- | -- |
 | 101 | pre-deploy: cache | Incorrect cache configuration (missing port or host) | {{site.data.cloud-error-messages.WRONG_CACHE_CONFIGURATION}} |
-| 102 | | File `./app/etc/env.php` is not writable | {{site.data.cloud-error-messages.ENV_PHP_IS_NOT_WRITABLE}} |
+| 102 | | Cannot write to the `./app/etc/env.php` file | {{site.data.cloud-error-messages.ENV_PHP_IS_NOT_WRITABLE}} |
 | 103 | | Configuration isn't defined in the `schema.yaml` file  | |
 | 104 | | Failed to parse the `.magento.env.yaml` file | {{site.data.cloud-error-messages.CONFIG_NOT_DEFINED}} |
 | 105 | | Unable to read the `.magento.env.yaml` file | {{site.data.cloud-error-messages.CONFIG_UNABLE_TO_READ}} |
 | 106 | | Unable to read the `.schema.yaml` file | |
 | 107 | pre-deploy: clean-redis-cache | Failed to clean the Redis cache | {{site.data.cloud-error-messages.
-REDIS_CACHE_CLEAN_FAILED}} |
+
+REDIS_CACHE_CLEAN_FAILED}}. See [Setup Redis service]({{site.baseurl}}/cloud/project/project-conf-files_services-redis.html). |
 | 108 | pre-deploy: set-production-mode | Command `/bin/magento maintenance:enable` failed | {{site.data.cloud-error-messages.CLOUD_LOG_VERBOSE_ACTION}} |
 | 109 | validate-config | Incorrect database configuration | {{site.data.cloud-error-messages.WRONG_CONFIGURATION_DB}} |
 | 110 | validate-config | Incorrect session configuration | {{site.data.cloud-error-messages.WRONG_CONFIGURATION_SESSION}} |

--- a/src/cloud/trouble/error-codes.md
+++ b/src/cloud/trouble/error-codes.md
@@ -1,194 +1,97 @@
 ---
 group: cloud-guide
-title: Ece-tools error codes
+title: Error message reference for ece-tools
 ---
 
-This page helps you to detect the problem in case of failed deployment process.
+{% assign errors = site.data.cloud-error-messages %}
 
+This {{site.data.var.ct}} error message reference provides information to resolve errors that occur during the {{site.data.var.ece}} deployment process.
 
-List of possible errors:
+Error messages are categorized by deployment stage–build, deploy, and post-deploy. Each section provides a list of associated errors with the following information for each error:
 
-### Build stage
+-  **Error code**:  The Magento-assigned identifier for the error message
+-  **Step**:  Indicates the step in the deployment scenario where the error can occur. If the _Step_ column is blank, the error is a general error that can occur in multiple steps, or during pre-processing operations. See [Scenario-based deployment]({{site.baseurl}}/cloud/deploy/scenario-based-deployment.html).
+-  **Error description**: A short phrase that summarizes the cause of the error
+-  **Suggested action**: Provides guidance to troubleshoot and resolve the error
 
-| Step | Description | Error code |
-| --- | --- | --- |
-| general | File `./app/etc/env.php` is not writable | [2](#ENV_PHP_IS_NOT_WRITABLE) |
-| | Configuration isn't defined in schema.yaml | [3](#CONFIG_NOT_DEFINED) |
-| | Failed to parse .magento.env.yaml | 4 |
-| | Unable to read .magento.env.yaml | 5 |
-| | Unable to read .schema.yaml | 6 |
-| refresh-modules | File `./app/etc/config.php` is not writable | 7 |
-| validate-config | Unable to read composer.json | 8 |
-| | Composer.json missed required autolad section | 9 |
-| | The file `.magento.env.yaml` contains an option which isn't declared in schema, or have invalid value or stage | 10 |
-| refresh-modules | Command `/bin/magento module:enable --all` failed | 11 |
-| apply-patches | Patch applying failed | 12 |
-| set-report-dir-nesting-level | Can't write to the file /pub/errors/local.xml | 13 |
-| copy-sample-data | Failed to copy sample data files | 14 |
-| compile-di | Command `/bin/magento setup:di:compile` failed | 15 |
-| dump-autoload | Command `composer dump-autoload` failed | 16 |
-| run-baler | If baler configured but execution of `baler` command failed | 17 |
-| compress-static-content | Required utility wasn't found (timeout, bash) | 18 |
-| deploy-static-content | Command `/bin/magento setup:static-content:deploy` failed | 19 |
-| compress-static-content | Compression of static content failed | 20 | 
-| backup-data: static-content | Failed to copy static content into init directory | 21 |
-| backup-data: static-content | Failed to clean `./init/pub/static/` directory | 24 |
-| backup-data: writable-dirs | Failed to copy some writable directory into init directory | 22 |
-| general | Unable to create a logger object | 23 |
-| | Composer package was not found | 25 |
+## Build stage
 
-### Deploy stage
+| Error code | Build step | Error description | Suggested action |
+| --- | --- | --- | -- |
+| 2 | | File `./app/etc/env.php` is not writable | {{site.data.cloud-error-messages.ENV_PHP_IS_NOT_WRITABLE}}|
+| 3 | | Configuration isn't defined in schema.yaml | {{site.data.cloud-error-messages.CONFIG_NOT_DEFINED}}|
+| 4 | | Failed to parse .magento.env.yaml | {{site.data.cloud-error-messages.CONFIG_PARSE_FAILED}}|
+| 5 | | Unable to read .magento.env.yaml | {{site.data.cloud-error-messages.CONFIG_UNABLE_TO_READ}}|
+| 6 | | Unable to read .schema.yaml | |
+| 7 | refresh-modules | File `./app/etc/config.php` is not writable |{{site.data.cloud-error-messages.CONFIG_PHP_IS_NOT_WRITABLE}} |
+| 8 | validate-config | Unable to read composer.json |{{site.data.cloud-error-messages.CANT_READ_COMPOSER_JSON}} |
+| 9 | validate-config | Composer.json missed required autoload section | {{site.data.cloud-error-messages.COMPOSER_MISSED_REQUIRED_AUTOLOAD}} |
+| 10 | validate-config | The file `.magento.env.yaml` contains an option which isn't declared in the schema, or has an invalid value or stage | {{site.data.cloud-error-messages.WRONG_CONFIGURATION_MAGENTO_ENV_YAML}}|
+| 11 | refresh-modules | Command `/bin/magento module:enable --all` failed | {{site.data.cloud-error-messages.CLOUD_LOG_VERBOSE_ACTION}} |
+| 12 | apply-patches | Patch applying failed | |
+| 13 | set-report-dir-nesting-level | Can't write to the file /pub/errors/local.xml | |
+| 14 | copy-sample-data | Failed to copy sample data files | |
+| 15 | compile-di | Command `/bin/magento setup:di:compile` failed | |
+| 16 | dump-autoload | Command `composer dump-autoload` failed | {{site.data.cloud-error-messages.COMPOSER_DUMP_AUTOLOAD_FAILED}} |
+| 17 | run-baler | The command to run `Baler` for Javascript bundling failed | {{site.data.cloud-error-messages.BALER_NOT_FOUND}} |
+| 18 | compress-static-content | Required utility wasn't found (timeout, bash) | {{site.data.cloud-error-messages.UTILITY_NOT_FOUND}} |
+| 19 | deploy-static-content | Command `/bin/magento setup:static-content:deploy` failed | {{site.data.cloud-error-messages.CLOUD_LOG_VERBOSE_ACTION}} |
+| 20 | compress-static-content | Static content compression failed | {{site.data.cloud-error-messages.CHECK_CLOUD_LOG_ACTION}} |
+| 21 | backup-data: static-content | Failed to copy static content into the `init` directory | {{site.data.cloud-error-messages.CHECK_CLOUD_LOG_ACTION}} |
+| 22 | backup-data: writable-dirs | Failed to copy some writable directories into the `init` directory | {{site.data.cloud-error-messages.WRITABLE_DIRECTORY_COPYING_FAILED}} |
+| 23 | | Unable to create a logger object | |
+| 24 | backup-data: static-content | Failed to clean the `./init/pub/static/` directory | {{ site.data.cloud-error-messages.CLEAN_INIT_PUB_STATIC_FAILED}} |
+| 25 | | Cannot find the Composer package | {{site.data.cloud-error-messages.COMPOSER_PACKAGE_NOT_FOUND}} |
 
-| Step | Description | Error code |
-| --- | --- | --- |
-| pre-deploy: cache | Wrong cache configuration (missed port or host) | 101 |
-| general | File `./app/etc/env.php` is not writable | 102 |
-| | Configuration isn't defined in schema.yaml | [103](#CONFIG_NOT_DEFINED) |
-| | Failed to parse .magento.env.yaml | 104 |
-| | Unable to read .magento.env.yaml | 105 |
-| | Unable to read .schema.yaml | 106 |
-| pre-deploy: clean-redis-cache | Failed to clean redis cache | 107 |
-| pre-deploy: set-production-mode | Command `/bin/magento maintenance:enable` failed | 108 |
-| validate-config | Wrong database configuration | 109 |
-| | Wrong session configuration | 110 |
-| | Wrong search configuration | 111 |
-| | Wrong resource configuration | 112 |
-| validate-config:elasticsuite-integrity | ElasticSuite is installed without available ElasticSearch service | 113 |
-| | ElasticSuite is installed but another search engine is used | 114 |
-| general | Database query execution failed | 115 |
-| install-update: setup | Command `/bin/magento setup:install` failed | 116 |
-| install-update: config-import | Command `app:config:import` failed | 117 |
-| general | Required utility wasn't found (timeout, bash) | 118 |
-| install-update: deploy-static-content	 | Command `/bin/magento setup:static-content:deploy` failed | 119 |
-| compress-static-content | Compression of static content failed | 120 |
-| deploy-static-content:generate | Cannot update deployed version | 121 |
-| clean-static-content | Failed to clean static content files | 122 |
-| install-update: split-db | Command `/bin/magento setup:db-schema:split` failed | 123 |
-| clean-view-preprocessed | Failed to clean var/view_preprocessed | 124 |
-| install-update: reset-password | Failed to update `/var/credentials_email.txt` file | 125 |
-| install-update: update | Command `/bin/magento setup:upgrade` failed | 126 |
-| clean-cache | Command `/bin/magento cache:flush` failed | 127 |
-| disable-maintenance-mode | Command `/bin/magento maintenance:disable` failed | 128 | 
-| install-update: reset-password | Enable to read reset password template | 129 |
+## Deploy stage
 
-### Post-deploy stage
+| Error code | Deploy step | Error description | Suggested action |
+| --- | --- | --- | -- |
+| 101 | pre-deploy: cache | Incorrect cache configuration (missing port or host) | {{site.data.cloud-error-messages.WRONG_CACHE_CONFIGURATION}} |
+| 102 | | File `./app/etc/env.php` is not writable | {{site.data.cloud-error-messages.ENV_PHP_IS_NOT_WRITABLE}} |
+| 103 | | Configuration isn't defined in the `schema.yaml` file  | |
+| 104 | | Failed to parse the `.magento.env.yaml` file | {{site.data.cloud-error-messages.CONFIG_NOT_DEFINED}} |
+| 105 | | Unable to read the `.magento.env.yaml` file | {{site.data.cloud-error-messages.CONFIG_UNABLE_TO_READ}} |
+| 106 | | Unable to read the `.schema.yaml` file | |
+| 107 | pre-deploy: clean-redis-cache | Failed to clean the Redis cache | {{site.data.cloud-error-messages.
+REDIS_CACHE_CLEAN_FAILED}} |
+| 108 | pre-deploy: set-production-mode | Command `/bin/magento maintenance:enable` failed | {{site.data.cloud-error-messages.CLOUD_LOG_VERBOSE_ACTION}} |
+| 109 | validate-config | Incorrect database configuration | {{site.data.cloud-error-messages.WRONG_CONFIGURATION_DB}} |
+| 110 | validate-config | Incorrect session configuration | {{site.data.cloud-error-messages.WRONG_CONFIGURATION_SESSION}} |
+| 111 | validate-config | Incorrect search configuration | {{site.data.cloud-error-messages.WRONG_CONFIGURATION_SEARCH}} |
+| 112 | validate-config | Incorrect resource configuration | {{site.data.cloud-error-messages.WRONG_CONFIGURATION_RESOURCE}} |
+| 113 | validate-config:elasticsuite-integrity | ElasticSuite is installed, but the ElasticSearch service is not available | {{site.data.cloud-error-messages.ELASTIC_SUITE_WITHOUT_ES}} |
+| 114 | validate-config:elasticsuite-integrity | ElasticSuite is installed, but another search engine is used | {{site.data.cloud-error-messages.ELASTIC_SUITE_WRONG_ENGINE}} |
+| 115 |  | Database query execution failed | |
+| 116 | install-update: setup | Command `/bin/magento setup:install` failed | {{site.data.cloud-error-messages.INSTALL_UPGRADE_ACTION}} |
+| 117 | install-update: config-import | Command `app:config:import` failed | {{site.data.cloud-error-messages.INSTALL_UPGRADE_ACTION}} |
+| 118 |  | Required utility wasn't found (timeout, bash) | {{site.data.cloud-error-messages.UTILITY_NOT_FOUND}} |
+| 119 | install-update: deploy-static-content | Command `/bin/magento setup:static-content:deploy` failed | {{site.data.cloud-error-messages.CLOUD_LOG_VERBOSE_ACTION}} |
+| 120 | compress-static-content | Static content compression failed | {{site.data.cloud-error-messages.CHECK_CLOUD_LOG_ACTION}} |
+| 121 | deploy-static-content:generate | Cannot update the deployed version | {{site.data.cloud-error-messages.SCD_UNABLE_UPDATE_VERSION}} |
+| 122 | clean-static-content | Failed to clean static content files | |
+| 123 | install-update: split-db | Command `/bin/magento setup:db-schema:split` failed | {{site.data.cloud-error-messages.CLOUD_LOG_VERBOSE_ACTION}} |
+| 124 | clean-view-preprocessed | Failed to clean the `var/view_preprocessed` folder | {{site.data.cloud-error-messages.VIEW_PREPROCESSED_CLEAN_FAILED}} |
+| 125 | install-update: reset-password | Failed to update the `/var/credentials_email.txt` file | {{site.data.cloud-error-messages.FILE_CREDENTIALS_EMAIL_NOT_WRITABLE}} |
+| 126 | install-update: update | Command `/bin/magento setup:upgrade` failed | |
+| 127 | clean-cache | Command `/bin/magento cache:flush` failed | {{site.data.cloud-error-messages.CLOUD_LOG_VERBOSE_ACTION}} |
+| 128 | disable-maintenance-mode | Command `/bin/magento maintenance:disable` failed | |
+| 129 | install-update: reset-password | Enable to read reset password template | |
 
-| Step | Description | Error code |
-| --- | --- | --- |  
-| is-deploy-failed | If deploy stage failed (flag `deploy_is_failed` exists) | 201 |
-| general |  File `./app/etc/env.php` is not writable | 202 |
-| | Configuration isn't defined in schema.yaml | 203 |
-| | Failed to parse .magento.env.yaml | 204 |
-| | Unable to read .magento.env.yaml | 205 |
-| | Unable to read .schema.yaml | 206 |
-| warm-up | Failed to warm-up some pages | 207 |
-| time-to-firs-byte | Failed to test time to first byte | 208 |
-| clean-cache | Command `/bin/magento cache:flush` failed | 227 |
+## Post-deploy stage
 
-## Errors suggestion
+| Error code | Post-deploy step | Error description | Suggested action |
+| --- | --- | --- | -- |
+| 201 | is-deploy-failed | Deploy stage failed | |
+| 202 |  | The `./app/etc/env.php` file is not writable | {{site.data.cloud-error-messages.ENV_PHP_IS_NOT_WRITABLE}} |
+| 203 |  | Configuration isn't defined in the `schema.yaml` file | {{site.data.cloud-error-messages.CONFIG_NOT_DEFINED}} |
+| 204 |  | Failed to parse the `.magento.env.yaml` file | |
+| 205 |  | Unable to read the `.magento.env.yaml` file | {{site.data.cloud-error-messages.CONFIG_UNABLE_TO_READ}} |
+| 206 |  | Unable to read the `.schema.yaml` file | |
+| 207 | warm-up | Failed to warm-up some pages | |
+| 208 | time-to-firs-byte | Failed to test time to first byte (TTFB) | |
+| 227 | clean-cache | Command `/bin/magento cache:flush` failed | {{site.data.cloud-error-messages.CLOUD_LOG_VERBOSE_ACTION}} |
 
-##### ENV_PHP_IS_NOT_WRITABLE
-Deployment script can't make required changes in the `/app/etc/env.php` file. Check your filesystem permissions.
+<!--Link definitions-->
 
-##### CONFIG_NOT_DEFINED
-Configuration isn't defined in the `./vendor/magento/ece-tools/config/schema.yaml` file. Check that config variable name is correct and it's defined.
-
-##### CONFIG_PARSE_FAILED
-File `./.magento.env.yaml` has formatting error. Format the file according to YAML standards.
-
-##### CONFIG_UNABLE_TO_READ
-Unable to read `./.magento.env.yaml` file. Check file permissions.
-
-##### CONFIG_PHP_IS_NOT_WRITABLE
-Deployment script can't make required changes in the `/app/etc/config.php` file. Check your filesystem permissions.
-
-##### CANT_READ_COMPOSER_JSON
-Unable to read `./composer.json` file. Check file permissions.
-
-##### COMPOSER_MISSED_REQUIRED_AUTOLOAD
-Required autoload section is missed in your `composer.json` file. Compare autoload section from the vanilla magento `composer.json` file and add missed configuration.
-
-##### WRONG_CONFIGURATION_MAGENTO_ENV_YAML
-File `./.magento.env.yaml` contains wrong configuration. Check error log for detailed info.
-
-##### MODULE_ENABLE_COMMAND_FAILED
-Check `cloud.log` for more information. Add `VERBOSE_COMMANDS: '-vvv'` into `.magento.env.yaml` for more detailed command output.
-
-##### COMPOSER_DUMP_AUTOLOAD_FAILED
-Command `composer dump-autoload` failed. Check `cloud.log` for more information.
-
-##### BALER_NOT_FOUND
-Check that `baler` is installed or disable baler in your configuration `SCD_USE_BALER: false`.
-
-##### UTILITY_NOT_FOUND
-One of required utilities was not found on server. Check `cloud.log` for more information and install required utility.
-
-##### SCD_FAILED
-Check `cloud.log` for more information. Add `VERBOSE_COMMANDS: '-vvv'` into `.magento.env.yaml` for more detailed command output.
-
-##### SCD_COMPRESSION_FAILED
-Check `cloud.log` for more information.
-
-##### SCD_COPYING_FAILED
-Check `cloud.log` for more information.
-
-##### WRITABLE_DIRECTORY_COPYING_FAILED
-Failed to copy writable directories into `./init` folder. Check your filesystem permissions.
-
-##### CLEAN_INIT_PUB_STATIC_FAILED
-Failed to clean `./init/pub/static` folder. Check your filesystem permissions.
-
-##### COMPOSER_PACKAGE_NOT_FOUND
-Check `cloud.log` for more information.
-In case of installation from git check if `DEPLOYED_MAGENTO_VERSION_FROM_GIT` is configured.
-
-##### WRONG_CACHE_CONFIGURATION
-Cache configuration missed required parameters `server` or `port`. Check `cloud.log` for more information.
-
-##### REDIS_CACHE_CLEAN_FAILED
-Failed to clean redis cache. Check that configuration is correct and redis service is available.
-
-##### MAINTENANCE_MODE_ENABLING_FAILED
-Check `cloud.log` for more information. Add `VERBOSE_COMMANDS: '-vvv'` into `.magento.env.yaml` for more detailed command output.
-
-##### WRONG_CONFIGURATION_DB
-Check that `DATABASE_CONFIGURATION` is configured properly.
-
-##### WRONG_CONFIGURATION_SESSION
-Check that `SESSION_CONFIGURATION` is configured properly. Configuration must contain at least `save` parameter.
-
-##### WRONG_CONFIGURATION_SEARCH
-Check that `SEARCH_CONFIGURATION` is configured properly. Configuration must contain at least `engine` parameter.
-
-##### WRONG_CONFIGURATION_RESOURCE
-Check that `RESOURCE_CONFIGURATION` is configured properly. Configuration must contain at least `connection` parameter.
-
-##### ELASTIC_SUITE_WITHOUT_ES
-ElasticSuite is installed without available ElasticSearch service. Check that elastic search service is enabled.
-
-##### ELASTIC_SUITE_WRONG_ENGINE
-ElasticSuite is installed but another search engine set. Change search engine to ElasticSearch.
-
-##### INSTALL_COMMAND_FAILED
-Check `cloud.log` and `install_upgrade.log` for more information. Add `VERBOSE_COMMANDS: '-vvv'` into `.magento.env.yaml` for more detailed command output.
-
-##### UPGRADE_COMMAND_FAILED
-Check `cloud.log` and `install_upgrade.log` for more information. Add `VERBOSE_COMMANDS: '-vvv'` into `.magento.env.yaml` for more detailed command output.
-
-##### CONFIG_IMPORT_COMMAND_FAILED
-Check `cloud.log` for more information. Add `VERBOSE_COMMANDS: '-vvv'` into `.magento.env.yaml` for more detailed command output.
-
-##### SCD_UNABLE_UPDATE_VERSION
-Cannot update `./pub/static/deployed_version.txt` file. Check your filesystem permissions.
-
-##### SPLIT_DB_COMMAND_FAILED
-Check `cloud.log` for more information. Add `VERBOSE_COMMANDS: '-vvv'` into `.magento.env.yaml` for more detailed command output.
-
-##### VIEW_PREPROCESSED_CLEAN_FAILED
-Unable to clean `./var/view_preprocessed` folder. Check your filesystem permissions.
-
-##### FILE_CREDENTIALS_EMAIL_NOT_WRITABLE
-Failed to update `/var/credentials_email.txt` file. Check your filesystem permissions.
-
-##### CACHE_FLUSH_COMMAND_FAILED
-Check `cloud.log` for more information. Add `VERBOSE_COMMANDS: '-vvv'` into `.magento.env.yaml` for more detailed command output.
+[Scenario-based deployment]: {{site.baseurl}}/cloud/deploy/scenario-based-deployment.html

--- a/src/cloud/trouble/error-codes.md
+++ b/src/cloud/trouble/error-codes.md
@@ -10,12 +10,19 @@ This {{site.data.var.ct}} error message reference provides information to resolv
 Error messages are categorized by deployment stage–build, deploy, and post-deploy. Each section provides a list of associated errors with the following information for each error:
 
 -  **Error code**:  The Magento-assigned identifier for the error message
--  **Step**:  Indicates the step in the deployment scenario where the error can occur. If the _Step_ column is blank, the error is a general error that can occur in multiple steps, or during pre-processing operations. See [Scenario-based deployment]({{site.baseurl}}/cloud/deploy/scenario-based-deployment.html).
+-  **Step**:  Indicates the step in the deployment scenario where the error can occur. If the _Step_ column is blank, the error is a general error that can occur in multiple steps, or during pre-processing operations. See [Scenario-based deployment]({{site.baseurl}}/cloud/deploy/scenario-based-deployment.html) for more information about the build, deploy, and post-deploy steps.
 -  **Error description**: A short phrase that summarizes the cause of the error
 -  **Suggested action**: Provides guidance to troubleshoot and resolve the error
 
 ## Build stage
 
+<style>
+table.my-special-table td:nth-child(1) {
+  width: 50px;
+}
+</style>
+
+{:.table.my-special-table}
 | Error code | Build step | Error description | Suggested action |
 | --- | --- | --- | -- |
 | 2 | | File `./app/etc/env.php` is not writable | {{site.data.cloud-error-messages.ENV_PHP_IS_NOT_WRITABLE}}|
@@ -55,7 +62,7 @@ Error messages are categorized by deployment stage–build, deploy, and post-dep
 | 106 | | Unable to read the `.schema.yaml` file | |
 | 107 | pre-deploy: clean-redis-cache | Failed to clean the Redis cache | {{site.data.cloud-error-messages.
 
-REDIS_CACHE_CLEAN_FAILED}}. See [Setup Redis service]({{site.baseurl}}/cloud/project/project-conf-files_services-redis.html). |
+REDIS_CACHE_CLEAN_FAILED}}. |
 | 108 | pre-deploy: set-production-mode | Command `/bin/magento maintenance:enable` failed | {{site.data.cloud-error-messages.CLOUD_LOG_VERBOSE_ACTION}} |
 | 109 | validate-config | Incorrect database configuration | {{site.data.cloud-error-messages.WRONG_CONFIGURATION_DB}} |
 | 110 | validate-config | Incorrect session configuration | {{site.data.cloud-error-messages.WRONG_CONFIGURATION_SESSION}} |


### PR DESCRIPTION
Merges changes from #7261

## Purpose of this pull request

Adds a deployment error reference for ece-tools errors to the Troubleshooting section of the _Cloud Guide_.

- [x] Technical review
- [ ] Editorial review
- [x] Staging build

## Affected DevDocs pages

- https://devdocs.magento.com/cloud/trouble/error-codes.html

## Links to Magento source code

https://github.com/magento/ece-tools/pull/726

whatsnew
Added an [Error message reference for ece-tools]( https://devdocs.magento.com/cloud/trouble/error-codes.html) to list errors and suggested actions for resolving errors that occur during the Magento Cloud deployment process.