### PR TITLE
GraphQL release notes

### DIFF
--- a/src/guides/v2.4/graphql/release-notes.md
+++ b/src/guides/v2.4/graphql/release-notes.md
@@ -21,7 +21,7 @@ These release notes can include:
 
 -  {:.new} **Added the [`categories` query]({{page.baseurl}}/graphql/queries/categories.html) returns a list of categories that match a specified filter.** This query differs from the `categoryList` query in that it supports pagination.
 
--  {:.new} **Added the [`pickupLocations` query]({{page.baseurl}}/graphql/queries/pickup-locations.html).** When the Inventory in-store pickup features is enabled, this query can be used to allow the shopper to select a pickup location. The `pickup_location_code` attribute has been added to the [`setShippingAddressesOnCart` mutation]({{page.baseurl}}/graphql/mutations/set-shipping-address.html) to specify which source will serve as the pickup location.
+-  {:.new} **Added the [`pickupLocations` query]({{page.baseurl}}/graphql/queries/pickup-locations.html).** When the Inventory in-store pickup feature is enabled, this query can be used to allow the shopper to select a pickup location. The `pickup_location_code` attribute has been added to the [`setShippingAddressesOnCart` mutation]({{page.baseurl}}/graphql/mutations/set-shipping-address.html) to specify which source will serve as the pickup location.
 
 ## {{site.data.var.ee}} and {{site.data.var.ce}} 2.3.5
 

--- a/src/guides/v2.4/graphql/release-notes.md
+++ b/src/guides/v2.4/graphql/release-notes.md
@@ -15,6 +15,14 @@ These release notes can include:
 -  {:.new}New features
 -  {:.fix}Fixes and improvements
 
+## {{site.data.var.ee}} and {{site.data.var.ce}} 2.4.0
+
+-  {:.new} **Added the [`reorderItems` mutation]({{page.baseurl}}/graphql/mutations/reorder-items.html).** This mutation enables the logged-in customer to add the contents of a previous order to their cart.
+
+-  {:.new} **Added the [`categories` query]({{page.baseurl}}/graphql/queries/categories.html) returns a list of categories that match a specified filter.** This query differs from the `categoryList` query in that it supports pagination.
+
+-  {:.new} **Added the [`pickupLocations` query]({{page.baseurl}}/graphql/queries/pickup-locations.html).** When the Inventory in-store pickup features is enabled, this query can be used to allow the shopper to select a pickup location. The `pickup_location_code` attribute has been added to the [`setShippingAddressesOnCart` mutation]({{page.baseurl}}/graphql/mutations/set-shipping-address.html) to specify which source will serve as the pickup location.
+
 ## {{site.data.var.ee}} and {{site.data.var.ce}} 2.3.5
 
 -  {:.new} **The `products` and `categoryList` queries can now be used to retrieve information about products and categories that have been added to a staged campaign.** These queries require an admin authorization token. See [Using queries](https://devdocs.magento.com/guides/v2.3/graphql/queries/index.html#staging) for details.

--- a/src/guides/v2.4/graphql/release-notes.md
+++ b/src/guides/v2.4/graphql/release-notes.md
@@ -21,7 +21,7 @@ These release notes can include:
 
 -  {:.new} **Added the [`categories` query]({{page.baseurl}}/graphql/queries/categories.html) returns a list of categories that match a specified filter.** This query differs from the `categoryList` query in that it supports pagination.
 
--  {:.new} **Added the [`pickupLocations` query]({{page.baseurl}}/graphql/queries/pickup-locations.html).** When the Inventory in-store pickup feature is enabled, this query can be used to allow the shopper to select a pickup location. The `pickup_location_code` attribute has been added to the [`setShippingAddressesOnCart` mutation]({{page.baseurl}}/graphql/mutations/set-shipping-address.html) to specify which source will serve as the pickup location.
+-  {:.new} **Added the [`pickupLocations` query]({{page.baseurl}}/graphql/queries/pickup-locations.html).** When the Inventory in-store pickup feature is enabled, this query allows the shopper to select a pickup location. The `pickup_location_code` attribute has been added to the [`setShippingAddressesOnCart` mutation]({{page.baseurl}}/graphql/mutations/set-shipping-address.html) to specify which source will serve as the pickup location.
 
 ## {{site.data.var.ee}} and {{site.data.var.ce}} 2.3.5
 


### PR DESCRIPTION
## Purpose of this pull request

This pull request (PR) adds GraphQL release notes for 2.4.0

## Affected DevDocs pages

<!-- REQUIRED List the affected pages on devdocs.magento.com (URLs). Not needed for large numbers of files. -->

-  https://devdocs.magento.com/guides/v2.4/graphql/release-notes.html

## Links to Magento source code

<!--  OPTIONAL - REMOVE THIS SECTION IF NOT USED. If this pull request references a file in a Magento codebase repository, add it here. -->

-  ...

<!--
If you are fixing a GitHub issue, note it using GitHub keyword format (https://help.github.com/en/articles/closing-issues-using-keywords#closing-an-issue-in-a-different-repository) to close the issue when this pull request is merged. Example: `Fixes #1234`

`master` is the default branch. Merged pull requests to `master` go live on the site automatically. Any requested changes to content on the `master` branch must be related to the released codebase. Any content related to future releases goes in the `develop` branch.

See Contribution guidelines (https://github.com/magento/devdocs/blob/master/.github/CONTRIBUTING.md) for more information.
-->
