### PR TITLE
Announce removal of the Braintree module in the 2.4 Payment Integrations Guide

### DIFF
--- a/src/_includes/layout/page-header.html
+++ b/src/_includes/layout/page-header.html
@@ -3,7 +3,7 @@
 
   {% if page.url contains "guides/v2.4/payments-integrations/base-integrations/" or page.url contains "guides/v2.4/payments-integrations/payment-gateway" or page.url contains "guides/v2.4/payments-integrations/vault" or page.url contains "guides/v2.4/payments-integrations/bk-payments-integrations" %}
   <div class="bs-callout-warning">
-    The Payment Provider Gateway documentation uses the Magento 2.3.x version of the Braintree module as a reference application. The Braintree module was removed in Magento 2.4.0. The concepts described in this guide are still applicable to Magento 2.4.0.
+    The Payment Provider Gateway documentation uses the Magento 2.3.x version of the Braintree module as a reference application. The Braintree module was removed in Magento 2.4.0. The concepts described in this guide are still applicable to Magento 2.4.0, but the code samples are not supported.
   </div>
   {% endif %}
 

--- a/src/_includes/layout/page-header.html
+++ b/src/_includes/layout/page-header.html
@@ -1,6 +1,12 @@
 <!-- page-header -->
 <section class="page-intro">
 
+  {% if page.url contains "guides/v2.4/payments-integrations/base-integrations/" or page.url contains "guides/v2.4/payments-integrations/payment-gateway" or page.url contains "guides/v2.4/payments-integrations/vault" or page.url contains "guides/v2.4/payments-integrations/bk-payments-integrations" %}
+  <div class="bs-callout-warning">
+    The Payment Provider Gateway documentation uses the Magento 2.3.x version of the Braintree module as a reference application. The Braintree module was removed in Magento 2.4.0. The concepts described in this guide are still applicable to Magento 2.4.0.
+  </div>
+  {% endif %}
+
   {% if page.url contains "guides/v2.3/install-gde/install/web/" or page.url contains "guides/v2.3/comp-mgr/upgrader/" or page.url contains "guides/v2.3/comp-mgr/module-man/" %}
   <div class="bs-callout-warning">
     The Web Setup Wizard is being deprecated in Magento 2.3.6 and will be removed in Magento 2.4.0. After it is removed, you must use the command line to <a href="https://devdocs.magento.com/guides/v2.3/install-gde/install/cli/install-cli.html">install</a> or <a href="https://devdocs.magento.com/guides/v2.3/comp-mgr/cli/cli-upgrade.html">upgrade</a> Magento.

--- a/src/guides/v2.3/payments-integrations/base-integration/admin-integration.md
+++ b/src/guides/v2.3/payments-integrations/base-integration/admin-integration.md
@@ -21,7 +21,7 @@ If your payment flow should be different for storefront and Admin panel, you can
 ## Example
 
 For example, on the storefront 3D Secure verification is integrated for the Braintree payment method, but it should not be available in Admin panel
-The DI configuration for [authorization](https://glossary.magento.com/authorization) request builder for [admin area]({{ site.mage2bloburl }}/{{ page.guide_version }}/app/code/Magento/Braintree/etc/adminhtml/di.xml) looks like following:
+The DI configuration for [authorization](https://glossary.magento.com/authorization) request builder for [admin area]({{ site.mage2bloburl }}/2.3/app/code/Magento/Braintree/etc/adminhtml/di.xml) looks like following:
 
 ```xml
 <virtualType name="BraintreeAuthorizeRequest" type="Magento\Payment\Gateway\Request\BuilderComposite">
@@ -35,5 +35,5 @@ The DI configuration for [authorization](https://glossary.magento.com/authorizat
 </virtualType>
 ```
 
-While the general [app/code/Magento/Braintree/etc/di.xml]({{ site.mage2bloburl }}/{{ page.guide_version }}/app/code/Magento/Braintree/etc/di.xml#L140) does not
+While the general [app/code/Magento/Braintree/etc/di.xml]({{ site.mage2bloburl }}/2.3/app/code/Magento/Braintree/etc/di.xml#L140) does not
 have 3D secure verification builder for Admin panel, but [virtual type](https://glossary.magento.com/virtual-type) has the same name (object will be created according to context of area).

--- a/src/guides/v2.3/payments-integrations/base-integration/admin-integration.md
+++ b/src/guides/v2.3/payments-integrations/base-integration/admin-integration.md
@@ -35,5 +35,4 @@ The DI configuration for [authorization](https://glossary.magento.com/authorizat
 </virtualType>
 ```
 
-While the general [app/code/Magento/Braintree/etc/di.xml]({{ site.mage2bloburl }}/2.3/app/code/Magento/Braintree/etc/di.xml#L140) does not
-have 3D secure verification builder for Admin panel, but [virtual type](https://glossary.magento.com/virtual-type) has the same name (object will be created according to context of area).
+While the general [app/code/Magento/Braintree/etc/di.xml]({{ site.mage2bloburl }}/2.3/app/code/Magento/Braintree/etc/di.xml) does not have 3D secure verification builder for Admin panel, but [virtual type](https://glossary.magento.com/virtual-type) has the same name (object will be created according to context of area).

--- a/src/guides/v2.3/payments-integrations/base-integration/facade-configuration.md
+++ b/src/guides/v2.3/payments-integrations/base-integration/facade-configuration.md
@@ -13,7 +13,7 @@ process payment actions between Magento Sales Management and payment processor.
 
 Add the [dependency injection (DI)]({{ page.baseurl }}/extension-dev-guide/depend-inj.html) configuration for [payment method](https://glossary.magento.com/payment-method) facade in your `%Vendor_Module%/etc/di.xml`.
 
-The following sample is an illustration of such configuration ([app/code/Magento/Braintree/etc/di.xml#L10]({{ site.mage2bloburl }}/2.3/app/code/Magento/Braintree/etc/di.xml#L10)):
+The following sample is an illustration of such configuration ([app/code/Magento/Braintree/etc/di.xml]({{ site.mage2bloburl }}/2.3/app/code/Magento/Braintree/etc/di.xml)):
 
 ```xml
 <virtualType name="BraintreeFacade" type="Magento\Payment\Model\Method\Adapter">
@@ -43,7 +43,7 @@ The following arguments must be configured (all arguments are mandatory):
 
 Let's look closer at the value handlers pool of a payment method. This pool enables you to set payment configuration that is based on certain conditions.
 
-For example, the `can_void` configuration option might depend on payment transaction status or paid amount. The following sample shows how to set the corresponding configuration ([app/code/Magento/Braintree/etc/di.xml#L296]({{ site.mage2bloburl }}/2.3/app/code/Magento/Braintree/etc/di.xml#L296)):
+For example, the `can_void` configuration option might depend on payment transaction status or paid amount. The following sample shows how to set the corresponding configuration ([app/code/Magento/Braintree/etc/di.xml]({{ site.mage2bloburl }}/2.3/app/code/Magento/Braintree/etc/di.xml)):
 
 ```xml
 <virtualType name="BraintreeValueHandlerPool" type="Magento\Payment\Gateway\Config\ValueHandlerPool">

--- a/src/guides/v2.3/payments-integrations/base-integration/facade-configuration.md
+++ b/src/guides/v2.3/payments-integrations/base-integration/facade-configuration.md
@@ -13,7 +13,7 @@ process payment actions between Magento Sales Management and payment processor.
 
 Add the [dependency injection (DI)]({{ page.baseurl }}/extension-dev-guide/depend-inj.html) configuration for [payment method](https://glossary.magento.com/payment-method) facade in your `%Vendor_Module%/etc/di.xml`.
 
-The following sample is an illustration of such configuration ([app/code/Magento/Braintree/etc/di.xml#L10]({{ site.mage2bloburl }}/{{ page.guide_version }}/app/code/Magento/Braintree/etc/di.xml#L10)):
+The following sample is an illustration of such configuration ([app/code/Magento/Braintree/etc/di.xml#L10]({{ site.mage2bloburl }}/2.3/app/code/Magento/Braintree/etc/di.xml#L10)):
 
 ```xml
 <virtualType name="BraintreeFacade" type="Magento\Payment\Model\Method\Adapter">
@@ -43,7 +43,7 @@ The following arguments must be configured (all arguments are mandatory):
 
 Let's look closer at the value handlers pool of a payment method. This pool enables you to set payment configuration that is based on certain conditions.
 
-For example, the `can_void` configuration option might depend on payment transaction status or paid amount. The following sample shows how to set the corresponding configuration ([app/code/Magento/Braintree/etc/di.xml#L296]({{ site.mage2bloburl }}/{{ page.guide_version }}/app/code/Magento/Braintree/etc/di.xml#L296)):
+For example, the `can_void` configuration option might depend on payment transaction status or paid amount. The following sample shows how to set the corresponding configuration ([app/code/Magento/Braintree/etc/di.xml#L296]({{ site.mage2bloburl }}/2.3/app/code/Magento/Braintree/etc/di.xml#L296)):
 
 ```xml
 <virtualType name="BraintreeValueHandlerPool" type="Magento\Payment\Gateway\Config\ValueHandlerPool">
@@ -71,7 +71,7 @@ In your configuration you can use default [Magento\Payment\Gateway\Config\Config
 
 `Magento\Payment\Gateway\Config\Config` can read configuration by payment method code, so is useful to use it or extend it for your own purposes.
 
-And [Magento\Braintree\Gateway\Config\Config]({{ site.mage2bloburl }}/{{ page.guide_version }}/app/code/Magento/Braintree/Gateway/Config/Config.php) reads
+And [Magento\Braintree\Gateway\Config\Config]({{ site.mage2bloburl }}/2.3/app/code/Magento/Braintree/Gateway/Config/Config.php) reads
 configuration from database or payment config file.
 
 Other handlers contain some logic, for example, `can_cancel` option is the same as `can_void` and depends on whether the order has paid amount (invoiced).

--- a/src/guides/v2.3/payments-integrations/base-integration/formblocktype.md
+++ b/src/guides/v2.3/payments-integrations/base-integration/formblocktype.md
@@ -69,7 +69,7 @@ For creating a template for the payment information rendering class, you can use
 
 Then add the template to the billing form layout `sales_order_create_index.xml`.
 
-The following example adds the Braintree-specific template [`app/code/Magento/Payment/view/adminhtml/templates/form/cc.phtml`]({{ site.mage2bloburl }}/{{ page.guide_version }}/app/code/Magento/Payment/view/adminhtml/templates/form/cc.phtml) to the [billing form layout in the Braintree module]({{ site.mage2bloburl }}/{{ page.guide_version }}/app/code/Magento/Braintree/view/adminhtml/layout/sales_order_create_index.xml).
+The following example adds the Braintree-specific template [`app/code/Magento/Payment/view/adminhtml/templates/form/cc.phtml`]({{ site.mage2bloburl }}/{{ page.guide_version }}/app/code/Magento/Payment/view/adminhtml/templates/form/cc.phtml) to the [billing form layout in the Braintree module]({{ site.mage2bloburl }}/2.3/app/code/Magento/Braintree/view/adminhtml/layout/sales_order_create_index.xml).
 
 ```xml
 <page xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="urn:magento:framework:View/Layout/etc/page_configuration.xsd">

--- a/src/guides/v2.3/payments-integrations/base-integration/get-payment-info.md
+++ b/src/guides/v2.3/payments-integrations/base-integration/get-payment-info.md
@@ -164,7 +164,7 @@ And this observer should be added to list of events (`Module_Name/etc/events.xml
 </config>
 ```
 
-This [event](https://glossary.magento.com/event) will be triggered in [Adapter::assignData()]({{ site.mage2bloburl }}/{{ page.guide_version }}/app/code/Magento/Payment/Model/Method/Adapter.php#L600) method call:
+This [event](https://glossary.magento.com/event) will be triggered in [Adapter::assignData()]({{ site.mage2bloburl }}/{{ page.guide_version }}/app/code/Magento/Payment/Model/Method/Adapter.php) method call:
 
 ```php
 public function assignData(\Magento\Framework\DataObject $data)

--- a/src/guides/v2.3/payments-integrations/base-integration/get-payment-info.md
+++ b/src/guides/v2.3/payments-integrations/base-integration/get-payment-info.md
@@ -62,7 +62,7 @@ In most cases, customers fill all required information (credit card, expiration 
 So our [payment method](https://glossary.magento.com/payment-method) implementation should provide the ability to display and process payment form on checkout step.
 
 We can send to [backend](https://glossary.magento.com/backend) any specific data, just need to override `getData()` method in
-[payment UI component]({{ site.mage2bloburl }}/{{ page.guide_version }}/app/code/Magento/Braintree/view/frontend/web/js/view/payment/method-renderer/cc-form.js):
+[payment UI component]({{ site.mage2bloburl }}/2.3/app/code/Magento/Braintree/view/frontend/web/js/view/payment/method-renderer/cc-form.js):
 
 ```javascript
 define(

--- a/src/guides/v2.3/payments-integrations/base-integration/integration-intro.md
+++ b/src/guides/v2.3/payments-integrations/base-integration/integration-intro.md
@@ -17,7 +17,7 @@ You can create integration with other payment providers, using [Magento payment 
 The Magento payment provider gateway allows creating secure and PCI-compliant integrations with payment services. To keep PCI compliance, you must not store sensitive credit card information.
 
 The topics in this chapter explain how to add an integration with a custom payment service provider (in other words, add a new payment method) and implement the authorize payment action for this [payment method](https://glossary.magento.com/payment-method). For illustration, we use code
-samples from the [Braintree]({{ site.mage2bloburl }}/{{ page.guide_version }}/app/code/Magento/Braintree) payment integration.
+samples from the [Braintree]({{ site.mage2bloburl }}/2.3/app/code/Magento/Braintree) payment integration.
 
 To simplify the development of a new payment integration, Magento developed the [Payment sample module](https://github.com/magento/magento2-samples/tree/master/sample-module-payment-gateway).
 It contains all required infrastructure and you can use it as starting point.

--- a/src/guides/v2.3/payments-integrations/cardinal/cardinal.md
+++ b/src/guides/v2.3/payments-integrations/cardinal/cardinal.md
@@ -66,7 +66,7 @@ And the `system.xml` file of the AuthorizenetAcceptjs payment method:
 
 You can pass this parameter on storefront via checkout config using `\Magento\Checkout\Model\ConfigProviderInterface`
 
-See [app\code\AuthorizenetCardinal\Model\Checkout\ConfigProvider.php]({{ site.mage2bloburl }}/{{page.guide_version}}/app/code/Magento/AuthorizenetCardinal/Model/Checkout/ConfigProvider.php#L19) as an example.
+See [app\code\AuthorizenetCardinal\Model\Checkout\ConfigProvider.php]({{ site.mage2bloburl }}/{{page.guide_version}}/app/code/Magento/AuthorizenetCardinal/Model/Checkout/ConfigProvider.php) as an example.
 
 ```php
 namespace Magento\AuthorizenetCardinal\Model\Checkout;
@@ -296,7 +296,7 @@ Then you can expect to see an additional field with a cardholder authentication 
 [list of compatible payment gateways]: https://www.cardinalcommerce.com/partners/gateways
 [module]: https://glossary.magento.com/module
 [payment method]: https://glossary.magento.com/payment-method
-[app\code\AuthorizenetCardinal\Model\Checkout\ConfigProvider.php]: {{ site.mage2bloburl }}/{{page.guide_version}}/app/code/Magento/AuthorizenetCardinal/Model/Checkout/ConfigProvider.php#L19
+[app\code\AuthorizenetCardinal\Model\Checkout\ConfigProvider.php]: {{ site.mage2bloburl }}/{{page.guide_version}}/app/code/Magento/AuthorizenetCardinal/Model/Checkout/ConfigProvider.php
 [JWT]: https://en.wikipedia.org/wiki/JSON_Web_Token
 [API Reference]: https://cardinaldocs.atlassian.net/wiki/spaces/CC/pages/98315/Response+Objects
 [\Magento\AuthorizenetCardinal\Gateway\Request\Authorize3DSecureBuilder]: {{ site.mage2bloburl }}/{{page.guide_version}}/app/code/Magento/AuthorizenetCardinal/Gateway/Request/Authorize3DSecureBuilder.php

--- a/src/guides/v2.3/payments-integrations/payment-gateway/command-pool.md
+++ b/src/guides/v2.3/payments-integrations/payment-gateway/command-pool.md
@@ -22,7 +22,7 @@ implements `CommandPoolInterface` and takes a list of commands as an optional ar
 
 ## Command pool configuration for a particular provider
 
-Following is an example of the command pool configuring for the Braintree payment provider, and adding it to the provider's [payment method](https://glossary.magento.com/payment-method) configuration ([`app/code/Magento/Braintree/etc/di.xml`]({{ site.mage2bloburl }}/{{ page.guide_version }}/app/code/Magento/Braintree/etc/di.xml)).
+Following is an example of the command pool configuring for the Braintree payment provider, and adding it to the provider's [payment method](https://glossary.magento.com/payment-method) configuration ([`app/code/Magento/Braintree/etc/di.xml`]({{ site.mage2bloburl }}/2.3/app/code/Magento/Braintree/etc/di.xml)).
 
 ```xml
 ...

--- a/src/guides/v2.3/payments-integrations/payment-gateway/error-code-mapper.md
+++ b/src/guides/v2.3/payments-integrations/payment-gateway/error-code-mapper.md
@@ -25,7 +25,7 @@ Customers | `<module>/frontend`
 
 The files placed in the `adminhtml` and `frontend` directories ensure that customers and store administrators see only audience-specific messages. For example, a customer should see error messages when a credit card fails verification due to mis-entered data and similar reasons. The store's administrator should have more detailed descriptions of why an attempt to create an invoice or refund failed.
 
-The  [braintree_error_mapping.xml]({{ site.mage2bloburl }}/{{ page.guide_version }}/app/code/Magento/Braintree/etc/braintree_error_mapping.xml) file provides an example  collection:
+The  [braintree_error_mapping.xml]({{ site.mage2bloburl }}/2.3/app/code/Magento/Braintree/etc/braintree_error_mapping.xml) file provides an example  collection:
 
 ```xml
 <mapping xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="urn:magento:module:Magento_Payment:etc/error_mapping.xsd">
@@ -102,7 +102,7 @@ A response validator verifies response codes from the payment gateway.
 It has different responsibilities and should not map messages, because it works on the lower layer of communication between Magento and the payment gateway.
 It is the responsibility of a gateway command to call an appropriate service.
 
-For example, Magento provides a response validator for Braintree: [`\Magento\Braintree\Gateway\Validator\GeneralResponseValidator`]({{ site.mage2bloburl }}/{{ page.guide_version }}/app/code/Magento/Braintree/Gateway/Validator/GeneralResponseValidator.php).
+For example, Magento provides a response validator for Braintree: [`\Magento\Braintree\Gateway\Validator\GeneralResponseValidator`]({{ site.mage2bloburl }}/2.3/app/code/Magento/Braintree/Gateway/Validator/GeneralResponseValidator.php).
 Its implementation allows to retrieve errors codes from a response.
 
 First, create a new code provider. It can be a simple class with a public method that should return a list of error codes by the provided response:

--- a/src/guides/v2.3/payments-integrations/payment-gateway/gateway-command.md
+++ b/src/guides/v2.3/payments-integrations/payment-gateway/gateway-command.md
@@ -22,7 +22,7 @@ The `\Magento\Payment\Gateway\Command\GatewayCommand` class is the default `Comm
 
 For each particular integration with a payment provider, gateway commands are added using virtual types in [dependency injection (DI)]({{ page.baseurl }}/extension-dev-guide/depend-inj.html) configuration.
 
-In the following example the `BraintreeAuthorizeCommand` gateway command is added. The command implements the "authorize" operation for the Braintree payment provider ([`app/code/Magento/Braintree/etc/di.xml#131`]({{ site.mage2bloburl }}/{{ page.guide_version }}/app/code/Magento/Braintree/etc/di.xml#L131)):
+In the following example the `BraintreeAuthorizeCommand` gateway command is added. The command implements the "authorize" operation for the Braintree payment provider ([`app/code/Magento/Braintree/etc/di.xml#131`]({{ site.mage2bloburl }}/2.3/app/code/Magento/Braintree/etc/di.xml#L131)):
 
 ```xml
 <virtualType name="BraintreeAuthorizeCommand" type="Magento\Payment\Gateway\Command\GatewayCommand">

--- a/src/guides/v2.3/payments-integrations/payment-gateway/gateway-command.md
+++ b/src/guides/v2.3/payments-integrations/payment-gateway/gateway-command.md
@@ -22,7 +22,7 @@ The `\Magento\Payment\Gateway\Command\GatewayCommand` class is the default `Comm
 
 For each particular integration with a payment provider, gateway commands are added using virtual types in [dependency injection (DI)]({{ page.baseurl }}/extension-dev-guide/depend-inj.html) configuration.
 
-In the following example the `BraintreeAuthorizeCommand` gateway command is added. The command implements the "authorize" operation for the Braintree payment provider ([`app/code/Magento/Braintree/etc/di.xml#131`]({{ site.mage2bloburl }}/2.3/app/code/Magento/Braintree/etc/di.xml#L131)):
+In the following example the `BraintreeAuthorizeCommand` gateway command is added. The command implements the "authorize" operation for the Braintree payment provider ([`app/code/Magento/Braintree/etc/di.xml`]({{ site.mage2bloburl }}/2.3/app/code/Magento/Braintree/etc/di.xml)):
 
 ```xml
 <virtualType name="BraintreeAuthorizeCommand" type="Magento\Payment\Gateway\Command\GatewayCommand">

--- a/src/guides/v2.3/payments-integrations/payment-gateway/request-builder.md
+++ b/src/guides/v2.3/payments-integrations/payment-gateway/request-builder.md
@@ -25,7 +25,7 @@ The concatenation strategy is defined in the `BuilderComposite::merge()` method.
 
 Builder composites are added using [dependency injection]({{ page.baseurl }}/extension-dev-guide/depend-inj.html) in `di.xml`. A builder composite might comprise simple builders as well as other builder composites.
 
-Example of adding composite builders for the Braintree payment provider ([`app/code/Magento/Braintree/etc/di.xml`]({{ site.mage2bloburl }}/{{ page.guide_version }}/app/code/Magento/Braintree/etc/di.xml)):
+Example of adding composite builders for the Braintree payment provider ([`app/code/Magento/Braintree/etc/di.xml`]({{ site.mage2bloburl }}/2.3/app/code/Magento/Braintree/etc/di.xml)):
 
 {% highlight xml %}
 ...

--- a/src/guides/v2.3/payments-integrations/payment-gateway/response-handler.md
+++ b/src/guides/v2.3/payments-integrations/payment-gateway/response-handler.md
@@ -25,7 +25,7 @@ Basic interface for a response handler is [`Magento\Payment\Gateway\Response\Han
 
 ### Example
 
-Example of a simple response handler ([`app/code/Magento/Braintree/Gateway/Response/PayPalDetailsHandler.php`]({{ site.mage2bloburl }}/{{ page.guide_version }}/app/code/Magento/Braintree/Gateway/Response/PayPalDetailsHandler.php)):
+Example of a simple response handler ([`app/code/Magento/Braintree/Gateway/Response/PayPalDetailsHandler.php`]({{ site.mage2bloburl }}/2.3/app/code/Magento/Braintree/Gateway/Response/PayPalDetailsHandler.php)):
 
 ```php
 class PayPalDetailsHandler implements HandlerInterface

--- a/src/guides/v2.3/payments-integrations/vault/customer-stored-payments.md
+++ b/src/guides/v2.3/payments-integrations/vault/customer-stored-payments.md
@@ -84,7 +84,7 @@ class CardRenderer extends AbstractCardRenderer
 
 Next, you need to create the [layout](https://glossary.magento.com/layout) to be used for displaying token details. In this layout, specify the previously created token renderer.
 
-Example ([vault_cards_listaction.xml]({{ site.mage2bloburl }}/{{ page.guide_version }}/app/code/Magento/Braintree/view/frontend/layout/vault_cards_listaction.xml)):
+Example ([vault_cards_listaction.xml]({{ site.mage2bloburl }}/2.3/app/code/Magento/Braintree/view/frontend/layout/vault_cards_listaction.xml)):
 
 ```xml
 <page xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="urn:magento:framework:View/Layout/etc/page_configuration.xsd">

--- a/src/guides/v2.3/payments-integrations/vault/enabler.md
+++ b/src/guides/v2.3/payments-integrations/vault/enabler.md
@@ -23,7 +23,7 @@ The following paragraphs describe these points in details.
 
 Add the vault enabling controls to the payment form. In the following example, a checkbox bound to the Vault enabler is added.
 
-Example ([Magento/Braintree/view/frontend/web/template/payment/form.html]({{ site.mage2bloburl }}/{{ page.guide_version }}/app/code/Magento/Braintree/view/frontend/web/template/payment/form.html)):
+Example ([Magento/Braintree/view/frontend/web/template/payment/form.html]({{ site.mage2bloburl }}/2.3/app/code/Magento/Braintree/view/frontend/web/template/payment/form.html)):
 
 ```html
 <form id="co-transparent-form-braintree" class="form" data-bind="" method="post" action="#" novalidate="novalidate">
@@ -55,7 +55,7 @@ The payment component must process the state of the vault-enabling control and u
 
 Magento has a default vault enabler [UI component](https://glossary.magento.com/ui-component) (`Magento_Vault/js/view/payment/vault-enabler`). In the payment component, you just need to call its `visitAdditionalData` to update the `additional_data` property. The rest is done by the [`\Magento\Vault\Observer\VaultEnableAssigner`]({{ site.mage2bloburl }}/{{ page.guide_version }}/app/code/Magento/Vault/Observer/VaultEnableAssigner.php) observer.
 
-Example: [the Braintree payment UI component]({{ site.mage2bloburl }}/{{ page.guide_version }}/app/code/Magento/Braintree/view/frontend/web/js/view/payment/method-renderer/cc-form.js)
+Example: [the Braintree payment UI component]({{ site.mage2bloburl }}/2.3/app/code/Magento/Braintree/view/frontend/web/js/view/payment/method-renderer/cc-form.js)
 
 ```javascript
 define([

--- a/src/guides/v2.4/howdoi/checkout/checkout_payment.md
+++ b/src/guides/v2.4/howdoi/checkout/checkout_payment.md
@@ -231,7 +231,7 @@ If your [module](https://glossary.magento.com/module) adds several payment metho
 
 In your custom module directory create a new `<your_module_dir>/view/frontend/web/template/<your_template>.html` file. The template can use [Knockout JS](http://knockoutjs.com/) syntax. You can find a sample `.html` template in any module implementing payment methods, for example the Paypal module.
 
-The template for rendering the Paypal Express payment method in checkout is [`<Magento_Paypal_module_dir>/frontend/web/template/payment/paypal-express.html`]({{ site.mage2bloburl }}/{{ page.guide_version }}/app/code/Magento/Braintree/view/frontend/web/template/payment/paypal-express.html).
+The template for rendering the Paypal Express payment method in checkout is [`<Magento_Paypal_module_dir>/frontend/web/template/payment/paypal-express.html`]({{ site.mage2bloburl }}/{{ page.guide_version }}/app/code/Magento/Paypal/view/frontend/web/template/payment/paypal-express.html).
 
 ## Step 4: Declare the payment method in layout {#layout}
 


### PR DESCRIPTION
## Purpose of this pull request

This pull request (PR):

- Adds a banner message to the top of all pages in the **Payment Integrations Guide** (except the Cardinal Commerce 3-D Secure) announcing the removal of the Braintree module in Magento 2.4.0
- Updates links to the magento2 codebase to point to the 2.3 branch

See internal ticket MC-35126 for details and a link to an internal staging build.

## Affected DevDocs pages

Most topics under the [Payments Integration Guide](https://devdocs.magento.com/guides/v2.4/payments-integrations/bk-payments-integrations.html) (except [CardinalCommerce 3-D Secure](https://devdocs.magento.com/guides/v2.4/payments-integrations/cardinal/cardinal.html)).

whatsnew
Added a banner message to the top of all pages in the [Payments Integration Guide](https://devdocs.magento.com/guides/v2.4/payments-integrations/bk-payments-integrations.html) (except [CardinalCommerce 3-D Secure](https://devdocs.magento.com/guides/v2.4/payments-integrations/cardinal/cardinal.html)) announcing the removal of the Braintree module in Magento 2.4.0 and updated links to the Magento 2 codebase to point to the 2.3 branch.