### PR TITLE
Add known issue for Inventory 1.2.0 (inventory_cleanup_reservations)

### DIFF
--- a/src/guides/v2.3/inventory/release-notes.md
+++ b/src/guides/v2.3/inventory/release-notes.md
@@ -32,9 +32,18 @@ The release notes include:
 
 -  {:.new} **Bulk interfaces.** Introduced new bulk interfaces for salability check: `\Magento\InventorySalesApi\Api\AreProductsSalableInterface`, `\Magento\InventorySalesApi\Api\AreProductsSalableForRequestedQtyInterface`.
 
--  {:.bug} Numerous bug fixes to resolve issues with source assignment, scalable environment feature support, and compatibility with PHP 7.4, MySQL 8, and PHPUNIT 9.
-
 -  {:.new} **Increased test coverage.** New functionality covered with automated tests, extended coverage for discovered and fixed issues.
+
+-  {:.fix} Numerous bug fixes to resolve issues with source assignment, scalable environment feature support, and compatibility with PHP 7.4, MySQL 8, and PHPUNIT 9.
+
+-  {:.bug} **Known issue.** The absence of the `object_id` field in the reservations metadata is preventing the `inventory_cleanup_reservations` cron job from working properly. This issue was introduced in [magento/inventory#3046](https://github.com/magento/inventory/pull/3046).
+
+   **Workaround:** Execute the following MySQL queries to manually cleanup reservations:
+
+   ```sql
+   SELECT GROUP_CONCAT(reservation_id) FROM inventory_reservation GROUP BY stock_id, sku HAVING SUM(quantity) = 0;
+   DELETE FROM inventory_reservation where reservation_id IN (result_of_the_first_query);
+   ```
 
 ### v1.1.5
 


### PR DESCRIPTION
## Purpose of this pull request

This pull request (PR) adds a known issue about the reservation cleanup cron job not working properly to the 1.2.0 Inventory release notes.

## Affected DevDocs pages

- https://devdocs.magento.com/guides/v2.4/inventory/release-notes.html
- https://devdocs.magento.com/guides/v2.3/inventory/release-notes.html

## Links to Magento source code

- https://github.com/magento/inventory/pull/3046

whatsnew
Added a known issue about the `inventory_cleanup_reservations` cron job not working properly in the [Inventory 1.2.0 release notes](https://devdocs.magento.com/guides/v2.4/inventory/release-notes.html).