### PR TITLE
Add documentation about running a PHP command through magento-docker

### DIFF
--- a/src/cloud/docker/docker-quick-reference.md
+++ b/src/cloud/docker/docker-quick-reference.md
@@ -86,6 +86,7 @@ Build application | `./bin/magento-docker ece-build`
 Deploy application | `./bin/magento-docker ece-deploy`
 Run post-deploy hooks | `./bin/magento-docker ece-post-deploy`
 Re-build and re-deploy application | `./bin/magento-docker ece-redeploy`
+Run a command in a PHP container | `./bin/magento-docker php <PHP version> <command>`
 Stop containers | `./bin/magento-docker stop`
 Start containers | `./bin/magento-docker start`
 Restart containers | `./bin/magento-docker restart`


### PR DESCRIPTION
## Purpose of this pull request

Document the `php` argument for the `magento-docker` CLI command.

## Affected DevDocs pages

https://devdocs.magento.com/cloud/docker/docker-quick-reference.html

## Links to Magento source code

https://github.com/magento/magento-cloud-docker/blob/develop/dist/bin/magento-docker#L22
