### PR TITLE
Updates to error reference for ece-tools deployment

### DIFF
--- a/src/_data/toc/cloud-guide.yml
+++ b/src/_data/toc/cloud-guide.yml
@@ -491,6 +491,10 @@ pages:
           url: /cloud/live/stage-prod-test.html
           versionless: true
 
+        - label: Error log message reference
+          url: /cloud/reference/error-codes.html
+          versionless: true
+
     - label: Site launch
       url: /cloud/live/live.html
       versionless: true
@@ -507,6 +511,7 @@ pages:
       url: /cloud/trouble/trouble.html
       versionless: true
       children:
+        
         - label: Troubleshoot deployment
           url: /cloud/trouble/troubleshoot-deployment.html
           versionless: true

--- a/src/_includes/cloud/note-error-message-reference-ece-tools.md
+++ b/src/_includes/cloud/note-error-message-reference-ece-tools.md
@@ -1,0 +1,2 @@
+{:.bs-callout-tip}
+See the [Error message reference for ece-tools]({{site.baseurl}}/cloud/reference/error-codes.html) to review errors that can occur during the build, deploy, and post-deploy stages.

--- a/src/cloud/live/stage-prod-test.md
+++ b/src/cloud/live/stage-prod-test.md
@@ -14,9 +14,9 @@ functional_areas:
 {:.ref-header}
 Previous step
 
-[Migrate data and static files]({{ site.baseurl }}/cloud/live/stage-prod-migrate.html)
+[Migrate data and static files][]
 
-When your code, files, and data is successfully migrated to Staging or Production, use the environment URLs to test your site(s) and store(s). For a list of your URLs, see [Starter]({{ site.baseurl }}/cloud/live/stage-prod-migrate-prereq.html#starter-urls) and [Pro]({{ site.baseurl }}/cloud/live/stage-prod-migrate-prereq.html#pro-urls) access information.
+When your code, files, and data is successfully migrated to Staging or Production, use the environment URLs to test your site(s) and store(s). For a list of your URLs, see [Starter][] and [Pro][] access information.
 
 The following information provides information on verifying logs, testing Fastly configurations, user acceptance testing (UAT), and more.
 
@@ -28,6 +28,8 @@ The deployment log is located in `/var/log/platform/<prodject ID>/deploy.log`. T
 
 When accessing logs in Production or Staging environments, you must use SSH to log in to each of the three nodes to locate the logs. See [Log locations]({{ site.baseurl }}/cloud/project/log-locations.html#application-logs).
 
+{%include cloud/note-error-message-reference-ece-tools.md%}
+
 ## Check the code base {#codebase}
 
 Verify your `master` code base correctly deployed to Staging and Production environments. The environments should have identical code bases.
@@ -38,9 +40,9 @@ Check the Magento configuration settings through the Admin panel including the B
 
 ## Check Fastly caching {#fastly}
 
-Verify Fastly is caching properly on Staging and Production. [Configuring Fastly]({{ site.baseurl }}/cloud/cdn/configure-fastly.html) requires careful attention to details, using the correct Fastly Service ID and Fastly API token, and a proper VCL snippet uploaded.
+Verify Fastly is caching properly on Staging and Production. [Configuring Fastly][] requires careful attention to details, using the correct Fastly Service ID and Fastly API token, and a proper VCL snippet uploaded.
 
-First, check for headers with a dig command to the URL. In a terminal application, enter `dig <url>` to verify Fastly services display in the headers. For additional `dig` tests, see Fastly's [Testing before changing DNS](https://docs.fastly.com/guides/basic-configuration/testing-setup-before-changing-domains).
+First, check for headers with a dig command to the URL. In a terminal application, enter `dig <url>` to verify Fastly services display in the headers. For additional `dig` tests, see Fastly's [Testing before changing DNS][].
 
 The following examples use Pro URLs. You can use any URL with the `dig` command.
 
@@ -53,7 +55,7 @@ Next, use a `curl` command to verify X-Magento-Tags exist and additional header 
 curl http[s]://<full site URL> -H "host: <url>" -k -vo /dev/null -HFastly-Debug:1
 ```
 
-For Starter, enter the full site URL from your environment [Access info]({{ site.baseurl }}/cloud/live/stage-prod-migrate-prereq.html#starter-urls) in the command to view the headers.
+For Starter, enter the full site URL from your environment [Access info][] in the command to view the headers.
 
 For Pro Staging and Production, the command differs per server:
 
@@ -71,8 +73,8 @@ Check the returned response headers and values:
 -  `Fastly-Module-Enabled` should be either `Yes` or the Fastly extension version number
 -  `X-Cache` should be either `HIT` or `HIT, HIT`
 -  `x-cache-hits` should be 1,1
--  [`Cache-Control: max-age`](https://www.w3.org/Protocols/rfc2616/rfc2616-sec14.html#sec14.9) should be greater than 0
--  [`Pragma`](https://www.w3.org/Protocols/rfc2616/rfc2616-sec14.html#sec14.32) should be `cache`
+-  [`Cache-Control: max-age`][] should be greater than 0
+-  [`Pragma`][] should be `cache`
 
 To verify Fastly is enabled in Staging and Production, check the configuration in the Magento Admin for each environment:
 
@@ -84,7 +86,7 @@ To verify Fastly is enabled in Staging and Production, check the configuration i
 {:.bs-callout-warning}
 Make sure you entered the correct Fastly Service ID and API token in your Staging and Production environments. If you enter Staging credentials in your Production environment, you may not be able to upload your VCL snippets, caching will not work correctly, and your caching will be pointed to the wrong server and stores. Your Fastly credentials are created and mapped per service environment.
 
-The module must be enabled to cache your site. If you have additional extensions enabled that affect headers, one of them could cause issues with Fastly. If you have further issues, see [Set up Fastly]({{ site.baseurl }}/cloud/cdn/cloud-fastly.html) and [Fastly troubleshooting]({{ site.baseurl }}/cloud/cdn/trouble-fastly.html).
+The module must be enabled to cache your site. If you have additional extensions enabled that affect headers, one of them could cause issues with Fastly. If you have further issues, see [Set up Fastly][] and [Fastly troubleshooting][].
 
 ## Complete UAT testing {#uat-testing}
 
@@ -212,16 +214,39 @@ We recommend that you review the [Magento Performance Toolkit]({{ site.mage2blob
 
 For best results, we recommend the following tools:
 
--  [Magento application performance test]({{ site.baseurl }}/cloud/env/variables-post-deploy.html#ttfb_tested_pages)—Test Magento application performance by configuring the `TTFB_TESTED_PAGES` environment variable to test site response time.
--  [Siege](https://www.joedog.org/siege-home/)—Traffic shaping and testing software to push your store to the limit. Hit your site with a configurable number of simulated clients. Siege supports basic authentication, cookies, HTTP, HTTPS and FTP protocols.
--  [Jmeter](http://jmeter.apache.org/)—Excellent load testing to help gauge performance for spiked traffic, like for flash sales. Create custom tests to run against your site.
+-  [Magento application performance test][]—Test Magento application performance by configuring the `TTFB_TESTED_PAGES` environment variable to test site response time.
+-  [Siege][]—Traffic shaping and testing software to push your store to the limit. Hit your site with a configurable number of simulated clients. Siege supports basic authentication, cookies, HTTP, HTTPS and FTP protocols.
+-  [Jmeter][]—Excellent load testing to help gauge performance for spiked traffic, like for flash sales. Create custom tests to run against your site.
 -  New Relic (provided)—Helps locate processes and areas of the site causing slow performance with tracked time spent per action like transmitting data, queries, Redis, and so on.
--  [WebPageTest](https://www.webpagetest.org/) and [Pingdom](https://www.pingdom.com/)—Real-time analysis of your site pages load time with different origin locations. Pingdom may require a fee. WebPageTest is a free tool.
+-  [WebPageTest][] and [Pingdom][]—Real-time analysis of your site pages load time with different origin locations. Pingdom may require a fee. WebPageTest is a free tool.
 
 ### Functional testing
 
-You can use the Magento Functional Testing Framework (MFTF) to complete functional testing for {{site.data.var.ee}} from the Cloud Docker environment. See [Magento application testing]({{site.baseurl}}/cloud/docker/docker-mftf.html).
+You can use the Magento Functional Testing Framework (MFTF) to complete functional testing for {{site.data.var.ee}} from the Cloud Docker environment. See [Magento application testing][]
 
 ## Set up Magento Security Scan Tool {#security-scan}
 
-We provide a free Security Scan Tool for your sites. To add your sites and run the tool, see [Magento Security Scan Tool]({{ site.baseurl }}/cloud/live/live.html#security-scan).
+We provide a free Security Scan Tool for your sites. To add your sites and run the tool, see [Magento Security Scan Tool][].
+
+<!--Link definitions>
+
+[Migrate data and static files]: {{ site.baseurl }}/cloud/live/stage-prod-migrate.html
+[Starter]: {{ site.baseurl }}/cloud/live/stage-prod-migrate-prereq.html#starter-urls
+[Pro]: {{ site.baseurl }}/cloud/live/stage-prod-migrate-prereq.html#pro-urls
+[Log locations]: {{ site.baseurl }}/cloud/project/log-locations
+[Error message reference for ece-tools]: {{site.baseurl}}/cloud/reference/error-codes.html
+[Configuring Fastly]: {{ site.baseurl }}/cloud/cdn/configure-fastly.html
+[Testing before changing DNS](https://docs.fastly.com/guides/basic-configuration/testing-setup-before-changing-domains
+[Access info]: {{ site.baseurl }}/cloud/live/stage-prod-migrate-prereq.html#starter-urls
+[`Cache-Control: max-age`]: https://www.w3.org/Protocols/rfc2616/rfc2616-sec14.html#sec14.9
+[`Pragma`]: https://www.w3.org/Protocols/rfc2616/rfc2616-sec14.html#sec14.32
+[Set up Fastly]: {{ site.baseurl }}/cloud/cdn/cloud-fastly.html
+[Fastly troubleshooting]: {{ site.baseurl }}/cloud/cdn/trouble-fastly.html
+[Magento Performance Toolkit]({{ site.mage2bloburl }}/{{ site.version }}/setup/performance-toolkit)
+[Magento application performance test]: {{ site.baseurl }}/cloud/env/variables-post-deployhtml#ttfb_tested_pages
+[Siege](https://www.joedog.org/siege-home/
+[Jmeter]: http://jmeter.apache.org/
+[WebPageTest]: https://www.webpagetest.org/
+[Pingdom]: https://www.pingdom.com/
+[Magento application testing]: {{site.baseurl}}/cloud/docker/docker-test-app-mftf.html
+[Magento Security Scan Tool]: {{ site.baseurl }}/cloud/live/live.html#security-scan

--- a/src/cloud/project/log-locations.md
+++ b/src/cloud/project/log-locations.md
@@ -116,6 +116,8 @@ You can use the same CLI command to view a deploy log from the Staging environme
 magento-cloud log platform/<project_id>_stg/deploy
 ```
 
+{%include cloud/note-error-message-reference-ece-tools.md%}
+
 ## Application logs
 
 Similar to deploy logs, application logs are unique for each environment. For Pro Staging and Production environments, the Deploy, Post-deploy, and Cron logs are available only on the first node in the cluster.

--- a/src/cloud/reference/discover-deploy.md
+++ b/src/cloud/reference/discover-deploy.md
@@ -23,7 +23,7 @@ You can track build and deploy actions in real-time using the terminal or the Pr
 If you are using external GitHub repositories, the log of operations does not display in the GitHub session. However, you can still follow activity in the interface for the external repository and the Project Web Interface. See [Integrations]({{ site.baseurl }}/cloud/integrations/cloud-integrations.html).
 
 {:.bs-callout-info}
-In Integration environments, you cannot view the deploy logs from the Project Web Interface. This feature is available only for Production and Staging environments. However, you can view logs for every phase of the deployment in any environment using the Magento [build and deploy]({{ site.baseurl }}/cloud/project/log-locations.html#build-and-deploy-logs) logs.
+In Integration environments, you cannot view the deploy logs from the Project Web Interface. This feature is available only for Production and Staging environments. However, you can view logs for every phase of the deployment in any environment using the Magento [build and deploy]({{ site.baseurl }}/cloud/project/log-locations.html#build-and-deploy-logs) logs. For troubleshooting information, see the [Deployment error reference]({{site.baseurl}}/cloud/reference/error-codes.html).
 
 ## Project configuration {#cloud-deploy-conf}
 

--- a/src/cloud/reference/error-codes.md
+++ b/src/cloud/reference/error-codes.md
@@ -1,0 +1,119 @@
+---
+group: cloud-guide
+title: Error message reference for ece-tools
+functional_areas:
+  - Cloud
+  - Deploy
+  - Configuration
+---
+
+{% assign errors = site.data.cloud-error-messages %}
+
+This {{site.data.var.ct}} error message reference provides information to troubleshoot errors that can occur during the {{site.data.var.ece}} deployment process.
+
+Error messages are categorized by deployment stage–*build*, *deploy*, and *post-deploy*. Each section provides a list of associated errors with the following information for each error:
+
+-  **Error code**:  The Magento-assigned identifier for the error message
+-  **Step**:  Indicates the step in the deployment scenario where the error can occur. If the _Step_ column is blank, the error is a general error that can occur in multiple steps, or during pre-processing operations. See [Scenario-based deployment]({{site.baseurl}}/cloud/deploy/scenario-based-deployment.html) for more information about the build, deploy, and post-deploy steps.
+-  **Error description**: A short phrase that summarizes the cause of the error
+-  **Suggested action**: Provides guidance to troubleshoot and resolve the error
+
+## Build stage
+
+{: .error-table}
+| Error code | Build step | Error description | Suggested action |
+| ---------- | ---------- | ----------------- | ---------------- |
+| 2 | | Cannot write to the `./app/etc/env.php` file | {{site.data.cloud-error-messages.ENV_PHP_IS_NOT_WRITABLE}}|
+| 3 | | Configuration isn't defined in the `schema.yaml` file | {{site.data.cloud-error-messages.CONFIG_NOT_DEFINED}}|
+| 4 | | Failed to parse the `.magento.env.yaml` file | {{site.data.cloud-error-messages.CONFIG_PARSE_FAILED}}|
+| 5 | | Unable to read the `.magento.env.yaml` file | {{site.data.cloud-error-messages.CONFIG_UNABLE_TO_READ}}|
+| 6 | | Unable to read the `.schema.yaml` file | |
+| 7 | refresh-modules | Cannot write to the `./app/etc/config.php` file |{{site.data.cloud-error-messages.CONFIG_PHP_IS_NOT_WRITABLE}} |
+| 8 | validate-config | Cannot read the `composer.json` file |{{site.data.cloud-error-messages.CANT_READ_COMPOSER_JSON}} |
+| 9 | validate-config | Composer.json is missing required autoload section | {{site.data.cloud-error-messages.COMPOSER_MISSED_REQUIRED_AUTOLOAD}} |
+| 10 | validate-config | The file `.magento.env.yaml` contains an option which isn't declared in the schema, or has an invalid value or stage | {{site.data.cloud-error-messages.WRONG_CONFIGURATION_MAGENTO_ENV_YAML}}|
+| 11 | refresh-modules | Command `/bin/magento module:enable --all` failed | {{site.data.cloud-error-messages.CLOUD_LOG_VERBOSE_ACTION}} |
+| 12 | apply-patches | Failed to apply patch | |
+| 13 | set-report-dir-nesting-level | Cannot write to the file `/pub/errors/local.xml` | |
+| 14 | copy-sample-data | Failed to copy sample data files | |
+| 15 | compile-di | Command `/bin/magento setup:di:compile` failed | {{site.data.cloud-error-messages.CLOUD_LOG_VERBOSE_ACTION}} |
+| 16 | dump-autoload | Command `composer dump-autoload` failed | {{site.data.cloud-error-messages.COMPOSER_DUMP_AUTOLOAD_FAILED}} |
+| 17 | run-baler | The command to run `Baler` for Javascript bundling failed | {{site.data.cloud-error-messages.BALER_NOT_FOUND}} |
+| 18 | compress-static-content | Required utility wasn't found (timeout, bash) | {{site.data.cloud-error-messages.UTILITY_NOT_FOUND}} |
+| 19 | deploy-static-content | Command `/bin/magento setup:static-content:deploy` failed | {{site.data.cloud-error-messages.CLOUD_LOG_VERBOSE_ACTION}} |
+| 20 | compress-static-content | Static content compression failed | {{site.data.cloud-error-messages.CHECK_CLOUD_LOG_ACTION}} |
+| 21 | backup-data: static-content | Failed to copy static content into the `init` directory | {{site.data.cloud-error-messages.CHECK_CLOUD_LOG_ACTION}} |
+| 22 | backup-data: writable-dirs | Failed to copy some writable directories into the `init` directory | {{site.data.cloud-error-messages.WRITABLE_DIRECTORY_COPYING_FAILED}} |
+| 23 | | Unable to create a logger object | |
+| 24 | backup-data: static-content | Failed to clean the `./init/pub/static/` directory | {{ site.data.cloud-error-messages.CLEAN_INIT_PUB_STATIC_FAILED}} |
+| 25 | | Cannot find the Composer package | {{site.data.cloud-error-messages.COMPOSER_PACKAGE_NOT_FOUND}} |
+
+## Deploy stage
+
+{: .error-table}
+| Error code | Deploy step | Error description | Suggested action |
+| --- | --- | --- | -- |
+| 101 | pre-deploy: cache | Incorrect cache configuration (missing port or host) | {{site.data.cloud-error-messages.WRONG_CACHE_CONFIGURATION}} |
+| 102 | | Cannot write to the `./app/etc/env.php` file | {{site.data.cloud-error-messages.ENV_PHP_IS_NOT_WRITABLE}} |
+| 103 | | Configuration isn't defined in the `schema.yaml` file  | {{site.data.cloud-error-messages.CONFIG_NOT_DEFINED}} |
+| 104 | | Failed to parse the `.magento.env.yaml` file | {{site.data.cloud-error-messages.CONFIG_NOT_DEFINED}} |
+| 105 | | Unable to read the `.magento.env.yaml` file | {{site.data.cloud-error-messages.CONFIG_UNABLE_TO_READ}} |
+| 106 | | Unable to read the `.schema.yaml` file | |
+| 107 | pre-deploy: clean-redis-cache | Failed to clean the Redis cache | {{site.data.cloud-error-messages.
+
+REDIS_CACHE_CLEAN_FAILED}}. |
+| 108 | pre-deploy: set-production-mode | Command `/bin/magento maintenance:enable` failed | {{site.data.cloud-error-messages.CLOUD_LOG_VERBOSE_ACTION}} |
+| 109 | validate-config | Incorrect database configuration | {{site.data.cloud-error-messages.WRONG_CONFIGURATION_DB}} |
+| 110 | validate-config | Incorrect session configuration | {{site.data.cloud-error-messages.WRONG_CONFIGURATION_SESSION}} |
+| 111 | validate-config | Incorrect search configuration | {{site.data.cloud-error-messages.WRONG_CONFIGURATION_SEARCH}} |
+| 112 | validate-config | Incorrect resource configuration | {{site.data.cloud-error-messages.WRONG_CONFIGURATION_RESOURCE}} |
+| 113 | validate-config:elasticsuite-integrity | ElasticSuite is installed, but the ElasticSearch service is not available | {{site.data.cloud-error-messages.ELASTIC_SUITE_WITHOUT_ES}} |
+| 114 | validate-config:elasticsuite-integrity | ElasticSuite is installed, but another search engine is used | {{site.data.cloud-error-messages.ELASTIC_SUITE_WRONG_ENGINE}} |
+| 115 |  | Database query execution failed | |
+| 116 | install-update: setup | Command `/bin/magento setup:install` failed | {{site.data.cloud-error-messages.INSTALL_UPGRADE_ACTION}} |
+| 117 | install-update: config-import | Command `app:config:import` failed | {{site.data.cloud-error-messages.CLOUD_LOG_VERBOSE_ACTION}} |
+| 118 |  | Required utility wasn't found (timeout, bash) | {{site.data.cloud-error-messages.UTILITY_NOT_FOUND}} |
+| 119 | install-update: deploy-static-content | Command `/bin/magento setup:static-content:deploy` failed | {{site.data.cloud-error-messages.CLOUD_LOG_VERBOSE_ACTION}} |
+| 120 | compress-static-content | Static content compression failed | {{site.data.cloud-error-messages.CHECK_CLOUD_LOG_ACTION}} |
+| 121 | deploy-static-content:generate | Cannot update the deployed version | {{site.data.cloud-error-messages.SCD_UNABLE_UPDATE_VERSION}} |
+| 122 | clean-static-content | Failed to clean static content files | |
+| 123 | install-update: split-db | Command `/bin/magento setup:db-schema:split` failed | {{site.data.cloud-error-messages.CLOUD_LOG_VERBOSE_ACTION}} |
+| 124 | clean-view-preprocessed | Failed to clean the `var/view_preprocessed` folder | {{site.data.cloud-error-messages.VIEW_PREPROCESSED_CLEAN_FAILED}} |
+| 125 | install-update: reset-password | Failed to update the `/var/credentials_email.txt` file | {{site.data.cloud-error-messages.FILE_CREDENTIALS_EMAIL_NOT_WRITABLE}} |
+| 126 | install-update: update | Command `/bin/magento setup:upgrade` failed | {{site.data.cloud-error-messages.INSTALL_UPGRADE_ACTION}} |
+| 127 | clean-cache | Command `/bin/magento cache:flush` failed | {{site.data.cloud-error-messages.CLOUD_LOG_VERBOSE_ACTION}} |
+| 128 | disable-maintenance-mode | Command `/bin/magento maintenance:disable` failed | {{site.data.cloud-error-messages.CLOUD_LOG_VERBOSE_ACTION}} |
+| 129 | install-update: reset-password | Enable to read reset password template | |
+
+## Post-deploy stage
+
+{: .error-table}
+| Error code | Post-deploy step | Error description | Suggested action |
+| --- | --- | --- | -- |
+| 201 | is-deploy-failed | Deploy stage failed | |
+| 202 |  | The `./app/etc/env.php` file is not writable | {{site.data.cloud-error-messages.ENV_PHP_IS_NOT_WRITABLE}} |
+| 203 |  | Configuration isn't defined in the `schema.yaml` file | {{site.data.cloud-error-messages.CONFIG_NOT_DEFINED}} |
+| 204 |  | Failed to parse the `.magento.env.yaml` file | {{site.data.cloud-error-messages.CONFIG_PARSE_FAILED}} |
+| 205 |  | Unable to read the `.magento.env.yaml` file | {{site.data.cloud-error-messages.CONFIG_UNABLE_TO_READ}} |
+| 206 |  | Unable to read the `.schema.yaml` file | |
+| 207 | warm-up | Failed to warm-up some pages | |
+| 208 | time-to-firs-byte | Failed to test time to first byte (TTFB) | |
+| 227 | clean-cache | Command `/bin/magento cache:flush` failed | {{site.data.cloud-error-messages.CLOUD_LOG_VERBOSE_ACTION}} |
+
+<!--Link definitions-->
+
+[Scenario-based deployment]: {{site.baseurl}}/cloud/deploy/scenario-based-deployment.html
+
+<!--Custom css-->
+
+<!--
+  This is a style declaration so that first column does not wrap
+-->
+
+<style>
+table.error-table td:nth-child(1) {
+  width: 125px;
+}
+table.error-table td:nth-child(2) {
+  width: 200px;
+}

--- a/src/cloud/trouble/trouble.md
+++ b/src/cloud/trouble/trouble.md
@@ -10,6 +10,7 @@ The troubleshooting topics help to resolve specific issues with your {{site.data
 
 -  Verify your [credentials]({{ site.baseurl }}/cloud/trouble/trouble_ce-creds.html)
 -  Review the [log files]({{ site.baseurl }}/cloud/live/stage-prod-test.html)
+-  For help with deployment errors, check the [Error message reference for ece-tools]({{site.baseurl}}/cloud/reference/error-codes.html)
 -  Search for relevant content in the {{site.data.var.ece}} documentation
 -  Search the [Magento Help Center](https://support.magento.com/hc/en-us) troubleshooting articles, FAQ, and Tech resources
 


### PR DESCRIPTION
Merges changes from #7261

## Purpose of this pull request

Adds a deployment error reference for ece-tools errors to the Troubleshooting section of the _Cloud Guide_.

- [x] Technical review
- [x] Editorial review
- [ ] Staging build

## Affected DevDocs pages

- https://devdocs.magento.com/cloud/trouble/error-codes.html

## Links to Magento source code

https://github.com/magento/ece-tools/pull/726

whatsnew
Added an [Error message reference for ece-tools]( https://devdocs.magento.com/cloud/trouble/error-codes.html) to list errors and suggested actions for resolving errors that occur during the Magento Cloud deployment process.