### PR TITLE
Add 2021 release dates to release info page

### DIFF
--- a/src/release/index.md
+++ b/src/release/index.md
@@ -9,33 +9,43 @@ Magento continually strives to find the right balance between making product upg
 
 The following table describes the status of Magento software availability and where to get it, particularly for software that is available outside the conventional {{site.data.var.ee}} Composer package.
 
-| Product                                           | Availability                                                                                                                                | How to get it                                                                                     |
-|---------------------------------------------------|---------------------------------------------------------------------------------------------------------------------------------------------|---------------------------------------------------------------------------------------------------|
-| **{{site.data.var.ee}} 2.3.5-p1**                 | Available now                                                                                                                               | [Composer]({{ site.baseurl }}/guides/v2.3/install-gde/composer.html)                              |
-| **{{site.data.var.ee}} 2.3.4-p2** (security only) | Available now                                                                                                                               | [Composer]({{ site.baseurl }}/guides/v2.3/install-gde/composer.html)                              |
-| **{{site.data.var.ece}} Tools (aka ECE-Tools)**   | Available now                                                                                                                               | [Composer]({{ site.baseurl }}/cloud/project/ece-tools-update.html)                                |
-| **Product Recommendations**                       | Available now                                                                                                                   | [Magento Marketplace](https://marketplace.magento.com/magento-product-recommendations.html) \| [Developer Documentation](https://devdocs.magento.com/recommendations/product-recs.html) \| [User Guide](https://docs.magento.com/m2/ee/user_guide/marketing/product-recommendations.html)                                 |
-| **PWA Studio**                                    | Available now                                                                                                                               | [Documentation](http://pwastudio.io) and [GitHub](https://github.com/magento-research/pwa-studio) |
-| **Amazon Sales Channel 4.1.0**                      | Available now for Magento versions 2.3.x (US, Canada, Mexico, and UK)                                                                  | [Magento Marketplace](https://marketplace.magento.com/magento-module-amazon.html)                 |
+| Product                                           | Availability                                                          | How to get it                                                                                                                                                                                                                                                                             |
+|---------------------------------------------------|-----------------------------------------------------------------------|-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| **{{site.data.var.ee}} 2.3.5-p1**                 | Available now                                                         | [Composer]({{ site.baseurl }}/guides/v2.3/install-gde/composer.html)                                                                                                                                                                                                                      |
+| **{{site.data.var.ee}} 2.3.4-p2** (security only) | Available now                                                         | [Composer]({{ site.baseurl }}/guides/v2.3/install-gde/composer.html)                                                                                                                                                                                                                      |
+| **{{site.data.var.ece}} Tools (aka ECE-Tools)**   | Available now                                                         | [Composer]({{ site.baseurl }}/cloud/project/ece-tools-update.html)                                                                                                                                                                                                                        |
+| **Product Recommendations**                       | Available now                                                         | [Magento Marketplace](https://marketplace.magento.com/magento-product-recommendations.html) \| [Developer Documentation](https://devdocs.magento.com/recommendations/product-recs.html) \| [User Guide](https://docs.magento.com/m2/ee/user_guide/marketing/product-recommendations.html) |
+| **PWA Studio**                                    | Available now                                                         | [Documentation](http://pwastudio.io) and [GitHub](https://github.com/magento-research/pwa-studio)                                                                                                                                                                                         |
+| **Amazon Sales Channel 4.1.0**                    | Available now for Magento versions 2.3.x (US, Canada, Mexico, and UK) | [Magento Marketplace](https://marketplace.magento.com/magento-module-amazon.html)                                                                                                                                                                                                         |
 
-## Patch schedule
+## Release schedule
 
 Magento releases security and functional patches for each supported release line of {{site.data.var.ee}} every quarter.
 
-Security releases provide fixes for vulnerabilities that have been identified in previous quarterly patch releases. You can install time-sensitive security fixes without applying the hundreds of functional fixes and enhancements that a full quarterly patch release contains. These releases are appended with `-p1`.
+### About security-only reeleases
+
+Security-only releases provide fixes for vulnerabilities that have been identified in previous quarterly patch releases. You can install time-sensitive security fixes without applying the hundreds of functional fixes and enhancements that a full quarterly patch release contains. These releases are appended with `-p1`.
 
 For general information about security releases, see [Introducing the New Security-only Patch Release](https://community.magento.com/t5/Magento-DevBlog/Introducing-the-New-Security-only-Patch-Release/ba-p/141287). For instructions on downloading and applying security patches, see [Install Magento using Composer]({{site.baseurl}}/guides/v2.3/install-gde/composer.html).
 
-The following table provides the dates for each patch scheduled for release in 2020:
+### Early access
 
-| Version              | Pre-release | GA         |
-|----------------------|-------------|------------|
-| 2.3.4<br>2.3.3-p1    | January 14  | January 28 |
-| 2.3.5-p1<br>2.3.4-p2 | April 14    | April 28   |
-| 2.3.5-p2             | N/A         | July 28    |
-| 2.3.6                | October 1   | October 15 |
+Pre-release is GA code that is available to {{site.data.var.ee}} merchants and all partners two weeks before GA. It allows for quicker deployment of code before GA.
 
-_These dates are subject to change._
+Beta is non-GA code that is available to all partners. It allows for extra time to review code and affected components.
+
+The following table provides the dates for each scheduled release in 2020 and 2021 (dates are subject to change):
+
+| Quarter             | Versions                   | GA               | Pre-release        | Beta               |
+|---------------------|----------------------------|------------------|--------------------|--------------------|
+| 2020 Q3             | 2.4.0<br>2.3.5-p2          | July 28, 2020    | None               | June 8, 2020       |
+| 2020 Q4             | 2.4.1<br>2.3.6             | October 15, 2020 | October 15, 2021   | September 10, 2020 |
+| 2021 Q1             | 2.4.2<br>2.4.1-p1<br>2.3.7 | February 9, 2021 | January 26, 2021   | January 5, 2021    |
+| 2021 Q2             | 2.4.3<br>2.4.2-p1<br>2.3.8 | May 11, 2021     | April 27, 2021     | April 6, 2021      |
+| 2021 Q3             | 2.4.4<br>2.4.3-p1<br>2.3.9 | August 10, 2021  | July 27, 2021      | July 6, 2021       |
+| 2021 Q4<sup>*</sup> | 2.4.4-p1<br>2.3.10         | October 12, 2021 | September 28, 2021 | None               |
+
+_<sup>*</sup>There will not be a 2.4.5 release in 2021 Q4._
 
 ## Compatibility
 


### PR DESCRIPTION
## Purpose of this pull request

This pull request (PR) adds the 2021 release dates to the release info page. Info provided by Product Management team.

## Affected DevDocs pages

-  https://devdocs.magento.com/release/

whatsnew
Added 2021 release dates to the [release information page](https://devdocs.magento.com/release/).