### PR TITLE
Change shipping methods to delivery methods in select cases

### DIFF
--- a/src/guides/v2.4/config-guide/multi-site/ms_over.md
+++ b/src/guides/v2.4/config-guide/multi-site/ms_over.md
@@ -23,7 +23,7 @@ You configure the websites, stores, and store views in the Magento [Admin](https
 
 Consider the following terms:
 
--  **Website**—is the top-level container for sites, shipping methods, payment methods, and more. To create completely separate sites that do not share cart, shipping methods, or other you must create separate websites.
+-  **Website**—is the top-level container for sites, delivery methods, payment methods, and more. To create completely separate sites that do not share cart, delivery methods, or other you must create separate websites.
 
    Website customer accounts can be shared between multiple websites within a single Magento instance. A website contains at least one store. Catalog prices should be managed at the website level.
 

--- a/src/guides/v2.4/config-guide/prod/config-reference-most.md
+++ b/src/guides/v2.4/config-guide/prod/config-reference-most.md
@@ -760,9 +760,9 @@ Name  | Config path | EE only? |
 Allow Shipping to Multiple Addresses | `multishipping/options/checkout_multiple` | <!-- ![Not EE-only]({{ site.baseurl }}/common/images/red-x.png) --> |
 Maximum Qty Allowed for Shipping to Multiple Addresses | `multishipping/options/checkout_multiple_maximum_qty` | <!-- ![Not EE-only]({{ site.baseurl }}/common/images/red-x.png) --> |
 
-### Shipping methods paths
+### Delivery methods paths
 
-These configuration values are available in the Magento Admin in **Stores** > Settings > **Configuration** > **Sales** > **Shipping Methods**.
+These configuration values are available in the Magento Admin in **Stores** > Settings > **Configuration** > **Sales** > **Delivery Methods**.
 
 Name  | Config path | EE only? |
 |--------------|--------------|--------------|

--- a/src/guides/v2.4/config-guide/prod/config-reference-sens.md
+++ b/src/guides/v2.4/config-guide/prod/config-reference-sens.md
@@ -199,9 +199,9 @@ These configuration values are available in the Magento Admin in **Stores** > Se
 |--------------|--------------|--------------|--------------|--------------|--------------|
 | Container Id | `google/analytics/container_id` | ![EE-only]({{ site.baseurl }}/common/images/cloud_ee.png) | | | ![Sensitive]({{ site.baseurl }}/common/images/cloud_sens.png) |
 
-### Shipping methods sensitive and system-specific paths
+### Delivery methods sensitive and system-specific paths
 
-These configuration values are available in the Magento Admin in **Stores** > Settings > **Configuration** > **Sales** > **Shipping Methods**.
+These configuration values are available in the Magento Admin in **Stores** > Settings > **Configuration** > **Sales** > **Delivery Methods**.
 
 | Name | Config path | EE only? | Encrypted? | System-specific? | Sensitive? |
 |--------------|--------------|--------------|--------------|--------------|--------------|

--- a/src/guides/v2.4/graphql/mutations/set-shipping-method.md
+++ b/src/guides/v2.4/graphql/mutations/set-shipping-method.md
@@ -1,11 +1,9 @@
 ---
 group: graphql
 title: setShippingMethodsOnCart mutation
-redirect from:
-  - /guides/v2.3/graphql/reference/quote-shipping-method.html
 ---
 
-The `setShippingMethodsOnCart` mutation sets one or more shipping methods on a cart. By default, Magento GraphQL supports the following shipping methods:
+The `setShippingMethodsOnCart` mutation sets one or more delivery methods on a cart. By default, Magento GraphQL supports the following delivery methods:
 
 Label | Carrier code | Method code
 --- | --- | ---
@@ -17,13 +15,16 @@ Best Way | tablerate | bestway
 United Parcel Service | ups | Varies
 United States Postal Service | usps | Varies
 
+{:.bs-callout-info}
+Do not run the `setShippingMethodsOnCart` mutation on in-store pickup orders. Instead, specify the `pickup_location_code` attribute in the [`setShippingAddressesOnCart` mutation]({{page.baseurl}}/graphql/mutations/set-shipping-address.html).
+
 ## Syntax
 
 `mutation: {setShippingMethodsOnCart(input: setShippingMethodsOnCartInput) {setShippingMethodsOnCartOutput}}`
 
 ## Example usage
 
-The following example sets the shipping method to Best Way.
+The following example sets the delivery method to Best Way.
 
 **Request:**
 
@@ -100,8 +101,8 @@ Attribute |  Data Type | Description
 
 Attribute |  Data Type | Description
 --- | --- | ---
-`carrier_code` | String! | A string that identifies a commercial carrier or an offline shipping method
-`method_code` | String! | A string that indicates which service a commercial carrier will use to ship items. For offline shipping methods, this value is similar to the label displayed on the checkout page
+`carrier_code` | String! | A string that identifies a commercial carrier or an offline delivery method
+`method_code` | String! | A string that indicates which service a commercial carrier will use to ship items. For offline delivery methods, this value is similar to the label displayed on the checkout page
 
 ## Output attributes
 
@@ -127,6 +128,6 @@ Error | Description
 `Required parameter "carrier_code" is missing.` | The value specified in the `shipping_methods`.`carrier_code` argument is empty.
 `Required parameter "method_code" is missing.` | The value specified in the `shipping_methods`.`method_code` argument is empty.
 `Required parameter "shipping_methods" is missing` | The value specified in the `shipping_methods` argument is empty.
-`The current user cannot perform operations on cart "XXX"` | An unauthorized user (guest) tried to set a shipping method for an order on behalf of an authorized user (customer), or a customer tried to set a shipping method for an order on behalf of another customer.
-`The shipping method can't be set for an empty cart. Add an item to cart and try again.` | The shipping method cannot be set for an empty cart.
-`You cannot specify multiple shipping methods.` | You can set only one shipping method for an order.
+`The current user cannot perform operations on cart "XXX"` | An unauthorized user (guest) tried to set a delivery method for an order on behalf of an authorized user (customer), or a customer tried to set a delivery method for an order on behalf of another customer.
+`The shipping method can't be set for an empty cart. Add an item to cart and try again.` | The delivery method cannot be set for an empty cart.
+`You cannot specify multiple shipping methods.` | You can set only one delivery method for an order.

--- a/src/guides/v2.4/graphql/tutorials/checkout/checkout-shipping-method.md
+++ b/src/guides/v2.4/graphql/tutorials/checkout/checkout-shipping-method.md
@@ -1,7 +1,7 @@
 ---
 layout: tutorial
 group: graphql
-title: Step 6. Set the shipping method
+title: Step 6. Set the delivery method
 subtitle: GraphQL checkout tutorial
 level3_subgroup: graphql-checkout
 return_to:
@@ -14,7 +14,7 @@ contributor_name: Atwix
 contributor_link: https://www.atwix.com/
 ---
 
-The `setShippingMethodsOnCart` mutation defines the shipping methods for your order. It requires these input parameters:
+The `setShippingMethodsOnCart` mutation defines the delivery methods for your order. It requires these input parameters:
 
 *  `cart_id`
 *  `carrier_code`
@@ -83,4 +83,4 @@ mutation {
 
 1. Go to Checkout.
 
-1. The selected shipping method is displayed in the Shipping Methods section on the Shipping step.
+1. The selected delivery method is displayed in the Shipping Methods section on the Shipping step.

--- a/src/guides/v2.4/rest/tutorials/orders/order-config-store.md
+++ b/src/guides/v2.4/rest/tutorials/orders/order-config-store.md
@@ -1,1 +1,56 @@
-../../../../v2.3/rest/tutorials/orders/order-config-store.md
+---
+layout: tutorial
+group: rest-api
+title: Step 1. Configure the store
+subtitle: Order processing tutorial
+return_to:
+  title: REST tutorials
+  url: rest/tutorials/index.html
+menu_order: 1
+level3_subgroup: order-tutorial
+redirect_from:
+  - /guides/v2.3/get-started/order-tutorial/order-config-store.html
+functional_areas:
+  - Integration
+  - Orders
+---
+
+The default Luma store needs additional configuration to run the REST calls mentioned in this tutorial.
+
+### Set the payment method {#set-payment}
+
+Since the Luma store is for demonstration purposes only, it is not set up to handle credit card payments. However, it can simulate any of the following offline payment methods:
+
+Payment type | Configuration name | Enabled by default?
+--- | --- | ---
+Check/Money Order | `checkmo` | Yes
+Bank Transfer Payment | `banktransfer` | No
+Cash on Delivery | `cashondelivery` | No
+Purchase Order | `purchaseorder` | No
+Zero Subtotal Checkout | `free` | Yes
+
+In this tutorial, configure Magento to accept bank transfer payments. To allow bank transfer payments (or any other offline payment method) as a payment method, log in to [Admin](https://glossary.magento.com/admin) and select **Stores** > **Settings** > **Configuration** > **Sales** > **Payment Methods**. Then enable the [payment method](https://glossary.magento.com/payment-method) and click **Save**.
+
+Upon clicking **Save**, a notification message states that the [cache](https://glossary.magento.com/cache) needs to be refreshed. Click the **System** > **Tools** > **Cache Management** link to refresh the cache.
+
+### Deactivate a cart price rule {#price-rule}
+
+By default, the Luma store includes a promotion where shipping is free if you spend at least $50. Since this tutorial shows shipping calculations, we need to deactivate this promotion. The promotion is defined in a cart price rule, which is also known as a sales rule. When you deactivate the cart price rule, shipping is charged at a flat rate of $5 per item.
+
+To disable this cart price rule, select **Marketing** > **Promotions** > **Cart Price Rules**. Then edit rule ID 2 (Spend $50 or more - shipping is free!), and toggle the **Active** switch to **No**. Be sure to save the change.
+
+### Configure supported delivery methods (optional) {#ship-method}
+
+If an order contains one or more simple, configurable, bundle, or group products, then you must specify how the order will be shipped. Downloadable items cannot be shipped, and Magento does not calculate shipping charges for downloadable items.
+
+Since we are not actually shipping any products in this tutorial, we do not need to set up an account with a shipping company such as UPS or Federal Express. Instead, we can use the offline delivery methods that are configured by default.
+
+Shipping type | Configuration name | Enabled by default?
+--- | --- | ---
+Flat rate | `flatrate` | Yes
+Table rate | `tablerate` | Yes
+Free shipping | `freeshipping` | No
+
+If you want to change which offline delivery methods are available, select **Stores** > Settings > **Configuration** > **Sales** > **Delivery Methods** in Admin. Enable or disable the delivery methods as desired, then click **Save**.
+
+Upon clicking **Save**, a notification message states that the cache needs to be refreshed. Click the **Cache Management** link to refresh the cache.


### PR DESCRIPTION
## Purpose of this pull request

The Inventory In-Store Pickup feature changed the Store > Configuration > Sales > Shipping Methods menu to Delivery Methods. This was a change of a label. The term "shipping method" was not excised from the code. 

This pull request updates

* Instances in devdocs that refer to the Shipping Methods label 
* Places in GraphQL and REST where the word can safely be changed

This pull request does not update:

* Every instance of the term "shipping method"
* The Inventory REST tutorial. These instances will be updated in a subsequent PR

Internal ticket: MC-33170

## Affected DevDocs pages

<!-- REQUIRED List the affected pages on devdocs.magento.com (URLs). Not needed for large numbers of files. -->

-  ...

## Links to Magento source code

<!--  OPTIONAL - REMOVE THIS SECTION IF NOT USED. If this pull request references a file in a Magento codebase repository, add it here. -->

-  ...

<!--
If you are fixing a GitHub issue, note it using GitHub keyword format (https://help.github.com/en/articles/closing-issues-using-keywords#closing-an-issue-in-a-different-repository) to close the issue when this pull request is merged. Example: `Fixes #1234`

`master` is the default branch. Merged pull requests to `master` go live on the site automatically. Any requested changes to content on the `master` branch must be related to the released codebase. Any content related to future releases goes in the `develop` branch.

See Contribution guidelines (https://github.com/magento/devdocs/blob/master/.github/CONTRIBUTING.md) for more information.
-->
