### PR TITLE
Upgrade whatsup_github gem

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -153,7 +153,7 @@ GEM
     unicode-display_width (1.7.0)
     verbal_expressions (0.1.5)
     wdm (0.1.1)
-    whatsup_github (0.2.0)
+    whatsup_github (0.3.0)
       netrc (~> 0.10)
       octokit (~> 4.14)
       thor (~> 0.20)

--- a/rakelib/update.rake
+++ b/rakelib/update.rake
@@ -49,7 +49,7 @@ namespace :update do
   task all: %w[devdocs subrepos]
 
   desc 'Update subrepositories only'
-  task subrepos: %w[m1 mbi pb pbm mftf]
+  task subrepos: %w[mbi pb pbm mftf]
 end
 
 def update_dir(dir)


### PR DESCRIPTION
## Purpose of this pull request

This pull request upgrades `whatsup_github` gem to [0.3.0](https://github.com/dshevtsov/whatsup_github/blob/master/CHANGELOG.md).

UPDATE: This also adds a minor fix by removing `m1` from the list of subrepositories at rake tasks.

### Required actions

In `.whatsnew.yml`, update configuration to match the following:

```
# Name of the base branch in GitHub PRs
base_branch: master

# Repositories for scanning. If you want to search private repositories, use credentials to specify
repos:
  - magento/devdocs

labels:
  required:
    - New Topic
    - Major Update
  optional:
    - Technical

magic_word: whatsnew

# Output format
output_format:
  - yaml
  
```
