### PR TITLE
Fix typo hightest

### DIFF
--- a/src/guides/v2.3/frontend-dev-guide/translations/theme_dictionary.md
+++ b/src/guides/v2.3/frontend-dev-guide/translations/theme_dictionary.md
@@ -20,7 +20,7 @@ When the [locale](https://glossary.magento.com/locale) is changed for a store, M
 1. Magento database (translations located in this database take precedence and override translations stored in other locations.)  Refer to the [user guide](https://docs.magento.com/m2/ce/user_guide/system/translate-inline.html) for more information.
 
 {:.bs-callout-info}
-Translation priority follows the inverse sequence, with "module translations" having the lowest priority and "magento database" having the hightest priority.
+Translation priority follows the inverse sequence, with "module translations" having the lowest priority and "magento database" having the highest priority.
 
 If there are competing translations for one string, the theme dictionary translations have priority over the [module](https://glossary.magento.com/module) translations, and child theme translations have priority over parent theme translations.
 


### PR DESCRIPTION
## Purpose of this pull request

This pull request (PR) fixes typo in word **highest**

## Affected DevDocs pages

<!-- REQUIRED List the affected pages on devdocs.magento.com (URLs). Not needed for large numbers of files. -->

-  https://devdocs.magento.com/guides/v2.4/frontend-dev-guide/translations/theme_dictionary.html
-  https://devdocs.magento.com/guides/v2.3/frontend-dev-guide/translations/theme_dictionary.html

<!--
If you are fixing a GitHub issue, note it using GitHub keyword format (https://help.github.com/en/articles/closing-issues-using-keywords#closing-an-issue-in-a-different-repository) to close the issue when this pull request is merged. Example: `Fixes #1234`

`master` is the default branch. Merged pull requests to `master` go live on the site automatically. Any requested changes to content on the `master` branch must be related to the released codebase. Any content related to future releases goes in the `develop` branch.

See Contribution guidelines (https://github.com/magento/devdocs/blob/master/.github/CONTRIBUTING.md) for more information.
-->
