### PR TITLE
Fix RSS feed

### DIFF
--- a/src/feed.xml
+++ b/src/feed.xml
@@ -1,5 +1,5 @@
 ---
-layout: null
+layout: none
 ---
 
 <?xml version="1.0" encoding="UTF-8"?>

--- a/src/whatsnew-feed.xml
+++ b/src/whatsnew-feed.xml
@@ -1,5 +1,5 @@
 ---
-layout: null
+layout: none
 ---
 
 <?xml version="1.0" encoding="UTF-8"?>


### PR DESCRIPTION
## Purpose of this pull request

This pull request (PR) fixes the RSS feed for the main devdocs site as well as the what's new page. Jekyll was overriding the `layout: null` frontmatter with the global default template, which was adding invalid XML to the feeds.

It appears that since Jekyll 3.5, `layout: null` is overridden by global defaults.

> Using `layout: none` will now produce a file with no layout. Equivalent to `layout: null`, with the exception that none is a truthy value and won’t be overwritten by front matter defaults.

https://jekyllrb.com/news/2017/06/15/jekyll-3-5-0-released/

## Affected DevDocs pages

-  https://devdocs.magento.com/feed.xml
-  https://devdocs.magento.com/whatsnew-feed.xml