### PR TITLE
Plugins - Fix link to $next

### DIFF
--- a/src/guides/v2.3/extension-dev-guide/plugins.md
+++ b/src/guides/v2.3/extension-dev-guide/plugins.md
@@ -364,7 +364,7 @@ With these methods:
 | **around**    |                  | aroundDispatch() |                  |
 | **after**     | afterDispatch()  | afterDispatch()  | afterDispatch()  |
 
-`PluginB`::`aroundDispatch()` defines the ($next)[{{ site.mage2bloburl }}/{{ page.guide_version }}/lib/internal/Magento/Framework/Interception/Interceptor.php] argument with a `callable` type. For example:
+`PluginB`::`aroundDispatch()` defines the [$next]({{ site.mage2bloburl }}/{{ page.guide_version }}/lib/internal/Magento/Framework/Interception/Interceptor.php) argument with a `callable` type. For example:
 
 ```php
 class PluginB


### PR DESCRIPTION
## Purpose of this pull request

This pull request (PR) fixes broken link to Magento/Framework/Interception/Interceptor

## Affected DevDocs pages

-  src/guides/v2.4/extension-dev-guide/plugins.md
