### PR TITLE
GraphQL caching: fix header name

### DIFF
--- a/src/guides/v2.3/graphql/caching.md
+++ b/src/guides/v2.3/graphql/caching.md
@@ -116,7 +116,7 @@ In developer mode, Magento returns several headers that could be useful for debu
 
 Header | Description
 --- |---
-`X-Magento=Cache-Debug` | HIT (the page was loaded from cache) or MISS (the page was not loaded from cache.
+`X-Magento-Cache-Debug` | HIT (the page was loaded from cache) or MISS (the page was not loaded from cache.
 `X-Magento-Tags` | A list of cache tags that correspond to the catalog, category, or CMS items returned in the query. Magento caches these items.
 
 ## Cache invalidation

--- a/src/guides/v2.4/graphql/caching.md
+++ b/src/guides/v2.4/graphql/caching.md
@@ -116,7 +116,7 @@ In developer mode, Magento returns several headers that could be useful for debu
 
 Header | Description
 --- |---
-`X-Magento=Cache-Debug` | HIT (the page was loaded from cache) or MISS (the page was not loaded from cache.
+`X-Magento-Cache-Debug` | HIT (the page was loaded from cache) or MISS (the page was not loaded from cache.
 `X-Magento-Tags` | A list of cache tags that correspond to the catalog, category, or CMS items returned in the query. Magento caches these items.
 
 ## Cache invalidation


### PR DESCRIPTION
## Purpose of this pull request

Change "=" to "-" in X-Magento=Cache-Debug header

## Affected DevDocs pages

https://devdocs.magento.com/guides/v2.3/graphql/caching.html
https://devdocs.magento.com/guides/v2.4/graphql/caching.html

<!--
If you are fixing a GitHub issue, note it using GitHub keyword format (https://help.github.com/en/articles/closing-issues-using-keywords#closing-an-issue-in-a-different-repository) to close the issue when this pull request is merged. Example: `Fixes #1234`

`master` is the default branch. Merged pull requests to `master` go live on the site automatically. Any requested changes to content on the `master` branch must be related to the released codebase. Any content related to future releases goes in the `develop` branch.

See Contribution guidelines (https://github.com/magento/devdocs/blob/master/.github/CONTRIBUTING.md) for more information.
-->
