### PR TITLE
adding new field as on 2.4

### DIFF
--- a/src/guides/v2.4/config-guide/prod/config-reference-most.md
+++ b/src/guides/v2.4/config-guide/prod/config-reference-most.md
@@ -211,6 +211,7 @@ Show Results Count for Each Suggestion | `catalog/search/search_suggestion_count
 Enable Search Recommendations | `catalog/search/search_recommendations_enabled` | ![EE-only]({{ site.baseurl }}/common/images/cloud_ee.png) |
 Search Recommendations Count | `catalog/search/search_recommendations_count` | ![EE-only]({{ site.baseurl }}/common/images/cloud_ee.png) |
 Show Results Count for Each Recommendation | `catalog/search/search_recommendations_count_results_enabled` | ![EE-only]({{ site.baseurl }}/common/images/cloud_ee.png) |
+Minimum Terms to Match | `catalog/search/minimum_should_match` | <!-- ![Not EE-only]({{ site.baseurl }}/common/images/red-x.png) --> |
 Popular Search Terms | `catalog/seo/search_terms` | <!-- ![Not EE-only]({{ site.baseurl }}/common/images/red-x.png) --> |
 Product URL Suffix | `catalog/seo/product_url_suffix` | <!-- ![Not EE-only]({{ site.baseurl }}/common/images/red-x.png) --> |
 Category URL Suffix | `catalog/seo/category_url_suffix` | <!-- ![Not EE-only]({{ site.baseurl }}/common/images/red-x.png) --> |


### PR DESCRIPTION
## Purpose of this pull request

This pull request (PR) provides information about the missing field as per the 2.4.0 both(Open Source and Commerce) editions.
The field introduced in the latest 2.4.0 version and part of Magento_ElasticSearch 7 module.

**Module Name: Magento_Elasticsearch7**

## Affected DevDocs pages

<!-- REQUIRED List the affected pages on devdocs.magento.com (URLs). Not needed for large numbers of files. -->

-  https://devdocs.magento.com/guides/v2.4/config-guide/prod/config-reference-most.html#catalog-paths

## Links to Magento source code

<!--  OPTIONAL - REMOVE THIS SECTION IF NOT USED. If this pull request references a file in a Magento codebase repository, add it here. -->

-  https://github.com/magento/magento2/blob/2.4/app/code/Magento/Elasticsearch7/etc/adminhtml/system.xml

<!--
If you are fixing a GitHub issue, note it using GitHub keyword format (https://help.github.com/en/articles/closing-issues-using-keywords#closing-an-issue-in-a-different-repository) to close the issue when this pull request is merged. Example: `Fixes #1234`

`master` is the default branch. Merged pull requests to `master` go live on the site automatically. Any requested changes to content on the `master` branch must be related to the released codebase. Any content related to future releases goes in the `develop` branch.

See Contribution guidelines (https://github.com/magento/devdocs/blob/master/.github/CONTRIBUTING.md) for more information.
-->
