### PR TITLE
Describe the otp parameter for Google Authenticator 2FA

### DIFF
--- a/src/guides/v2.4/get-started/authentication/gs-authentication-token.md
+++ b/src/guides/v2.4/get-started/authentication/gs-authentication-token.md
@@ -39,7 +39,7 @@ Magento provides a separate token service for administrators and customers. When
 
 The Magento web API framework allows *guest users* to access resources that are configured with the permission level of anonymous. Guest users are users who the framework cannot authenticate through existing authentication mechanisms. As a guest user, you do not need to, but you can, specify a token in a web API call for a resource with anonymous permission. [Restricting access to anonymous web APIs]({{ page.baseurl }}/rest/anonymous-api-security.html) contains a list of APIs that do not require a token.
 
-The following table lists endpoints and services that can be used to get an authentication token. Some 2FA providers may require multiple calls.
+The following table lists endpoints and services that can be used to get an authentication token. Admin accounts must be authenticated with a [two factor authentication]({{page.baseurl}}/security/two-factor-authentication.html) provider. Some providers may require multiple calls.
 
 Token type |REST| SOAP
 ---|---|---

--- a/src/guides/v2.4/rest/tutorials/orders/order-admin-token.md
+++ b/src/guides/v2.4/rest/tutorials/orders/order-admin-token.md
@@ -46,7 +46,9 @@ This section lists the information that Magento sends to the REST client. These 
 
 In a production environment, you would typically [create an integration]({{page.baseurl}}/get-started/create-integration.html) and supply the integration token with any REST call that requires admin privileges. The token allows Magento to verify that the caller is authorized to access a system resource.
 
-Here, we will supply an admin token instead. To get a token, you must have 2FA configured. Your request must specify the admin user's username and password as well as the 2FA one-time authorization code in the payload.
+Here, we will supply an admin token instead. To get a token, you must have 2FA configured. This tutorial assumes that you are using Google Authenticator as your 2FA solution. The endpoint and payload will be different for other 2FA solutions. See [Two-Factor Authentication]({{page.baseurl}}/security/two-factor-authentication.html) for more information.
+
+Your request must specify the admin user's `username`, `password` and `otp` (one time password). The `otp` value is the six-digit authorization code that Google Authenticator generates.
 
 By default, an admin token is valid for 4 hours. To change this value, log in to Admin and go to **Stores** > **Settings** > **Configuration** > **Services** > **OAuth** > **Access Token Expiration** > **Admin Token Lifetime (hours)**.
 

--- a/src/guides/v2.4/rest/tutorials/orders/order-intro.md
+++ b/src/guides/v2.4/rest/tutorials/orders/order-intro.md
@@ -1,1 +1,41 @@
-../../../../v2.3/rest/tutorials/orders/order-intro.md
+---
+layout: tutorial
+group: rest-api
+title: Order processing tutorial
+menu_title: Initial tasks
+return_to:
+  title: REST tutorials
+  url: rest/tutorials/index.html
+menu_order: 0
+level3_subgroup: order-tutorial
+functional_areas:
+  - Integration
+  - Orders
+  - Sales
+---
+
+This tutorial shows a system integrator how REST APIs are used in the lifecycle of an order, including configuring a store and creating a customer; creating quotes, orders, invoices, and shipments; preparing for checkout; and more order-related tasks.
+
+The **10-step tutorial** generally takes **30 minutes**.
+
+### Before you begin
+
+Complete the following prerequisites:
+
+*  Install a Magento 2.3 (or later) instance with sample data.
+
+  The sample data defines a functional store, called Luma, that sells fitness clothing and accessories. The store does not provide any sandbox accounts for testing credit card payments, so transactions will be simulated using an offline [payment method](https://glossary.magento.com/payment-method).
+
+*  Install a REST client. You can use any REST client to send calls to Magento. [Postman](https://www.getpostman.com/) is recommended.
+
+*  Set up [two-factor authentication]({{page.baseurl}}/security/two-factor-authentication.html). This tutorial assumes Google Authenticator is your 2FA solution.
+
+*  Know how to construct a REST call in Magento. See [Construct a request]({{ page.baseurl }}/get-started/gs-web-api-request.html) for details.
+
+*  Find the Magento REST API documentation. You can view the [static REST API documentation on devdocs]({{ site.baseurl }}/redoc/{{page.guide_version}}/) or [generate a local API reference]({{ page.baseurl }}/rest/generate-local.html).
+
+*  Find the Magento Merchant documentation. Refer to [Getting Started with {{site.data.var.ce}} 2.1](http://docs.magento.com/m2/ce/user_guide/getting-started.html) for information about the Luma store that is created when you install Magento with the sample data.
+
+### Other resources
+
+*  [REST Tutorials]({{ page.baseurl }}/rest/tutorials/index.html) provides additional information about completing any Magento REST tutorial.

--- a/src/guides/v2.4/rest/tutorials/prerequisite-tasks/create-admin-token.md
+++ b/src/guides/v2.4/rest/tutorials/prerequisite-tasks/create-admin-token.md
@@ -8,7 +8,9 @@ functional_areas:
 
 In a production environment, you would typically [create an integration]({{page.baseurl}}/get-started/create-integration.html) and supply the integration token with any REST call that requires admin privileges. The token allows Magento to verify that the caller is authorized to access the affected system resource.
 
-In this tutorial, we will supply an admin token instead. To get a token, you must have 2FA configured. Your request must specify the admin user's username and password as well as the 2FA one-time authorization code in the payload.
+In this tutorial, we will supply an admin token instead. To get a token, you must have 2FA configured. This tutorial assumes that you are using Google Authenticator as your 2FA solution. The endpoint and payload will be different for other 2FA solutions. See [Two-Factor Authentication]({{page.baseurl}}/security/two-factor-authentication.html) for more information.
+
+Your request must specify the admin user's `username`, `password` and `otp` (one time password). The `otp` value is the six-digit authorization code that Google Authenticator generates.
 
 By default, an admin token is valid for 4 hours. To change this value, log in to Admin and go to **Stores** > **Settings** > **Configuration** > **Services** > **OAuth** > **Access Token Expiration** > **Admin Token Lifetime (hours)**.
 


### PR DESCRIPTION
## Purpose of this pull request

This pull request (PR) describes the `otp` parameter shown in examples of the  `POST /V1/tfa/provider/google/authenticate` endpoint. I also added links to the Two Factor Authentication VBE topic.

This PR is a follow-up to #7576 

## Affected DevDocs pages

<!-- REQUIRED List the affected pages on devdocs.magento.com (URLs). Not needed for large numbers of files. -->

- https://devdocs.magento.com/guides/v2.4/rest/tutorials/orders/order-admin-token.html
- https://devdocs.magento.com/guides/v2.4/rest/tutorials/prerequisite-tasks/create-admin-token.html

## Links to Magento source code

<!--  OPTIONAL - REMOVE THIS SECTION IF NOT USED. If this pull request references a file in a Magento codebase repository, add it here. -->

-  ...

<!--
If you are fixing a GitHub issue, note it using GitHub keyword format (https://help.github.com/en/articles/closing-issues-using-keywords#closing-an-issue-in-a-different-repository) to close the issue when this pull request is merged. Example: `Fixes #1234`

`master` is the default branch. Merged pull requests to `master` go live on the site automatically. Any requested changes to content on the `master` branch must be related to the released codebase. Any content related to future releases goes in the `develop` branch.

See Contribution guidelines (https://github.com/magento/devdocs/blob/master/.github/CONTRIBUTING.md) for more information.
-->
