### PR TITLE
MCLOUD-6137: Mention error log file

### DIFF
--- a/src/cloud/project/log-locations.md
+++ b/src/cloud/project/log-locations.md
@@ -76,7 +76,7 @@ Re-deploying environment project-integration-ID
 
 ### Error logs
 
-Errors and warnings which were identified by `ece-tools` are written in `var/log/cloud.log` and also duplicated in separate file `var/log/cloud.error.log`. This file has contains errors only from the latest deployment, if file is empty - it means that no error occurred in last deployment.
+Error and warning messages generated during the deployment process are written to both the `var/log/cloud.log` and the `var/log/cloud.error.log` files. The Cloud error log file contains only errors and warnings from the latest deployment. An empty file indicates a successful deployment with no errors.
 
 The following logs have a common location for all Cloud projects:
 

--- a/src/cloud/project/log-locations.md
+++ b/src/cloud/project/log-locations.md
@@ -74,9 +74,14 @@ Re-deploying environment project-integration-ID
     [2019-01-03 19:44:32] NOTICE: Post-deploy is complete.
 ```
 
+### Error logs
+
+Errors and warnings which were identified by `ece-tools` are written in `var/log/cloud.log` and also duplicated in separate file `var/log/cloud.error.log`. This file has contains errors only from the latest deployment, if file is empty - it means that no error occurred in last deployment.
+
 The following logs have a common location for all Cloud projects:
 
--  **Build log**: `var/log/cloud.log`
+-  **Deployment log**: `var/log/cloud.log`
+-  **Last deployment error log**: `var/log/cloud.error.log`
 -  **Debug log**: `var/log/debug.log`
 -  **Exception log**: `var/log/exception.log`
 -  **Reports**: `var/reports/`

--- a/src/cloud/reference/error-codes.md
+++ b/src/cloud/reference/error-codes.md
@@ -11,6 +11,8 @@ functional_areas:
 
 This {{site.data.var.ct}} error message reference provides information to troubleshoot errors that can occur during the {{site.data.var.ece}} deployment process.
 
+All error or warning messages can be found not only in `var/log/cloud.log` but also in a separate file `/var/log/cloud.error.log` which contains only errors and only from the latest deployment. If file is empty - no error occurred during last deployment.
+
 Error messages are categorized by deployment stage–*build*, *deploy*, and *post-deploy*. Each section provides a list of associated errors with the following information for each error:
 
 -  **Error code**:  The Magento-assigned identifier for the error message

--- a/src/cloud/reference/error-codes.md
+++ b/src/cloud/reference/error-codes.md
@@ -11,7 +11,7 @@ functional_areas:
 
 This {{site.data.var.ct}} error message reference provides information to troubleshoot errors that can occur during the {{site.data.var.ece}} deployment process.
 
-All error or warning messages can be found not only in `var/log/cloud.log` but also in a separate file `/var/log/cloud.error.log` which contains only errors and only from the latest deployment. If file is empty - no error occurred during last deployment.
+All error and warning messages generated during deployment are written to both the `var/log/cloud.log` and `/var/log/cloud.error.log` files. The Cloud error log file contains only errors and warnings from the latest deployment. An empty file indicates a successful deployment with no errors.
 
 Error messages are categorized by deployment stage–*build*, *deploy*, and *post-deploy*. Each section provides a list of associated errors with the following information for each error:
 


### PR DESCRIPTION
## Purpose of this pull request

Added documentation for the Cloud error log which contains all error and warning messages from the latest deployment of the Cloud environment.

## Affected DevDocs pages

<!-- REQUIRED List the affected pages on devdocs.magento.com (URLs). Not needed for large numbers of files. -->

-  https://devdocs.magento.com/cloud/reference/error-codes.html
- https://devdocs.magento.com/cloud/project/log-locations.html

## Links to Magento source code

<!--  OPTIONAL - REMOVE THIS SECTION IF NOT USED. If this pull request references a file in a Magento codebase repository, add it here. -->

whatsnew
Added information about the [Cloud error log](https://devdocs.magento.com/cloud/project/log-locations.html) (`var/log/Cloud.error.log`) which contains all error and warning messages from the latest deployment of the Cloud environment. 