### PR TITLE
Add info about Xdebug container for Cloud Docker and update configuration instructions

### DIFF
--- a/src/cloud/docker/docker-config.md
+++ b/src/cloud/docker/docker-config.md
@@ -9,7 +9,9 @@ redirect_from:
   - /cloud/reference/docker-config.html
 ---
 
-The `{{site.data.var.ct}}` package (version 2002.0.13 or later) deploys to a read-only file system by default in the Docker environment, which mirrors the read-only file system deployed in the Production environment. You can use the `ece-docker build:compose` command in the `{{site.data.var.ct}}` package to generate the Docker Compose configuration and deploy {{site.data.var.ece}} in a Docker container.
+`{{site.data.var.mcd-prod}}` deploys to a read-only file system by default in the Docker environment, which mirrors the read-only file system deployed in the Production environment. You also have the option to deploy a Docker environment in developer mode, which provides an active development environment with full, writable filesystem permissions.
+
+You use the `ece-docker build:compose` command to generate the Docker Compose configuration and deploy {{site.data.var.ece}} in a Docker container.
 
 {: .bs-callout-warning }
 The `ece-docker build:compose` command overwrites the existing `docker-compose.yml` configuration file. You can save your customizations for the Docker Compose configuration in a `docker-compose.override.yml` file. See a detailed example in the [Docker quick reference][docker-reference].
@@ -48,8 +50,6 @@ The `ece-docker build:compose` command overwrites the existing `docker-compose.y
    ```bash
    sudo apachectl stop
    ```
-
-1. Optionally, [enable Xdebug].
 
 ## Set the launch mode
 

--- a/src/cloud/docker/docker-containers-service.md
+++ b/src/cloud/docker/docker-containers-service.md
@@ -121,7 +121,7 @@ The FPM container includes the following volumes:
 {:.bs-callout-tip}
 You can add custom PHP extensions and manage their status from the `runtime` section of the `.magento.app.yaml` file. See [PHP extensions]. To test custom extensions without updating the {{site.data.var.ece}} environment configuration, you can add the custom configuration to the [`docker-compose.override.yml`][Docker override file]. Configuration settings in this file are applied only when you build and deploy to the Docker environment.
 
-For additional information about configuring the php environment, see the [XDebug for Docker] documentation.
+Optionally, you can add Xdebug to your Cloud Docker environment to debug your PHP code. See [Configure XDebug for Docker][].
 
 ## RabbitMQ container
 
@@ -238,10 +238,10 @@ To mount the custom index.php file using volumes:
 [mariadb Docker documentation]: https://hub.docker.com/_/mariadb
 [Manage the database]: {{site.baseurl}}/cloud/docker/docker-containers-service.html
 [php-cloud]: https://hub.docker.com/r/magento/magento-cloud-docker-php
-[XDebug for Docker]: {{site.baseurl}}/cloud/docker/docker-development-debug.html
 [redis]: https://hub.docker.com/_/redis
 [rabbitmq]: https://hub.docker.com/_/rabbitmq
 [FPM]: https://php-fpm.org
+[Configure Xdebug for Docker]: {{site.baseurl}}/cloud/docker/docker-development-debug.html
 [varnish]: https://hub.docker.com/r/magento/magento-cloud-docker-varnish
 [tls]: https://hub.docker.com/r/magento/magento-cloud-docker-tls
 [debian:jessie]: https://hub.docker.com/_/debian

--- a/src/cloud/docker/docker-containers.md
+++ b/src/cloud/docker/docker-containers.md
@@ -32,13 +32,13 @@ See [Docker CLI containers] for details.
 | ------------- | ---------- | ---------- | ------------------ |------------------
 | [db] | MariaDB     | `--db` | 10.0, 10.1, 10.2 |  Standard database container
 | [elasticsearch] | Elasticsearch | `--es`<br>`--es-env-var` | 1.7, 2.4, 5.2, 6.5, 6.8, 7.5, 7.6 |
-| [FPM][fpm-container] | PHP FPM | `--php` | 7.0, 7.1, 7.2, 7.3, 7.4 |  Used for all incoming requests
+| [FPM][fpm-container] | PHP FPM | `--php`<br>`--with-xdebug` | 7.0, 7.1, 7.2, 7.3, 7.4 |  Used for all incoming requests. Optionally, add Xdebug configuration to debug PHP code in the Docker environment.
 | [node][node-container] | Node | `--node` | 6, 8, 10, 11 |  Used gulp or other NPM based commands
 | [rabbitmq][rabbitmq-container]| RabbitMQ | `--rmq` | 3.5, 3.7, 3.8 |
 | [redis][redis-container] | Redis     | `--redis` | 3.2, 4.0, 5.0 |   Standard redis container
 | [selenium][selenium-container]| Selenium | `--with-selenium`<br>`--selenium-version`<br>`--selenium-image`| Any | Enables Magento application testing using the Magento Functional Testing Framework (MFTF)
 | [tls][tls-container] | SSL Endpoint |  |   |  Terminates SSL, can be configured to pass to varnish or nginx
-| [varnish][varnish-container] | Varnish | `--no-varnish` | 4, 6.2 |
+| [varnish][varnish-container] | Varnish | `--no-varnish` | 4, 6.2 | Varnish is provisioned by default. Use the `--no-varnish` option to skip Varnish service installation
 | [web][web-container] | NGINX | `--nginx` | 1.9, latest |
 
 The `ece-docker build:compose` command runs in interactive mode and verifies the configured service versions. To skip interactive mode, use the `-n, --no-interaction` option.

--- a/src/cloud/docker/docker-development-debug.md
+++ b/src/cloud/docker/docker-development-debug.md
@@ -8,7 +8,9 @@ functional_areas:
 - Debug
 ---
 
-Xdebug is an extension for debugging your PHP. The following explains how to configure Xdebug and PhpStorm to debug in your local Docker environment.
+Xdebug is an extension for debugging your PHP. {{site.data.var.mcd-prod}} provides a separate container to handle Xdebug requests in the Docker environment.  Using this container allows you to enable and use Xdebug to debug in your Docker environment without affecting your {{site.data.var.ece}} project configuration.
+
+The following explains how to configure Xdebug and PhpStorm to debug in your local Docker environment.
 
 If you use Microsoft Windows, take the following steps before continuing:
 
@@ -18,38 +20,47 @@ If you use Microsoft Windows, take the following steps before continuing:
 
 ## Enable Xdebug
 
-To enable Xdebug for your project, add `xdebug` to the `runtime:extensions` section of the `.magento.app.yaml` file.
+1. To enable Xdebug for your Docker environment, generate the Docker Compose configuration file in developer mode with the `--with-xdebug` option and any other required options, for example.
 
-```yaml
-runtime:
-    extensions:
-        - redis
-        - xsl
-        - json
-        - newrelic
-        - xdebug
-```
+   ```bash
+   vendor/bin/ece-docker build:compose --mode --sync-engine="mutagen" developer --with-xdebug
+   ```
 
-## Configure Xdebug
-
-1. Rebuild the `docker-compose.yml` file by continuing to configure your local workstation to [launch the Docker environment]({{ site.baseurl }}/cloud/docker/docker-config.html). The following is an excerpt from the `docker-compose.yml` file that shows Docker global variables.
+   This command adds the Xdebug configuration to your `docker-compose.yml` file.
 
    ```yaml
-   generic:
-     image: alpine
-     environment:
-       - PHP_MEMORY_LIMIT=2048M
-       - UPLOAD_MAX_FILESIZE=64M
-       - MAGENTO_ROOT=/app
-       - PHP_IDE_CONFIG=serverName=magento_cloud_docker
-       - XDEBUG_CONFIG=remote_host=host.docker.internal
-       - 'PHP_EXTENSIONS=bcmath bz2 calendar exif gd gettext intl mysqli pcntl pdo_mysql soap sockets sysvmsg sysvsem sysvshm opcache zip redis xsl xdebug'
+      fpm_xdebug:
+       hostname: fpm_xdebug.magento2.docker
+       image: 'magento/magento-cloud-docker-php:7.3-fpm-1.1'
+       extends: generic
+       ports:
+         - '9001:9001'
+       volumes:
+         - 'mymagento-magento-sync:/app:nocopy'
+       environment:
+         - 'PHP_EXTENSIONS=bcmath bz2 calendar exif gd gettext intl mysqli pcntl pdo_mysql soap    socketssysvmsg    sysvsem sysvshm opcache zip redis xsl sodium'
+       networks:
+         magento:
+           aliases:
+             - fpm_xdebug.magento2.docker
+       depends_on:
+         db:
+           condition: service_started
    ```
    {:.no-copy}
 
-1. Change any Xdebug configuration using the`XDEBUG_CONFIG` option. For example, to change the `xdebug.remote_port` option:
+1. Follow the steps to [launch the Docker environment in Developer mode][].
 
-   ```yaml
+   The default Docker environment configuration sets the following Xdebug configuration variables:
+
+   ```conf
+   PHP_IDE_CONFIG=serverName=magento_cloud_docker
+   XDEBUG_CONFIG=remote_host=host.docker.internal
+   ```
+
+1. Change any Xdebug configuration using the `XDEBUG_CONFIG` option. For example, to change the xdebug.remote_port option:
+
+   ```bash
    XDEBUG_CONFIG='remote_host=host.docker.internal remote_port=9002'
    ```
 
@@ -67,7 +78,7 @@ To configure PhpStorm to work with Xdebug:
 
 1. Configure the following settings for the new server configuration:
 
-   -  **Name**—Enter the name used for the `serverName` in `PHP_IDE_CONFIG` option from `docker-compose.yml` file.
+   -  **Name**—Enter the name used for the `serverName` option from `PHP_IDE_CONFIG` value.
    -  **Host**—Enter `localhost`.
    -  **Port**—Enter `80`.
    -  **Debugger**—Select `Xdebug`.
@@ -155,4 +166,5 @@ To use Xdebug Helper with Chrome:
    ![Xdebug Helper options]({{ site.baseurl }}/common/images/cloud-xdebug_helper-options.png){:width="400px"}
 
 [docker-config]: {{site.baseurl}}/cloud/docker/docker-config.html
+[launch the Docker environment in Developer mode]: {{site.baseurl}}/cloud/docker/docker-mode-developer.html
 [Xdebug Helper extension]: https://chrome.google.com/webstore/detail/xdebug-helper/eadndfjplgieldjbigjakmdgkmoaaaoc?hl=en

--- a/src/cloud/docker/docker-development-debug.md
+++ b/src/cloud/docker/docker-development-debug.md
@@ -8,9 +8,9 @@ functional_areas:
 - Debug
 ---
 
-Xdebug is an extension for debugging your PHP. {{site.data.var.mcd-prod}} provides a separate container to handle Xdebug requests in the Docker environment.  Using this container allows you to enable and use Xdebug to debug in your Docker environment without affecting your {{site.data.var.ece}} project configuration.
+Xdebug is an extension for debugging your PHP. {{site.data.var.mcd-prod}} provides a separate container to handle Xdebug requests in the Docker environment.  Use this container to enable Xdebug and debug PHP code in your Docker environment without affecting your {{site.data.var.ece}} project configuration.
 
-The following explains how to configure Xdebug and PhpStorm to debug in your local Docker environment.
+The following instructions explain how to configure Xdebug and PhpStorm to debug in your local Docker environment.
 
 If you use Microsoft Windows, take the following steps before continuing:
 

--- a/src/cloud/docker/docker-mode-developer.md
+++ b/src/cloud/docker/docker-mode-developer.md
@@ -46,13 +46,14 @@ To launch the Docker environment in developer mode:
    ./vendor/bin/ece-docker build:compose --mode="developer" --sync-engine="mutagen"
    ```
 
+   {:.bs-callout-info}
+   You can further customize the Docker Compose configuration file by adding additional options to the `build:compose` command. For example, you can set the software version for a service, or add Xdebug configuration. See [service keys][].
+
 1. _Optional_: If you have a custom PHP configuration file, copy the default configuration DIST file to your custom configuration file and make any necessary changes.
 
    ```bash
    cp .docker/config.php.dist .docker/config.php
    ```
-
-1. _Optional_: Configure the Docker global variables in the `docker-compose.yml` file. For example, you can enable Xdebug in the `.magento.app.yaml` file, and then update the configuration in the `docker-compose.yml` file. See [Configure Xdebug for Docker][xdebug].
 
 1. If you selected `docker-sync` for file synchronization, start the file synchronization.
 
@@ -126,6 +127,7 @@ To launch the Docker environment in developer mode:
 [cloud-repo]: https://github.com/magento/magento-cloud
 [magento-creds]: {{site.baseurl}}/guides/v2.3/install-gde/prereq/connect-auth.html
 [services]: {{site.baseurl}}/cloud/docker/docker-containers.html#service-containers
-[xdebug]: {{site.baseurl}}/cloud/docker/docker-development-debug.html#configure-xdebug
+[xdebug]: {{site.baseurl}}/cloud/docker/docker-development-debug.html#configure-xdebug]
+[service key]: {{site.baseurl}}/cloud/docker/docker-containers.html#service-containers
 [dsync-install]: https://docker-sync.readthedocs.io/en/latest/getting-started/installation.html
 [mutagen-install]: https://mutagen.io/documentation/introduction/installation/

--- a/src/cloud/docker/docker-mode-production.md
+++ b/src/cloud/docker/docker-mode-production.md
@@ -36,8 +36,6 @@ To launch the Docker environment in production mode:
    cp .docker/config.php.dist .docker/config.php
    ```
 
-1. _Optional_: Configure the Docker global variables in the `docker-compose.yml` file. For example, you can [configure Xdebug].
-
 1. Build files to containers and run in the background.
 
    ```bash

--- a/src/cloud/howtos/debug.md
+++ b/src/cloud/howtos/debug.md
@@ -12,6 +12,9 @@ functional_areas:
 
 Xdebug is an extension for debugging your PHP. The following explains how to configure Xdebug and PhpStorm to debug in your local environment. You can use the IDE of your choice. See the vendor documentation for those applications for further configuration information.
 
+{:.bs-callout-info}
+You can also configure Xdebug to run in the {{site.data.var.mcd-prod}} environment for local debugging without changing your {{site.data.var.ece}} project configuration. See [Configure Xdebug for Docker]{{site.baseurl}}/cloud/docker/docker-development-debug.html).
+
 To set up Xdebug, you need to [configure](#configure-xdebug) a file in your Git repository, configure your IDE, and set up port forwarding. You can configure settings in the `magento.app.yaml` file. After editing, you can push the Git changes across all Starter environments and Pro Integration environments to enable Xdebug. To push these settings to Pro plan Staging and Production environments, you must enter a ticket.
 
 Once configured, you can debug [CLI commands](#debugcli), [web requests](#webrequests), and [code](#code). Remember, all {{site.data.var.ece}} environments are read-only. You need to pull code to your local development environment to perform debugging. For Pro Staging and Production environments, we include [additional instructions](#pro-debug) for Xdebug.

--- a/src/cloud/howtos/debug.md
+++ b/src/cloud/howtos/debug.md
@@ -13,7 +13,7 @@ functional_areas:
 Xdebug is an extension for debugging your PHP. The following explains how to configure Xdebug and PhpStorm to debug in your local environment. You can use the IDE of your choice. See the vendor documentation for those applications for further configuration information.
 
 {:.bs-callout-info}
-You can also configure Xdebug to run in the {{site.data.var.mcd-prod}} environment for local debugging without changing your {{site.data.var.ece}} project configuration. See [Configure Xdebug for Docker]{{site.baseurl}}/cloud/docker/docker-development-debug.html).
+You can configure Xdebug to run in the {{site.data.var.mcd-prod}} environment for local debugging without changing your {{site.data.var.ece}} project configuration. See [Configure Xdebug for Docker]{{site.baseurl}}/cloud/docker/docker-development-debug.html).
 
 To set up Xdebug, you need to [configure](#configure-xdebug) a file in your Git repository, configure your IDE, and set up port forwarding. You can configure settings in the `magento.app.yaml` file. After editing, you can push the Git changes across all Starter environments and Pro Integration environments to enable Xdebug. To push these settings to Pro plan Staging and Production environments, you must enter a ticket.
 

--- a/src/cloud/release-notes/mcd-release-notes.md
+++ b/src/cloud/release-notes/mcd-release-notes.md
@@ -20,15 +20,19 @@ The release notes include:
 
 -  {:.new}**Container updates**–
 
-   -  {:.new}**PHP-FPM**—Fixed an issue in the Docker entrypoint script (docker-entrypoint.sh) that caused errors when connecting to the PHP container.<!--MAGECLOUD-5142-->
+   -  {:.new}**PHP-FPM-XDEBUG**—Added a separate Docker container to handle Xdebug requests that simplifies configuration and improves performance when debugging PHP code. See [Configure Xdebug]{{site.baseurl}}/cloud/docker/docker-development-debug.html).<!--MCLOUD-4098-->
 
-   -  {:.new}**Varnish**—The Varnish service is now provisioned by default when you deploy a Magento Cloud Docker environment using a supported version of the Magento Cloud application template.<!--MAGECLOUD-2634-->
+   -  {:.new}**Varnish**—The Varnish service is now provisioned by default when you deploy a Magento Cloud Docker environment using a supported version of the Magento Cloud application template.<!--MCLOUD-2634-->
+
+   -  {:.fix}**PHP-FPM**—Fixed an issue in the Docker entrypoint script (docker-entrypoint.sh) that caused errors when connecting to the PHP container.<!--MCLOUD-3958-->
 
 -  {:.new}**Command changes**–
 
    -  {:.new}Added the `--no-varnish` option to the `ece-tools build:compose` command to skip Varnish service installation when you generate the configuration for a Magento Cloud Docker environment.<!--MCLOUD-2634-->
 
    -  {:.new}Added the `--es-env-var` option to the `ece-tools build:compose` command to customize the [Elasticsearch container configuration]({{ site.baseurl }}/cloud/docker/docker-containers-service.html#elasticsearch-container) when you generate the configuration for a Magento Cloud Docker environment.<!--MCLOUD-3059-->
+
+   - {:.new}Added the `--with-xdebug` option to the `ece-tools build:compose` command to add a separate container to handle Xdebug requests.<!--MCLOUD-4098-->
 
 ## v1.0.0
 *Release date: Nov 14, 2019*<br/>

--- a/src/cloud/release-notes/mcd-release-notes.md
+++ b/src/cloud/release-notes/mcd-release-notes.md
@@ -32,7 +32,7 @@ The release notes include:
 
    -  {:.new}Added the `--es-env-var` option to the `ece-tools build:compose` command to customize the [Elasticsearch container configuration]({{ site.baseurl }}/cloud/docker/docker-containers-service.html#elasticsearch-container) when you generate the configuration for a Magento Cloud Docker environment.<!--MCLOUD-3059-->
 
-   - {:.new}Added the `--with-xdebug` option to the `ece-tools build:compose` command to add a separate container to handle Xdebug requests.<!--MCLOUD-4098-->
+   -  {:.new}Added the `--with-xdebug` option to the `ece-tools build:compose` command to add a separate container to handle Xdebug requests.<!--MCLOUD-4098-->
 
 ## v1.0.0
 *Release date: Nov 14, 2019*<br/>


### PR DESCRIPTION
## Purpose of this pull request

Updated documentation to debug PHP code using Xdebug in a Magento Cloud Docker environment.
- Added information about the `--with-xdebug` option to build a PHP-FPM-XDEBUG container for handling Xdebug requests
- Updated instructions to configure Xdebug in Docker environment
- Added release note

## Affected DevDocs pages

- https://devdocs.magento.com/cloud/docker/docker-config.html
- https://devdocs.magento.com/cloud/docker/docker-containers-service.html
- https://devdocs.magento.com/cloud/docker/docker-containers.html
- https://devdocs.magento.com/cloud/docker/docker-development-debug.html
- https://devdocs.magento.com/cloud/docker/docker-mode-developer.html
- https://devdocs.magento.com/cloud/docker/docker-mode-production.html
- https://devdocs.magento.com/cloud/howtos/debug.html
- https://devdocs.magento.com/cloud/release-notes/mcd-release-notes.html

## Links to Magento source code

https://github.com/magento/magento-cloud-docker/pull/122

whatsnew
Updated the [Xdebug configuration instructions]( https://devdocs.magento.com/cloud/docker/docker-development-debug.html) for Magento Cloud Docker, which now requires using the `--with-xdedug` option to build a container to handle Xdebug requests instead of adding the Xdebug configuration to the `.magento.app.yaml` file.