### PR TITLE
Fix encoding issue on the Security.txt page

### DIFF
--- a/src/guides/v2.4/security/security-txt.md
+++ b/src/guides/v2.4/security/security-txt.md
@@ -2,7 +2,7 @@
 group: configuration-guide
 title: Security.txt
 contributor_name: Kalpesh Mehta from Corra
-contributor_link: https://partners.magento.com/portal/details/partner/id/70/
+contributor_link: https://partners.magento.com/portal/details/partner/id/70/
 functional_areas:
   - Configuration
 ---


### PR DESCRIPTION
## Purpose of this pull request

This pull request (PR) fixes an encoding issue introduced in #7615 that is breaking the page.

## Affected DevDocs pages

- https://devdocs.magento.com/guides/v2.4/security/security-txt.html