### PR TITLE
Add Edge to supported browsers page

### DIFF
--- a/src/_includes/browsers/supported-browsers-24.md
+++ b/src/_includes/browsers/supported-browsers-24.md
@@ -1,5 +1,6 @@
 Storefront and Admin:
 
+*  Microsoft Edge, latest–1
 *  Firefox latest, latest&ndash;1 (any operating system)
 *  Chrome latest, latest&ndash;1 (any operating system)
 *  Safari latest, latest&ndash;1 (Mac OS only)


### PR DESCRIPTION
## Purpose of this pull request

This pull request (PR) adds Edge to the list of supported browsers for 2.4.0, which was mistakenly removed in #7419. 

Fixes #7433 

## Affected DevDocs pages

- https://devdocs.magento.com/guides/v2.4/install-gde/system-requirements_browsers.html