### PR TITLE
Fix typo in release calendar

### DIFF
--- a/src/release/index.md
+++ b/src/release/index.md
@@ -22,7 +22,7 @@ The following table describes the status of Magento software availability and wh
 
 Magento releases security and functional patches for each supported release line of {{site.data.var.ee}} every quarter.
 
-### About security-only reeleases
+### About security-only releases
 
 Security-only releases provide fixes for vulnerabilities that have been identified in previous quarterly patch releases. You can install time-sensitive security fixes without applying the hundreds of functional fixes and enhancements that a full quarterly patch release contains. These releases are appended with `-p1`.
 
@@ -30,20 +30,20 @@ For general information about security releases, see [Introducing the New Securi
 
 ### Early access
 
-Pre-release is GA code that is available to {{site.data.var.ee}} merchants and all partners two weeks before GA. It allows for quicker deployment of code before GA.
+Pre-release is General Availability code that is available to {{site.data.var.ee}} merchants and all partners two weeks before GA. It allows for quicker deployment of code before General Availability.
 
-Beta is non-GA code that is available to all partners. It allows for extra time to review code and affected components.
+Beta is non-General Availability code that is available to all partners. It allows for extra time to review code and affected components.
 
 The following table provides the dates for each scheduled release in 2020 and 2021 (dates are subject to change):
 
-| Quarter             | Versions                   | GA               | Pre-release        | Beta               |
-|---------------------|----------------------------|------------------|--------------------|--------------------|
-| 2020 Q3             | 2.4.0<br>2.3.5-p2          | July 28, 2020    | None               | June 8, 2020       |
-| 2020 Q4             | 2.4.1<br>2.3.6             | October 15, 2020 | October 15, 2021   | September 10, 2020 |
-| 2021 Q1             | 2.4.2<br>2.4.1-p1<br>2.3.7 | February 9, 2021 | January 26, 2021   | January 5, 2021    |
-| 2021 Q2             | 2.4.3<br>2.4.2-p1<br>2.3.8 | May 11, 2021     | April 27, 2021     | April 6, 2021      |
-| 2021 Q3             | 2.4.4<br>2.4.3-p1<br>2.3.9 | August 10, 2021  | July 27, 2021      | July 6, 2021       |
-| 2021 Q4<sup>*</sup> | 2.4.4-p1<br>2.3.10         | October 12, 2021 | September 28, 2021 | None               |
+| Quarter             | Versions                   | General Availability | Pre-release        | Beta               |
+|---------------------|----------------------------|----------------------|--------------------|--------------------|
+| 2020 Q3             | 2.4.0<br>2.3.5-p2          | July 28, 2020        | None               | June 8, 2020       |
+| 2020 Q4             | 2.4.1<br>2.3.6             | October 15, 2020     | October 15, 2021   | September 10, 2020 |
+| 2021 Q1             | 2.4.2<br>2.4.1-p1<br>2.3.7 | February 9, 2021     | January 26, 2021   | January 5, 2021    |
+| 2021 Q2             | 2.4.3<br>2.4.2-p1<br>2.3.8 | May 11, 2021         | April 27, 2021     | April 6, 2021      |
+| 2021 Q3             | 2.4.4<br>2.4.3-p1<br>2.3.9 | August 10, 2021      | July 27, 2021      | July 6, 2021       |
+| 2021 Q4<sup>*</sup> | 2.4.4-p1<br>2.3.10         | October 12, 2021     | September 28, 2021 | None               |
 
 _<sup>*</sup>There will not be a 2.4.5 release in 2021 Q4._
 

--- a/src/release/index.md
+++ b/src/release/index.md
@@ -30,7 +30,7 @@ For general information about security releases, see [Introducing the New Securi
 
 ### Early access
 
-Pre-release is General Availability code that is available to {{site.data.var.ee}} merchants and all partners two weeks before GA. It allows for quicker deployment of code before General Availability.
+Pre-release is General Availability code that is available to {{site.data.var.ee}} merchants and all partners two weeks before General Availability. It allows for quicker deployment of code before General Availability.
 
 Beta is non-General Availability code that is available to all partners. It allows for extra time to review code and affected components.
 


### PR DESCRIPTION
## Purpose of this pull request

This pull request (PR) fixes a typo in the release info page.

## Affected DevDocs pages

- https://devdocs.magento.com/release/