### PR TITLE
MCLOUD-6485: Add validator for braintree variable existence

### DIFF
--- a/src/cloud/project/project-conf-files_magento-app.md
+++ b/src/cloud/project/project-conf-files_magento-app.md
@@ -299,13 +299,22 @@ If your project requires custom cron jobs, you can add them to the default cron 
 
 ## Variables
 
-The following environment variables are included in `.magento.app.yaml`. These are required for {{site.data.var.ece}} 2.2.x.
+The following environment variables are included in `.magento.app.yaml`. These are required for {{site.data.var.ece}} 2.2.x - 2.3.x.
 
 ```yaml
 variables:
     env:
         CONFIG__DEFAULT__PAYPAL_ONBOARDING__MIDDLEMAN_DOMAIN: 'payment-broker.magento.com'
         CONFIG__STORES__DEFAULT__PAYMENT__BRAINTREE__CHANNEL: 'Magento_Enterprise_Cloud_BT'
+        CONFIG__STORES__DEFAULT__PAYPAL__NOTATION_CODE: 'Magento_Enterprise_Cloud'
+```
+
+For {{site.data.var.ece}} 2.4.x. set next variables
+
+```yaml
+variables:
+    env:
+        CONFIG__DEFAULT__PAYPAL_ONBOARDING__MIDDLEMAN_DOMAIN: 'payment-broker.magento.com'
         CONFIG__STORES__DEFAULT__PAYPAL__NOTATION_CODE: 'Magento_Enterprise_Cloud'
 ```
 

--- a/src/cloud/project/project-conf-files_magento-app.md
+++ b/src/cloud/project/project-conf-files_magento-app.md
@@ -309,7 +309,7 @@ variables:
         CONFIG__STORES__DEFAULT__PAYPAL__NOTATION_CODE: 'Magento_Enterprise_Cloud'
 ```
 
-For {{site.data.var.ece}} 2.4.x. set next variables
+For Magento 2.4.x., set the following variables:
 
 ```yaml
 variables:

--- a/src/cloud/project/project-conf-files_magento-app.md
+++ b/src/cloud/project/project-conf-files_magento-app.md
@@ -299,7 +299,7 @@ If your project requires custom cron jobs, you can add them to the default cron 
 
 ## Variables
 
-The following environment variables are included in `.magento.app.yaml`. These are required for {{site.data.var.ece}} 2.2.x - 2.3.x.
+The following environment variables are included in `.magento.app.yaml`. These are required for Magento 2.2.x - 2.3.x.
 
 ```yaml
 variables:

--- a/src/cloud/project/project-upgrade.md
+++ b/src/cloud/project/project-upgrade.md
@@ -77,6 +77,8 @@ To update the `.magento.app.yaml` file:
 
 1. Add the following environment variables to the end of the `magento.app.yaml` file.
 
+   For 2.2.x - 2.3.x.
+   
    ```yaml
    variables:
        env:
@@ -84,6 +86,15 @@ To update the `.magento.app.yaml` file:
            CONFIG__STORES__DEFAULT__PAYMENT__BRAINTREE__CHANNEL: 'Magento_Enterprise_Cloud_BT'
            CONFIG__STORES__DEFAULT__PAYPAL__NOTATION_CODE: 'Magento_Enterprise_Cloud'
     ```
+   
+   For 2.4.x.
+   
+   ```yaml
+   variables:
+       env:
+           CONFIG__DEFAULT__PAYPAL_ONBOARDING__MIDDLEMAN_DOMAIN: 'payment-broker.magento.com'
+           CONFIG__STORES__DEFAULT__PAYPAL__NOTATION_CODE: 'Magento_Enterprise_Cloud'
+    ```   
 
 1. Save the file. Do not commit or push changes to your branch yet.
 

--- a/src/cloud/project/project-upgrade.md
+++ b/src/cloud/project/project-upgrade.md
@@ -77,7 +77,7 @@ To update the `.magento.app.yaml` file:
 
 1. Add the following environment variables to the end of the `magento.app.yaml` file.
 
-   For 2.2.x - 2.3.x.
+   For Magento 2.2.x - 2.3.x:
    
    ```yaml
    variables:
@@ -87,7 +87,7 @@ To update the `.magento.app.yaml` file:
            CONFIG__STORES__DEFAULT__PAYPAL__NOTATION_CODE: 'Magento_Enterprise_Cloud'
     ```
    
-   For 2.4.x.
+   For Magento 2.4.x:
    
    ```yaml
    variables:


### PR DESCRIPTION
## Purpose of this pull request

This pull request (PR) update documentation for cloud env variables for Magento 2.4.x

## Affected DevDocs pages

<!-- REQUIRED List the affected pages on devdocs.magento.com (URLs). Not needed for large numbers of files. -->

- https://devdocs.magento.com/cloud/project/project-conf-files_magento-app.html#variables
- https://devdocs.magento.com/cloud/project/project-upgrade.html#update-the-configuration-file


<!--
If you are fixing a GitHub issue, note it using GitHub keyword format (https://help.github.com/en/articles/closing-issues-using-keywords#closing-an-issue-in-a-different-repository) to close the issue when this pull request is merged. Example: `Fixes #1234`

`master` is the default branch. Merged pull requests to `master` go live on the site automatically. Any requested changes to content on the `master` branch must be related to the released codebase. Any content related to future releases goes in the `develop` branch.

See Contribution guidelines (https://github.com/magento/devdocs/blob/master/.github/CONTRIBUTING.md) for more information.
-->
