### PR TITLE
magento/devdocs#7363: Add “gift_message” to CustomerOrders query

### DIFF
--- a/src/guides/v2.4/graphql/queries/customer-orders.md
+++ b/src/guides/v2.4/graphql/queries/customer-orders.md
@@ -75,11 +75,22 @@ The `CustomerOrder` object defines details about each order the customer has pla
 Attribute | Data type | Description
 --- | --- | ---
 `created_at` | String | A timestamp indicating when the order was placed
+`gift_message` | [GiftMessage]({{page.baseurl}}/graphql/queries/customer-orders.html#GiftMessage) | The entered gift message for the order
 `grand_total` | Float | The total of the order
 `id` | Int | The ID assigned to the customer's order
 `increment_id` | String | Deprecated. Use `order_number` instead. An ID that indicates the sequence of the order in the customer's order history
 `order_number` | String! | The order number assigned to the order
 `status` | String | The status of the order, such as `open`, `processing`, or `closed`
+
+#### GiftMessage object {#GiftMessage}
+
+The `GiftMessage` object contains the following required attributes.
+
+Attribute | Data Type | Description
+--- | --- | ---
+`to` | String! | Recipient name
+`from` | String! | Sender name
+`message` | String! | Gift message text
 
 ## Errors
 


### PR DESCRIPTION


## Purpose of this pull request

This pull request (PR) updates [customerOrders query](https://devdocs.magento.com/guides/v2.4/graphql/queries/customer-orders.html) with `gift_messages` attribute.

## Affected DevDocs pages

<!-- REQUIRED List the affected pages on devdocs.magento.com (URLs). Not needed for large numbers of files. -->

- https://devdocs.magento.com/guides/v2.4/graphql/queries/customer-orders.html

## Links to Magento source code

<!--  OPTIONAL - REMOVE THIS SECTION IF NOT USED. If this pull request references a file in a Magento codebase repository, add it here. -->

- [customerOrder](https://github.com/magento/magento2/blob/2.4-develop/app/code/Magento/GiftMessageGraphQl/etc/schema.graphqls#L46)

<!--
If you are fixing a GitHub issue, note it using GitHub keyword format (https://help.github.com/en/articles/closing-issues-using-keywords#closing-an-issue-in-a-different-repository) to close the issue when this pull request is merged. Example: `Fixes #1234`

`master` is the default branch. Merged pull requests to `master` go live on the site automatically. Any requested changes to content on the `master` branch must be related to the released codebase. Any content related to future releases goes in the `develop` branch.

See Contribution guidelines (https://github.com/magento/devdocs/blob/master/.github/CONTRIBUTING.md) for more information.
-->
