### PR TITLE
Add updates for error code reference

### DIFF
--- a/src/_data/codebase/cloud/cloud-error-messages.yml
+++ b/src/_data/codebase/cloud/cloud-error-messages.yml
@@ -1,0 +1,92 @@
+# Error messages
+
+# Magento Cloud error labels and suggested solutions to include in Cloud error reference table
+
+# ENV_PHP_IS_NOT_WRITEABLE applies to errors 102 and 202
+
+ENV_PHP_IS_NOT_WRITABLE: "Deployment script cannot make required changes to the `/app/etc/env.php` file. Check your filesystem permissions."
+
+# CONFIG_NOT_DEFINED applies to errors 103 and 203
+
+CONFIG_NOT_DEFINED: "Configuration isn't defined in the `./vendor/magento/ece-tools/config/schema.yaml` file. Check that the config variable name is correct, and that it defined."
+
+# CONFIG_PARSE_FAILED applies to 4, 104, 204
+CONFIG_PARSE_FAILED: The `./.magento.env.yaml` file format is invalid. Use a YAML parser to check the syntax and fix any errors.
+
+# CONFIG_UNABLE_TO_READ applies to 5, 105, 205
+CONFIG_UNABLE_TO_READ: Unable to read the `./.magento.env.yaml` file. Check file permissions.
+
+CONFIG_PHP_IS_NOT_WRITABLE: Deployment script cannot make required changes to the `/app/etc/config.php` file. Check your filesystem permissions.
+
+CANT_READ_COMPOSER_JSON: Unable to read the `./composer.json` file. Check file permissions.
+
+COMPOSER_MISSED_REQUIRED_AUTOLOAD: Required `autoload` section is missing from the `composer.json` file. Compare the autoload section from the Magento `composer.json` file template, and add the missing configuration.
+
+WRONG_CONFIGURATION_MAGENTO_ENV_YAML: The `./.magento.env.yaml` file contains invalid configuration. Check the error log for detailed info.
+
+COMPOSER_DUMP_AUTOLOAD_FAILED: The `composer dump-autoload` command failed. Check the `cloud.log` for more information.
+
+BALER_NOT_FOUND: "Check the `SCD_USE_BALER` environment variable to verify that the Baler module is configured and enabled for JS bundling. If you don't need the Baler module, set `SCD_USE_BALER: false`."
+
+#The UTILITY_NOT_FOUND_ACTION applies to the following errors: 
+#  BUILD_UTILITY_NOT_FOUND = 18
+#  DEPLOY_UTILITY_NOT_FOUND = 118
+
+UTILITY_NOT_FOUND_ACTION: One of required utilities was not found on server. Check the `cloud.log` for more information and install required utility.
+
+# The CHECK_CLOUD_LOG_ACTION applies to the following errors:
+# SCD_COMPRESSION_FAILED = 20, 120
+# SCD_COPYING_FAILED = 21
+
+CHECK_CLOUD_LOG_ACTION: Check the `cloud.log` for more information.
+
+WRITABLE_DIRECTORY_COPYING_FAILED: Failed to copy writable directories into the `./init` folder. Check your filesystem permissions.
+
+CLEAN_INIT_PUB_STATIC_FAILED: Failed to clean `./init/pub/static` folder. Check your filesystem permissions.
+
+COMPOSER_PACKAGE_NOT_FOUND: If you installed the Magento application version directly from the Magento git repository, verify that the `DEPLOYED_MAGENTO_VERSION_FROM_GIT` environment variable is configured.
+
+WRONG_CACHE_CONFIGURATION: Cache configuration is missing required parameters `server` or `port`. Check the `cloud.log` for more information.
+
+REDIS_CACHE_CLEAN_FAILED: Failed to clean the Redis cache. Check that the Redis cache configuration is correct and that the Redis service is available. See [Setup Redis service](https://devdocs.magento.com/cloud/project/project-conf-files_services-redis.html).
+
+WRONG_CONFIGURATION_DB: Check that the the `DATABASE_CONFIGURATION` environment variable is configured correctly.
+
+WRONG_CONFIGURATION_SESSION: Check that the `SESSION_CONFIGURATION` environment variable is configured correctly. The configuration must contain at least the `save` parameter.
+
+WRONG_CONFIGURATION_SEARCH: Check that the `SEARCH_CONFIGURATION` environment variable is configured correctly.. The configuration must contain at least the `engine` parameter.
+
+WRONG_CONFIGURATION_RESOURCE: Check that the `RESOURCE_CONFIGURATION` environment variable is configured correctly. The configuration must contain at least `connection` parameter.
+
+ELASTIC_SUITE_WITHOUT_ES: ElasticSuite is installed, but the Elasticsearch service is not available. Check that the `SEARCH_CONFIGURATION` environment variable is configured correctly, and verify that the Elasticsearch service is available.
+
+ELASTIC_SUITE_WRONG_ENGINE: ElasticSuite is installed but another search engine is configured. Update the `SEARCH_CONFIGURATION` environment variable to enable Elasticsearch and verify the Elasticsearch service configuration in the `services.yaml` file.
+
+#The INSTALL_UPGRADE_ACTION applies to the following errors: 
+#  INSTALL_COMMAND_FAILED - 116
+#  UPGRADE_COMMAND_FAILED - 126
+
+INSTALL_UPGRADE_ACTION: "Check the `cloud.log` and `install_upgrade.log` for more information. Add `VERBOSE_COMMANDS: '-vvv'` into `.magento.env.yaml` for more detailed command output."
+
+SCD_UNABLE_UPDATE_VERSION: Cannot update `./pub/static/deployed_version.txt` file. Check your filesystem permissions.
+
+VIEW_PREPROCESSED_CLEAN_FAILED: Unable to clean the `./var/view_preprocessed` folder. Check your filesystem permissions.
+
+FILE_CREDENTIALS_EMAIL_NOT_WRITABLE: Failed to update the `/var/credentials_email.txt` file. Check your filesystem permissions.
+
+#The CLOUD_LOG_VERBOSE_ACTION applies to the following errors:
+
+#  MODULE_ENABLE_COMMAND_FAILED - 11
+#  SCD_FAILED - 19, 119, 
+#  MAINTENANCE_MODE_ENABLING_FAILED - 108,  
+#  CONFIG_IMPORT_COMMAND_FAILED- 117
+#  SPLIT_DB_COMMAND_FAILED - 123
+#  CACHE_FLUSH_COMMAND_FAILED - 127, 227
+
+CLOUD_LOG_VERBOSE_ACTION: "Check the `cloud.log` for more information. Add `VERBOSE_COMMANDS: '-vvv'` into `.magento.env.yaml` for more detailed command output."
+
+CACHE_ENABLE_FAILED: "Command `php ./bin/magento cache:enable` runs only when Magento was installed but `./app/etc/env.php` file was absent or empty at the beginning of the deployment. Check the `cloud.log` for more information. Add `VERBOSE_COMMANDS: '-vvv'` into `.magento.env.yaml` for more detailed command output."
+
+CRYPT_KEY_IS_ABSENT: "This error occurs if the `./app/etc/env.php` file is not present when Magento deployment begins, or if the `crypt/key` value is undefined.
+If you migrated the database from another environment, retrieve the crypt key value from that environment and add the value to the [CRYPT_KEY](https://devdocs.magento.com/cloud/env/variables-deploy.html#crypt_key) cloud environment variable in your current environment, see [Add the Magento encryption key](https://devdocs.magento.com/cloud/setup/first-time-setup-import-import.html#encryption-key).
+If you accidentally removed the `./app/etc/env.php` file, use the following command to restore it from the backup files created from a previous deployment: `./vendor/bin/ece-tools backup:restore` CLI command ."

--- a/src/_data/toc/cloud-guide.yml
+++ b/src/_data/toc/cloud-guide.yml
@@ -491,6 +491,10 @@ pages:
           url: /cloud/live/stage-prod-test.html
           versionless: true
 
+        - label: Error log message reference
+          url: /cloud/reference/error-codes.html
+          versionless: true
+
     - label: Site launch
       url: /cloud/live/live.html
       versionless: true

--- a/src/_includes/cloud/note-error-message-reference-ece-tools.md
+++ b/src/_includes/cloud/note-error-message-reference-ece-tools.md
@@ -1,0 +1,2 @@
+{:.bs-callout-tip}
+See the [Error message reference for ece-tools]({{site.baseurl}}/cloud/reference/error-codes.html) to review errors that can occur during the build, deploy, and post-deploy stages.

--- a/src/cloud/live/stage-prod-test.md
+++ b/src/cloud/live/stage-prod-test.md
@@ -14,9 +14,9 @@ functional_areas:
 {:.ref-header}
 Previous step
 
-[Migrate data and static files]({{ site.baseurl }}/cloud/live/stage-prod-migrate.html)
+[Migrate data and static files][]
 
-When your code, files, and data is successfully migrated to Staging or Production, use the environment URLs to test your site(s) and store(s). For a list of your URLs, see [Starter]({{ site.baseurl }}/cloud/live/stage-prod-migrate-prereq.html#starter-urls) and [Pro]({{ site.baseurl }}/cloud/live/stage-prod-migrate-prereq.html#pro-urls) access information.
+When your code, files, and data is successfully migrated to Staging or Production, use the environment URLs to test your site(s) and store(s). For a list of your URLs, see [Starter][] and [Pro][] access information.
 
 The following information provides information on verifying logs, testing Fastly configurations, user acceptance testing (UAT), and more.
 
@@ -28,6 +28,8 @@ The deployment log is located in `/var/log/platform/<prodject ID>/deploy.log`. T
 
 When accessing logs in Production or Staging environments, you must use SSH to log in to each of the three nodes to locate the logs. See [Log locations]({{ site.baseurl }}/cloud/project/log-locations.html#application-logs).
 
+{%include cloud/note-error-message-reference-ece-tools.md%}
+
 ## Check the code base {#codebase}
 
 Verify your `master` code base correctly deployed to Staging and Production environments. The environments should have identical code bases.
@@ -38,9 +40,9 @@ Check the Magento configuration settings through the Admin panel including the B
 
 ## Check Fastly caching {#fastly}
 
-Verify Fastly is caching properly on Staging and Production. [Configuring Fastly]({{ site.baseurl }}/cloud/cdn/configure-fastly.html) requires careful attention to details, using the correct Fastly Service ID and Fastly API token, and a proper VCL snippet uploaded.
+Verify Fastly is caching properly on Staging and Production. [Configuring Fastly][] requires careful attention to details, using the correct Fastly Service ID and Fastly API token, and a proper VCL snippet uploaded.
 
-First, check for headers with a dig command to the URL. In a terminal application, enter `dig <url>` to verify Fastly services display in the headers. For additional `dig` tests, see Fastly's [Testing before changing DNS](https://docs.fastly.com/guides/basic-configuration/testing-setup-before-changing-domains).
+First, check for headers with a dig command to the URL. In a terminal application, enter `dig <url>` to verify Fastly services display in the headers. For additional `dig` tests, see Fastly's [Testing before changing DNS][].
 
 The following examples use Pro URLs. You can use any URL with the `dig` command.
 
@@ -53,7 +55,7 @@ Next, use a `curl` command to verify X-Magento-Tags exist and additional header 
 curl http[s]://<full site URL> -H "host: <url>" -k -vo /dev/null -HFastly-Debug:1
 ```
 
-For Starter, enter the full site URL from your environment [Access info]({{ site.baseurl }}/cloud/live/stage-prod-migrate-prereq.html#starter-urls) in the command to view the headers.
+For Starter, enter the full site URL from your environment [Access info][] in the command to view the headers.
 
 For Pro Staging and Production, the command differs per server:
 
@@ -71,8 +73,8 @@ Check the returned response headers and values:
 -  `Fastly-Module-Enabled` should be either `Yes` or the Fastly extension version number
 -  `X-Cache` should be either `HIT` or `HIT, HIT`
 -  `x-cache-hits` should be 1,1
--  [`Cache-Control: max-age`](https://www.w3.org/Protocols/rfc2616/rfc2616-sec14.html#sec14.9) should be greater than 0
--  [`Pragma`](https://www.w3.org/Protocols/rfc2616/rfc2616-sec14.html#sec14.32) should be `cache`
+-  [`Cache-Control: max-age`][] should be greater than 0
+-  [`Pragma`][] should be `cache`
 
 To verify Fastly is enabled in Staging and Production, check the configuration in the Magento Admin for each environment:
 
@@ -84,7 +86,7 @@ To verify Fastly is enabled in Staging and Production, check the configuration i
 {:.bs-callout-warning}
 Make sure you entered the correct Fastly Service ID and API token in your Staging and Production environments. If you enter Staging credentials in your Production environment, you may not be able to upload your VCL snippets, caching will not work correctly, and your caching will be pointed to the wrong server and stores. Your Fastly credentials are created and mapped per service environment.
 
-The module must be enabled to cache your site. If you have additional extensions enabled that affect headers, one of them could cause issues with Fastly. If you have further issues, see [Set up Fastly]({{ site.baseurl }}/cloud/cdn/cloud-fastly.html) and [Fastly troubleshooting]({{ site.baseurl }}/cloud/cdn/trouble-fastly.html).
+The module must be enabled to cache your site. If you have additional extensions enabled that affect headers, one of them could cause issues with Fastly. If you have further issues, see [Set up Fastly][] and [Fastly troubleshooting][].
 
 ## Complete UAT testing {#uat-testing}
 
@@ -212,16 +214,38 @@ We recommend that you review the [Magento Performance Toolkit]({{ site.mage2blob
 
 For best results, we recommend the following tools:
 
--  [Magento application performance test]({{ site.baseurl }}/cloud/env/variables-post-deploy.html#ttfb_tested_pages)—Test Magento application performance by configuring the `TTFB_TESTED_PAGES` environment variable to test site response time.
--  [Siege](https://www.joedog.org/siege-home/)—Traffic shaping and testing software to push your store to the limit. Hit your site with a configurable number of simulated clients. Siege supports basic authentication, cookies, HTTP, HTTPS and FTP protocols.
--  [Jmeter](http://jmeter.apache.org/)—Excellent load testing to help gauge performance for spiked traffic, like for flash sales. Create custom tests to run against your site.
+-  [Magento application performance test][]—Test Magento application performance by configuring the `TTFB_TESTED_PAGES` environment variable to test site response time.
+-  [Siege][]—Traffic shaping and testing software to push your store to the limit. Hit your site with a configurable number of simulated clients. Siege supports basic authentication, cookies, HTTP, HTTPS and FTP protocols.
+-  [Jmeter][]—Excellent load testing to help gauge performance for spiked traffic, like for flash sales. Create custom tests to run against your site.
 -  New Relic (provided)—Helps locate processes and areas of the site causing slow performance with tracked time spent per action like transmitting data, queries, Redis, and so on.
--  [WebPageTest](https://www.webpagetest.org/) and [Pingdom](https://www.pingdom.com/)—Real-time analysis of your site pages load time with different origin locations. Pingdom may require a fee. WebPageTest is a free tool.
+-  [WebPageTest][] and [Pingdom][]—Real-time analysis of your site pages load time with different origin locations. Pingdom may require a fee. WebPageTest is a free tool.
 
 ### Functional testing
 
-You can use the Magento Functional Testing Framework (MFTF) to complete functional testing for {{site.data.var.ee}} from the Cloud Docker environment. See [Magento application testing]({{site.baseurl}}/cloud/docker/docker-test-app-mftf.html).
+You can use the Magento Functional Testing Framework (MFTF) to complete functional testing for {{site.data.var.ee}} from the Cloud Docker environment. See [Magento application testing][]
 
 ## Set up Magento Security Scan Tool {#security-scan}
 
-We provide a free Security Scan Tool for your sites. To add your sites and run the tool, see [Magento Security Scan Tool]({{ site.baseurl }}/cloud/live/live.html#security-scan).
+We provide a free Security Scan Tool for your sites. To add your sites and run the tool, see [Magento Security Scan Tool][].
+
+<!--Link definitions>
+
+[Migrate data and static files]: {{ site.baseurl }}/cloud/live/stage-prod-migrate.html
+[Starter]: {{ site.baseurl }}/cloud/live/stage-prod-migrate-prereq.html#starter-urls
+[Pro]: {{ site.baseurl }}/cloud/live/stage-prod-migrate-prereq.html#pro-urls
+[Log locations]: {{ site.baseurl }}/cloud/project/log-locations
+[Configuring Fastly]: {{ site.baseurl }}/cloud/cdn/configure-fastly.html
+[Testing before changing DNS](https://docs.fastly.com/guides/basic-configuration/testing-setup-before-changing-domains
+[Access info]: {{ site.baseurl }}/cloud/live/stage-prod-migrate-prereq.html#starter-urls
+[`Cache-Control: max-age`]: https://www.w3.org/Protocols/rfc2616/rfc2616-sec14.html#sec14.9
+[`Pragma`]: https://www.w3.org/Protocols/rfc2616/rfc2616-sec14.html#sec14.32
+[Set up Fastly]: {{ site.baseurl }}/cloud/cdn/cloud-fastly.html
+[Fastly troubleshooting]: {{ site.baseurl }}/cloud/cdn/trouble-fastly.html
+[Magento Performance Toolkit]({{ site.mage2bloburl }}/{{ site.version }}/setup/performance-toolkit)
+[Magento application performance test]: {{ site.baseurl }}/cloud/env/variables-post-deployhtml#ttfb_tested_pages
+[Siege](https://www.joedog.org/siege-home/
+[Jmeter]: http://jmeter.apache.org/
+[WebPageTest]: https://www.webpagetest.org/
+[Pingdom]: https://www.pingdom.com/
+[Magento application testing]: {{site.baseurl}}/cloud/docker/docker-test-app-mftf.html
+[Magento Security Scan Tool]: {{ site.baseurl }}/cloud/live/live.html#security-scan

--- a/src/cloud/project/log-locations.md
+++ b/src/cloud/project/log-locations.md
@@ -74,9 +74,14 @@ Re-deploying environment project-integration-ID
     [2019-01-03 19:44:32] NOTICE: Post-deploy is complete.
 ```
 
+### Error logs
+
+Error and warning messages generated during the deployment process are written to both the `var/log/cloud.log` and the `var/log/cloud.error.log` files. The Cloud error log file contains only errors and warnings from the latest deployment. An empty file indicates a successful deployment with no errors.
+
 The following logs have a common location for all Cloud projects:
 
--  **Build log**: `var/log/cloud.log`
+-  **Deployment log**: `var/log/cloud.log`
+-  **Last deployment error log**: `var/log/cloud.error.log`
 -  **Debug log**: `var/log/debug.log`
 -  **Exception log**: `var/log/exception.log`
 -  **Reports**: `var/reports/`
@@ -115,6 +120,8 @@ You can use the same CLI command to view a deploy log from the Staging environme
 ```bash
 magento-cloud log platform/<project_id>_stg/deploy
 ```
+
+{%include cloud/note-error-message-reference-ece-tools.md%}
 
 ## Application logs
 

--- a/src/cloud/reference/discover-deploy.md
+++ b/src/cloud/reference/discover-deploy.md
@@ -23,7 +23,7 @@ You can track build and deploy actions in real-time using the terminal or the Pr
 If you are using external GitHub repositories, the log of operations does not display in the GitHub session. However, you can still follow activity in the interface for the external repository and the Project Web Interface. See [Integrations]({{ site.baseurl }}/cloud/integrations/cloud-integrations.html).
 
 {:.bs-callout-info}
-In Integration environments, you cannot view the deploy logs from the Project Web Interface. This feature is available only for Production and Staging environments. However, you can view logs for every phase of the deployment in any environment using the Magento [build and deploy]({{ site.baseurl }}/cloud/project/log-locations.html#build-and-deploy-logs) logs.
+In Integration environments, you cannot view the deploy logs from the Project Web Interface. This feature is available only for Production and Staging environments. However, you can view logs for every phase of the deployment in any environment using the Magento [build and deploy]({{ site.baseurl }}/cloud/project/log-locations.html#build-and-deploy-logs) logs. For troubleshooting information, see the [Deployment error reference]({{site.baseurl}}/cloud/reference/error-codes.html).
 
 ## Project configuration {#cloud-deploy-conf}
 

--- a/src/cloud/reference/error-codes.md
+++ b/src/cloud/reference/error-codes.md
@@ -1,0 +1,123 @@
+---
+group: cloud-guide
+title: Error message reference for ece-tools
+functional_areas:
+  - Cloud
+  - Deploy
+  - Configuration
+---
+
+{% assign errors = site.data.cloud-error-messages %}
+
+This {{site.data.var.ct}} error message reference provides information to troubleshoot errors that can occur during the {{site.data.var.ece}} deployment process.
+
+All error and warning messages generated during deployment are written to both the `var/log/cloud.log` and `/var/log/cloud.error.log` files. The Cloud error log file contains only errors and warnings from the latest deployment. An empty file indicates a successful deployment with no errors.
+
+Error messages are categorized by deployment stage–*build*, *deploy*, and *post-deploy*. Each section provides a list of associated errors with the following information for each error:
+
+-  **Error code**:  The Magento-assigned identifier for the error message
+-  **Step**:  Indicates the step in the deployment scenario where the error can occur. If the _Step_ column is blank, the error is a general error that can occur in multiple steps, or during pre-processing operations. See [Scenario-based deployment]({{site.baseurl}}/cloud/deploy/scenario-based-deployment.html) for more information about the build, deploy, and post-deploy steps.
+-  **Error description**: A short phrase that summarizes the cause of the error
+-  **Suggested action**: Provides guidance to troubleshoot and resolve the error
+
+## Build stage
+
+{: .error-table}
+| Error code | Build step | Error description | Suggested action |
+| ---------- | ---------- | ----------------- | ---------------- |
+| 2 | | Cannot write to the `./app/etc/env.php` file | {{site.data.cloud-error-messages.ENV_PHP_IS_NOT_WRITABLE}}|
+| 3 | | Configuration isn't defined in the `schema.yaml` file | {{site.data.cloud-error-messages.CONFIG_NOT_DEFINED}}|
+| 4 | | Failed to parse the `.magento.env.yaml` file | {{site.data.cloud-error-messages.CONFIG_PARSE_FAILED}}|
+| 5 | | Unable to read the `.magento.env.yaml` file | {{site.data.cloud-error-messages.CONFIG_UNABLE_TO_READ}}|
+| 6 | | Unable to read the `.schema.yaml` file | |
+| 7 | refresh-modules | Cannot write to the `./app/etc/config.php` file |{{site.data.cloud-error-messages.CONFIG_PHP_IS_NOT_WRITABLE}} |
+| 8 | validate-config | Cannot read the `composer.json` file |{{site.data.cloud-error-messages.CANT_READ_COMPOSER_JSON}} |
+| 9 | validate-config | Composer.json is missing required autoload section | {{site.data.cloud-error-messages.COMPOSER_MISSED_REQUIRED_AUTOLOAD}} |
+| 10 | validate-config | The file `.magento.env.yaml` contains an option which isn't declared in the schema, or has an invalid value or stage | {{site.data.cloud-error-messages.WRONG_CONFIGURATION_MAGENTO_ENV_YAML}}|
+| 11 | refresh-modules | Command `/bin/magento module:enable --all` failed | {{site.data.cloud-error-messages.CLOUD_LOG_VERBOSE_ACTION}} |
+| 12 | apply-patches | Failed to apply patch | |
+| 13 | set-report-dir-nesting-level | Cannot write to the file `/pub/errors/local.xml` | |
+| 14 | copy-sample-data | Failed to copy sample data files | |
+| 15 | compile-di | Command `/bin/magento setup:di:compile` failed | {{site.data.cloud-error-messages.CLOUD_LOG_VERBOSE_ACTION}} |
+| 16 | dump-autoload | Command `composer dump-autoload` failed | {{site.data.cloud-error-messages.COMPOSER_DUMP_AUTOLOAD_FAILED}} |
+| 17 | run-baler | The command to run `Baler` for Javascript bundling failed | {{site.data.cloud-error-messages.BALER_NOT_FOUND}} |
+| 18 | compress-static-content | Required utility wasn't found (timeout, bash) | {{site.data.cloud-error-messages.UTILITY_NOT_FOUND}} |
+| 19 | deploy-static-content | Command `/bin/magento setup:static-content:deploy` failed | {{site.data.cloud-error-messages.CLOUD_LOG_VERBOSE_ACTION}} |
+| 20 | compress-static-content | Static content compression failed | {{site.data.cloud-error-messages.CHECK_CLOUD_LOG_ACTION}} |
+| 21 | backup-data: static-content | Failed to copy static content into the `init` directory | {{site.data.cloud-error-messages.CHECK_CLOUD_LOG_ACTION}} |
+| 22 | backup-data: writable-dirs | Failed to copy some writable directories into the `init` directory | {{site.data.cloud-error-messages.WRITABLE_DIRECTORY_COPYING_FAILED}} |
+| 23 | | Unable to create a logger object | |
+| 24 | backup-data: static-content | Failed to clean the `./init/pub/static/` directory | {{ site.data.cloud-error-messages.CLEAN_INIT_PUB_STATIC_FAILED}} |
+| 25 | | Cannot find the Composer package | {{site.data.cloud-error-messages.COMPOSER_PACKAGE_NOT_FOUND}} |
+
+## Deploy stage
+
+{: .error-table}
+| Error code | Deploy step | Error description | Suggested action |
+| --- | --- | --- | -- |
+| 101 | pre-deploy: cache | Incorrect cache configuration (missing port or host) | {{site.data.cloud-error-messages.WRONG_CACHE_CONFIGURATION}} |
+| 102 | | Cannot write to the `./app/etc/env.php` file | {{site.data.cloud-error-messages.ENV_PHP_IS_NOT_WRITABLE}} |
+| 103 | | Configuration isn't defined in the `schema.yaml` file  | {{site.data.cloud-error-messages.CONFIG_NOT_DEFINED}} |
+| 104 | | Failed to parse the `.magento.env.yaml` file | {{site.data.cloud-error-messages.CONFIG_NOT_DEFINED}} |
+| 105 | | Unable to read the `.magento.env.yaml` file | {{site.data.cloud-error-messages.CONFIG_UNABLE_TO_READ}} |
+| 106 | | Unable to read the `.schema.yaml` file | |
+| 107 | pre-deploy: clean-redis-cache | Failed to clean the Redis cache | {{site.data.cloud-error-messages.
+
+REDIS_CACHE_CLEAN_FAILED}}. |
+| 108 | pre-deploy: set-production-mode | Command `/bin/magento maintenance:enable` failed | {{site.data.cloud-error-messages.CLOUD_LOG_VERBOSE_ACTION}} |
+| 109 | validate-config | Incorrect database configuration | {{site.data.cloud-error-messages.WRONG_CONFIGURATION_DB}} |
+| 110 | validate-config | Incorrect session configuration | {{site.data.cloud-error-messages.WRONG_CONFIGURATION_SESSION}} |
+| 111 | validate-config | Incorrect search configuration | {{site.data.cloud-error-messages.WRONG_CONFIGURATION_SEARCH}} |
+| 112 | validate-config | Incorrect resource configuration | {{site.data.cloud-error-messages.WRONG_CONFIGURATION_RESOURCE}} |
+| 113 | validate-config:elasticsuite-integrity | ElasticSuite is installed, but the ElasticSearch service is not available | {{site.data.cloud-error-messages.ELASTIC_SUITE_WITHOUT_ES}} |
+| 114 | validate-config:elasticsuite-integrity | ElasticSuite is installed, but another search engine is used | {{site.data.cloud-error-messages.ELASTIC_SUITE_WRONG_ENGINE}} |
+| 115 |  | Database query execution failed | |
+| 116 | install-update: setup | Command `/bin/magento setup:install` failed | {{site.data.cloud-error-messages.INSTALL_UPGRADE_ACTION}} |
+| 117 | install-update: config-import | Command `app:config:import` failed | {{site.data.cloud-error-messages.CLOUD_LOG_VERBOSE_ACTION}} |
+| 118 |  | Required utility wasn't found (timeout, bash) | {{site.data.cloud-error-messages.UTILITY_NOT_FOUND}} |
+| 119 | install-update: deploy-static-content | Command `/bin/magento setup:static-content:deploy` failed | {{site.data.cloud-error-messages.CLOUD_LOG_VERBOSE_ACTION}} |
+| 120 | compress-static-content | Static content compression failed | {{site.data.cloud-error-messages.CHECK_CLOUD_LOG_ACTION}} |
+| 121 | deploy-static-content:generate | Cannot update the deployed version | {{site.data.cloud-error-messages.SCD_UNABLE_UPDATE_VERSION}} |
+| 122 | clean-static-content | Failed to clean static content files | |
+| 123 | install-update: split-db | Command `/bin/magento setup:db-schema:split` failed | {{site.data.cloud-error-messages.CLOUD_LOG_VERBOSE_ACTION}} |
+| 124 | clean-view-preprocessed | Failed to clean the `var/view_preprocessed` folder | {{site.data.cloud-error-messages.VIEW_PREPROCESSED_CLEAN_FAILED}} |
+| 125 | install-update: reset-password | Failed to update the `/var/credentials_email.txt` file | {{site.data.cloud-error-messages.FILE_CREDENTIALS_EMAIL_NOT_WRITABLE}} |
+| 126 | install-update: update | Command `/bin/magento setup:upgrade` failed | {{site.data.cloud-error-messages.INSTALL_UPGRADE_ACTION}} |
+| 127 | clean-cache | Command `/bin/magento cache:flush` failed | {{site.data.cloud-error-messages.CLOUD_LOG_VERBOSE_ACTION}} |
+| 128 | disable-maintenance-mode | Command `/bin/magento maintenance:disable` failed | {{site.data.cloud-error-messages.CLOUD_LOG_VERBOSE_ACTION}} |
+| 129 | install-update: reset-password | Enable to read reset password template | |
+| 130 | install-update: cache_type | Command `php ./bin/magento cache:enable` failed. | {{site.data.cloud-error-messages.CACHE_ENABLE_FAILED}} |
+| 131 | install-update | The `crypt/key`  key value does not exist in the `./app/etc/env.php` file or the `CRYPT_KEY` cloud environment variable | {{site.data.cloud-error-messages.CRYPT_KEY_IS_ABSENT}} |
+
+## Post-deploy stage
+
+{: .error-table}
+| Error code | Post-deploy step | Error description | Suggested action |
+| --- | --- | --- | -- |
+| 201 | is-deploy-failed | Deploy stage failed | |
+| 202 |  | The `./app/etc/env.php` file is not writable | {{site.data.cloud-error-messages.ENV_PHP_IS_NOT_WRITABLE}} |
+| 203 |  | Configuration isn't defined in the `schema.yaml` file | {{site.data.cloud-error-messages.CONFIG_NOT_DEFINED}} |
+| 204 |  | Failed to parse the `.magento.env.yaml` file | {{site.data.cloud-error-messages.CONFIG_PARSE_FAILED}} |
+| 205 |  | Unable to read the `.magento.env.yaml` file | {{site.data.cloud-error-messages.CONFIG_UNABLE_TO_READ}} |
+| 206 |  | Unable to read the `.schema.yaml` file | |
+| 207 | warm-up | Failed to warm-up some pages | |
+| 208 | time-to-firs-byte | Failed to test time to first byte (TTFB) | |
+| 227 | clean-cache | Command `/bin/magento cache:flush` failed | {{site.data.cloud-error-messages.CLOUD_LOG_VERBOSE_ACTION}} |
+
+<!--Link definitions-->
+
+[Scenario-based deployment]: {{site.baseurl}}/cloud/deploy/scenario-based-deployment.html
+
+<!--Custom css-->
+
+<!--
+  This is a style declaration so that first column does not wrap
+-->
+
+<style>
+table.error-table td:nth-child(1) {
+  width: 125px;
+}
+table.error-table td:nth-child(2) {
+  width: 200px;
+}

--- a/src/cloud/release-notes/ece-release-notes.md
+++ b/src/cloud/release-notes/ece-release-notes.md
@@ -22,7 +22,9 @@ See [Upgrades and patches]({{ site.baseurl }}/cloud/project/project-upgrade-pare
 
 -  {:.new}**Environment variable updates**–
 
-   -  {:.new}Added the **SCD_USE_BALER** variable to enable the Magento Baler module for JavaScript bundling during the {{site.data.var.ece }} build process. See the variable description in the [build variables]({{site.variable}}/cloud/env/variables-build.html#scd_use_baler).<!-- MAGECLOUD-4593 -->
+   -  {:.new}Added the **SCD_USE_BALER** variable to enable the Magento Baler module for JavaScript bundling during the {{site.data.var.ece }} build process. See the variable description in the [build variables]({{site.variable}}/cloud/env/variables-build.html#scd_use_baler).<!-- MAGECLOUD-3457-->
+   
+-  {:.new}**Logging improvements**–Improved log tracking capability by assigning exit codes to critical deploy errors and exposing the exit codes in error message notifications and log events.<!-- MCLOUD-5637-->
 
 ## v2002.1.0
 *Release date: February 6, 2020*<br/>

--- a/src/cloud/trouble/trouble.md
+++ b/src/cloud/trouble/trouble.md
@@ -10,6 +10,7 @@ The troubleshooting topics help to resolve specific issues with your {{site.data
 
 -  Verify your [credentials]({{ site.baseurl }}/cloud/trouble/trouble_ce-creds.html)
 -  Review the [log files]({{ site.baseurl }}/cloud/live/stage-prod-test.html)
+-  For help with deployment errors, check the [Error message reference for ece-tools]({{site.baseurl}}/cloud/reference/error-codes.html)
 -  Search for relevant content in the {{site.data.var.ece}} documentation
 -  Search the [Magento Help Center](https://support.magento.com/hc/en-us) troubleshooting articles, FAQ, and Tech resources
 


### PR DESCRIPTION
## Purpose of this pull request

- Added error message reference log for ece-tools build and deploy
- Fixed broken links

 (Ticket references: MCLOUD-5636 and MCLOUD-6137)

## Affected DevDocs pages

- https://devdocs.magento.com/cloud/live/stage-prod-test.html
- https://devdocs.magento.com/cloud/project/log-locations.html
- https://devdocs.magento.com/cloud/reference/discover-deploy.html
- https://devdocs.magento.com/cloud/trouble/trouble.html
- https://devdocs.magento.com/cloud/reference/error-codes.html

## Links to Magento source code

- https://github.com/magento/ece-tools/pull/726
- https://github.com/magento/ece-tools/pull/736