### PR TITLE
Inventory 1.2.0 release notes.

### DIFF
--- a/src/guides/v2.3/inventory/release-notes.md
+++ b/src/guides/v2.3/inventory/release-notes.md
@@ -34,7 +34,7 @@ The release notes include:
 
 -  {:.bug} Numerous bug fixes to resolve issues with source assignment, scalable environment feature support, and compatibility with PHP 7.4, MySQL 8, and PHPUNIT 9.
 
--  {:.new} **Increased test coverage.** New functionality covered with automated tests, extended coverage for discovered and fixed issues. 
+-  {:.new} **Increased test coverage.** New functionality covered with automated tests, extended coverage for discovered and fixed issues.
 
 ### v1.1.5
 
@@ -44,7 +44,7 @@ The release notes include:
 
 -  {:.bug} Bug fixes to prevent product oversell, "Out of stock" products visibility on the storefront, numerous fixes for scalable environment support and user interface improvements.
 
--  {:.new} **Functional tests.** Introduced new functional tests to eliminate the test coverage gap. Fixed several issues to make tests more stable and reliable).   
+-  {:.new} **Functional tests.** Introduced new functional tests to eliminate the test coverage gap. Fixed several issues to make tests more stable and reliable).
 
 ### v1.1.4
 

--- a/src/guides/v2.3/inventory/release-notes.md
+++ b/src/guides/v2.3/inventory/release-notes.md
@@ -24,27 +24,27 @@ The release notes include:
 
 {{site.data.var.im}} 1.2.0 (module version: `magento/inventory-metapackage = 1.2.0`) is supported with version 2.4.0 of {{site.data.var.ce}}, {{site.data.var.ee}}, and {{site.data.var.ece}}.
 
--  {:.new} In-store delivery method: allows to select a source to be used as a pickup location during the checkout of your order.
+-  {:.new} **In-store delivery method.** Added a new option for users to select a source to be used as a pickup location during checkout.
 
--  {:.new} Bundle product support for multi source mode. Inventory is supporting all product types with multiple sources.
+-  {:.new} **Bundle product support for multi source mode.** Inventory supports all product types with multiple sources.
 
--  {:.new} Asynchronous stock re-indexation. Provides an ability to re-index stock asynchronously and improve performance on several critical scenarios.
+-  {:.new} **Asynchronous stock re-indexing.** Added the ability to asynchronously re-index stock and improved the performance of several critical scenarios.
 
--  {:.new} Introduced new bulk interfaces for salability check: `\Magento\InventorySalesApi\Api\AreProductsSalableInterface`, `\Magento\InventorySalesApi\Api\AreProductsSalableForRequestedQtyInterface`.
+-  {:.new} **Bulk interfaces.** Introduced new bulk interfaces for salability check: `\Magento\InventorySalesApi\Api\AreProductsSalableInterface`, `\Magento\InventorySalesApi\Api\AreProductsSalableForRequestedQtyInterface`.
 
--  {:.bug} Numerous bug fixes targeted to resolve issues with source assignment, scalable environment feature support and provided compatibility with PHP 7.4, MySQL 8 and PHPUNIT 9.
+-  {:.bug} Numerous bug fixes to resolve issues with source assignment, scalable environment feature support, and compatibility with PHP 7.4, MySQL 8, and PHPUNIT 9.
 
--  {:.new} **Increased test coverage.** New functionality covered with automated tests, extended coverage for discovered and fixed issue. 
+-  {:.new} **Increased test coverage.** New functionality covered with automated tests, extended coverage for discovered and fixed issues. 
 
 ### v1.1.5
 
 {{site.data.var.im}} 1.1.5 (module version: `inventory-composer-metapackage = 1.1.5`) is supported with version 2.3.5 and compatible with version 2.3.4, 2.3.3, 2.3.2, 2.3.1, and 2.3.0 of {{site.data.var.ce}}, {{site.data.var.ee}}, and {{site.data.var.ece}}.
 
--  {:.new} Update inventory once product SKU is changed. Introduced new setting in the configuration to switch to the new behavior: "Synchronize with Catalog".
+-  {:.new} **Update inventory once product SKU is changed.** Introduced a new configuration setting to switch to the new behavior: "Synchronize with Catalog".
 
--  {:.bug} Bug fixes targeted to prevent products oversell, "Out of stock" products visibility on the storefront, numerous fixes for scalable environment support, user UI improvements and so on.
+-  {:.bug} Bug fixes to prevent product oversell, "Out of stock" products visibility on the storefront, numerous fixes for scalable environment support and user interface improvements.
 
--  {:.new} New functional tests are introduced to eliminate the coverage gap, several fixes to make tests stable and reliable.   
+-  {:.new} **Functional tests.** Introduced new functional tests to eliminate the test coverage gap. Fixed several issues to make tests more stable and reliable).   
 
 ### v1.1.4
 

--- a/src/guides/v2.3/inventory/release-notes.md
+++ b/src/guides/v2.3/inventory/release-notes.md
@@ -20,6 +20,32 @@ The release notes include:
 -  {:.fix}Fixes and improvements
 -  {:.bug}Known issues
 
+### v1.2.0
+
+{{site.data.var.im}} 1.2.0 (module version: `magento/inventory-metapackage = 1.2.0`) is supported with version 2.4.0 of {{site.data.var.ce}}, {{site.data.var.ee}}, and {{site.data.var.ece}}.
+
+-  {:.new} In-store delivery method: allows to select a source to be used as a pickup location during the checkout of your order.
+
+-  {:.new} Bundle product support for multi source mode. Inventory is supporting all product types with multiple sources.
+
+-  {:.new} Asynchronous stock re-indexation. Provides an ability to re-index stock asynchronously and improve performance on several critical scenarios.
+
+-  {:.new} Introduced new bulk interfaces for salability check: `\Magento\InventorySalesApi\Api\AreProductsSalableInterface`, `\Magento\InventorySalesApi\Api\AreProductsSalableForRequestedQtyInterface`.
+
+-  {:.bug} Numerous bug fixes targeted to resolve issues with source assignment, scalable environment feature support and provided compatibility with PHP 7.4, MySQL 8 and PHPUNIT 9.
+
+-  {:.new} **Increased test coverage.** New functionality covered with automated tests, extended coverage for discovered and fixed issue. 
+
+### v1.1.5
+
+{{site.data.var.im}} 1.1.5 (module version: `inventory-composer-metapackage = 1.1.5`) is supported with version 2.3.5 and compatible with version 2.3.4, 2.3.3, 2.3.2, 2.3.1, and 2.3.0 of {{site.data.var.ce}}, {{site.data.var.ee}}, and {{site.data.var.ece}}.
+
+-  {:.new} Update inventory once product SKU is changed. Introduced new setting in the configuration to switch to the new behavior: "Synchronize with Catalog".
+
+-  {:.bug} Bug fixes targeted to prevent products oversell, "Out of stock" products visibility on the storefront, numerous fixes for scalable environment support, user UI improvements and so on.
+
+-  {:.new} New functional tests are introduced to eliminate the coverage gap, several fixes to make tests stable and reliable.   
+
 ### v1.1.4
 
 {{site.data.var.im}} 1.1.4 (module version: `inventory-composer-metapackage = 1.1.4`) is supported with version 2.3.4 and compatible with version 2.3.3, 2.3.2, 2.3.1, and 2.3.0 of {{site.data.var.ce}}, {{site.data.var.ee}}, and {{site.data.var.ece}}.


### PR DESCRIPTION
## Purpose of this pull request

This pull request (PR) adds release notes for the inventory 1.2.0 release.

## Affected DevDocs pages

-  https://devdocs.magento.com/guides/v2.4/inventory/release-notes.html

whatsnew
Added inventory 1.2.0 [release notes](https://devdocs.magento.com/guides/v2.4/inventory/release-notes.html).