### PR TITLE
Update REST table of contents

### DIFF
--- a/src/_data/toc/rest-api.yml
+++ b/src/_data/toc/rest-api.yml
@@ -12,15 +12,15 @@ pages:
           children:
 
             - label: Admin REST endpoints
-              url: /redoc/2.3/admin-rest-api.html
+              url: https://magento.redoc.ly/
               versionless: true
 
             - label: Customer REST endpoints
-              url: /redoc/2.3/customer-rest-api.html
+              url: https://magento.redoc.ly/
               versionless: true
 
             - label: Guest REST endpoints
-              url: /redoc/2.3/guest-rest-api.html
+              url: https://magento.redoc.ly/
               versionless: true
 
             - label: Asynchronous Admin REST endpoints


### PR DESCRIPTION
## Purpose of this pull request

This pull request (PR) replaces redoc links to the Synchronous REST endpoints in the table of contents with links to Redocly hosted docs.

We've reported the inability to use "anchor" links to the different schemas to Redocly. If/when they fix that, we can update these links accordingly. Or, we can leave these as-is until a fix is in place and rely on redirects in the meantime (already implemented in another PR).

## Affected DevDocs pages

- http://devdocs.magento.com/guides/v2.3/rest/bk-rest.html