### PR TITLE
Corrected format of memory value for PHP.

### DIFF
--- a/src/guides/v2.3/performance-best-practices/software.md
+++ b/src/guides/v2.3/performance-best-practices/software.md
@@ -65,7 +65,7 @@ To guarantee successful execution of all Magento instances without dumping data 
 To get maximum speed out of Magento 2 on PHP7, you must activate the OpCache module and properly configure it. These settings are recommended for the module:
 
 ```bash
-  opcache.memory_consumption=2GB
+  opcache.memory_consumption=2048
   opcache.max_accelerated_files=60000
   opcache.consistency_checks=0
   opcache.validate_timestamps=0


### PR DESCRIPTION
## Purpose of this pull request

This pull request (PR) fixes the format of the memory value: '2GB' should be '2048'

## Affected DevDocs pages

https://devdocs.magento.com/guides/v2.3/performance-best-practices/software.html#php-settings
