### PR TITLE
Added release notes for Cloud Patches 1.0.5

### DIFF
--- a/src/cloud/release-notes/mcp-release-notes.md
+++ b/src/cloud/release-notes/mcp-release-notes.md
@@ -19,7 +19,7 @@ See [Apply patches]({{site.baseurl}}/cloud/project/project-patch.html) to learn 
 ## v1.0.5
 *Release date: June ##, 2020*<br/>
 
-- **Redis performance improvements**–Adds Redis optimization features to Magento versions 2.3.3 and 2.3.4.  These fixes were included in the Magento version 2.3.5 release. See [Performance boosts]({{site.baseurl}}/guides/v2.3/release-notes/release-notes-2-3-5-commerce.html#performance-boosts) in the _Magento Commerce 2.3.5 Release Notes_.<!--MCLOUD-5771-->
+- **Redis performance improvements**–Adds Redis optimization features to Magento versions 2.3.3 and 2.3.4. These fixes were included in the Magento version 2.3.5 release. See [Performance boosts]({{site.baseurl}}/guides/v2.3/release-notes/release-notes-2-3-5-commerce.html#performance-boosts) in the _Magento Commerce 2.3.5 Release Notes_.<!--MCLOUD-5771-->
 
 - **New Relic log enricher**–Adds the Monolog ProcessorInterface required to support improvements to New Relic logging capabilities introduced in {{site.data.var.mcc-prod}} version 1.0.5. This patch is required to deploy Magento 2.1.x. If the patch is not applied, the build fails during the `di:compile` process.<!--MCLOUD-6029-->
 

--- a/src/cloud/release-notes/mcp-release-notes.md
+++ b/src/cloud/release-notes/mcp-release-notes.md
@@ -19,7 +19,7 @@ See [Apply patches]({{site.baseurl}}/cloud/project/project-patch.html) to learn 
 ## v1.0.5
 *Release date: June ##, 2020*<br/>
 
-- **Redis performance improvements**–Adds Redis optimization features to Magento versions 2.3.3 and 2.3.4.  These fixes were included in the Magento version 2.4 release. See [Performance improvements]({{site.baseurl}}/guides/v2.4/release-notes/release-notes-2-4-0-commerce.html#performance-improvements) in the _Magento Commerce 2.4.0 Release Notes_.<!--MCLOUD-5771-->
+- **Redis performance improvements**–Adds Redis optimization features to Magento versions 2.3.3 and 2.3.4.  These fixes were included in the Magento version 2.3.5 release. See [Performance improvements]({{site.baseurl}}/guides/v2.3/release-notes/release-notes-2-3-5-commerce.html#performance-boosts) in the _Magento Commerce 2.3.5 Release Notes_.<!--MCLOUD-5771-->
 
 - **New Relic log enricher**–Adds the Monolog ProcessorInterface required to support improvements to New Relic logging capabilities introduced in {{site.data.var.mcc-prod}} version 1.0.5. This patch is required to deploy Magento 2.1.x. If the patch is not applied, the build fails during the `di:compile` process.<!--MCLOUD-6029-->
 

--- a/src/cloud/release-notes/mcp-release-notes.md
+++ b/src/cloud/release-notes/mcp-release-notes.md
@@ -16,6 +16,13 @@ The `{{site.data.var.mcp}}` package uses the following version sequence: `<major
 {:.bs-callout-info}
 See [Apply patches]({{site.baseurl}}/cloud/project/project-patch.html) to learn how to apply Magento patches and hot fixes to your {{site.data.var.ece}} project.
 
+## v1.0.5
+*Release date: June ##, 2020*<br/>
+
+- **Redis performance improvements**–Adds Redis optimization features to Magento versions 2.3.3 and 2.3.4.  These fixes were included in the Magento version 2.4 release. See [Performance improvements]({{site.baseurl}}/guides/v2.4/release-notes/release-notes-2-4-0-commerce.html#performance-improvements) in the _Magento Commerce 2.4.0 Release Notes_.<!--MCLOUD-5771-->
+
+- **New Relic log enricher**–Adds the Monolog ProcessorInterface required to support improvements to New Relic logging capabilities introduced in {{site.data.var.mcc-prod}} version 1.0.5. This patch is required to deploy Magento 2.1.x. If the patch is not applied, the build fails during the `di:compile` process.<!--MCLOUD-6029-->
+
 ## v1.0.4
 *Release date: May 12, 2020*<br/>
 

--- a/src/cloud/release-notes/mcp-release-notes.md
+++ b/src/cloud/release-notes/mcp-release-notes.md
@@ -19,7 +19,7 @@ See [Apply patches]({{site.baseurl}}/cloud/project/project-patch.html) to learn 
 ## v1.0.5
 *Release date: June ##, 2020*<br/>
 
-- **Redis performance improvements**–Adds Redis optimization features to Magento versions 2.3.3 and 2.3.4.  These fixes were included in the Magento version 2.3.5 release. See [Performance improvements]({{site.baseurl}}/guides/v2.3/release-notes/release-notes-2-3-5-commerce.html#performance-boosts) in the _Magento Commerce 2.3.5 Release Notes_.<!--MCLOUD-5771-->
+- **Redis performance improvements**–Adds Redis optimization features to Magento versions 2.3.3 and 2.3.4.  These fixes were included in the Magento version 2.3.5 release. See [Performance boosts]({{site.baseurl}}/guides/v2.3/release-notes/release-notes-2-3-5-commerce.html#performance-boosts) in the _Magento Commerce 2.3.5 Release Notes_.<!--MCLOUD-5771-->
 
 - **New Relic log enricher**–Adds the Monolog ProcessorInterface required to support improvements to New Relic logging capabilities introduced in {{site.data.var.mcc-prod}} version 1.0.5. This patch is required to deploy Magento 2.1.x. If the patch is not applied, the build fails during the `di:compile` process.<!--MCLOUD-6029-->
 


### PR DESCRIPTION
## Purpose of this pull request

- Added release notes for Magento Cloud Patches v 1.0.5

- [x] Technical review
- [ ] Editorial review
- [x] Staging preview

## Affected DevDocs pages

https://devdocs.magento.com/cloud/release-notes/mcc-release-notes.html

## Links to Magento source code

[magento/magento-cloud-patches v1.0.5 GitHub PRs](https://github.com/magento/magento-cloud-patches/pulls?q=is%3Apr+label%3A%22Release%3A+1.0.5%22+)

<!--
If you are fixing a GitHub issue, note it using GitHub keyword format (https://help.github.com/en/articles/closing-issues-using-keywords#closing-an-issue-in-a-different-repository) to close the issue when this pull request is merged. Example: `Fixes #1234`

`master` is the default branch. Merged pull requests to `master` go live on the site automatically. Any requested changes to content on the `master` branch must be related to the released codebase. Any content related to future releases goes in the `develop` branch.

See Contribution guidelines (https://github.com/magento/devdocs/blob/master/.github/CONTRIBUTING.md) for more information.
-->

whatsnew
Added [Magento Cloud Patches v 1.0.5 Release Notes]( https://devdocs.magento.com/cloud/release-notes/mcc-release-notes.html)
