### PR TITLE
Adding heading to Page Builder install section

### DIFF
--- a/src/recommendations/install-configure.md
+++ b/src/recommendations/install-configure.md
@@ -25,6 +25,8 @@ The `magento/product-recommendations` module requires the following dependencies
    {:.bs-callout-info}
    If you prefer, you can install the above modules explicitly using Composer: `composer require magento/data-services` and `composer require magento/saas-export`
 
+### Add Page Builder support {#pbsupport}
+
 Product Recommendations for [Page Builder]({{ site.baseurl }}/page-builder/docs/index.html) is an optional module and is installed separately. To use Product Recommendations with Page Builder, install the module by running the following command:
 
 ```bash


### PR DESCRIPTION
## Purpose of this pull request

This pull request (PR) adds a heading to the section about how to install support for Page Builder.

## Affected DevDocs pages

<!-- REQUIRED List the affected pages on devdocs.magento.com (URLs). Not needed for large numbers of files. -->

-  https://devdocs.magento.com/recommendations/install-configure.html
