### PR TITLE
GraphQL: Add id_v2 for gift cards

### DIFF
--- a/src/guides/v2.4/graphql/product/gift-card-product.md
+++ b/src/guides/v2.4/graphql/product/gift-card-product.md
@@ -1,1 +1,83 @@
-../../../v2.3/graphql/product/gift-card-product.md
+---
+group: graphql
+title: Gift card product data types
+ee_only: True
+redirect_from:
+  - /guides/v2.3/graphql/reference/gift-card-product.html
+---
+
+The `GiftCardProduct` data type defines properties of a gift card, including the minimum and maximum values and an array that contains the current and past values on the specific gift card
+
+It implements the following interfaces:
+
+-  `ProductInterface`
+-  `PhysicalProductInterface`
+-  `CustomizableProductInterface`
+
+## GiftCardProduct object
+
+The `GiftCardProduct` object contains the following attributes:
+
+Attribute | Type | Description
+--- | --- | ---
+`allow_message` | Boolean | Indicates whether the customer can provide a message to accompany the gift card
+`allow_open_amount` | Boolean | Indicates whether customers have the ability to set the value of the gift card
+`giftcard_amounts` | [`GiftCardAmounts`] | An array that contains information about the values and ID of a gift card
+`giftcard_type` | `GiftCardTypeEnum` | Either VIRTUAL, PHYSICAL, or COMBINED
+`is_redeemable` | Boolean | Indicates whether the customer can redeem the value on the card for cash
+`lifetime` | Int | The number of days after purchase until the gift card expires. A null value means there is no limit
+`message_max_length` | Int | The maximum number of characters a gift card message can contain
+`open_amount_max` | Float | The maximum acceptable value of an open amount gift card
+`open_amount_min` | Float | The minimum acceptable value of an open amount gift card
+
+## GiftCardAmounts object
+
+The `GiftCardAmounts` object contains the following attributes:
+
+Attribute | Type | Description
+--- | --- | ---
+`attribute_id` | Int | An internal attribute ID
+`value_id` | Int | An ID that is  assigned to each unique gift card amount
+`value` | Float | The value of the gift card
+`website_value` | Float |The value of the gift card
+`website_id` | Int | ID of the website that generated the gift card
+
+## Sample Query
+
+The following query returns information about gift card product `GiftCard25`. (It is not defined in the sample data.)
+
+```graphql
+{
+  products(filter: { sku: { eq: "GiftCard25" } }) {
+    items {
+      id
+      __typename
+      name
+      sku
+      ... on GiftCardProduct {
+        allow_message
+        message_max_length
+        allow_open_amount
+        open_amount_min
+        open_amount_max
+        is_returnable
+        is_redeemable
+        giftcard_type
+        giftcard_amounts {
+          value_id
+          website_id
+          value
+          attribute_id
+          website_value
+        }
+      }
+    }
+  }
+}
+```
+
+## Related topics
+
+-  [applyGiftCardToCart mutation]({{page.baseurl}}/graphql/mutations/apply-giftcard.html)
+-  [redeemGiftCardBalanceAsStoreCredit mutation]({{page.baseurl}}/graphql/mutations/redeem-giftcard-balance.html)
+-  [removeGiftCardFromCart mutation]({{page.baseurl}}/graphql/mutations/remove-giftcard.html)


### PR DESCRIPTION
## Purpose of this pull request

This pull request (PR) adds the id_v2 attribute to the GiftCardAmounts object, per https://github.com/magento/partners-magento2ee/pull/263

## Affected DevDocs pages

<!-- REQUIRED List the affected pages on devdocs.magento.com (URLs). Not needed for large numbers of files. -->

-  https://devdocs.magento.com/guides/v2.4/graphql/product/gift-card-product.html

## Links to Magento source code

<!--  OPTIONAL - REMOVE THIS SECTION IF NOT USED. If this pull request references a file in a Magento codebase repository, add it here. -->

-  ...

<!--
If you are fixing a GitHub issue, note it using GitHub keyword format (https://help.github.com/en/articles/closing-issues-using-keywords#closing-an-issue-in-a-different-repository) to close the issue when this pull request is merged. Example: `Fixes #1234`

`master` is the default branch. Merged pull requests to `master` go live on the site automatically. Any requested changes to content on the `master` branch must be related to the released codebase. Any content related to future releases goes in the `develop` branch.

See Contribution guidelines (https://github.com/magento/devdocs/blob/master/.github/CONTRIBUTING.md) for more information.
-->
