### PR TITLE
 DOC-185: Update What's new in devdocs. No update since May 28th

### DIFF
--- a/src/_data/whats-new.yml
+++ b/src/_data/whats-new.yml
@@ -12,9 +12,8 @@ entries:
   type: Major Update
   date: June 3, 2020
   link: https://github.com/magento/devdocs/pull/7343
-- description: Added a brief note about a new known issue with the Magento Extension
-    Manager  in 2.3.x deployments and provides a link to the related Knowledge Base
-    article.<br/>https://devdocs.magento.com/guides/v2.3/release-notes/release-notes-2-3-5-open-source.html<br/>https://devdocs.magento.com/guides/v2.3/release-notes/release-notes-2-3-5-commerce.html<br/>https://devdocs.magento.com/guides/v2.3/release-notes/release-notes-2-3-4-open-source.html<br/>https://devdocs.magento.com/guides/v2.3/release-notes/release-notes-2-3-4-commerce.html<br/>https://devdocs.magento.com/guides/v2.3/release-notes/release-notes-2-3-3-open-source.html<br/>https://devdocs.magento.com/guides/v2.3/release-notes/release-notes-2-3-3-commerce.html<br/>https://devdocs.magento.com/guides/v2.3/release-notes/ReleaseNotes2.3.2OpenSource.html<br/>https://devdocs.magento.com/guides/v2.3/release-notes/ReleaseNotes2.3.2Commerce.html<br/>https://devdocs.magento.com/guides/v2.3/release-notes/ReleaseNotes2.3.1OpenSource.html<br/>https://devdocs.magento.com/guides/v2.3/release-notes/ReleaseNotes2.3.1Commerce.html<br/>https://devdocs.magento.com/guides/v2.3/release-notes/ReleaseNotes2.3.0OpenSource.html<br/>https://devdocs.magento.com/guides/v2.3/release-notes/ReleaseNotes2.3.0Commerce.html
+- description: Added a brief note about a new known issue with the [Extension Manager
+    showing no extensions in Magento Commerce 2.3.x](https://support.magento.com/hc/en-us/articles/360043980352).
   versions: 2.3.x
   type: Major Update
   date: June 3, 2020

--- a/src/_data/whats-new.yml
+++ b/src/_data/whats-new.yml
@@ -7,7 +7,7 @@ thread: /whatsnew-feed.xml
 updated: Tue Jun 9 10:53:40 2020
 entries:
 - description: Removed the Extension Manager section of the Software Update Guide
-    and redirected to [CLI installation](https://devdocs.magento.com/extensions/install/).
+    and redirected it to the [CLI installation](https://devdocs.magento.com/extensions/install/).
   versions: 2.3.x
   type: Major Update
   date: June 3, 2020

--- a/src/_data/whats-new.yml
+++ b/src/_data/whats-new.yml
@@ -4,8 +4,27 @@ description:
   We exclude from this list proofreading, spelling checks, and all minor updates.
 link: /whats-new.html
 thread: /whatsnew-feed.xml
-updated: Thu May 28 15:55:01 2020
+updated: Tue Jun 9 10:53:40 2020
 entries:
+- description: Removed the Extension Manager section of the Software Update Guide
+    and redirected to [CLI installation](https://devdocs.magento.com/extensions/install/).
+  versions: 2.3.x
+  type: Major Update
+  date: June 3, 2020
+  link: https://github.com/magento/devdocs/pull/7343
+- description: Added a brief note about a new known issue with the Magento Extension
+    Manager  in 2.3.x deployments and provides a link to the related Knowledge Base
+    article.<br/>https://devdocs.magento.com/guides/v2.3/release-notes/release-notes-2-3-5-open-source.html<br/>https://devdocs.magento.com/guides/v2.3/release-notes/release-notes-2-3-5-commerce.html<br/>https://devdocs.magento.com/guides/v2.3/release-notes/release-notes-2-3-4-open-source.html<br/>https://devdocs.magento.com/guides/v2.3/release-notes/release-notes-2-3-4-commerce.html<br/>https://devdocs.magento.com/guides/v2.3/release-notes/release-notes-2-3-3-open-source.html<br/>https://devdocs.magento.com/guides/v2.3/release-notes/release-notes-2-3-3-commerce.html<br/>https://devdocs.magento.com/guides/v2.3/release-notes/ReleaseNotes2.3.2OpenSource.html<br/>https://devdocs.magento.com/guides/v2.3/release-notes/ReleaseNotes2.3.2Commerce.html<br/>https://devdocs.magento.com/guides/v2.3/release-notes/ReleaseNotes2.3.1OpenSource.html<br/>https://devdocs.magento.com/guides/v2.3/release-notes/ReleaseNotes2.3.1Commerce.html<br/>https://devdocs.magento.com/guides/v2.3/release-notes/ReleaseNotes2.3.0OpenSource.html<br/>https://devdocs.magento.com/guides/v2.3/release-notes/ReleaseNotes2.3.0Commerce.html
+  versions: 2.3.x
+  type: Major Update
+  date: June 3, 2020
+  link: https://github.com/magento/devdocs/pull/7344
+- description: Published documentation deliverables for the Commerce and Open Source
+    2.4.0 beta releases.
+  versions: 2.4.0
+  type: Major Update
+  date: June 1, 2020
+  link: https://github.com/magento/devdocs/pull/7312
 - description: Added [release notes highlights](https://devdocs.magento.com/guides/v2.4/release-notes/bk-release-notes.html)
     to support the 2.4.0 beta release.
   versions: 2.4.0


### PR DESCRIPTION
## Purpose of this pull request

This pull request (PR) updates the **What's new** topic in the devdocs site, there was no update since May 28th.

_Internal ticket: DOC-185_


