### PR TITLE
GraphQL: Break links for files using cart-object.md file

### DIFF
--- a/src/guides/v2.4/graphql/mutations/add-bundle-products.md
+++ b/src/guides/v2.4/graphql/mutations/add-bundle-products.md
@@ -1,1 +1,248 @@
-../../../v2.3/graphql/mutations/add-bundle-products.md
+---
+group: graphql
+title: addBundleProductsToCart mutation
+contributor_name: Atwix
+contributor_link: https://www.atwix.com/
+---
+
+Use the `addBundleProductsToCart` mutation to add bundle products to a specific cart.
+
+## Syntax
+
+`mutation: {addBundleProductsToCart(input: AddBundleProductsToCartInput): {AddBundleProductsToCartOutput}}`
+
+## Example usage
+
+The following example uses a bundle product "Sprite Yoga Companion Kit" from Magento sample data.
+The SKU of this product is: **24-WG080**
+
+This example adds one bundle product with following children to the specified shopping cart:
+
+-  Sprite Stasis Ball 65 cm (x1)
+-  Sprite Foam Yoga Brick (x2)
+-  Sprite Yoga Strap 10 foot (x1)
+-  Sprite Foam Roller (x1)
+
+The `cart_id` used in this example was [generated]({{ page.baseurl }}/graphql/mutations/create-empty-cart.html) by creating an empty cart.
+
+**Request:**
+
+```graphql
+mutation {
+  addBundleProductsToCart(
+    input: {
+      cart_id: "wARFaDnHva0tgzuforUYR4rvXincj5eu"
+      cart_items: [
+      {
+        data: {
+          sku: "24-WG080"
+          quantity: 1
+        }
+        bundle_options: [
+          {
+            id: 1
+            quantity: 1
+            value: [
+              "2"
+            ]
+          },
+          {
+            id: 2
+            quantity: 2
+            value: [
+              "4"
+            ]
+          },
+          {
+            id: 3
+            quantity: 1
+            value: [
+              "7"
+            ]
+          },
+          {
+            id: 4
+            quantity: 1
+            value: [
+              "8"
+            ]
+          }
+        ]
+      },
+    ]
+  }) {
+    cart {
+      items {
+        id
+        quantity
+        product {
+          sku
+        }
+        ... on BundleCartItem {
+          bundle_options {
+            id
+            label
+            type
+            values {
+              id
+              label
+              price
+              quantity
+            }
+          }
+        }
+      }
+    }
+  }
+}
+```
+
+**Response:**
+
+```json
+{
+  "data": {
+    "addBundleProductsToCart": {
+      "cart": {
+        "items": [
+          {
+            "id": "7",
+            "quantity": 1,
+            "product": {
+              "sku": "24-WG080"
+            },
+            "bundle_options": [
+              {
+                "id": 1,
+                "label": "Sprite Stasis Ball",
+                "type": "radio",
+                "values": [
+                  {
+                    "id": 2,
+                    "label": "Sprite Stasis Ball 65 cm",
+                    "price": 27,
+                    "quantity": 1
+                  }
+                ]
+              },
+              {
+                "id": 2,
+                "label": "Sprite Foam Yoga Brick",
+                "type": "radio",
+                "values": [
+                  {
+                    "id": 4,
+                    "label": "Sprite Foam Yoga Brick",
+                    "price": 5,
+                    "quantity": 2
+                  }
+                ]
+              },
+              {
+                "id": 3,
+                "label": "Sprite Yoga Strap",
+                "type": "radio",
+                "values": [
+                  {
+                    "id": 7,
+                    "label": "Sprite Yoga Strap 10 foot",
+                    "price": 21,
+                    "quantity": 1
+                  }
+                ]
+              },
+              {
+                "id": 4,
+                "label": "Sprite Foam Roller",
+                "type": "radio",
+                "values": [
+                  {
+                    "id": 8,
+                    "label": "Sprite Foam Roller",
+                    "price": 19,
+                    "quantity": 1
+                  }
+                ]
+              }
+            ]
+          }
+        ]
+      }
+    }
+  }
+}
+```
+
+## Input attributes
+
+The top-level `AddBundleProductsToCartInput` object is listed first. All interfaces and child objects are listed in alphabetical order.
+
+### AddBundleProductsToCartInput object
+
+The `AddBundleProductsToCartInput` object contains the following attributes:
+
+Attribute | Type | Description
+--- | --- | ---
+`cart_id` | String! | The unique ID that identifies the customer's cart
+`cart_items` | [[BundleProductCartItemInput!]!](#bundleProductCartItemInput) | An array of bundle items to add to the cart
+
+### BundleProductCartItemInput object {#bundleProductCartItemInput}
+
+The `BundleProductCartItemInput` object contains the following attributes:
+
+Attribute | Type | Description
+--- | --- | ---
+`bundle_options` | [[BundleOptionInput!]!](#bundleOptionInput) | An object that contains an array of options of the bundle product with the chosen value and quantity of each option
+`customizable_options` | [[CustomizableOptionInput!]](#customOptionInput) | An object that contains the ID and value of the product
+`data` | [CartItemInput!](#cartItemInput) | An object that contains the quantity and SKU of the bundle product
+
+### BundleOptionInput object {#bundleOptionInput}
+
+The `BundleOptionInput` object contains the following attributes:
+
+Attribute | Type | Description
+--- | --- | ---
+`id` | Int! | ID of the option
+`quantity` | Float! | The number of a specific child item to add to the cart
+`value` | [String!]! | An array with the chosen value of the option
+
+### CartItemInput object {#cartItemInput}
+
+The `CartItemInput` object contains the following attributes:
+
+Attribute | Type | Description
+--- | --- | ---
+`quantity` | Float! | The number of items to add to the cart
+`sku` | String! | The SKU of the product
+
+### CustomizableOptionInput object {#customOptionInput}
+
+The `CustomizableOptionInput` object must contain the following attributes:
+
+{% include graphql/customizable-option-input.md %}
+
+## Output attributes
+
+The `AddBundleProductsToCartOutput` object contains the `Cart` object.
+
+Attribute |  Data Type | Description
+--- | --- | ---
+`cart` |[Cart!](#CartObject) | Describes the contents of the specified shopping cart
+
+### Cart object {#CartObject}
+
+{% include graphql/cart-object.md %}
+
+[Cart query output]({{page.baseurl}}/graphql/queries/cart.html#cart-output) provides more information about the `Cart` object.
+
+## Errors
+
+Error | Description
+--- | ---
+`Could not find a product with SKU "XXX"` | A simple product with the SKU specified in the `data.sku` argument does not exist.
+`Could not find a cart with ID "XXX"` | The specified `cart_id` value does not exist in the `quote_id_mask` database table.
+`Required parameter "cart_id" is missing` | The `cart_id` argument is omitted or contains an empty value.
+
+## Related topics
+
+-  [Bundle product data types]({{page.baseurl}}/graphql/product/bundle-product.html)

--- a/src/guides/v2.4/graphql/mutations/add-configurable-products.md
+++ b/src/guides/v2.4/graphql/mutations/add-configurable-products.md
@@ -1,1 +1,148 @@
-../../../v2.3/graphql/mutations/add-configurable-products.md
+---
+group: graphql
+title: addConfigurableProductsToCart mutation
+---
+
+Use the `addConfigurableProductsToCart` mutation to add configurable products to a specific cart.
+
+## Syntax
+
+`mutation: {addConfigurableProductsToCart(input: AddConfigurableProductsToCartInput) {AddConfigurableProductsToCartOutput}}`
+
+## Example usage
+
+The following example adds two black Teton Pullover Hoodies size extra-small to the specified shopping cart. The `cart_id` used in this example was [generated]({{ page.baseurl }}/graphql/mutations/create-empty-cart.html) by creating an empty cart.
+
+**Request:**
+
+```graphql
+mutation {
+  addConfigurableProductsToCart(
+    input: {
+      cart_id: "4JQaNVJokOpFxrykGVvYrjhiNv9qt31C"
+      cart_items: [
+        {
+          parent_sku: "MH02"
+          data: {
+            quantity: 2
+            sku: "MH02-XS-Black"
+          }
+        }
+      ]
+    }
+  ) {
+    cart {
+      items {
+        id
+        quantity
+        product {
+          name
+          sku
+        }
+        ... on ConfigurableCartItem {
+          configurable_options {
+            option_label
+          }
+        }
+      }
+    }
+  }
+}
+```
+
+**Response:**
+
+```json
+{
+  "data": {
+    "addConfigurableProductsToCart": {
+      "cart": {
+        "items": [
+          {
+            "id": "5",
+            "quantity": 2,
+            "product": {
+              "name": "Teton Pullover Hoodie",
+              "sku": "MH02"
+            },
+            "configurable_options": [
+              {
+                "option_label": "Color"
+              },
+              {
+                "option_label": "Size"
+              }
+            ]
+          }
+        ]
+      }
+    }
+  }
+}
+```
+
+## Input attributes
+
+### AddConfigurableProductsToCartInput object
+
+The `AddConfigurableProductsToCartInput` object contains the following attributes:
+
+Attribute | Type | Description
+--- | --- | ---
+`cart_id` | String! | The unique ID that identifies the customer's cart
+`cart_items` | [[ConfigurableProductCartItemInput]](#configProdCartItemInput) | An array of configurable items to add to the cart
+
+### ConfigurableProductCartItemInput object {#configProdCartItemInput}
+
+The `ConfigurableProductCartItemInput` object contains the following attributes:
+
+Attribute | Type | Description
+--- | --- | ---
+`customizable_options` | [CustomizableOptionInput](#customOptionInput) | An object that contains the ID and value of the product
+`data` | [CartItemInput!](#cartItemInput) | An object that contains the quantity and SKU of the configurable product
+`parent_sku` | String | The SKU of the simple product's parent configurable product. If you do not specify this attribute, Magento treats the product being added to the cart as a simple product
+`variant_sku` | String | Deprecated. Use `CartItemInput.sku` instead. The SKU of the simple product
+
+### CustomizableOptionInput object {#customOptionInput}
+
+The `CustomizableOptionInput` object contains the following attributes:
+
+Attribute | Type | Description
+--- | --- | ---
+`id` | Int | The ID of the customizable option
+`value` | String | The value of the customizable option. For example, if color was the customizable option, a possible value could be `black`
+
+### CartItemInput object {#cartItemInput}
+
+The `CartItemInput` object must contain the following attributes:
+
+{% include graphql/cart-item-input.md %}
+
+## Output attributes
+
+The `AddConfigurableProductsToCartOutput` object contains the `Cart` object.
+
+Attribute |  Data Type | Description
+--- | --- | ---
+`cart` |[Cart!](#CartObject) | Describes the contents of the specified shopping cart
+
+### Cart object {#CartObject}
+
+{% include graphql/cart-object.md %}
+
+[Cart query output]({{page.baseurl}}/graphql/queries/cart.html#cart-output) provides more information about the `Cart` object.
+
+## Errors
+
+Error | Description
+--- | ---
+`Could not add the product with SKU configurable to the shopping cart: The product that was requested doesn't exist. Verify the product and try again.` | The simple product with the SKU specified in the `data`.`sku` attribute does not exist.
+`Could not find a product with SKU "XXX"` | The configurable product with SKU specified in the `parent_sku` argument does not exist.
+`Could not find specified product.` | The simple product specified in the `data`.`sku` argument is not assigned to the configurable product provided in the `parent_sku` attribute.
+`Required parameter "cart_id" is missing` | The `cart_id` argument was omitted or contains an empty value.
+`Required parameter "email" is missing` | The `email` argument was omitted or contains an empty value.
+`The requested qty is not available` | The requested quantity specified `data`.`quantity` is not available.
+
+## Related topics
+
+-  [Configurable product data types]({{page.baseurl}}/graphql/product/configurable-product.html)

--- a/src/guides/v2.4/graphql/mutations/add-downloadable-products.md
+++ b/src/guides/v2.4/graphql/mutations/add-downloadable-products.md
@@ -1,1 +1,263 @@
-../../../v2.3/graphql/mutations/add-downloadable-products.md
+---
+group: graphql
+title: addDownloadableProductsToCart mutation
+contributor_name: Atwix
+contributor_link: https://www.atwix.com/
+---
+
+A downloadable product can be anything that you can deliver as a file, such as an eBook, music, video, software application, or an update. To add a downloadable product to a cart, you must provide the cart ID, the SKU, and the quantity. In some cases, you must include the IDs for downloadable product links. You can also optionally specify customizable options.
+
+## Syntax
+
+```graphql
+mutation: {
+    addDownloadableProductsToCart(
+        input: AddDownloadableProductsToCartInput
+    ): {
+        AddDownloadableProductsToCartOutput
+    }
+}
+```
+
+## Example usage
+
+The following examples show how to add a downloadable product to a shopping cart , depending on whether the **Links can be purchased separately** option is selected on the **Downloadable Information** section of the product page.
+
+### Add a downloadable product to a cart with `Links can be purchased separately` enabled
+
+The following example shows how to add a downloadable product in which the **Links can be purchased separately** option is enabled. The payload includes custom downloadable links `Episode 2` and `Episode 3`.
+
+**Request:**
+
+```graphql
+mutation {
+  addDownloadableProductsToCart(
+    input: {
+      cart_id: "gMV2BFQuNGiQmTnepQlMGko7Xc4P3X1w"
+      cart_items: {
+        data: {
+          sku: "240-LV09"
+          quantity: 1
+        }
+        downloadable_product_links: [
+          {
+            link_id: 7                 # Episode 2
+          }
+          {
+            link_id: 8                 # Episode 3
+          }
+        ]
+      }
+    }
+  ) {
+    cart {
+      items {
+        product {
+          sku
+        }
+        quantity
+        ... on DownloadableCartItem {
+          links {
+            title
+            price
+          }
+          samples {
+            title
+            sample_url
+          }
+        }
+      }
+    }
+  }
+}
+```
+
+**Response:**
+
+```text
+{
+  "data": {
+    "addDownloadableProductsToCart": {
+      "cart": {
+        "items": [
+          {
+            "product": {
+              "sku": "240-LV09"
+            },
+            "quantity": 1,
+            "links": [
+              {
+                "title": "Episode 2",
+                "price": 9
+              },
+              {
+                "title": "Episode 3",
+                "price": 9
+              }
+            ],
+            "samples": [
+              {
+                "title": "Trailer #1",
+                "sample_url": "https://<M2_INSTANCE>/downloadable/download/sample/sample_id/16/"
+              },
+              {
+                "title": "Trailer #2",
+                "sample_url": "https://<M2_INSTANCE>/downloadable/download/sample/sample_id/17/"
+              },
+              {
+                "title": "Trailer #3",
+                "sample_url": "https://<M2_INSTANCE>/downloadable/download/sample/sample_id/18/"
+              }
+            ]
+          }
+        ]
+      }
+    }
+  }
+}
+```
+
+### Add a downloadable product to a cart with disabled `Links can be purchased separately`
+
+The following example shows how to add a downloadable product in which the **Links can be purchased separately** option is disabled. All downloadable links are added to the cart automatically.
+
+**Request:**
+
+```graphql
+mutation {
+  addDownloadableProductsToCart(
+    input: {
+      cart_id: "gMV2BFQuNGiQmTnepQlMGko7Xc4P3X1w"
+      cart_items: {
+        data: {
+          sku: "240-LV07"
+          quantity: 1
+        }
+      }
+    }
+  ) {
+    cart {
+      items {
+        product {
+          sku
+        }
+        quantity
+        ... on DownloadableCartItem {
+          links {
+            title
+            price
+          }
+          samples {
+            title
+            sample_url
+          }
+        }
+      }
+    }
+  }
+}
+```
+
+**Response:**
+
+```text
+{
+  "data": {
+    "addDownloadableProductsToCart": {
+      "cart": {
+        "items": [
+          {
+            "product": {
+              "sku": "240-LV07"
+            },
+            "quantity": 2,
+            "links": [
+              {
+                "title": "Solo Power Circuit",
+                "price": 14
+              }
+            ],
+            "samples": [
+              {
+                "title": "Trailer #1",
+                "sample_url": "https://<M2_INSTANCE>/downloadable/download/sample/sample_id/10/"
+              },
+              {
+                "title": "Trailer #2",
+                "sample_url": "https://<M2_INSTANCE>/downloadable/download/sample/sample_id/11/"
+              },
+              {
+                "title": "Trailer #3",
+                "sample_url": "https://<M2_INSTANCE>/downloadable/download/sample/sample_id/12/"
+              }
+            ]
+          }
+        ]
+      }
+    }
+  }
+}
+```
+
+## Input attributes
+
+The top-level `AddDownloadableProductsToCartInput` object is listed first. All child objects are listed in alphabetical order.
+
+### AddDownloadableProductsToCartInput object {#AddDownloadableProductsToCartInput}
+
+The `AddDownloadableProductsToCartInput` object must contain the following attributes:
+
+Attribute |  Data Type | Description
+--- | --- | ---
+`cart_id` | String! | The unique ID that identifies the customer's cart
+`cart_items` | [[DownloadableProductCartItemInput!]!](#DownloadableProductCartItemInput) | Contains the cart item IDs and quantity of each item
+
+### CartItemInput object {#CartItemInputVirtual}
+
+The `CartItemInput` object must contain the following attributes:
+
+{% include graphql/cart-item-input.md %}
+
+### CustomizableOptionInput object {#CustomizableOptionInputVirtual}
+
+The `CustomizableOptionInput` object must contain the following attributes:
+
+{% include graphql/customizable-option-input.md %}
+
+### DownloadableProductCartItemInput object {#DownloadableProductCartItemInput}
+
+The `DownloadableProductCartItemInput` object can contain the following attribute:
+
+Attribute |  Data Type | Description
+--- | --- | ---
+`customizable_options` |[[CustomizableOptionInput!]](#CustomizableOptionInputVirtual) | An array that defines customizable options for the product
+`data` | [CartItemInput!](#CartItemInputVirtual) | Required. An object containing the `sku` and `quantity` of the product
+`downloadable_product_links` | [[DownloadableProductLinksInput!]](#DownloadableProductLinksInput) | An object containing the `link_id` of the downloadable product link
+
+### DownloadableProductLinksInput object {#DownloadableProductLinksInput}
+
+If specified, the `DownloadableProductLinksInput` object must contain the following attribute.
+
+Attribute |  Data Type | Description
+--- | --- | ---
+`link_id` | Int! | A unique ID (`downloadable_link`.`link_id`) of the downloadable product link
+
+## Output attributes
+
+The `AddDownloadableProductsToCartOutput` object contains the `Cart` object.
+
+Attribute |  Data Type | Description
+--- | --- | ---
+`cart` |[Cart!](#CartObject) | Describes the contents of the specified shopping cart
+
+### Cart object {#CartObject}
+
+{% include graphql/cart-object.md %}
+
+## Errors
+
+Error | Description
+--- | ---
+`Required parameter "cart_id" is missing` | The mutation does not contain a `cart_id` argument.
+`Required parameter "cart_items" is missing` | The `cart_items` argument is empty or is not of type `array`.
+`Please specify product link(s).` | You tried to add a downloadable product in which the `Links can be purchased separately` option is enabled, but you did not specify individual product links.

--- a/src/guides/v2.4/graphql/mutations/add-simple-products.md
+++ b/src/guides/v2.4/graphql/mutations/add-simple-products.md
@@ -1,1 +1,282 @@
-../../../v2.3/graphql/mutations/add-simple-products.md
+---
+group: graphql
+title: addSimpleProductsToCart mutation
+redirect from:
+  - /guides/v2.3/graphql/reference/quote-add-simple-products.html
+---
+
+The `addSimpleProductsToCart` mutation allows you to add any number of simple and group products to the cart at the same time.
+
+Simple products are physical products that do not have variations, such as color, size, or price. Group products are a set of simple standalone products that are assigned a unique SKU and are presented as a group. Each product in the group is purchased as a separate item.
+
+To add a simple or grouped product to a cart, you must provide the cart ID, the SKU, and the quantity. You can also optionally provide customizable options.
+
+## Syntax
+
+`mutation: {addSimpleProductsToCart(input: AddSimpleProductsToCartInput): {AddSimpleProductsToCartOutput}}`
+
+## Example usage
+
+These examples show the minimal payload and a payload that includes customizable options.
+
+### Add a simple product to a cart
+
+The following example adds a simple product to a cart. The response contains the entire contents of the customer's cart.
+
+**Request:**
+
+```graphql
+mutation {
+  addSimpleProductsToCart(
+    input: {
+      cart_id: "IeTUiU0oCXjm0uRqGCOuhQ2AuQatogjG"
+      cart_items: [
+        {
+          data: {
+            quantity: 1
+            sku: "24-MB04"
+          }
+        }
+      ]
+    }
+  ) {
+    cart {
+      items {
+        id
+        product {
+          name
+          sku
+        }
+        quantity
+      }
+    }
+  }
+}
+```
+
+**Response:**
+
+```json
+{
+  "data": {
+    "addSimpleProductsToCart": {
+      "cart": {
+        "items": [
+          {
+            "id": "13",
+            "product": {
+              "name": "Strive Shoulder Pack",
+              "sku": "24-MB04"
+            },
+            "quantity": 1
+          }
+        ]
+      }
+    }
+  }
+}
+```
+
+### Add a simple product with customizable options to a cart
+
+If a product has a customizable option, you can specify the option's value in the `addSimpleProductsToCart` request.
+
+**Request:**
+
+```graphql
+mutation {
+  addSimpleProductsToCart (input: {
+    cart_id: "IeTUiU0oCXjm0uRqGCOuhQ2AuQatogjG",
+    cart_items: {
+      data: {
+        sku: "simple"
+        quantity: 1
+      },
+      customizable_options: [
+        {
+          id: 121
+          value_string: "field value"
+        }
+      ]
+    }
+  }) {
+    cart {
+      items {
+        product {
+           name
+        }
+        quantity
+        ... on SimpleCartItem {
+          customizable_options {
+            label
+            values {
+              value
+            }
+          }
+        }
+      }
+    }
+  }
+}
+```
+
+**Response:**
+
+```text
+{
+  "data": {
+    "addSimpleProductsToCart": {
+      "cart": {
+        "items": [
+          {
+            "product": {
+              "name": "simple"
+            },
+            "quantity": 1,
+            "customizable_options": [
+              {
+                "label": "Field Option",
+                "values": [
+                  {
+                    "value": "field value"
+                  }
+                ]
+              }
+            ]
+          }
+        ]
+      }
+    }
+  }
+}
+```
+### Add a grouped product to a cart
+
+The following example adds a grouped product (`Workout-Kit`) to a cart. The grouped product contains three simple products.
+
+**Request:**
+
+```graphql
+mutation {
+  addSimpleProductsToCart(
+    input: {
+      cart_id: "IeTUiU0oCXjm0uRqGCOuhQ2AuQatogjG"
+      cart_items: [
+        {
+          data: {
+            quantity: 1
+            sku: "Workout-Kit"
+          }
+        }
+      ]
+    }
+  ) {
+    cart {
+      items {
+        id
+        product {
+          name
+          sku
+        }
+        quantity
+      }
+    }
+  }
+}
+```
+
+**Response:**
+
+```json
+{
+  "data": {
+    "addSimpleProductsToCart": {
+      "cart": {
+        "items": [
+          {
+            "id": "5",
+            "product": {
+              "name": "Go-Get'r Pushup Grips",
+              "sku": "24-UG05"
+            },
+            "quantity": 1
+          },
+          {
+            "id": "6",
+            "product": {
+              "name": "Dual Handle Cardio Ball",
+              "sku": "24-UG07"
+            },
+            "quantity": 1
+          },
+          {
+            "id": "7",
+            "product": {
+              "name": "Harmony Lumaflex&trade; Strength Band Kit ",
+              "sku": "24-UG03"
+            },
+            "quantity": 1
+          }
+        ]
+      }
+    }
+  }
+}
+```
+
+## Input attributes
+
+The top-level `AddSimpleProductsToCartInput` object is listed first. All child objects are listed in alphabetical order.
+
+### AddSimpleProductsToCartInput object {#AddSimpleProductsToCartInput}
+
+The `AddSimpleProductsToCartInput` object must contain the following attributes:
+
+Attribute |  Data Type | Description
+--- | --- | ---
+`cart_id` | String! | The unique ID that identifies the customer's cart
+`cart_items` | [SimpleProductCartItemInput!](#SimpleProductCartItemInput) | Contains the cart item IDs and quantity of each item
+
+### CartItemInput object {#CartItemInputSimple}
+
+The `CartItemInput` object must contain the following attributes:
+
+{% include graphql/cart-item-input.md %}
+
+### CustomizableOptionInput object {#CustomizableOptionInputSimple}
+
+The `CustomizableOptionInput` object must contain the following attributes:
+
+{% include graphql/customizable-option-input.md %}
+
+### SimpleProductCartItemInput object {#SimpleProductCartItemInput}
+
+The `SimpleProductCartItemInput` object must contain the following attributes:
+
+`customizable_options` |[[CustomizableOptionInputSimple]](#CustomizableOptionInputSimple) | An array that defines customizable options for the product
+`data` | [CartItemInput!](#CartItemInputSimple) | An object containing the `sku` and `quantity` of the product.
+
+## Output attributes
+
+The `AddSimpleProductsToCartOutput` object contains the `Cart` object.
+
+Attribute |  Data Type | Description
+--- | --- | ---
+`cart` |[Cart!](#CartObject) | Describes the contents of the specified shopping cart
+
+### Cart object {#CartObject}
+
+{% include graphql/cart-object.md %}
+
+[Cart query output]({{page.baseurl}}/graphql/queries/cart.html#cart-output) provides more information about the `Cart` object.
+
+## Errors
+
+Error | Description
+--- | ---
+`Could not find a cart with ID "XXX"` | The specified `cart_id` value does not exist in the `quote_id_mask` table.
+`Could not find a product with SKU "YYY"` | A simple product with the SKU specified in the `data`.`sku` argument does not exist.
+`Required parameter "cart_id" is missing` | The `cart_id` argument was omitted or contains an empty value.
+`Required parameter "cart_items" is missing` | The `cart_items` argument was omitted or contains an empty value.
+`The current user cannot perform operations on cart XXX` | An unauthorized user (guest) tried to add the product into a customer's cart, or an authorized user (customer) tried to add the product into the cart of another customer.
+`The product's required option(s) weren't entered. Make sure the options are entered and try again.` | A simple product has customizable options that were not specified in the mutation, but are required for adding the product into the cart.

--- a/src/guides/v2.4/graphql/mutations/add-virtual-products.md
+++ b/src/guides/v2.4/graphql/mutations/add-virtual-products.md
@@ -1,1 +1,140 @@
-../../../v2.3/graphql/mutations/add-virtual-products.md
+---
+group: graphql
+title: addVirtualProductsToCart mutation
+redirect from:
+  - /guides/v2.3/graphql/reference/quote-add-virtual-products.html
+---
+
+A virtual product represents a saleable item that is not physical, such as a membership, service, warranty, or subscription. Virtual products do not need to be shipped or downloaded, nor do they require stock management.
+
+The `addVirtualProductsToCart` mutation allows you to add multiple virtual products to the cart at the same time, but you cannot add other product types with this mutation. To add a virtual product to a cart, you must provide the cart ID, the SKU, and the quantity. You can also optionally provide customizable options.
+
+## Syntax
+
+`mutation: {addVirtualProductsToCart(input: AddVirtualProductsToCartInput): {AddVirtualProductsToCartOutput}}`
+
+## Example usage
+
+The Luma sample data does not include any virtual products. The following example requires that you create a virtual product with the `sku` value of `Membership-Gold` with a price of $49.99.
+
+**Request:**
+
+```text
+
+mutation {
+  addVirtualProductsToCart(
+    input: {
+      cart_id: "IeTUiU0oCXjm0uRqGCOuhQ2AuQatogjG",
+      cart_items: [
+        {
+          data: {
+            quantity: 1
+            sku: "Membership-Gold"
+          }
+        }
+       ]
+    }
+  ) {
+    cart {
+      items {
+        product {
+          name
+        }
+        quantity
+      }
+      prices {
+        grand_total {
+          value
+          currency
+        }
+      }
+    }
+  }
+}
+```
+
+**Response:**
+
+```json
+{
+  "data": {
+    "addVirtualProductsToCart": {
+      "cart": {
+        "items": [
+          {
+            "product": {
+              "name": "Gold Membership"
+            },
+            "quantity": 1
+          }
+        ],
+        "prices": {
+          "grand_total": {
+            "value": 49.99,
+            "currency": "USD"
+          }
+        }
+      }
+    }
+  }
+}
+```
+
+## Input attributes
+
+The top-level `AddVirtualProductsToCartInput` object is listed first. All child objects are listed in alphabetical order.
+
+### AddVirtualProductsToCartInput object {#AddVirtualProductsToCartInput}
+
+The `AddVirtualProductsToCartInput` object must contain the following attributes:
+
+Attribute |  Data Type | Description
+--- | --- | ---
+`cart_id` | String! | The unique ID that identifies the customer's cart
+`cart_items` | [VirtualProductCartItemInput!](#VirtualProductCartItemInput) | Contains the cart item IDs and quantity of each item
+
+### CartItemInput object {#CartItemInputVirtual}
+
+The `CartItemInput` object must contain the following attributes:
+
+{% include graphql/cart-item-input.md %}
+
+### CustomizableOptionInput object {#CustomizableOptionInputVirtual}
+
+The `CustomizableOptionInput` object must contain the following attributes:
+
+{% include graphql/customizable-option-input.md %}
+
+### VirtualProductCartItemInput object {#VirtualProductCartItemInput}
+
+The `VirtualProductCartItemInput` object must contain the following attributes:
+
+Attribute |  Data Type | Description
+--- | --- | ---
+`customizable_options` |[[CustomizableOptionInput]](#CustomizableOptionInputVirtual) | An array that defines customizable options for the product
+`data` | [CartItemInput!](#CartItemInputVirtual) | An object containing the `sku` and `quantity` of the product
+
+## Output attributes
+
+The `AddVirtualProductsToCartOutput` object contains the `Cart` object.
+
+Attribute |  Data Type | Description
+--- | --- | ---
+`cart` |[Cart!](#CartObject) | Describes the contents of the specified shopping cart
+
+### Cart object {#CartObject}
+
+{% include graphql/cart-object.md %}
+
+[Cart query output]({{page.baseurl}}/graphql/queries/cart.html#cart-output) provides more information about the `Cart` object.
+
+## Errors
+
+Error | Description
+--- | ---
+`Could not find a cart with ID "XXX"` | The specified `cart_id` value does not exist in the `quote_id_mask` table.
+`Could not find a product with SKU "YYY"` | A virtual product with the SKU specified in the `data`.`sku` argument does not exist.
+`Required parameter "cart_id" is missing` | The `cart_id` argument was omitted or contains an empty value.
+`Required parameter "cart_items" is missing` | The `cart_items` argument was omitted or contains an empty value.
+`The current user cannot perform operations on cart XXX` | An unauthorized user (guest) tried to add the product into a customer's cart, or an authorized user (customer) tried to add the product into the cart of another customer.
+`The product's required option(s) weren't entered. Make sure the options are entered and try again.` | A virtual product has customizable options that were not specified in the mutation, but are required for adding the product into the cart.

--- a/src/guides/v2.4/graphql/mutations/apply-coupon.md
+++ b/src/guides/v2.4/graphql/mutations/apply-coupon.md
@@ -1,1 +1,127 @@
-../../../v2.3/graphql/mutations/apply-coupon.md
+---
+group: graphql
+title: applyCouponToCart mutation
+redirect from:
+  - /guides/v2.3/graphql/reference/quote-apply-coupon.html
+---
+
+The `applyCouponToCart` mutation applies a pre-defined coupon code to the specified cart. Valid coupon codes are defined in cart price rules.
+
+## Syntax
+
+`mutation: {applyCouponToCart(input: ApplyCouponToCartInput) {ApplyCouponToCartOutput}}`
+
+## Example usage
+
+The following example applies the coupon code `H2O` to the cart. For this coupon to be valid, the Affirm Water Bottle (`sku`: 24-UG06) must be in the cart.
+
+**Request:**
+
+``` text
+mutation {
+  applyCouponToCart(
+    input: {
+      cart_id: "IeTUiU0oCXjm0uRqGCOuhQ2AuQatogjG",
+      coupon_code: "H20"
+    }
+  ) {
+    cart {
+      items {
+        product {
+          name
+        }
+        quantity
+      }
+      applied_coupons {
+        code
+      }
+      prices {
+        grand_total{
+          value
+          currency
+        }
+      }
+    }
+  }
+}
+```
+
+**Response:**
+
+```json
+{
+  "data": {
+    "applyCouponToCart": {
+      "cart": {
+        "items": [
+          {
+            "product": {
+              "name": "Gold Membership"
+            },
+            "quantity": 2
+          },
+          {
+            "product": {
+              "name": "Strive Shoulder Pack"
+            },
+            "quantity": 1
+          },
+          {
+            "product": {
+              "name": "Affirm Water Bottle "
+            },
+            "quantity": 1
+          }
+        ],
+        "applied_coupons": {
+          "code": "H20"
+        },
+        "prices": {
+          "grand_total": {
+            "value": 134.08,
+            "currency": "USD"
+          }
+        }
+      }
+    }
+  }
+}
+```
+
+## Input attributes
+
+The `applyCouponToCart` mutation requires the `cart_id` and `coupon_code`.
+
+### ApplyCouponToCartInput object {#ApplyCouponToCartInput}
+
+The `ApplyCouponToCartInput` object must contain the following attributes:
+
+Attribute |  Data Type | Description
+--- | --- | ---
+`cart_id` | String! | The unique ID that identifies the customer's cart
+`coupon_code` | String! | A valid coupon code
+
+## Output attributes
+
+The `ApplyCouponToCartOutput` object contains the `Cart` object.
+
+Attribute |  Data Type | Description
+--- | --- | ---
+`cart` |[Cart!](#CartObject) | Describes the contents of the specified shopping cart
+
+### Cart object {#CartObject}
+
+{% include graphql/cart-object.md %}
+
+[Cart query output]({{page.baseurl}}/graphql/queries/cart.html#cart-output) provides more information about the `Cart` object.
+
+## Errors
+
+Error | Description
+--- | ---
+`A coupon is already applied to the cart. Please remove it to apply another` | The value specified in the `coupon_code` argument has already applied to cart. Use [removeCouponFromCart]({{page.baseurl}}/graphql/mutations/remove-coupon.html) to remove the current coupon and to apply another.
+`Cart does not contain products.` | The coupon cannot be applied to an empty cart.
+`Could not find a cart with ID "XXX"` | The specified `cart_id` value does not exist in the `quote_id_mask` table.
+`Required parameter "coupon_code" is missing` | The required `coupon_code` argument contains an empty value.
+`The coupon code isn't valid. Verify the code and try again.` | The entered coupon code is not applicable. Check the existing shopping cart price rules for details.
+`The current user cannot perform operations on cart XXX` | An unauthorized user (guest) tried to add the product into a customer's cart, or an authorized user (customer) tried to add the product into the cart of another customer.

--- a/src/guides/v2.4/graphql/mutations/apply-giftcard.md
+++ b/src/guides/v2.4/graphql/mutations/apply-giftcard.md
@@ -1,1 +1,99 @@
-../../../v2.3/graphql/mutations/apply-giftcard.md
+---
+group: graphql
+title: applyGiftCardToCart mutation
+ee_only: True
+redirect from:
+  - /guides/v2.3/graphql/reference/quote-apply-giftcard.html
+---
+
+The `applyGiftCardToCart` mutation applies a pre-defined gift card code to the specified cart.
+
+## Syntax
+
+ `mutation: applyGiftCardToCart(input: ApplyGiftCardToCartInput): ApplyGiftCardToCartOutput`
+
+## Example usage
+
+The following example adds a gift card with the code `0330CEIVTLB4` to the cart. The gift card has a value of $20.
+
+**Request:**
+
+```graphql
+mutation {
+  applyGiftCardToCart(
+    input: {
+      cart_id: "lY8PnKhlHBGc4WS5v0Y3dWjxiA5PvvgY"
+      gift_card_code: "0330CEIVTLB4"
+    }
+  ) {
+    cart {
+      applied_gift_cards {
+        applied_balance {
+          value
+          currency
+        }
+        code
+        current_balance {
+          value
+          currency
+        }
+        expiration_date
+      }
+    }
+  }
+}
+```
+
+**Response:**
+
+```json
+{
+  "data": {
+    "applyGiftCardToCart": {
+      "cart": {
+        "applied_gift_cards": [
+          {
+            "applied_balance": {
+              "value": 20,
+              "currency": "USD"
+            },
+            "code": "0330CEIVTLB4",
+            "current_balance": {
+              "value": 20,
+              "currency": "USD"
+            },
+            "expiration_date": null
+          }
+        ]
+      }
+    }
+  }
+}
+```
+
+## Input attributes
+
+The `applyGiftCardToCart` mutation requires the `cart_id` and `gift_card_code`.
+
+### ApplyGiftCardToCartInput object {#ApplyGiftCardToCartInput}
+
+The `ApplyGiftCardToCartInput` object must contain the following attributes:
+
+Attribute | Data Type | Description
+--- | --- | ---
+`cart_id` | String! | The unique ID that identifies the customer's cart
+`gift_card_code` | String! | The gift card code
+
+## Output attributes
+
+The `ApplyGiftCardToCartOutput` object contains the `Cart` object.
+
+Attribute |  Data Type | Description
+--- | --- | ---
+`cart` |[Cart!](#CartObject) | Describes the contents of the specified shopping cart
+
+### Cart object {#CartObject}
+
+ {% include graphql/cart-object.md %}
+
+[Cart query output]({{page.baseurl}}/graphql/queries/cart.html#cart-output) provides more information about the `Cart` object.

--- a/src/guides/v2.4/graphql/mutations/apply-store-credit.md
+++ b/src/guides/v2.4/graphql/mutations/apply-store-credit.md
@@ -1,1 +1,104 @@
-../../../v2.3/graphql/mutations/apply-store-credit.md
+---
+group: graphql
+title: applyStoreCreditToCart mutation
+ee_only: true
+---
+
+The `applyStoreCreditToCart` mutation applies store credit to the specified cart. Store credit must be enabled on the store to run this mutation.
+
+Store credit is an amount that the merchant applies to a customer account as a result of a refund or similar transaction. If gift cards are enabled for a store, then a customer receives store credit when redeeming a gift card. No matter how the customer obtains store credit, these funds can be used to pay for purchases.
+
+The amount returned in the `current_balance` indicates how much store credit at the time you run the `applyStoreCreditToCart` mutation. This amount is not decreased until you place the order.
+
+{:.bs-callout-info}
+If the amount of available store credit equals or exceeds the grand total of the quote, set the payment method to `free` in the `setPaymentMethodOnCart` mutation.
+
+## Syntax
+
+`mutation: {applyStoreCreditToCart(input: ApplyStoreCreditToCartInput): {ApplyStoreCreditToCartOutput}}`
+
+## Example usage
+
+In the following example, the customer starts with $10 of store credit. The subtotal of the items in the cart before applying the store credit plus shipping and tax is $34.64. The grand total on the cart after applying the store credit is $24.64.
+
+**Request:**
+
+```graphql
+mutation {
+  applyStoreCreditToCart(
+    input: {
+      cart_id: "4HHaKzxpKM2ZwD0IcheRfcPNBWS3OvRM"
+    }
+  ) {
+    cart {
+      applied_store_credit {
+        applied_balance {
+          currency
+          value
+        }
+        current_balance {
+          currency
+          value
+        }
+      }
+      prices {
+        grand_total {
+          currency
+          value
+        }
+      }
+    }
+  }
+}
+```
+
+**Response:**
+
+```json
+{
+  "data": {
+    "applyStoreCreditToCart": {
+      "cart": {
+        "applied_store_credit": {
+          "applied_balance": {
+            "currency": "USD",
+            "value": 34.64
+          },
+          "current_balance": {
+            "currency": "USD",
+            "value": 10
+          }
+        },
+        "prices": {
+          "grand_total": {
+            "currency": "USD",
+            "value": 24.64
+          }
+        }
+      }
+    }
+  }
+}
+```
+
+## Input attributes
+
+The `ApplyStoreCreditToCartInput` object must contain the following attributes.
+
+Attribute |  Data Type | Description
+--- | --- | ---
+`cart_id` | String! | The unique ID that identifies the customer’s cart
+
+## Output attributes
+
+The `ApplyStoreCreditToCartOutput` object returns the `Cart` object.
+
+Attribute |  Data Type | Description
+--- | --- | ---
+`cart` |[Cart!](#CartObject) | Describes the contents of the specified shopping cart
+
+### Cart object {#CartObject}
+
+{% include graphql/cart-object.md %}
+
+[Cart query output]({{page.baseurl}}/graphql/queries/cart.html#cart-output) provides more information about the `Cart` object.

--- a/src/guides/v2.4/graphql/mutations/handle-payflow-pro-response.md
+++ b/src/guides/v2.4/graphql/mutations/handle-payflow-pro-response.md
@@ -1,1 +1,83 @@
-../../../v2.3/graphql/mutations/handle-payflow-pro-response.md
+---
+group: graphql
+title: handlePayflowProResponse mutation
+---
+
+The `handlePayflowProResponse` mutation sends the silent post data that the client received from the Payflow Pro gateway to the Magento server. The content of this payload varies based on factors such as the merchant's location, the items purchased, and the billing/shipping addresses. The following is an example payload:
+
+```text
+'BILLTOCITY=CityM&AMT=0.00&BILLTOSTREET=Green+str,+67&VISACARDLEVEL=12&SHIPTOCITY=CityM'
+'&NAMETOSHIP=John+Smith&ZIP=75477&BILLTOLASTNAME=Smith&BILLTOFIRSTNAME=John'
+'&RESPMSG=Verified&PROCCVV2=M&STATETOSHIP=AL&NAME=John+Smith&BILLTOZIP=75477&CVV2MATCH=Y'
+'&PNREF=B70CCC236815&ZIPTOSHIP=75477&SHIPTOCOUNTRY=US&SHIPTOSTREET=Green+str,+67&CITY=CityM'
+'&HOSTCODE=A&LASTNAME=Smith&STATE=AL&SECURETOKEN=MYSECURETOKEN&CITYTOSHIP=CityM&COUNTRYTOSHIP=US'
+'&AVSDATA=YNY&ACCT=1111&AUTHCODE=111PNI&FIRSTNAME=John&RESULT=0&IAVS=N&POSTFPSMSG=No+Rules+Triggered&'
+'BILLTOSTATE=AL&BILLTOCOUNTRY=US&EXPDATE=0222&CARDTYPE=0&PREFPSMSG=No+Rules+Triggered&SHIPTOZIP=75477&'
+'PROCAVS=A&COUNTRY=US&AVSZIP=N&ADDRESS=Green+str,+67&BILLTONAME=John+Smith&'
+'ADDRESSTOSHIP=Green+str,+67&'
+'AVSADDR=Y&SECURETOKENID=MYSECURETOKENID&SHIPTOSTATE=AL&TRANSTIME=2019-06-24+07%3A53%3A10'
+```
+
+See [Paypal Payflow Pro payment method]({{page.baseurl}}/graphql/payment-methods/payflow-pro.html) for detailed information about the workflow of PayPal Payflow Pro transactions.
+
+## Syntax
+
+`handlePayflowProResponse(input: PayflowProResponseInput!): PayflowProResponseOutput`
+
+## Example usage
+
+The following example sends the Payflow Pro payload to Magento:
+
+**Request:**
+
+```graphql
+mutation {
+  handlePayflowProResponse(
+    input: {
+      cart_id: "Po1WkfK7d3vZE0qga610NwJIbxgqllpt"
+      paypal_payload: "$payload"
+    }
+  ){
+    cart {
+      selected_payment_method {
+        code
+      }
+    }
+  }
+}
+```
+
+**Response:**
+
+```json
+{
+  "data": {
+    "handlePayflowProResponse": {
+      "cart": {
+        "selected_payment_method": {
+          "code": "payflowpro",
+        }
+      }
+    }
+  }
+}
+```
+
+## Input attributes
+
+The `PayflowProResponseInput` object must contain the `cart_id` and `paypal_payload` attributes.
+
+Attribute |  Data Type | Description
+--- | --- | ---
+`cart_id` | String! | The unique ID that identifies the customer's cart
+`paypal_payload` | String! | The payload returned from PayPal
+
+## Output attributes
+
+The PayflowProResponseOutput contains a `Cart` object.
+
+### Cart object {#CartObject}
+
+{% include graphql/cart-object.md %}
+
+[Cart query output]({{page.baseurl}}/graphql/queries/cart.html#cart-output) provides more information about the `Cart` object.

--- a/src/guides/v2.4/graphql/mutations/merge-carts.md
+++ b/src/guides/v2.4/graphql/mutations/merge-carts.md
@@ -1,1 +1,95 @@
-../../../v2.3/graphql/mutations/merge-carts.md
+---
+group: graphql
+title: mergeCarts mutation
+---
+
+The `mergeCarts` mutation transfers the contents of a guest cart into the cart of a logged-in customer. This mutation must be run on behalf of a logged-in customer.
+
+The mutation retains any items that were already in the logged-in customer's cart. If both the guest and customer carts contain the same item, `mergeCarts` adds the quantities. Upon success, the mutation deletes the original guest cart.
+
+Use the [`customerCart` query]({{page.baseurl}}/graphql/queries/customer-cart.html) to determine the value of the `destination_cart_id` attribute.
+
+## Syntax
+
+`mergeCarts(source_cart_id: String!, destination_cart_id: String!): Cart!`
+
+## Example usage
+
+In the following example, the customer had one Overnight Duffle in the cart (`CYmiiQRjPVc2gJUc5r7IsBmwegVIFO43`) before a guest cart (`mPKE05OOtcxErbk1Toej6gw6tcuxvT9O`) containing a Radiant Tee and another Overnight Duffle was merged. The cart now includes three items, including two Overnight Duffles.
+
+**Request:**
+
+```graphql
+mutation {
+  mergeCarts(source_cart_id: "mPKE05OOtcxErbk1Toej6gw6tcuxvT9O", destination_cart_id: "CYmiiQRjPVc2gJUc5r7IsBmwegVIFO43") {
+    items {
+      id
+      product {
+        name
+        sku
+      }
+      quantity
+    }
+  }
+}
+```
+
+**Response:**
+
+```json
+{
+  "data": {
+    "mergeCarts": {
+      "items": [
+        {
+          "id": "14",
+          "product": {
+            "name": "Overnight Duffle",
+            "sku": "24-WB07"
+          },
+          "quantity": 2
+        },
+        {
+          "id": "17",
+          "product": {
+            "name": "Radiant Tee",
+            "sku": "WS12"
+          },
+          "quantity": 1
+        }
+      ]
+    }
+  }
+}
+```
+
+## Input attributes
+
+Attribute |  Data Type | Description
+--- | --- | ---
+`destination_cart_id` | String! | The ID of the logged-in customer's cart
+`source_cart_id` | String! | The ID of the guest cart
+
+## Output attributes
+
+The `mergeCarts` mutation returns a `Cart` object.
+
+Attribute |  Data Type | Description
+--- | --- | ---
+`cart` |[Cart!](#CartObject) | Describes the contents of the specified shopping cart
+
+### Cart object {#CartObject}
+
+{% include graphql/cart-object.md %}
+
+[Cart query output]({{page.baseurl}}/graphql/queries/cart.html#cart-output) provides more information about the `Cart` object.
+
+## Errors
+
+Error | Description
+--- | ---
+`Current user does not have an active cart.` | The `mergeCarts` mutation deactivates the guest cart specified in the `source_cart_id` after merging. The guest cannot make any further operations with it.
+`Required parameter "destination_cart_id" is missing` | The `destination_cart_id` attribute contains an empty value.
+`Required parameter "source_cart_id" is missing` | The `source_cart_id` attribute contains an empty value.
+`The current customer isn't authorized.` | The current customer is not currently logged in, or the customer's token does not exist in the `oauth_token` table, or you tried to merge two guest carts.
+`The current user cannot perform operations on cart` | The authorized customer tried to merge a guest cart into the cart of another customer.

--- a/src/guides/v2.4/graphql/mutations/remove-coupon.md
+++ b/src/guides/v2.4/graphql/mutations/remove-coupon.md
@@ -1,1 +1,113 @@
-../../../v2.3/graphql/mutations/remove-coupon.md
+---
+group: graphql
+title: removeCouponFromCart mutation
+redirect from:
+  - /guides/v2.3/graphql/reference/quote-remove-coupon.html
+---
+
+The `removeCouponFromCart` mutation removes a previously-applied coupon from the cart. The cart must contain at least one item in order to remove the coupon.
+
+## Syntax
+
+`mutation: {removeCouponFromCart(input: RemoveCouponFromCartInput)  {RemoveCouponFromCartOutput}}`
+
+## Example usage
+
+The following example removes a coupon from the cart.
+
+**Request:**
+
+``` text
+mutation {
+  removeCouponFromCart(
+    input:
+      { cart_id: "IeTUiU0oCXjm0uRqGCOuhQ2AuQatogjG" }
+    ) {
+    cart {
+      items {
+        product {
+          name
+        }
+        quantity
+      }
+      applied_coupons {
+        code
+      }
+      prices {
+        grand_total{
+          value
+          currency
+        }
+      }
+    }
+  }
+}
+```
+
+**Response:**
+
+```json
+{
+  "data": {
+    "removeCouponFromCart": {
+      "cart": {
+        "items": [
+          {
+            "product": {
+              "name": "Strive Shoulder Pack"
+            },
+            "quantity": 1
+          },
+          {
+            "product": {
+              "name": "Affirm Water Bottle "
+            },
+            "quantity": 1
+          }
+        ],
+        "applied_coupons": null,
+        "prices": {
+          "grand_total": {
+            "value": 39,
+            "currency": "USD"
+          }
+        }
+      }
+    }
+  }
+}
+```
+
+## Input attributes
+
+The `removeCouponFromCart` mutation must contain the following attribute:
+
+Attribute |  Data Type | Description
+--- | --- | ---
+`cart_id` | String! | The unique ID that identifies the customer's cart
+
+## Output attributes
+
+The `removeCouponFromCart` mutation returns the `Cart` object.
+
+Attribute |  Data Type | Description
+--- | --- | ---
+`cart` |[Cart!](#CartObject) | Describes the contents of the specified shopping cart
+
+### Cart object {#CartObject}
+
+{% include graphql/cart-object.md %}
+
+[Cart query output]({{page.baseurl}}/graphql/queries/cart.html#cart-output) provides more information about the `Cart` object.
+
+## Errors
+
+Error | Description
+--- | ---
+`Cart does not contain products.` | The coupon cannot be removed from the empty cart.
+`Could not find a cart with ID "XXX"` | The specified `cart_id` value does not exist in the `quote_id_mask` table.
+`Current user does not have an active cart.` | The user cannot perform this mutation on the inactive cart.
+`Required parameter "cart_id" is missing` | The required `cart_id` argument contains an empty value.
+`The coupon code couldn't be deleted. Verify the coupon code and try again.` | The coupon was not removed from the cart. Check the existing shopping cart price rules for details.
+`The current user cannot perform operations on cart XXX` | An unauthorized user (guest) tried to add the product into a customer's cart, or an authorized user (customer) tried to add the product into the cart of another customer.
+`Wrong store code specified for cart` | The specified `cart_id` does not exist in specified store.

--- a/src/guides/v2.4/graphql/mutations/remove-giftcard.md
+++ b/src/guides/v2.4/graphql/mutations/remove-giftcard.md
@@ -1,1 +1,71 @@
-../../../v2.3/graphql/mutations/remove-giftcard.md
+---
+group: graphql
+title: removeGiftCardFromCart mutation
+ee_only: True
+---
+
+The `removeGiftCardFromCart` mutation removes a previously-applied gift card from the cart.
+
+## Syntax
+
+ `mutation: removeGiftCardFromCart(input: RemoveGiftCardFromCartInput): RemoveGiftCardFromCartOutput`
+
+## Example usage
+
+ The following example removes a gift card from the cart.
+
+**Request:**
+
+ ``` text
+mutation {
+  removeGiftCardFromCart(
+    input: {
+      cart_id: "lOeLKsVkZ1PEvA8A7EaCvmEAk4JRBR7A"
+      gift_card_code: "049XDMZ6L81X"
+    }
+  ) {
+    cart {
+      applied_gift_cards {
+        code
+      }
+    }
+  }
+}
+```
+
+**Response:**
+
+ ```json
+{
+  "data": {
+    "removeGiftCardFromCart": {
+      "cart": {
+        "applied_gift_cards": []
+      }
+    }
+  }
+}
+```
+
+## Input attributes
+
+The `removeGiftCardFromCartInput` object must contain the following attributes:
+
+Attribute |  Data Type | Description
+--- | --- | ---
+`cart_id` | String! | The unique ID that identifies the customer's cart
+`gift_card_code` | String! | The gift card code
+
+## Output attributes
+
+The `removeGiftCardFromCartOutput` object contains the `Cart` object.
+
+Attribute |  Data Type | Description
+--- | --- | ---
+`cart` |[Cart!](#CartObject) | Describes the contents of the specified shopping cart
+
+### Cart object {#CartObject}
+
+ {% include graphql/cart-object.md %}
+
+[Cart query output]({{page.baseurl}}/graphql/queries/cart.html#cart-output) provides more information about the `Cart` object.

--- a/src/guides/v2.4/graphql/mutations/remove-item.md
+++ b/src/guides/v2.4/graphql/mutations/remove-item.md
@@ -1,1 +1,109 @@
-../../../v2.3/graphql/mutations/remove-item.md
+---
+group: graphql
+title: removeItemFromCart mutation
+redirect from:
+  - /guides/v2.3/graphql/reference/quote-remove-item.html
+---
+
+The `removeItemFromCart` mutation deletes the entire quantity of a specified item from the cart. If you remove all items from the cart, the cart continues to exist.
+
+## Syntax
+
+`mutation: {removeItemFromCart(input: RemoveItemFromCartInput): {RemoveItemFromCartOutput}}`
+
+## Example usage
+
+The following example removes cart item 14 from the cart.
+
+**Request:**
+
+```graphql
+mutation {
+  removeItemFromCart(
+    input: {
+      cart_id: "IeTUiU0oCXjm0uRqGCOuhQ2AuQatogjG",
+      cart_item_id: 14
+    }
+  )
+ {
+  cart {
+    items {
+      id
+      product {
+        name
+      }
+      quantity
+    }
+    prices {
+      grand_total{
+        value
+        currency
+      }
+    }
+  }
+ }
+}
+```
+
+**Response:**
+
+```json
+{
+  "data": {
+    "removeItemFromCart": {
+      "cart": {
+        "items": [
+          {
+            "id": "13",
+            "product": {
+              "name": "Strive Shoulder Pack"
+            },
+            "quantity": 3
+          }
+        ],
+        "prices": {
+          "grand_total": {
+            "value": 96,
+            "currency": "USD"
+          }
+        }
+      }
+    }
+  }
+}
+```
+
+## Input attributes
+
+### RemoveItemFromCartInput object {#RemoveItemFromCartInput}
+
+The `RemoveItemFromCartInput` object must contain the following attributes:
+
+Attribute |  Data Type | Description
+--- | --- | ---
+`cart_id` | String! | The unique ID that identifies the customer's cart
+`cart_item_id` | Int! | The unique ID assigned when a customer places an item in the cart
+
+## Output attributes
+
+The `RemoveItemFromCartOutput` object contains the `Cart` object.
+
+Attribute |  Data Type | Description
+--- | --- | ---
+`cart` |[Cart!](#CartObject) | Describes the contents of the specified shopping cart
+
+### Cart object {#CartObject}
+
+{% include graphql/cart-object.md %}
+
+## Errors
+
+Error | Description
+--- | ---
+`Cart doesn't contain the ZZZ item.` | The item ID specified in the `cart_item_id` argument does not exist in the requested shopping cart.
+`Could not find a cart with ID "XXX"` | The specified `cart_id` value does not exist in the `quote_id_mask` table.
+`Required parameter "cart_id" is missing.` | The value specified in the `cart_id` argument is empty.
+`Required parameter "cart_item_id" is missing.` | The value specified in the `cart_item_id` argument is equal to zero.
+`The current user cannot perform operations on cart "XXX"` | An unauthorized user (guest) tried to remove a product from the shopping cart of authorized user (customer), or a customer tried to remove a product from the shopping cart of another customer.
+
+[Cart query output]({{page.baseurl}}/graphql/queries/cart.html#cart-output) provides more information about the `Cart` object.

--- a/src/guides/v2.4/graphql/mutations/remove-store-credit.md
+++ b/src/guides/v2.4/graphql/mutations/remove-store-credit.md
@@ -1,1 +1,97 @@
-../../../v2.3/graphql/mutations/remove-store-credit.md
+---
+group: graphql
+title: removeStoreCreditFromCart mutation
+ee_only: true
+---
+
+The `removeStoreCreditFromCart` mutation removes store credit previously applied to the specified cart with the [`applyStoreCreditToCart`]({{page.baseurl}}/graphql/mutations/apply-store-credit.html) mutation. Magento restores the customer's available store credit to its original amount and recalculates all cart totals.
+
+Store credit must be enabled on the store to run this mutation.
+
+## Syntax
+
+`mutation: {RemoveStoreCreditFromCart(input: RemoveStoreCreditFromCartInput): {RemoveStoreCreditFromCartOutput}}`
+
+## Example usage
+
+**Request:**
+
+```graphql
+mutation {
+  removeStoreCreditFromCart(
+    input: {
+      cart_id: "4HHaKzxpKM2ZwD0IcheRfcPNBWS3OvRM"
+    }
+  ) {
+    cart {
+      applied_store_credit {
+        applied_balance {
+          currency
+          value
+        }
+        current_balance {
+          currency
+          value
+        }
+      }
+      prices {
+        grand_total {
+          currency
+          value
+        }
+      }
+    }
+  }
+}
+```
+
+**Response:**
+
+```json
+{
+  "data": {
+    "removeStoreCreditFromCart": {
+      "cart": {
+        "applied_store_credit": {
+          "applied_balance": {
+            "currency": "USD",
+            "value": 0
+          },
+          "current_balance": {
+            "currency": "USD",
+            "value": 10
+          }
+        },
+        "prices": {
+          "grand_total": {
+            "currency": "USD",
+            "value": 34.64
+          }
+        }
+      }
+    }
+  }
+}
+```
+
+## Input attributes
+
+The `RemoveStoreCreditFromCartInput` object must contain the following attributes.
+
+Attribute |  Data Type | Description
+--- | --- | ---
+`cart_id` | String! | The unique ID that identifies the customer’s cart
+
+## Output attributes
+
+The `RemoveStoreCreditFromCartOutput` object returns the `Cart` object.
+
+Attribute |  Data Type | Description
+--- | --- | ---
+`cart` |[Cart!](#CartObject) | Describes the contents of the specified shopping cart
+
+### Cart object {#CartObject}
+
+{% include graphql/cart-object.md %}
+
+[Cart query output]({{page.baseurl}}/graphql/queries/cart.html#cart-output) provides more information about the `Cart` object.

--- a/src/guides/v2.4/graphql/mutations/set-guest-email.md
+++ b/src/guides/v2.4/graphql/mutations/set-guest-email.md
@@ -1,1 +1,81 @@
-../../../v2.3/graphql/mutations/set-guest-email.md
+---
+group: graphql
+title: setGuestEmailOnCart mutation
+redirect from:
+  - /guides/v2.3/graphql/reference/quote-set-guest-email.html
+---
+
+For guest customers, you must assign an email to the cart before you place the order.
+
+A logged-in customer specifies an email address when they create an account. Therefore, you can place the order without explicitly setting the email.
+
+## Syntax
+
+`mutation: {setGuestEmailOnCart(input: SetGuestEmailOnCartInput): {SetGuestEmailOnCartOutput}}`
+
+## Example usage
+
+**Request:**
+
+```graphql
+mutation {
+  setGuestEmailOnCart(
+    input: {
+      cart_id: "4JQaNVJokOpFxrykGVvYrjhiNv9qt31C"
+      email: "jdoe@example.com"
+    }
+  ) {
+    cart {
+      email
+    }
+  }
+}
+```
+
+**Response:**
+
+```json
+{
+  "data": {
+    "setGuestEmailOnCart": {
+      "cart": {
+        "email": "jdoe@example.com"
+      }
+    }
+  }
+}
+```
+
+## Input attributes
+
+The `SetGuestEmailOnCartInput` object must contain the following attributes.
+
+Attribute |  Data Type | Description
+--- | --- | ---
+`cart_id` | String! | The unique ID that identifies the customer’s cart
+`email` | String! | The guest user's email
+
+## Output attributes
+
+The `SetGuestEmailOnCartOutput` object contains the `Cart` object.
+
+Attribute |  Data Type | Description
+--- | --- | ---
+`cart` |[Cart!](#CartObject) | Describes the contents of the specified shopping cart
+
+### Cart object {#CartObject}
+
+{% include graphql/cart-object.md %}
+
+[Cart query output]({{page.baseurl}}/graphql/queries/cart.html#cart-output) provides more information about the `Cart` object.
+
+## Errors
+
+Error | Description
+--- | ---
+`Could not find a cart with ID "XXX"` | The ID specified in the `cart` argument does not exist.
+`Invalid email format` | The value specified in the `email` argument has an incorrect format.
+`Required parameter "cart_id" is missing` | The `cart_id` argument was omitted or contains an empty value.
+`Required parameter "email" is missing` | The `email` argument was omitted or contains an empty value.
+`The current user cannot perform operations on cart "XXX"` | An unauthorized user (guest) tried to set the email address on the customer's cart.
+`The request is not allowed for logged in customers` | An authorized user (customer) is not allowed to use the `setGuestEmailOnCart` mutation.

--- a/src/guides/v2.4/graphql/mutations/set-shipping-method.md
+++ b/src/guides/v2.4/graphql/mutations/set-shipping-method.md
@@ -1,1 +1,132 @@
-../../../v2.3/graphql/mutations/set-shipping-method.md
+---
+group: graphql
+title: setShippingMethodsOnCart mutation
+redirect from:
+  - /guides/v2.3/graphql/reference/quote-shipping-method.html
+---
+
+The `setShippingMethodsOnCart` mutation sets one or more shipping methods on a cart. By default, Magento GraphQL supports the following shipping methods:
+
+Label | Carrier code | Method code
+--- | --- | ---
+DHL | dhl | Varies
+Federal Express | fedex | Varies
+Flat Rate | flatrate | flatrate
+Free Shipping | freeshipping | freeshipping
+Best Way | tablerate | bestway
+United Parcel Service | ups | Varies
+United States Postal Service | usps | Varies
+
+## Syntax
+
+`mutation: {setShippingMethodsOnCart(input: setShippingMethodsOnCartInput) {setShippingMethodsOnCartOutput}}`
+
+## Example usage
+
+The following example sets the shipping method to Best Way.
+
+**Request:**
+
+```graphql
+mutation {
+  setShippingMethodsOnCart(
+    input: {
+      cart_id: "IeTUiU0oCXjm0uRqGCOuhQ2AuQatogjG",
+      shipping_methods: [
+        {
+          carrier_code: "tablerate"
+          method_code: "bestway"
+        }
+      ]
+    }
+  ) {
+    cart {
+      shipping_addresses {
+        selected_shipping_method {
+          carrier_code
+          carrier_title
+          method_code
+          method_title
+          amount {
+            value
+            currency
+          }
+        }
+      }
+    }
+  }
+}
+```
+
+**Response:**
+
+```json
+{
+  "data": {
+    "setShippingMethodsOnCart": {
+      "cart": {
+        "shipping_addresses": [
+          {
+            "selected_shipping_method": {
+              "carrier_code": "tablerate",
+              "carrier_title": "Best Way",
+              "method_code": "bestway",
+              "method_title": "Table Rate",
+              "amount": {
+                "value": 0,
+                "currency": "USD"
+              }
+            }
+          }
+        ]
+      }
+    }
+  }
+}
+```
+
+## Input attributes
+
+The top-level `setShippingMethodsOnCartInput` object is listed first. All child objects are listed in alphabetical order.
+
+### setShippingMethodsOnCartInput object {#setShippingMethodsOnCartInput}
+
+Attribute |  Data Type | Description
+--- | --- | ---
+`cart_id` | String! | The unique ID that identifies the customer's cart
+`shipping_methods` | [ShippingMethodInput!](#ShippingMethodInput) | The shipping address for a specific cart
+
+### ShippingMethodInput object {#ShippingMethodInput}
+
+Attribute |  Data Type | Description
+--- | --- | ---
+`carrier_code` | String! | A string that identifies a commercial carrier or an offline shipping method
+`method_code` | String! | A string that indicates which service a commercial carrier will use to ship items. For offline shipping methods, this value is similar to the label displayed on the checkout page
+
+## Output attributes
+
+The `ShippingMethodOutput` object contains the `Cart` object.
+
+Attribute |  Data Type | Description
+--- | --- | ---
+`cart` |[ Cart!](#CartObject) | Describes the contents of the specified shopping cart
+
+### Cart object {#CartObject}
+
+{% include graphql/cart-object.md %}
+
+[Cart query output]({{page.baseurl}}/graphql/queries/cart.html#cart-output) provides more information about the `Cart` object.
+
+## Errors
+
+Error | Description
+--- | ---
+`Could not find a cart with ID "XXX"` | The specified `cart_id` value does not exist in the `quote_id_mask` table.
+`Carrier with such method not found: carrier_code, method_code` | A specified carrier method was not found, or it is not applicable for the defined shipping address.
+`Required parameter "cart_id" is missing` | The value specified in the `cart_id` argument is empty.
+`Required parameter "carrier_code" is missing.` | The value specified in the `shipping_methods`.`carrier_code` argument is empty.
+`Required parameter "method_code" is missing.` | The value specified in the `shipping_methods`.`method_code` argument is empty.
+`Required parameter "shipping_methods" is missing` | The value specified in the `shipping_methods` argument is empty.
+`The current user cannot perform operations on cart "XXX"` | An unauthorized user (guest) tried to set a shipping method for an order on behalf of an authorized user (customer), or a customer tried to set a shipping method for an order on behalf of another customer.
+`The shipping method can't be set for an empty cart. Add an item to cart and try again.` | The shipping method cannot be set for an empty cart.
+`You cannot specify multiple shipping methods.` | You can set only one shipping method for an order.

--- a/src/guides/v2.4/graphql/mutations/update-cart-items.md
+++ b/src/guides/v2.4/graphql/mutations/update-cart-items.md
@@ -1,1 +1,142 @@
-../../../v2.3/graphql/mutations/update-cart-items.md
+---
+group: graphql
+title: updateCartItems mutation
+redirect from:
+  - /guides/v2.3/graphql/reference/quote-update-cart-items.html
+---
+
+The `updateCartItems` mutation allows you to replace the current quantity of one or more cart items with the specified quantities. It does not perform calculations to determine the quantity of cart items.
+
+{:.bs-callout-info}
+Setting the quantity to `0` removes an item from the cart.
+
+## Syntax
+
+`mutation: {updateCartItems(input: UpdateCartItemsInput): {UpdateCartItemsOutput}}`
+
+## Example usage
+
+The following example changes the quantity of cart item `13`. The new quantity is `3`.
+
+**Request:**
+
+```graphql
+mutation {
+  updateCartItems(
+    input: {
+      cart_id: "IeTUiU0oCXjm0uRqGCOuhQ2AuQatogjG",
+      cart_items: [
+        {
+          cart_item_id: 13
+          quantity: 3
+        }
+      ]
+    }
+  ){
+    cart {
+      items {
+        id
+        product {
+          name
+        }
+        quantity
+      }
+      prices {
+        grand_total{
+          value
+          currency
+        }
+      }
+    }
+  }
+}
+```
+
+**Response:**
+
+```json
+{
+  "data": {
+    "updateCartItems": {
+      "cart": {
+        "items": [
+          {
+            "id": "13",
+            "product": {
+              "name": "Strive Shoulder Pack"
+            },
+            "quantity": 3
+          },
+          {
+            "id": "14",
+            "product": {
+              "name": "Affirm Water Bottle "
+            },
+            "quantity": 1
+          }
+        ],
+        "prices": {
+          "grand_total": {
+            "value": 103,
+            "currency": "USD"
+          }
+        }
+      }
+    }
+  }
+}
+```
+
+## Input attributes
+
+The `UpdateCartItemsInput` object is listed first. All child objects are listed in alphabetical order.
+
+### UpdateCartItemsInput object {#UpdateCartItemsInput}
+
+The `UpdateCartItemsInput` object must contain the following attributes:
+
+Attribute |  Data Type | Description
+--- | --- | ---
+`cart_id` | String! | The unique ID that identifies the customer's cart
+`cart_items` | [CartItemUpdateInput!](#CartItemUpdateInput) | Contains the cart item IDs and quantity of each item
+
+### CartItemUpdateInput object {#CartItemUpdateInput}
+
+The `CartItemUpdateInput` object must contain the following attributes:
+
+Attribute |  Data Type | Description
+--- | --- | ---
+`cart_item_id` | Int! | The unique ID assigned when a customer places an item in the cart
+`customizable_options` | [CustomizableOptionInput!] | An array that defines customizable options for the product
+`quantity` | Float | The new quantity of the item. A value of `0` removes the item from the cart
+
+### CustomizableOptionInput object {#CustomizableOptionInputSimple}
+
+The `CustomizableOptionInput` object must contain the following attributes:
+
+{% include graphql/customizable-option-input.md %}
+
+## Output attributes
+
+The `UpdateCartItemsOutput` object contains the `Cart` object.
+
+Attribute |  Data Type | Description
+--- | --- | ---
+`cart` |[Cart!](#CartObject) | Describes the contents of the specified shopping cart
+
+### Cart object {#CartObject}
+
+{% include graphql/cart-object.md %}
+
+[Cart query output]({{page.baseurl}}/graphql/queries/cart.html#cart-output) provides more information about the `Cart` object.
+
+## Errors
+
+Error | Description
+--- | ---
+`Could not find cart item with id: XXX` | The specified `input`.`cart_items`.`cart_item_id` value does not exist in the `quote_item` database table.
+`Could not find a cart with ID "XXX"` | The specified `cart_id` value does not exist in the `quote_id_mask` database table.
+`Required parameter "cart_id" is missing.` | The value specified in the `cart_id` argument is empty.
+`Required parameter "cart_items" is missing.` | The `cart_items` argument is empty, or its value is specified as a non-array value.
+`Required parameter "quantity" for "cart_items" is missing.` | The required `input`.`cart_items`.`quantity` argument must be specified.
+`The current user cannot perform operations on cart "XXX"` | An unauthorized user (guest) tried to update a customer's cart, or an authorized user (customer) tried to update the cart of another customer.

--- a/src/guides/v2.4/graphql/queries/customer-cart.md
+++ b/src/guides/v2.4/graphql/queries/customer-cart.md
@@ -1,1 +1,82 @@
-../../../v2.3/graphql/queries/customer-cart.md
+---
+group: graphql
+title: customerCart query
+---
+
+The `customerCart` query returns the active cart for the logged-in customer. If the cart does not exist, the query creates one. The customer's authorization token must be specified in the headers.
+
+The `customerCart` query differs from the `cart` query in the following ways:
+
+-  The `customerCart` query must be run on behalf of a logged-in customer. If you run this query on behalf of a guest, an exception will be thrown.
+-  The `cart` query requires a `cart_id` value as input. The `customerCart` query does not take any input parameters.
+
+You can define the query to return the `id` attribute. You can use the value of this attribute as the `destination_cart_id` input parameter in the [`mergeCarts` mutation]({{page.baseurl}}/graphql/mutations/merge-carts.html). (The `mergeCarts` mutation provides the ability to merge a guest cart with the logged-in customer's cart.)
+
+{: .bs-callout-tip }
+If you know the value of the logged-in customer's cart ID, you can allow the customer to start an order on one device and complete it on another.
+
+## Syntax
+
+`customerCart: Cart!`
+
+## Example usage
+
+The following query lists the products in the logged-in customer's cart:
+
+**Request:**
+
+```graphql
+{
+  customerCart {
+    id
+    items {
+      id
+      product {
+        name
+        sku
+      }
+      quantity
+    }
+  }
+}
+```
+
+**Response:**
+
+```json
+{
+  "data": {
+    "customerCart": {
+      "id": "CYmiiQRjPVc2gJUc5r7IsBmwegVIFO43",
+      "items": [
+        {
+          "id": "11",
+          "product": {
+            "name": "Strive Shoulder Pack",
+            "sku": "24-MB04"
+          },
+          "quantity": 1
+        },
+        {
+          "id": "12",
+          "product": {
+            "name": "Radiant Tee",
+            "sku": "WS12"
+          },
+          "quantity": 1
+        }
+      ]
+    }
+  }
+}
+```
+
+## Output attributes
+
+The `customerCart` query returns the `Cart` object.
+
+### Cart object {#CartObject}
+
+{% include graphql/cart-object.md %}
+
+[Cart query output]({{page.baseurl}}/graphql/queries/cart.html#cart-output) provides more information about the `Cart` object.


### PR DESCRIPTION
## Purpose of this pull request

This pull request (PR) does nothing but break symlinks for files that reference the `cart-object.md` include file. By breaking symlinks separately, the technical review for the actual changes in the `cart-object.md` file will be easier.

## Affected DevDocs pages

<!-- REQUIRED List the affected pages on devdocs.magento.com (URLs). Not needed for large numbers of files. -->

-  Many

## Links to Magento source code

<!--  OPTIONAL - REMOVE THIS SECTION IF NOT USED. If this pull request references a file in a Magento codebase repository, add it here. -->

-  ...

<!--
If you are fixing a GitHub issue, note it using GitHub keyword format (https://help.github.com/en/articles/closing-issues-using-keywords#closing-an-issue-in-a-different-repository) to close the issue when this pull request is merged. Example: `Fixes #1234`

`master` is the default branch. Merged pull requests to `master` go live on the site automatically. Any requested changes to content on the `master` branch must be related to the released codebase. Any content related to future releases goes in the `develop` branch.

See Contribution guidelines (https://github.com/magento/devdocs/blob/master/.github/CONTRIBUTING.md) for more information.
-->
