### PR TITLE
Remove link to Baler config instructions

### DIFF
--- a/src/cloud/env/variables-build.md
+++ b/src/cloud/env/variables-build.md
@@ -21,24 +21,6 @@ The following variables were removed in v2.2:
 -  `skip_di_clearing`
 -  `skip_di_compilation`
 
-### `SCD_USE_BALER`
-
--  **Default**—_Not set_
--  **Version**—Magento 2.3.0 and later
-
-[Baler](https://github.com/magento/baler) scans your generated JavaScript code and creates an optimized JavaScript bundle. Deploying the optimized bundle to your site can reduce the number of network requests when loading your site and improve page load times.
-
-Set to `true` to run Baler after performing static content deployment.
-
-```yaml
-stage:
-  build:
-    SCD_USE_BALER: true
-```
-
-{:.bs-callout-info}
-You must install and configure the Baler module before using this feature. See [Optimize JavaScript and HTML content]({{site.baseurl}}/cloud/deploy/static-content-deployment.html#optimize-javascript-and-html-content). Because Baler is currently in alpha release, we do not recommend using it in Production environments.
-
 ### `ERROR_REPORT_DIR_NESTING_LEVEL`
 
 -  **Default**—`1`
@@ -155,6 +137,24 @@ stage:
 ```
 
 To further reduce deployment time, we recommend using [Configuration Management]({{ site.baseurl }}/cloud/live/sens-data-over.html) with the `scd-dump` command to move static deployment into the build phase.
+
+### `SCD_USE_BALER`
+
+-  **Default**—_Not set_
+-  **Version**—Magento 2.3.0 and later
+
+[Baler](https://github.com/magento/baler) scans your generated JavaScript code and creates an optimized JavaScript bundle. Deploying the optimized bundle to your site can reduce the number of network requests when loading your site and improve page load times.
+
+Set to `true` to run Baler after performing static content deployment.
+
+```yaml
+stage:
+  build:
+    SCD_USE_BALER: true
+```
+
+{:.bs-callout-info}
+Because Baler is currently in alpha release, we do not recommend using it in Production environments.
 
 ### `SKIP_SCD`
 


### PR DESCRIPTION
## Purpose of this pull request

Remove reference to Baler config instructions, and put variable in alphabetical order

## Affected DevDocs pages

- https://devdocs.magento.com/cloud/env/variables-build.html
