### PR TITLE
Update the beta banner to warn of source code links

### DIFF
--- a/src/_includes/layout/page-header.html
+++ b/src/_includes/layout/page-header.html
@@ -9,7 +9,7 @@
 
   {% if page.guide_version == "2.4" %}
   <div class="message-banner">
-    This is the 2.4.0 beta release version of documentation. Content in this version is subject to change.
+    This is a beta release of documentation for Magento 2.4, published for previewing soon-to-be-released functionality. Content in this version is subject to change. Links to the v2.4 code base may not properly resolve until the code is officially released.
   </div>
   {% endif %}
 


### PR DESCRIPTION
## Purpose of this pull request

This pull request (PR) updates the 2.4 beta doc banner to warn that links to 2.4 codebase may not work until release.
Fixes #7346.