### PR TITLE
Fix Composer syntax for installing upgrade plugin

### DIFF
--- a/src/guides/v2.3/comp-mgr/cli/upgrade-with-plugin.md
+++ b/src/guides/v2.3/comp-mgr/cli/upgrade-with-plugin.md
@@ -27,7 +27,7 @@ Backup the existing `composer.json` file in the Magento installation directory.
 ## Install the plugin
 
 ```bash
-composer require magento/composer-root-update-plugin ~1.0 --no-update
+composer require magento/composer-root-update-plugin=~1.0 --no-update
 ```
 
 Update the dependencies:

--- a/src/guides/v2.4/comp-mgr/cli/cli-upgrade.md
+++ b/src/guides/v2.4/comp-mgr/cli/cli-upgrade.md
@@ -43,7 +43,7 @@ Complete the following prerequisites to prepare your environment before starting
    To install the plugin:
 
    ```bash
-   composer require magento/composer-root-update-plugin ~1.0 --no-update
+   composer require magento/composer-root-update-plugin=~1.0 --no-update
    ```
 
    Update the dependencies:


### PR DESCRIPTION
## Purpose of this pull request

This pull request (PR) fixes the Composer syntax in the CLI upgrade topic for installing the upgrade plugin. 
The composer plugin command needs to be `composer require magento/composer-root-update-plugin=~1.0 --no-update`  (with the equals sign); apparently not using the equals sign causes the command to fail when using zsh instead of bash

## Affected DevDocs pages

-  https://devdocs.magento.com/guides/v2.4/comp-mgr/cli/cli-upgrade.html
- https://devdocs.magento.com/guides/v2.3/comp-mgr/cli/upgrade-with-plugin.html