### PR TITLE
Added a redirect for page linked from admin UI

### DIFF
--- a/src/guides/v2.4/release-notes/bk-release-notes.md
+++ b/src/guides/v2.4/release-notes/bk-release-notes.md
@@ -1,6 +1,7 @@
 ---
 group: release-notes
 title: 2.4 Release Information
+redirect_from: magento-release-information.html
 ---
 
 ## Magento 2.4.x release notes

--- a/src/release/index.md
+++ b/src/release/index.md
@@ -1,7 +1,6 @@
 ---
 title: Upcoming releases
 group: release
-redirect_from: magento-release-information.html
 ---
 
 Magento continually strives to find the right balance between making product upgrades simple and predictable and delivering improvements and new features to early adopters faster. Over the last year, we have refined how we deliver software to support this balance. For additional information, refer to our [release policy]({{site.baseurl}}/release/policy/).

--- a/src/release/index.md
+++ b/src/release/index.md
@@ -1,6 +1,7 @@
 ---
 title: Upcoming releases
 group: release
+redirect_from: magento-release-information.html
 ---
 
 Magento continually strives to find the right balance between making product upgrades simple and predictable and delivering improvements and new features to early adopters faster. Over the last year, we have refined how we deliver software to support this balance. For additional information, refer to our [release policy]({{site.baseurl}}/release/policy/).


### PR DESCRIPTION
## Purpose of this pull request

This pull request (PR) adds a redirect from `https://devdocs.magento.com/magento-release-information.html` to `https://devdocs.magento.com/release/`.

The `https://devdocs.magento.com/magento-release-information.html` link is hardcoded in the Admin UI, but we removed that page from devdocs a long time ago because it didn't contain any useful info.

The best replacement for that old page is the new page `https://devdocs.magento.com/release/`.

## Affected DevDocs pages

-  https://devdocs.magento.com/magento-release-information.html
-  https://devdocs.magento.com/release/