### PR TITLE
Added missing release note for B2B

### DIFF
--- a/src/guides/v2.4/release-notes/b2b-release-notes.md
+++ b/src/guides/v2.4/release-notes/b2b-release-notes.md
@@ -11,6 +11,7 @@ These release notes can include:
 
 ## Magento B2B - Version 1.2.0
 
+-  {:.new} [Storefront Order Search](https://github.com/magento/partners-magento2b2b/pull/16) added thanks to [Divante](https://www.divante.com/) and community members.
 -  {:.new} Purchase Orders have been enhanced and rewritten. They are now included by default in {{site.data.var.ee}}.
 -  {:.new} Purchase Order Approval Rules have been implemented. These rules allow users to control the Purchase Order workflow by creating purchasing rules for orders.
 -  {:.new} Login as Customer is now included by default in {{site.data.var.ee}}. This allows site employees to assist customers by logging in as the customer to see what they see.

--- a/src/guides/v2.4/release-notes/b2b-release-notes.md
+++ b/src/guides/v2.4/release-notes/b2b-release-notes.md
@@ -11,7 +11,7 @@ These release notes can include:
 
 ## Magento B2B - Version 1.2.0
 
--  {:.new} [Storefront Order Search](https://github.com/magento/partners-magento2b2b/pull/16) added thanks to [Divante](https://www.divante.com/) and community members.
+-  {:.new} [Storefront Order Search](https://github.com/magento/partners-magento2b2b/pull/16) added thanks to contribution by [Marek Mularczyk]( https://github.com/mmularski) from [Divante](https://www.divante.com/) and community members.
 -  {:.new} Purchase Orders have been enhanced and rewritten. They are now included by default in {{site.data.var.ee}}.
 -  {:.new} Purchase Order Approval Rules have been implemented. These rules allow users to control the Purchase Order workflow by creating purchasing rules for orders.
 -  {:.new} Login as Customer is now included by default in {{site.data.var.ee}}. This allows site employees to assist customers by logging in as the customer to see what they see.


### PR DESCRIPTION
## Purpose of this pull request

This pull request (PR) adds missing release note, attributing the work to a partner.

## Affected DevDocs pages

https://devdocs.magento.com/guides/v2.4/release-notes/b2b-release-notes.html