### PR TITLE
Add a 2.4.0 beta banner message to 2.4 docs

### DIFF
--- a/src/_includes/layout/page-header.html
+++ b/src/_includes/layout/page-header.html
@@ -7,6 +7,12 @@
   </div>
   {% endif %}
 
+  {% if page.guide_version == "2.4" %}
+  <div class="message-banner">
+    This is the 2.4.0 beta release version of documentation. Content in this version is subject to change.
+  </div>
+  {% endif %}
+
   <h1 class="page-title">{{ page.title }}</h1>
 
   {% if page.subtitle %}


### PR DESCRIPTION
## Purpose of this pull request

This pull request (PR) adds a banner message to the top of all 2.4 devdocs topics explaining that the docs are in beta and subject to change.

## Affected DevDocs pages

-  All 2.4 devdocs pages