### PR TITLE
Wrong path to setShippingAddressesOnCart mutation

### DIFF
--- a/src/guides/v2.3/graphql/tutorials/checkout/checkout-shipping-address.md
+++ b/src/guides/v2.3/graphql/tutorials/checkout/checkout-shipping-address.md
@@ -14,7 +14,7 @@ contributor_name: Atwix
 contributor_link: https://www.atwix.com/
 ---
 
-Use the [setShippingAddressesOnCart]({{ page.baseurl }}/graphql/mutations/set-shipping-method.html) mutation to set a shipping address. You can set the shipping address in the following ways:
+Use the [setShippingAddressesOnCart]({{ page.baseurl }}/graphql/mutations/set-shipping-address.html) mutation to set a shipping address. You can set the shipping address in the following ways:
 
 *  Add a new shipping address
 *  Assign the shipping address to be the same as the billing address


### PR DESCRIPTION

## Purpose of this pull request

This pull request (PR) fixes wrong path to `setShippingAddressesOnCart` mutation on page `Step 4. Set the shipping address` 

Current URL:
https://devdocs.magento.com/guides/v2.4/graphql/mutations/set-shipping-method.html

Expected:
https://devdocs.magento.com/guides/v2.4/graphql/mutations/set-shipping-address.html

## Affected DevDocs pages

<!-- REQUIRED List the affected pages on devdocs.magento.com (URLs). Not needed for large numbers of files. -->

-  [Step 4. Set the shipping address](https://devdocs.magento.com/guides/v2.4/graphql/tutorials/checkout/checkout-shipping-address.html)


