### PR TITLE
MCLOUD-3734: Wizard CLI command for split Db  'wizard:split-db-state'

### DIFF
--- a/src/cloud/deploy/smart-wizards.md
+++ b/src/cloud/deploy/smart-wizards.md
@@ -24,6 +24,7 @@ Command | Description
 `wizard:scd-on-demand` | Check that the `SCD_ON_DEMAND` global environment variable is `true`.
 `wizard:scd-on-build` | Check that the `SCD_ON_DEMAND` global environment variable is `false` and the `SKIP_SCD` environment variable is `false` for the _build_ stage. Verifies that the `config.php` file contains information for stores, store groups, and websites.
 `wizard:scd-on-deploy` | Check that the `SCD_ON_DEMAND` global environment variable is `false` and the `SKIP_SCD` environment variable is `false` for the _deploy_ stage. Verifies that the `config.php` file does _NOT_ contain the list of stores, store groups, and websites with related information.
+`wizard:split-db-state` | Checks existence of ability to split Magento DB on current environment. This command also checks whether split DB was already done or not.
 
 As an example, you can verify that your configuration properly enables the SCD on-demand feature:
 

--- a/src/cloud/deploy/smart-wizards.md
+++ b/src/cloud/deploy/smart-wizards.md
@@ -14,6 +14,7 @@ The smart wizards can help you determine whether your Cloud configuration follow
 -  Ideal state for minimal deployment downtime
 -  Load balancing configuration for database and Redis
 -  Static Content Deployment (SCD) for on-demand, the build stage, or the deploy stage
+-  Check ability to split DBs and display for what DBs split was already done
 
 Each of the smart wizard commands provides a verification response and, if applicable, a recommendation for the proper configuration.
 


### PR DESCRIPTION
## Purpose of this pull request

Description `wizard:split-db-state` CLI command

## Affected DevDocs pages

<!-- REQUIRED List the affected pages on devdocs.magento.com (URLs). Not needed for large numbers of files. -->

-  https://devdocs.magento.com/cloud/deploy/smart-wizards.html

## Links to Magento source code

https://github.com/magento/ece-tools/pull/685
