### PR TITLE
Magento 2.4.0 Backward Incompatibility Highlights Update for MFTF

### DIFF
--- a/src/guides/v2.4/release-notes/backward-incompatible-changes/index.md
+++ b/src/guides/v2.4/release-notes/backward-incompatible-changes/index.md
@@ -60,6 +60,9 @@ Magento\CatalogSearch\Model\Indexer\Scope\IndexTableNotExistException
 Magento\CatalogSearch\Model\Indexer\Fulltext\Action\IndexIterator
 Magento\CatalogSearch\Model\Adapter\Mysql\Filter\AliasResolver
 ```
+### Magento Functional Testing Framework (MFTF)
+
+MFTF now uses Google Authenticator to execute tests with 2FA enabled. MFTF will not work with Magento 2.4.0 without additional configuration steps to enable Google Authenticator. See [Configuring MFTF for Two-Factor Authentication (2FA)](https://devdocs.magento.com/guides/v2.4/security/two-factor-authentication.html#magento-functional-testing-framework).
 
 ### Inventory asynchronous reindex
 

--- a/src/guides/v2.4/release-notes/backward-incompatible-changes/index.md
+++ b/src/guides/v2.4/release-notes/backward-incompatible-changes/index.md
@@ -60,6 +60,7 @@ Magento\CatalogSearch\Model\Indexer\Scope\IndexTableNotExistException
 Magento\CatalogSearch\Model\Indexer\Fulltext\Action\IndexIterator
 Magento\CatalogSearch\Model\Adapter\Mysql\Filter\AliasResolver
 ```
+
 ### Magento Functional Testing Framework (MFTF)
 
 MFTF now uses Google Authenticator to execute tests with 2FA enabled. MFTF will not work with Magento 2.4.0 without additional configuration steps to enable Google Authenticator. See [Configuring MFTF for Two-Factor Authentication (2FA)](https://devdocs.magento.com/guides/v2.4/security/two-factor-authentication.html#magento-functional-testing-framework).


### PR DESCRIPTION
## Purpose of this pull request

This pull request (PR) adds information to the Backward Incompatibility Highlights  about an MFTF deployment issue in Magento 2.4.0. 

## Affected DevDocs pages

https://devdocs.magento.com/guides/v2.4/release-notes/backward-incompatible-changes/index.html