### PR TITLE
Cleanup obsolete metadata in troubleshooting topics

### DIFF
--- a/src/cloud/trouble/trouble-crypt-key-variable.md
+++ b/src/cloud/trouble/trouble-crypt-key-variable.md
@@ -1,10 +1,6 @@
 ---
 group: cloud-guide
-subgroup: 170_trouble
 title: Resolve issues with encryption key
-menu_title: Resolve issues with encryption key
-menu_order: 25
-menu_node:
 functional_areas:
   - Cloud
   - Setup

--- a/src/cloud/trouble/trouble-error-html-minification.md
+++ b/src/cloud/trouble/trouble-error-html-minification.md
@@ -1,10 +1,6 @@
 ---
 group: cloud-guide
-subgroup: 170_trouble
 title: Resolve issues with HTML minification
-menu_title: Resolve issues with HTML minification
-menu_order: 30
-menu_node:
 functional_areas:
   - Cloud
   - Configuration

--- a/src/cloud/trouble/trouble-google-analytics-deploy.md
+++ b/src/cloud/trouble/trouble-google-analytics-deploy.md
@@ -1,10 +1,6 @@
 ---
 group: cloud-guide
-subgroup: 170_trouble
 title: Resolve issues with Google Analytics during deployment
-menu_title: Resolve issues with Google Analytics during deployment
-menu_order: 35
-menu_node:
 functional_areas:
   - Cloud
   - Configuration

--- a/src/cloud/trouble/trouble_ce-creds.md
+++ b/src/cloud/trouble/trouble_ce-creds.md
@@ -1,10 +1,6 @@
 ---
 group: cloud-guide
-subgroup: 170_trouble
 title: Incorrect credentials
-menu_title: Incorrect credentials
-menu_order: 7
-menu_node:
 functional_areas:
   - Cloud
   - Configuration

--- a/src/cloud/trouble/trouble_proj-startover.md
+++ b/src/cloud/trouble/trouble_proj-startover.md
@@ -1,10 +1,6 @@
 ---
 group: cloud-guide
-subgroup: 170_trouble
 title: Resolve issues with a new project
-menu_title: Resolve issues with a new project
-menu_order: 10
-menu_node:
 functional_areas:
   - Cloud
   - Setup


### PR DESCRIPTION
## Purpose of this pull request

Removes obsolete metadata from troubleshooting topics in the _Cloud Guide_.

## Affected DevDocs pages

- https://devdocs.magento.com/cloud/trouble/trouble-crypt-key-variable.html
- https://devdocs.magento.com/cloud/trouble/trouble-error-html-minification.html
- https://devdocs.magento.com/cloud/trouble/trouble-google-analytics-deploy.html
- https://devdocs.magento.com/cloud/trouble/trouble_ce-creds.html
- https://devdocs.magento.com/cloud/trouble/trouble_proj-startover.html