### PR TITLE
Update database configuration commands for MySQL 8

### DIFF
--- a/src/guides/v2.4/install-gde/prereq/mysql.md
+++ b/src/guides/v2.4/install-gde/prereq/mysql.md
@@ -140,16 +140,16 @@ To configure a MySQL database instance:
 1. Enter the MySQL `root` user's password when prompted.
 1. Enter the following commands in the order shown to create a database instance named `magento` with username `magento`:
 
-   ```shell
+   ```sql
    create database magento;
    ```
 
-   ```shell
-   create user magento IDENTIFIED BY 'magento';
+   ```sql
+   create user 'magento'@'localhost' IDENTIFIED BY 'magento';
    ```
 
-   ```shell
-   GRANT ALL ON magento.* TO magento@localhost IDENTIFIED BY 'magento';
+   ```sql
+   GRANT ALL ON magento.* TO 'magento'@'localhost';
    ```
 
    ```shell

--- a/src/guides/v2.4/install-gde/prereq/mysql.md
+++ b/src/guides/v2.4/install-gde/prereq/mysql.md
@@ -152,7 +152,7 @@ To configure a MySQL database instance:
    GRANT ALL ON magento.* TO 'magento'@'localhost';
    ```
 
-   ```shell
+   ```sql
    flush privileges;
    ```
 


### PR DESCRIPTION
## Purpose of this pull request

This pull request (PR) updates commands to create MySQL database instance, since the old syntax is not supported in MySQL 8.

## Affected DevDocs pages

<!-- REQUIRED List the affected pages on devdocs.magento.com (URLs). Not needed for large numbers of files. -->

-  https://devdocs.magento.com/guides/v2.4/install-gde/prereq/mysql.html