### PR TITLE
Added deprecation notice for Elasticsearch 6

### DIFF
--- a/src/_includes/config/es-elasticsearch-magento.md
+++ b/src/_includes/config/es-elasticsearch-magento.md
@@ -1,10 +1,7 @@
 This section discusses the minimum settings you must choose to test Elasticsearch with Magento 2.
 For additional details about configuring Elasticsearch, see the [{{site.data.var.ee}} User Guide](http://docs.magento.com/m2/ee/user_guide/catalog/search-elasticsearch.html).
 
-{:.bs-callout-warning}
-Magento 2.3.5 adds support for Elasticsearch 7.x.x and 6.8.x.
-Versions 2.x and 5.x are [End of Life](https://www.elastic.co/support/eol) and are not supported.
-Follow the instructions in [Change the Elasticsearch Client]({{page.baseurl}}/config-guide/elasticsearch/es-downgrade.html).
+{% include config/es-version-23.md %}
 
 ## Configure Elasticsearch within Magento
 

--- a/src/_includes/config/es-version-23.md
+++ b/src/_includes/config/es-version-23.md
@@ -1,0 +1,9 @@
+{:.bs-callout-warning}
+{{site.data.var.ee}} 2.3.6 supports Elasticsearch 7.x.x. (default).
+Both Elasticsearch 2.x and 5.x have reached [end-of-life][] and are no longer supported. Support for Elasticsearch 6.8 has been deprecated in Magento 2.3.6, but you can still use it in Magento 2.3.5 and 2.3.6.
+Follow the instructions in [Change Elasticsearch Client][].
+
+<!-- Link Definitions -->
+
+[end-of-life]: https://www.elastic.co/support/eol
+[Change Elasticsearch Client]: {{page.baseurl}}/config-guide/elasticsearch/es-downgrade.html

--- a/src/_includes/config/es-version-23.md
+++ b/src/_includes/config/es-version-23.md
@@ -1,9 +1,6 @@
 {:.bs-callout-warning}
-{{site.data.var.ee}} 2.3.6 supports Elasticsearch 7.x.x. (default).
-Both Elasticsearch 2.x and 5.x have reached [end-of-life][] and are no longer supported. Support for Elasticsearch 6.8 has been deprecated in Magento 2.3.6, but you can still use it in Magento 2.3.5 and 2.3.6.
-Follow the instructions in [Change Elasticsearch Client][].
+As of version 2.3.6, {{site.data.var.ee}} supports Elasticsearch 7.x, with a preference for 7.6.x. Support for Elasticsearch 6.x has been deprecated, but it can still be used. Both Elasticsearch 2.x and 5.x have reached [end-of-life][] and are no longer supported.
 
 <!-- Link Definitions -->
 
 [end-of-life]: https://www.elastic.co/support/eol
-[Change Elasticsearch Client]: {{page.baseurl}}/config-guide/elasticsearch/es-downgrade.html

--- a/src/guides/v2.3/config-guide/elasticsearch/es-downgrade.md
+++ b/src/guides/v2.3/config-guide/elasticsearch/es-downgrade.md
@@ -8,9 +8,7 @@ functional_areas:
   - Setup
 ---
 
-The Magento 2.3.5 update adds support for Elasticsearch (ES) 6.8.x and 7.x.x.
-
-Both ES 2.x and 5.x are [End of Life][] and are no longer supported in Magento.
+{% include config/es-version-23.md %}
 
 ## Change the Elasticsearch Client version
 
@@ -30,6 +28,4 @@ Then configure Elasticsearch within [Magento Admin][].
 
 <!-- Link Definitions -->
 
-[End of Life]: https://www.elastic.co/support/eol
-[PHP client]: https://github.com/elastic/elasticsearch-php
 [Magento Admin]: https://docs.magento.com/m2/ee/user_guide/catalog/search-elasticsearch.html

--- a/src/guides/v2.3/config-guide/elasticsearch/es-overview.md
+++ b/src/guides/v2.3/config-guide/elasticsearch/es-overview.md
@@ -32,14 +32,7 @@ Using [Elasticsearch][] as your [catalog](https://glossary.magento.com/catalog) 
 
 ### Supported versions {#es-spt-versions}
 
-Magento 2.3.5 adds support for Elasticsearch 7.x.x (default) and 6.8.x.
-Both ES 2.x and 5.x are [End of Life][] and are no longer supported in Magento.
-Follow the instructions in [Change Elasticsearch Client][].
-
-{{site.data.var.ee}} version 2.3.5 supports the following Elasticsearch versions:
-
-*  Elasticsearch 7.x.x
-*  Elasticsearch 6.8.x
+{% include config/es-version-23.md %}
 
 ### Recommended configuration {#es-arch}
 
@@ -133,9 +126,7 @@ For additional information, see [Elasticsearch documentation][]{:target="_blank"
 [Configure Magento to use Elasticsearch]: {{page.baseurl}}/config-guide/elasticsearch/configure-magento.html
 [Elasticsearch Ubuntu documentation]: https://www.elastic.co/guide/en/elasticsearch/reference/current/deb.html
 [Configuring Elasticsearch]: https://www.elastic.co/guide/en/elasticsearch/reference/current/settings.html
-[End of Life]: https://www.elastic.co/support/eol
 [Upgrading Elasticsearch]: https://www.elastic.co/guide/en/elasticsearch/reference/current/setup-upgrade.html
 [Full cluster restart upgrade]: https://www.elastic.co/guide/en/elasticsearch/reference/current/restart-upgrade.html
 [Elasticsearch documentation]: https://www.elastic.co/guide/en/elasticsearch/reference/current/index.html
-[Change Elasticsearch Client]: {{page.baseurl}}/config-guide/elasticsearch/es-downgrade.html
 [Installing Elasticsearch]: https://www.elastic.co/guide/en/elasticsearch/reference/current/install-elasticsearch.html

--- a/src/guides/v2.3/install-gde/system-requirements-tech.md
+++ b/src/guides/v2.3/install-gde/system-requirements-tech.md
@@ -167,5 +167,4 @@ There is a known issue with `xdebug` that can affect Magento installations or ac
 [Varnish]: {{page.baseurl}}/config-guide/varnish/config-varnish.html
 [Elasticsearch]: {{page.baseurl}}/config-guide/elasticsearch/es-overview.html
 [Elasticsearch PHP client]: https://github.com/elastic/elasticsearch-php
-[end-of-life]: https://www.elastic.co/support/eol
 [RabbitMQ]: {{page.baseurl}}/config-guide/mq/rabbitmq-overview.html

--- a/src/guides/v2.3/install-gde/system-requirements-tech.md
+++ b/src/guides/v2.3/install-gde/system-requirements-tech.md
@@ -111,18 +111,7 @@ Mail Transfer Agent (MTA) or an SMTP server
 *  [Varnish]({{page.baseurl}}/config-guide/varnish/config-varnish.html) version 6.x (tested with 6.3.1)
 *  [Elasticsearch]({{page.baseurl}}/config-guide/elasticsearch/es-overview.html)
 
-   {{site.data.var.ee}} version 2.3.x supports the following Elasticsearch versions:
-
-   *  Elasticsearch 6.8.x
-
-      Magento 2.3 supports [Elasticsearch PHP client][]{:target="_blank"} version 6.8.
-
-   *  Elasticsearch 7.x.x
-
-      {:.bs-callout-warning}
-      Magento no longer provides support for Elasticsearch [2.x and 5.x][] as they are End of Life.
-
-      Follow the instructions in [Change Elasticsearch Module][].
+   {% include config/es-version-23.md %}
 
 *  RabbitMQ 3.8.x (compatible with 2.0 and later)
 
@@ -178,5 +167,5 @@ There is a known issue with `xdebug` that can affect Magento installations or ac
 [Varnish]: {{page.baseurl}}/config-guide/varnish/config-varnish.html
 [Elasticsearch]: {{page.baseurl}}/config-guide/elasticsearch/es-overview.html
 [Elasticsearch PHP client]: https://github.com/elastic/elasticsearch-php
-[2.x and 5.x]: https://www.elastic.co/support/eol
+[end-of-life]: https://www.elastic.co/support/eol
 [RabbitMQ]: {{page.baseurl}}/config-guide/mq/rabbitmq-overview.html


### PR DESCRIPTION
## Purpose of this pull request

This pull request (PR) adds deprecation messaging about Elasticsearch 6.x for Magento 2.3.6.

It also consolidates all ES version info into a single include file for Magento 2.3.x to make future updates easier.

## Affected DevDocs pages

- https://devdocs.magento.com/guides/v2.3/install-gde/system-requirements-tech.html#technologies-magento-can-use
- https://devdocs.magento.com/guides/v2.3/config-guide/elasticsearch/es-overview.html#es-spt-versions
- https://devdocs.magento.com/guides/v2.3/config-guide/elasticsearch/es-downgrade.html
- https://devdocs.magento.com/guides/v2.3/config-guide/elasticsearch/configure-magento.html
- https://devdocs.magento.com/guides/v2.3/config-guide/elasticsearch/es-config-nginx.html#elastic-m2-configure
- https://devdocs.magento.com/guides/v2.3/config-guide/elasticsearch/es-config-apache.html#elastic-m2-configure
- https://devdocs.magento.com/guides/v2.3/config-guide/elasticsearch/configure-magento.html

## Additional info

See internal ticket MC-35400 for details and a link to an internal staging build.

whatsnew
Added a [deprecation notice](https://devdocs.magento.com/guides/v2.3/install-gde/system-requirements-tech.html#technologies-magento-can-use) for Elasticsearch 6.x.