### PR TITLE
Assign page.guide_version via configuration scopes

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -55,15 +55,15 @@ defaults:
   
   - 
     scope:
-      path: 'guides/v2.3'
+      path: guides/v2.3
     values:
-      guide_version: 2.3
+      guide_version: '2.3'
   
   - 
     scope:
-      path: 'guides/v2.4'
+      path: guides/v2.4
     values:
-      guide_version: 2.4
+      guide_version: '2.4'
 
   -
     scope:

--- a/_config.yml
+++ b/_config.yml
@@ -52,6 +52,18 @@ defaults:
       github_link: true
       # Enables the 'Give us feedback' appearances on pages
       feedback_link: true
+  
+  - 
+    scope:
+      path: 'guides/v2.3'
+    values:
+      guide_version: 2.3
+  
+  - 
+    scope:
+      path: 'guides/v2.4'
+    values:
+      guide_version: 2.4
 
   -
     scope:

--- a/_plugins/page-params/page-baseurl-generator.rb
+++ b/_plugins/page-params/page-baseurl-generator.rb
@@ -15,20 +15,11 @@
 # if the path doesn't contain "guides/v2.x", then the version is unset and returns the nil object (same as null)
 Jekyll::Hooks.register :pages, :post_init do |page|
   # Glossary. Create and assign variables to be used in the script.
-  pattern = %r{\Aguides/v(?<version_from_path>2\.\d)}
   baseurl = page.site.baseurl
-  path = page.path
   data = page.data
   version = data['guide_version']
 
-  # Process 'page.guide_version' pararmeter
-  if version.nil? && path.start_with?('guides')
-    pattern.match(path)
-    version = Regexp.last_match(:version_from_path)
-    data['guide_version'] = version
-  end
-
-  # Process 'page.baseurl' parameter
+  # Create 'page.baseurl' parameter
   data['baseurl'] =
     if version
       "#{baseurl}/guides/v#{version}"

--- a/_plugins/page-params/page-baseurl-generator.rb
+++ b/_plugins/page-params/page-baseurl-generator.rb
@@ -6,13 +6,12 @@
 # This custom plugin dynamically sets and injects the page.baseurl variable
 # based on the page's destination.
 #
-# The hook introduces the page.baseurl and
-# page.guide_version data parameters for each page.
+# The hook introduces the page.baseurl parameter for each page.
 # For pages at guides/v2.x the page.baseurl parameter is set
 # as "{site.baseurl}/guides/v#{version}".
 # The {version} is taken from the 'guide_version' front matter parameter on the page;
-# if it is not set, then the 'guide_version' is set to version from the page path (for example, "2.2" in the "guides/v2.2/**/*.md");
-# if the path doesn't contain "guides/v2.x", then the version is unset and returns the nil object (same as null)
+# if it is not set, then the 'guide_version' is set to version from the _config.yml depending on a scope by path (for example, "2.4" at the "guides/v2.4/");
+# otherwise, the version is unset and returns the nil object (same as null).
 Jekyll::Hooks.register :pages, :post_init do |page|
   # Glossary. Create and assign variables to be used in the script.
   baseurl = page.site.baseurl


### PR DESCRIPTION
## Purpose of this pull request

This pull request (PR) delegates generation of the `page.guide_version` parameter to native Jekyll means using configuration scopes, instead of expensive plugin with regex. This allows to reduce build time by ~1 min.