### PR TITLE
magento/devdocs#7363:  GraphQL: Add support for gift messages

### DIFF
--- a/src/_includes/graphql/cart-object-24.md
+++ b/src/_includes/graphql/cart-object-24.md
@@ -1,0 +1,28 @@
+Attribute |  Data Type | Description
+--- | --- | ---
+`applied_coupon` | [`AppliedCoupon`][AppliedCoupon] | Deprecated. Use `applied_coupons` instead
+`applied_coupons` | [[`AppliedCoupon`]][AppliedCoupon] | An array of `AppliedCoupon` objects. Each object contains the `code` text attribute, which specifies the coupon code
+`applied_gift_cards` | [[`AppliedGiftCard`]][AppliedGiftCard] | An array of `AppliedGiftCard` objects. An `AppliedGiftCard` object contains the `code` text attribute, which specifies the gift card code. `applied_gift_cards` is a Commerce-only attribute, defined in the GiftCardAccountGraphQl module
+`applied_store_credit` | [`AppliedStoreCredit`][AppliedStoreCredit] | Contains store credit information applied to the cart. `applied_store_credit` is a Commerce-only attribute, defined in the CustomerBalanceGraphQl module
+`available_payment_methods` | [[AvailablePaymentMethod]][AvailablePaymentMethod] | Available payment methods
+`billing_address` | [BillingCartAddress][BillingCartAddress] | Contains the billing address specified in the customer's cart
+`email` | String | The customer's email address
+`gift_message` | [`GiftMessage`][GiftMessage] | Contains the entered gift message for the cart
+`id` | ID! | The ID of the cart
+`is_virtual` | Boolean! | Indicates whether the cart contains only virtual products
+`items` | [[CartItemInterface]][CartItemInterface] | Contains the items in the customer's cart
+`prices` | [CartPrices][CartPrices] | Contains subtotals and totals
+`selected_payment_method` | [SelectedPaymentMethod][SelectedPaymentMethod] | Selected payment method
+`shipping_addresses` | [[ShippingCartAddress]][ShippingCartAddress]! | Contains one or more shipping addresses
+`total_quantity` | Float! | Total Quantity of products in the cart
+
+[AppliedCoupon]: {{page.baseurl}}/graphql/queries/cart.html#AppliedCoupon
+[AppliedGiftCard]: {{page.baseurl}}/graphql/queries/cart.html#AppliedGiftCard
+[AppliedStoreCredit]: {{page.baseurl}}/graphql/queries/cart.html#AppliedStoreCredit
+[AvailablePaymentMethod]: {{page.baseurl}}/graphql/queries/cart.html#AvailablePaymentMethod
+[BillingCartAddress]: {{page.baseurl}}/graphql/queries/cart.html#BillingCartAddress
+[CartItemInterface]: {{page.baseurl}}/graphql/queries/cart.html#CartItemInterface
+[CartPrices]: {{page.baseurl}}/graphql/queries/cart.html#CartPrices
+[GiftMessage]: {{page.baseurl}}/graphql/queries/cart.html#GiftMessage
+[SelectedPaymentMethod]: {{page.baseurl}}/graphql/queries/cart.html#SelectedPaymentMethod
+[ShippingCartAddress]: {{page.baseurl}}/graphql/queries/cart.html#ShippingCartAddress

--- a/src/_includes/graphql/gift-message-24.md
+++ b/src/_includes/graphql/gift-message-24.md
@@ -1,0 +1,5 @@
+Attribute | Data Type | Description
+--- | --- | ---
+`to` | String! | Recipient name
+`from` | String! | Sender name
+`message` | String! | Gift message text

--- a/src/guides/v2.4/graphql/mutations/update-cart-items.md
+++ b/src/guides/v2.4/graphql/mutations/update-cart-items.md
@@ -102,12 +102,13 @@ Attribute |  Data Type | Description
 
 ### CartItemUpdateInput object {#CartItemUpdateInput}
 
-The `CartItemUpdateInput` object must contain the following attributes:
+The `CartItemUpdateInput` object may contain the following attributes:
 
 Attribute |  Data Type | Description
 --- | --- | ---
 `cart_item_id` | Int! | The unique ID assigned when a customer places an item in the cart
 `customizable_options` | [CustomizableOptionInput!] | An array that defines customizable options for the product
+`gift_message` | [GiftMessageInput](#GiftMessageInput) | Gift message details for the cart item
 `quantity` | Float | The new quantity of the item. A value of `0` removes the item from the cart
 
 ### CustomizableOptionInput object {#CustomizableOptionInputSimple}
@@ -115,6 +116,12 @@ Attribute |  Data Type | Description
 The `CustomizableOptionInput` object must contain the following attributes:
 
 {% include graphql/customizable-option-input.md %}
+
+### GiftMessageInput object {#GiftMessageInput}
+
+The `GiftMessageInput` object must contain the following attributes:
+
+{% include graphql/gift-message-24.md %}
 
 ## Output attributes
 

--- a/src/guides/v2.4/graphql/queries/cart.md
+++ b/src/guides/v2.4/graphql/queries/cart.md
@@ -383,6 +383,40 @@ The `3T1free` rule is applied first, and Magento returns the price of a single s
 }
 ```
 
+### Gift message example
+
+The following example shows how to retrieve a gift message for cart.
+
+**Request:**
+
+```graphql
+{
+    cart(cart_id: "8RNne0xE1QGaTAtHl1D9hdpxvlePKeXp") {
+        gift_message {
+            to
+            from
+            message
+        }
+    }
+}
+```
+
+**Response:**
+
+```json
+{
+  "data": {
+    "cart": {
+      "gift_message": {
+        "to": "Mercutio",
+        "from": "Romeo",
+        "message": "I thought all for the best."
+      }
+    }
+  }
+}
+```
+
 ### Tier price example
 
 In the following example, tier prices has been established for product `24-UG01` and `24-UG05`, as shown in the following table:
@@ -562,7 +596,7 @@ query {
 
 ## Input attributes
 
-Attribute |  Data Type | Description
+Attribute | Data Type | Description
 --- | --- | ---
 `cart_id` | String! | A 32-character string that is created when you [create a cart]({{page.baseurl}}/graphql/mutations/create-empty-cart.html)
 
@@ -574,13 +608,13 @@ The top-level `Cart` object is listed first. All interfaces and child objects ar
 
 The `Cart` object can contain the following attributes.
 
-{% include graphql/cart-object.md %}
+{% include graphql/cart-object-24.md %}
 
 ### AppliedCoupon object {#AppliedCoupon}
 
-The `AppliedCoupon` object must contain the following attributes.
+The `AppliedCoupon` object must contain the following attribute.
 
-Attribute |  Data Type | Description
+Attribute | Data Type | Description
 --- | --- | ---
 `code` | String! | The coupon code applied to the order
 
@@ -588,7 +622,7 @@ Attribute |  Data Type | Description
 
 The `AppliedGiftCard` object can contain the following attributes.
 
-Attribute |  Data Type | Description
+Attribute | Data Type | Description
 --- | --- | ---
 `applied_balance` | Money | Applied balance to the current cart
 `code` | String | The gift card code applied to the order
@@ -609,7 +643,7 @@ Attribute |  Data Type | Description
 
 The `AvailablePaymentMethod` object must contain the following attributes.
 
-Attribute |  Data Type | Description
+Attribute | Data Type | Description
 --- | --- | ---
 `code` |  String! | The payment method code
 `title` | String! | The payment method title
@@ -618,7 +652,7 @@ Attribute |  Data Type | Description
 
 The `AvailableShippingMethod` object can contain the following attributes.
 
-Attribute |  Data Type | Description
+Attribute | Data Type | Description
 --- | --- | ---
 `amount` | Money! | The cost of shipping using this shipping method
 `available` | Boolean! | Indicates whether this shipping method can be applied to the cart
@@ -639,7 +673,7 @@ The `BillingCartAddress` object implements [`CartAddressInterface`](#CartAddress
 
 The `CartAddressCountry` object can contain the following attributes.
 
-Attribute |  Data Type | Description
+Attribute | Data Type | Description
 --- | --- | ---
 `code` | String! | The country code
 `label` | String! | The display label for the country
@@ -648,7 +682,7 @@ Attribute |  Data Type | Description
 
 The `CartAddressInterface` contains the following attributes.
 
-Attribute |  Data Type | Description
+Attribute | Data Type | Description
 --- | --- | ---
 `city` | String! | The city specified for the billing address
 `company` | String | The company specified for the billing address
@@ -665,7 +699,7 @@ Attribute |  Data Type | Description
 
 The `CartAddressRegion` object can contain the following attributes.
 
-Attribute |  Data Type | Description
+Attribute | Data Type | Description
 --- | --- | ---
 `code` | String | The state or province code
 `label` | String | The display label for the region
@@ -675,7 +709,7 @@ Attribute |  Data Type | Description
 
 The `CartDiscount` object must contain the following attributes.
 
-Attribute |  Data Type | Description
+Attribute | Data Type | Description
 --- | --- | ---
 `amount` | Money | The amount of all discounts applied to the cart
 `label` | [String!]! | A concatenated list of strings that describe each applied discount
@@ -684,7 +718,7 @@ Attribute |  Data Type | Description
 
 The `CartItemInterface` can contain the following attributes.
 
-Attribute |  Data Type | Description
+Attribute | Data Type | Description
 --- | --- | ---
 `id` | String | ID of the item
 `prices` | [CartItemPrices](#CartItemPrices) | Includes the price of an item, any applied discounts, and calculated totals
@@ -695,7 +729,7 @@ Attribute |  Data Type | Description
 
 The `CartItemPrices` object can contain the following attributes.
 
-Attribute |  Data Type | Description
+Attribute | Data Type | Description
 --- | --- | ---
 `discounts`| [Discount] | An array of discounts to be applied to the cart item
 `price` | Money! | The price of the item before any discounts were applied
@@ -716,7 +750,7 @@ Attribute |  Data Type | Description
 
 The `CartPrices` object can contain the following attributes.
 
-Attribute |  Data Type | Description
+Attribute | Data Type | Description
 --- | --- | ---
 `applied_taxes` | [[CartTaxItem]](#CartTaxItem) | An array containing the names and amounts of taxes applied to the item
 `discount` | CartDiscount | Deprecated. Use `discounts` instead
@@ -730,7 +764,7 @@ Attribute |  Data Type | Description
 
 The `CartTaxItem` object must contain the following attributes.
 
-Attribute |  Data Type | Description
+Attribute | Data Type | Description
 --- | --- | ---
 `amount` | Money! | The amount of tax applied to the item
 `label` | String! | The description of the tax
@@ -743,16 +777,22 @@ If a cart rule does not have a label, Magento uses `Discount` as the default lab
 
 The `Discount` object must contain the following attributes.
 
-Attribute |  Data Type | Description
+Attribute | Data Type | Description
 --- | --- | ---
 `amount` | Money! | The amount of the discount applied to the cart
 `label` | String! | The description of the discount
+
+### GiftMessage object {#GiftMessage}
+
+The `GiftMessage` object must contain the following attributes.
+
+{% include graphql/gift-message-24.md %}
 
 ### SelectedPaymentMethod object {#SelectedPaymentMethod}
 
 The `SelectedPaymentMethod` object can contain the following attributes.
 
-Attribute |  Data Type | Description
+Attribute | Data Type | Description
 --- | --- | ---
 `code` | String! | The payment method code
 `purchase_order_number` | String | The purchase order number
@@ -762,7 +802,7 @@ Attribute |  Data Type | Description
 
 The `SelectedShippingMethod` object can contain the following attributes.
 
-Attribute |  Data Type | Description
+Attribute | Data Type | Description
 --- | --- | ---
 `amount` | Money! | The cost of shipping using this shipping method
 `base_amount` | Money | Deprecated. This attribute is not applicable for GraphQL
@@ -775,7 +815,7 @@ Attribute |  Data Type | Description
 
 The `ShippingCartAddress` object implements [`CartAddressInterface`](#CartAddressInterface). It can also contain the following attributes.
 
-Attribute |  Data Type | Description
+Attribute | Data Type | Description
 --- | --- | ---
 `available_shipping_methods` | [[AvailableShippingMethod]](#AvailableShippingMethod) | An array that lists the shipping methods that can be applied to the cart
 `cart_items` | [[CartItemQuantity]](#CartItemQuantity) | Deprecated. Use `cart_items_v2` instead


### PR DESCRIPTION

## Purpose of this pull request

This pull request (PR) provides an update for `cart` query regarding to https://github.com/magento/devdocs/issues/7363.

## Affected DevDocs pages

<!-- REQUIRED List the affected pages on devdocs.magento.com (URLs). Not needed for large numbers of files. -->

- https://devdocs.magento.com/guides/v2.4/graphql/queries/cart.html

## Links to Magento source code

<!--  OPTIONAL - REMOVE THIS SECTION IF NOT USED. If this pull request references a file in a Magento codebase repository, add it here. -->

- [gift_message](https://github.com/magento/magento2/blob/2.4-develop/app/code/Magento/GiftMessageGraphQl/etc/schema.graphqls#L10)

<!--
If you are fixing a GitHub issue, note it using GitHub keyword format (https://help.github.com/en/articles/closing-issues-using-keywords#closing-an-issue-in-a-different-repository) to close the issue when this pull request is merged. Example: `Fixes #1234`

`master` is the default branch. Merged pull requests to `master` go live on the site automatically. Any requested changes to content on the `master` branch must be related to the released codebase. Any content related to future releases goes in the `develop` branch.

See Contribution guidelines (https://github.com/magento/devdocs/blob/master/.github/CONTRIBUTING.md) for more information.
-->
