### PR TITLE
Removed irrelevant info about encryption keys

### DIFF
--- a/src/guides/v2.3/config-guide/cli/config-cli-subcommands-spt-util.md
+++ b/src/guides/v2.3/config-guide/cli/config-cli-subcommands-spt-util.md
@@ -74,11 +74,24 @@ Where:
 -  **`--name`** specifies the dump file name (optional). If you omit this parameter, the dump file is time and date-stamped.
 -  **`-o|--output=<path>` is the absolute file system path to store the backup (required).
 -  **`-l|--logs`** includes log files (optional).
--  **`-i|--ignore-sanitize`** means that data is preserved; omit the flag to hash [sensitive data](#sens-data) stored in the database when creating the backup (optional).
+-  **`-i|--ignore-sanitize`** means that data is preserved; omit the flag to hash sensitive data stored in the database when creating the backup (optional).
+
+Sensitive data includes customer information from the following database tables:
+
+```terminal
+'customer_entity',
+'customer_entity_varchar',
+'customer_address_entity',
+'customer_address_entity_varchar',
+'customer_grid_flat',
+'quote',
+'quote_address',
+'sales_order',
+'sales_order_address',
+'sales_order_grid'
+```
 
 After the command completes, provide the database backup to Magento Support.
-
-{% include install/sens-data.md %}
 
 ## Troubleshooting: display utilities and paths {#config-cli-spt-utils-trouble}
 


### PR DESCRIPTION
## Purpose of this pull request

This pull request (PR) removes the irrelevant association of encryption keys with sensitive data when using the `bin/magento support:backup:code` command.

## Affected DevDocs pages

- https://devdocs.magento.com/guides/v2.3/config-guide/cli/config-cli-subcommands-spt-util.html
- https://devdocs.magento.com/guides/v2.4/config-guide/cli/config-cli-subcommands-spt-util.html