### PR TITLE
Decouple MBI from Advanced Reports (DevDocs side)

### DIFF
--- a/src/guides/v2.3/advanced-reporting/data-collection.md
+++ b/src/guides/v2.3/advanced-reporting/data-collection.md
@@ -5,16 +5,16 @@ functional_areas:
     - Reports
 ---
 
-A Magento instance collects data that the Magento Business Intelligence (MBI) service uses to build the advanced reports.
-All the data are stored in an encrypted archive file which is securely transferred to the MBI.
-Data collection is declared in a configuration file `etc/analytics.xml`. It declares:
+A Magento instance collects data that the Magento Business Intelligence (MBI) service uses to build the advanced reports. All the data are stored in an encrypted archive file which is securely transferred to MBI. Data collection is declared in a configuration file `etc/analytics.xml`. It declares:
 
 -  Which report files must be included into the archive file.
 -  Which provider classes must collect data for each report file.
 -  Which report data configuration must be applied to collected data.
 
+You do not need to have an MBI account to use Advanced Reporting.
+
 {:.bs-callout-warning}
-This topic serves to provide better understanding of how data collection works. Any changes in configuration files will cause issues, because the MBI service doesn't expect any changes of configuration in the current version.
+This topic serves to provide better understanding of how data collection works. Any changes in configuration files will cause issues, because the MBI service does not expect any changes of configuration in the current version.
 
 ## Example
 

--- a/src/guides/v2.3/advanced-reporting/modules.md
+++ b/src/guides/v2.3/advanced-reporting/modules.md
@@ -42,6 +42,3 @@ Advanced reporting functionality is implemented in the following Magento modules
 [WishlistAnalytics]: {{ site.mage2bloburl }}/{{ page.guide_version }}/app/code/Magento/WishlistAnalytics/README.md
 
 [report data collection]: ./data-collection.html
-
-<!-- ABBREVIATIONS -->
-*[MBI]: Magento Business Analytics

--- a/src/guides/v2.3/advanced-reporting/modules.md
+++ b/src/guides/v2.3/advanced-reporting/modules.md
@@ -9,7 +9,7 @@ Advanced reporting functionality is implemented in the following Magento modules
 
 [Analytics] implements the following:
 
-*  Enabling subscription to the Magento Business Intelligence (MBI) and automatic re-subscription
+*  Enabling subscription to Magento Business Intelligence (MBI) and automatic re-subscription
 *  Changing the base URL without change of the MBI account
 *  Declaring the configuration schemas for [report data collection]
 *  Collecting the Magento instance data as reports for the MBI

--- a/src/guides/v2.3/advanced-reporting/overview.md
+++ b/src/guides/v2.3/advanced-reporting/overview.md
@@ -5,16 +5,16 @@ functional_areas:
     - Reports
 ---
 
-[Advanced reporting functionality]{:target="_blank"} is free to Magento Commerce and Open Source customers and is provided through an integration of a Magento instance with [Magento Business Intelligence]{:target="_blank"} (MBI). Magento collects data and sends this information to MBI for analytics. You do not need to have an MBI account to use Advanced Reporting.
+[Advanced reporting functionality] is free to Magento Commerce and Open Source customers and is provided through an integration of a Magento instance with [Magento Business Intelligence] (MBI). Magento collects data and sends this information to MBI for analytics. You do not need to have an MBI account to use Advanced Reporting.
 
 ## Prerequisites
 
 1. The website must run on a public web server.
 1. The domain must have a valid security (SSL) certificate.
 1. Magento must have been installed or upgraded successfully without error.
-1. In the Magento configuration, the [Base URL (Secure) setting][base url]{:target="_blank"} for the store view must point to the secure URL. For example https://yourdomain.com.
+1. In the Magento configuration, the [Base URL (Secure) setting][base url] for the store view must point to the secure URL. For example https://yourdomain.com.
 1. In the Magento configuration, **Use Secure URLs on Storefront**, **and Use Secure URLs in Admin** must be set to **Yes**.
-1. Make sure that [Magento crontab]{:target="_blank"} is created and cron jobs are running on the installed server.
+1. Make sure that [Magento crontab] is created and cron jobs are running on the installed server.
 
 The merchant can now click on the **Go to Advanced Reporting** button on the Admin dashboard to launch the advanced reporting features.
 
@@ -27,14 +27,14 @@ To avoid system overload during its prime time, you can set the preferable time 
 
 ## Extensibility
 
-Though the Analytics module provides an API, it is used specifically to interchange data with MBI. Magento does not recommend you extend the advanced reporting functionality in this version.
+Though the Analytics module provides an API, it is used specifically to interchange data with MBI. Magento does not recommend extending the advanced reporting functionality.
 
 {:.ref-header}
 Related topics
 
-[Magento modules that implement the functionality][modules]{:target="_blank"}
+[Magento modules that implement the functionality][modules]
 
-[Data collection configuration and settings][collection]{:target="_blank"}
+[Data collection configuration and settings][collection]
 
 <!-- LINK DEFINITIONS -->
 

--- a/src/guides/v2.3/advanced-reporting/overview.md
+++ b/src/guides/v2.3/advanced-reporting/overview.md
@@ -5,8 +5,7 @@ functional_areas:
     - Reports
 ---
 
-[Advanced reporting functionality]{:target="_blank"} is provided through integration of a Magento instance with the [Magento Business Intelligence]{:target="_blank"} (MBI).
-Magento collects data and sends this information to the MBI for analytics.
+[Advanced reporting functionality]{:target="_blank"} is free to Magento Commerce and Open Source customers and is provided through an integration of a Magento instance with [Magento Business Intelligence]{:target="_blank"} (MBI). Magento collects data and sends this information to MBI for analytics. You do not need to have an MBI account to use Advanced Reporting.
 
 ## Prerequisites
 
@@ -17,10 +16,10 @@ Magento collects data and sends this information to the MBI for analytics.
 1. In the Magento configuration, **Use Secure URLs on Storefront**, **and Use Secure URLs in Admin** must be set to **Yes**.
 1. Make sure that [Magento crontab]{:target="_blank"} is created and cron jobs are running on the installed server.
 
-The merchant can now click on the Go to Advanced Reporting button on the Admin dashboard to launch the advanced reporting features at `https://advancedreporting.rjmetrics.com/report`.
+The merchant can now click on the **Go to Advanced Reporting** button on the Admin dashboard to launch the advanced reporting features.
 
- {:.bs-callout-info}
-The first synchronization of a Magento instance and the MBI can take up to a day to complete after the successful subscription.
+{:.bs-callout-info}
+It can take up to a day for data to be available in Advanced Reporting.
 
 ## Recommendations
 
@@ -28,7 +27,7 @@ To avoid system overload during its prime time, you can set the preferable time 
 
 ## Extensibility
 
-Though the Analytics module provides an API, it is used specifically to interchange data with the MBI. We do not recommend to extend the advanced reporting functionality in this version.
+Though the Analytics module provides an API, it is used specifically to interchange data with MBI. Magento does not recommend you extend the advanced reporting functionality in this version.
 
 {:.ref-header}
 Related topics


### PR DESCRIPTION
## Purpose of this pull request

This pull request (PR)  addresses task MBI-11185. Need to decouple MBI from advanced reporting as it was causing confusion among customers who thought you needed MBI to get advanced reporting to work.

## Affected DevDocs pages

<!-- REQUIRED List the affected pages on devdocs.magento.com (URLs). Not needed for large numbers of files. -->

-  https://devdocs.magento.com/guides/v2.4/advanced-reporting/overview.html
- https://devdocs.magento.com/guides/v2.4/advanced-reporting/data-collection.html
- https://devdocs.magento.com/guides/v2.4/advanced-reporting/modules.html

