### PR TITLE
Update extension compatibility for 2.4.0

### DIFF
--- a/src/_data/mde.yml
+++ b/src/_data/mde.yml
@@ -5,6 +5,7 @@ versions:
   - 2.3.3
   - 2.3.4
   - 2.3.5-p1
+  - 2.4.0
 extensions:
   -
     name: Amazon Sales Channel
@@ -17,7 +18,8 @@ extensions:
           2.3.2: supported
           2.3.3: supported
           2.3.4: supported
-          2.3.5-p1: supported 
+          2.3.5-p1: supported
+          2.4.0: supported
       -
         name: 4.0.0
         support:
@@ -26,7 +28,8 @@ extensions:
           2.3.2: compatible
           2.3.3: compatible
           2.3.4: compatible
-          2.3.5-p1: not supported     
+          2.3.5-p1: not supported
+          2.4.0: compatible
       -
         name: 3.0.1
         support:
@@ -36,6 +39,7 @@ extensions:
           2.3.3: compatible
           2.3.4: compatible
           2.3.5-p1: compatible
+          2.4.0: not supported
       -
         name: 3.0.0
         support:
@@ -45,6 +49,7 @@ extensions:
           2.3.3: compatible
           2.3.4: compatible
           2.3.5-p1: compatible
+          2.4.0: not supported
       -
         name: 2.0.0
         support:
@@ -54,9 +59,20 @@ extensions:
           2.3.3: compatible
           2.3.4: compatible
           2.3.5-p1: compatible
+          2.4.0: not supported
   -
     name: Magento Inventory
     versions:
+      -
+        name: 1.1.6
+        support:
+          2.3.0: compatible
+          2.3.1: compatible
+          2.3.2: compatible
+          2.3.3: compatible
+          2.3.4: compatible
+          2.3.5-p1: compatible
+          2.4.0: supported
       -
         name: 1.1.5
         support:
@@ -66,6 +82,7 @@ extensions:
           2.3.3: compatible
           2.3.4: compatible
           2.3.5-p1: supported
+          2.4.0: compatible
       -
         name: 1.1.4
         support:
@@ -75,6 +92,7 @@ extensions:
           2.3.3: compatible
           2.3.4: supported
           2.3.5-p1: compatible
+          2.4.0: compatible
       -
         name: 1.1.3
         support:
@@ -84,6 +102,7 @@ extensions:
           2.3.3: supported
           2.3.4: compatible
           2.3.5-p1: compatible
+          2.4.0: compatible
       -
         name: 1.1.2
         support:
@@ -93,6 +112,7 @@ extensions:
           2.3.3: compatible
           2.3.4: compatible
           2.3.5-p1: compatible
+          2.4.0: compatible
       -
         name: 1.1.1
         support:
@@ -102,6 +122,7 @@ extensions:
           2.3.3: compatible
           2.3.4: compatible
           2.3.5-p1: compatible
+          2.4.0: compatible
       -
         name: 1.1.0
         support:
@@ -111,9 +132,20 @@ extensions:
           2.3.3: compatible
           2.3.4: compatible
           2.3.5-p1: compatible
+          2.4.0: compatible
   -
     name: Page Builder
     versions:
+      - 
+        name: 1.4.0
+        support:
+          2.3.0: not supported
+          2.3.1: not supported
+          2.3.2: not supported
+          2.3.3: not supported
+          2.3.4: not supported
+          2.3.5-p1: not supported
+          2.4.0: supported
       -
         name: 1.3.1
         support:
@@ -123,6 +155,7 @@ extensions:
           2.3.3: not supported
           2.3.4: not supported
           2.3.5-p1: supported
+          2.4.0: not supported
       -
         name: 1.2.0
         support:
@@ -132,6 +165,7 @@ extensions:
           2.3.3: not supported
           2.3.4: supported
           2.3.5-p1: not supported
+          2.4.0: not supported
       -
         name: 1.1.0
         support:
@@ -141,6 +175,7 @@ extensions:
           2.3.3: supported
           2.3.4: not supported
           2.3.5-p1: not supported
+          2.4.0: not supported
       -
         name: 1.0.1
         support:
@@ -150,6 +185,7 @@ extensions:
           2.3.3: not supported
           2.3.4: not supported
           2.3.5-p1: not supported
+          2.4.0: not supported
       -
         name: 1.0.0
         support:
@@ -159,6 +195,7 @@ extensions:
           2.3.3: not supported
           2.3.4: not supported
           2.3.5-p1: not supported
+          2.4.0: not supported
   -
     name: Product Recommendations
     versions:
@@ -171,6 +208,7 @@ extensions:
           2.3.3: supported
           2.3.4: supported
           2.3.5-p1: supported
+          2.4.0: supported
       -
         name: 2.0.0
         support:
@@ -180,3 +218,4 @@ extensions:
           2.3.3: supported
           2.3.4: supported
           2.3.5-p1: supported
+          2.4.0: supported

--- a/src/_data/mde.yml
+++ b/src/_data/mde.yml
@@ -19,7 +19,7 @@ extensions:
           2.3.3: supported
           2.3.4: supported
           2.3.5-p1: supported
-          2.4.0: supported
+          2.4.0: not supported
       -
         name: 4.0.0
         support:
@@ -29,7 +29,7 @@ extensions:
           2.3.3: compatible
           2.3.4: compatible
           2.3.5-p1: not supported
-          2.4.0: compatible
+          2.4.0: not supported
       -
         name: 3.0.1
         support:

--- a/src/_data/vbe.yml
+++ b/src/_data/vbe.yml
@@ -5,10 +5,21 @@ versions:
   - 2.3.3
   - 2.3.4
   - 2.3.5-p1
+  - 2.4.0
 extensions:
   -
     name: Amazon
     versions:
+      -
+        name: 4.0.1
+        support:
+          2.3.0: not supported
+          2.3.1: not supported
+          2.3.2: not supported
+          2.3.3: not supported
+          2.3.4: not supported
+          2.3.5-p1: not supported
+          2.4.0: supported
       -
         name: 3.4.1
         support:
@@ -18,6 +29,7 @@ extensions:
           2.3.3: not supported
           2.3.4: not supported
           2.3.5-p1: supported
+          2.4.0: not supported
       -
         name: 3.3.1
         support:
@@ -27,6 +39,7 @@ extensions:
           2.3.3: not supported
           2.3.4: supported
           2.3.5-p1: not supported
+          2.4.0: not supported
       -
         name: 3.2.13
         support:
@@ -36,6 +49,7 @@ extensions:
           2.3.3: supported
           2.3.4: not supported
           2.3.5-p1: not supported
+          2.4.0: not supported
       -
         name: 3.2.9
         support:
@@ -45,6 +59,7 @@ extensions:
           2.3.3: not supported
           2.3.4: not supported
           2.3.5-p1: not supported
+          2.4.0: not supported
       -
         name: 3.1.4
         support:
@@ -54,6 +69,7 @@ extensions:
           2.3.3: not supported
           2.3.4: not supported
           2.3.5-p1: not supported
+          2.4.0: not supported
       -
         name: 3.0.0
         support:
@@ -63,9 +79,20 @@ extensions:
           2.3.3: not supported
           2.3.4: not supported
           2.3.5-p1: not supported
+          2.4.0: not supported
   -
     name: dotdigital
     versions:
+      -
+        name: 4.6.0
+        support:
+          2.3.0: not supported
+          2.3.1: not supported
+          2.3.2: not supported
+          2.3.3: not supported
+          2.3.4: not supported
+          2.3.5-p1: not supported
+          2.4.0: supported
       -
         name: 4.4.0
         support:
@@ -75,6 +102,7 @@ extensions:
           2.3.3: not supported
           2.3.4: not supported
           2.3.5-p1: supported
+          2.4.0: not supported
       -
         name: 4.1.0
         support:
@@ -84,6 +112,7 @@ extensions:
           2.3.3: not supported
           2.3.4: supported
           2.3.5-p1: not supported
+          2.4.0: not supported
       -
         name: 3.3.0
         support:
@@ -93,6 +122,7 @@ extensions:
           2.3.3: supported
           2.3.4: not supported
           2.3.5-p1: not supported
+          2.4.0: not supported
       -
         name: 3.1.2
         support:
@@ -102,6 +132,7 @@ extensions:
           2.3.3: not supported
           2.3.4: not supported
           2.3.5-p1: not supported
+          2.4.0: not supported
       -
         name: 3.1.1
         support:
@@ -111,6 +142,7 @@ extensions:
           2.3.3: not supported
           2.3.4: not supported
           2.3.5-p1: not supported
+          2.4.0: not supported
       -
         name: 3.0.1
         support:
@@ -120,9 +152,20 @@ extensions:
           2.3.3: not supported
           2.3.4: not supported
           2.3.5-p1: not supported
+          2.4.0: not supported
   -
     name: Klarna
     versions:
+      -
+        name: 8.0.0
+        support:
+          2.3.0: not supported
+          2.3.1: not supported
+          2.3.2: not supported
+          2.3.3: not supported
+          2.3.4: not supported
+          2.3.5-p1: not supported
+          2.4.0: supported
       -
         name: 7.5.0
         support:
@@ -132,6 +175,7 @@ extensions:
           2.3.3: not supported
           2.3.4: not supported
           2.3.5-p1: supported
+          2.4.0: not supported
       -
         name: 7.4.3
         support:
@@ -141,6 +185,7 @@ extensions:
           2.3.3: not supported
           2.3.4: supported
           2.3.5-p1: not supported
+          2.4.0: not supported
       -
         name: 7.3.5
         support:
@@ -150,6 +195,7 @@ extensions:
           2.3.3: supported
           2.3.4: not supported
           2.3.5-p1: not supported
+          2.4.0: not supported
       -
         name: 7.1.1
         support:
@@ -159,6 +205,7 @@ extensions:
           2.3.3: not supported
           2.3.4: not supported
           2.3.5-p1: not supported
+          2.4.0: not supported
       -
         name: 7.1.0
         support:
@@ -168,6 +215,7 @@ extensions:
           2.3.3: not supported
           2.3.4: not supported
           2.3.5-p1: not supported
+          2.4.0: not supported
       -
         name: 7.0.0
         support:
@@ -177,9 +225,20 @@ extensions:
           2.3.3: not supported
           2.3.4: not supported
           2.3.5-p1: not supported
+          2.4.0: not supported
   -
     name: Vertex
     versions:
+      -
+        name: 4.0.0
+        support:
+          2.3.0: not supported
+          2.3.1: not supported
+          2.3.2: not supported
+          2.3.3: not supported
+          2.3.4: not supported
+          2.3.5-p1: not supported
+          2.4.0: supported
       -
         name: 3.4.0
         support:
@@ -189,6 +248,7 @@ extensions:
           2.3.3: not supported
           2.3.4: not supported
           2.3.5-p1: supported
+          2.4.0: not supported
       -
         name: 3.3.0
         support:
@@ -198,6 +258,7 @@ extensions:
           2.3.3: not supported
           2.3.4: supported
           2.3.5-p1: not supported
+          2.4.0: not supported
       -
         name: 3.2.0
         support:
@@ -207,6 +268,7 @@ extensions:
           2.3.3: supported
           2.3.4: not supported
           2.3.5-p1: not supported
+          2.4.0: not supported
       -
         name: 3.1.0
         support:
@@ -216,6 +278,7 @@ extensions:
           2.3.3: not supported
           2.3.4: not supported
           2.3.5-p1: not supported
+          2.4.0: not supported
       -
         name: 3.0.0
         support:
@@ -225,9 +288,20 @@ extensions:
           2.3.3: not supported
           2.3.4: not supported
           2.3.5-p1: not supported
+          2.4.0: not supported
   -
     name: Yotpo
     versions:
+      -
+        name: 3.1.1
+        support:
+          2.3.0: not supported
+          2.3.1: not supported
+          2.3.2: not supported
+          2.3.3: not supported
+          2.3.4: not supported
+          2.3.5-p1: not supported
+          2.4.0: supported
       -
         name: 3.1.0
         support:
@@ -237,6 +311,7 @@ extensions:
           2.3.3: not supported
           2.3.4: not supported
           2.3.5-p1: supported
+          2.4.0: not supported
       -
         name: 3.0.1
         support:
@@ -246,6 +321,7 @@ extensions:
           2.3.3: not supported
           2.3.4: supported
           2.3.5-p1: not supported
+          2.4.0: not supported
       -
         name: 3.0.0
         support:
@@ -255,3 +331,4 @@ extensions:
           2.3.3: supported
           2.3.4: not supported
           2.3.5-p1: not supported
+          2.4.0: not supported


### PR DESCRIPTION
## Purpose of this pull request

This pull request (PR) updates Magento-developed extension (MDE) and vendor-bundled extension (VBE) compatibility for 2.4.0.

## Affected DevDocs pages

- https://devdocs.magento.com/release/#compatibility
- https://devdocs.magento.com/extensions/vendor/#compatibility

whatsnew
Updated [Magento-developed extension (MDE)](https://devdocs.magento.com/release/#compatibility) and [vendor-bundled extension (VBE)](https://devdocs.magento.com/extensions/vendor/#compatibility) compatibility for Magento 2.4.0.