### PR TITLE
Updated inter server communication section

### DIFF
--- a/src/guides/v2.3/install-gde/prereq/security.md
+++ b/src/guides/v2.3/install-gde/prereq/security.md
@@ -48,7 +48,7 @@ The preceding commands work only with the Apache web server. Because of the vari
 
 ### Enable inter-server communication
 
-If Apache and the database server are on the same host, you can skip this section and continue with [Opening Ports In Your Firewall](#install-iptables).
+If Apache and the database server are on the same host, you will still need to use the following command if you are planning to use integrations that use curl (ex. Paypal and USPS).
 
 To enable Apache to initiate a connection to another host with SELinux enabled:
 

--- a/src/guides/v2.3/install-gde/prereq/security.md
+++ b/src/guides/v2.3/install-gde/prereq/security.md
@@ -48,7 +48,7 @@ The preceding commands work only with the Apache web server. Because of the vari
 
 ### Enable inter-server communication
 
-If Apache and the database server are on the same host, you will still need to use the following command if you are planning to use integrations that use curl (ex. Paypal and USPS).
+If Apache and the database server are on the same host, you may still need to use the following command if you are planning to use integrations that use curl (ex. Paypal and USPS).
 
 To enable Apache to initiate a connection to another host with SELinux enabled:
 

--- a/src/guides/v2.3/install-gde/prereq/security.md
+++ b/src/guides/v2.3/install-gde/prereq/security.md
@@ -48,8 +48,7 @@ The preceding commands work only with the Apache web server. Because of the vari
 
 ### Enable inter-server communication
 
-If Apache and the database server are on the same host, you may still need to use the following command if you are planning to use integrations that use curl (ex. Paypal and USPS).
-
+If Apache and the database server are on the same host, use the following command if you plan to use integrations that use `curl` (ex. Paypal and USPS).
 To enable Apache to initiate a connection to another host with SELinux enabled:
 
 1. To determine if SELinux is enabled, use the following command:


### PR DESCRIPTION
## Purpose of this pull request

This is initially confusing because users would assume that they can skip this step if they had their database and apache on the same server. While this did allow the user to complete the installation process, it still prevented curl being used by any of the necessary integrations such as payment and shipping. This update will allow users to make a more accurate decision at this point.

## Affected DevDocs pages

https://devdocs.magento.com/guides/v2.3/install-gde/prereq/security.html
