### PR TITLE
magento/devdocs#7363: Update the storeConfig query to include new fields

### DIFF
--- a/src/guides/v2.4/graphql/queries/store-config.md
+++ b/src/guides/v2.4/graphql/queries/store-config.md
@@ -331,6 +331,15 @@ Attribute |  Data Type | Description | Configuration path | Default Value
 `minimum_password_length` | String | The minimum number of characters required for a valid password. | customer/password/minimum_password_length | 6
 `required_character_classes_number` | String | The number of different character classes required in a password (lowercase, uppercase, digits, special characters). | customer/password/required_character_classes_number | 2
 
+### Supported gift messages attributes
+
+Retrieves information about the store's gift message settings. These attributes are defined in the `GiftMessageGraphQl` module.
+
+Attribute |  Data Type | Description | Configuration path | Default Value
+--- | --- | ---
+`allow_order` | String | Allows gift messages on order level. Possible values: 1 (Yes) and 0 (No). | sales/gift_options/allow_order | 0
+`allow_items` | String | Allows gift messages for order items. Possible values: 1 (Yes) and 0 (No). | sales/gift_options/allow_items | 0
+
 ### Supported WEEE (fixed product tax) attributes
 
 The **Stores** > Settings > **Configuration** > **Sales** > **Tax** > **Fixed Product Taxes** panel contains several fields that determine how to display fixed product tax (FPT) values and descriptions. Use the following attributes to determine the values of the **Fixed Product Taxes** fields. These attributes are defined in the `WeeeGraphQl` module.

--- a/src/guides/v2.4/graphql/queries/store-config.md
+++ b/src/guides/v2.4/graphql/queries/store-config.md
@@ -331,13 +331,13 @@ Attribute |  Data Type | Description | Configuration path | Default Value
 `minimum_password_length` | String | The minimum number of characters required for a valid password. | customer/password/minimum_password_length | 6
 `required_character_classes_number` | String | The number of different character classes required in a password (lowercase, uppercase, digits, special characters). | customer/password/required_character_classes_number | 2
 
-### Supported gift messages attributes
+### Supported gift message attributes
 
-Retrieves information about the store's gift message settings. These attributes are defined in the `GiftMessageGraphQl` module.
+These attributes retrieve information about the store's gift message settings. They are defined in the `GiftMessageGraphQl` module.
 
 Attribute |  Data Type | Description | Configuration path | Default Value
 --- | --- | ---
-`allow_order` | String | Allows gift messages on order level. Possible values: 1 (Yes) and 0 (No). | sales/gift_options/allow_order | 0
+`allow_order` | String | Allows gift messages at the order level. Possible values: 1 (Yes) and 0 (No). | sales/gift_options/allow_order | 0
 `allow_items` | String | Allows gift messages for order items. Possible values: 1 (Yes) and 0 (No). | sales/gift_options/allow_items | 0
 
 ### Supported WEEE (fixed product tax) attributes


### PR DESCRIPTION


## Purpose of this pull request

This pull request (PR) fixes the first point of https://github.com/magento/devdocs/issues/7363:
- Update the `storeConfig` query to include new fields

## Affected DevDocs pages

<!-- REQUIRED List the affected pages on devdocs.magento.com (URLs). Not needed for large numbers of files. -->

-  https://devdocs.magento.com/guides/v2.4/graphql/queries/store-config.html

## Links to Magento source code

<!--  OPTIONAL - REMOVE THIS SECTION IF NOT USED. If this pull request references a file in a Magento codebase repository, add it here. -->

-  [di.xml](https://github.com/magento/magento2/blob/2.4-develop/app/code/Magento/GiftMessageGraphQl/etc/graphql/di.xml#L13)

<!--
If you are fixing a GitHub issue, note it using GitHub keyword format (https://help.github.com/en/articles/closing-issues-using-keywords#closing-an-issue-in-a-different-repository) to close the issue when this pull request is merged. Example: `Fixes #1234`

`master` is the default branch. Merged pull requests to `master` go live on the site automatically. Any requested changes to content on the `master` branch must be related to the released codebase. Any content related to future releases goes in the `develop` branch.

See Contribution guidelines (https://github.com/magento/devdocs/blob/master/.github/CONTRIBUTING.md) for more information.
-->
