### PR TITLE
closing tag

### DIFF
--- a/src/guides/v2.3/extension-dev-guide/admin-grid.md
+++ b/src/guides/v2.3/extension-dev-guide/admin-grid.md
@@ -185,7 +185,7 @@ The UI component `dev_grid_category_listing` must be defined separately in a fil
          <filter>text</filter>
          <bodyTmpl>ui/grid/cells/text</bodyTmpl>
          <label translate="true">Path</label>
-      </settings
+     </settings>
     </column>
     <column name="name">
       <settings>


### PR DESCRIPTION
## Purpose of this pull request

This pull request (PR) adds a missing closing tag in documentation example.

## Affected DevDocs pages

https://devdocs.magento.com/guides/v2.4/extension-dev-guide/admin-grid.html

