### PR TITLE
Added Magento Cloud Components 1.0.6 release notes

### DIFF
--- a/src/cloud/release-notes/mcc-release-notes.md
+++ b/src/cloud/release-notes/mcc-release-notes.md
@@ -16,7 +16,7 @@ The `{{site.data.var.mcc-package}}` package uses the following version sequence:
 
 <!--Add release notes below-->
 
--  {:.new}**Improve Redis performance**–Added the `./bin/magento cache:evict` command to remove expired Redis keys, which reduces Redis memory usage to improve performance.
+-  {:.new}**Improve Redis performance**–Added the `./bin/magento cache:evict` command to remove expired Redis keys, which reduces Redis memory usage to improve performance.<!--MCLOUD-6023-->
 
 -  {:.fix}Removed support for *New Relic Logs in Context* to fix a performance issue.<!--MCLOUD-6422-->
 

--- a/src/cloud/release-notes/mcc-release-notes.md
+++ b/src/cloud/release-notes/mcc-release-notes.md
@@ -16,6 +16,10 @@ The `{{site.data.var.mcc-package}}` package uses the following version sequence:
 
 <!--Add release notes below-->
 
+-  {:.new}**Improve Redis performance**–Added the `./bin/magento cache:evict` command to remove expired Redis keys, which reduces Redis memory usage to improve performance.
+
+-  {:.fix}Removed support for *New Relic Logs in Context* to fix a performance issue.<!--MCLOUD-6422-->
+
 ## v1.0.5
 *Release date: June 25, 2020*<br/>
 


### PR DESCRIPTION
## Purpose of this pull request

Add Magento Cloud Components 1.0.6 release notes

## Affected DevDocs pages

- https://devdocs.magento.com/cloud/release-notes/mcc-release-notes.html

whatsnew
Added [release notes for Magento Cloud Components v1.0.6](https://devdocs.magento.com/cloud/release-notes/mcc-release-notes.html#v1.0.6).