### PR TITLE
Add missing text to the MRG 2.4

### DIFF
--- a/src/_data/codebase/v2_4/mrg/ce/Backend.yml
+++ b/src/_data/codebase/v2_4/mrg/ce/Backend.yml
@@ -5,6 +5,7 @@ release: 2.4.0
 github_path: app/code/Magento/Backend/README.md
 last_modified_at: '2020-03-26 15:07:34 +0200'
 content: |
+  The Magento_Backend module contains common infrastructure and assets for other modules to be defined and used in their
   administration user interface (UI).
 
   The Magento_Backend module does not contain anything specific to other modules. Among many things it handles the logic of authenticating and authorizing users.

--- a/src/_data/codebase/v2_4/mrg/ce/CatalogAnalytics.yml
+++ b/src/_data/codebase/v2_4/mrg/ce/CatalogAnalytics.yml
@@ -7,4 +7,4 @@ last_modified_at: '2019-08-06 14:40:28 -0500'
 content: 'The Magento_CatalogAnalytics module configures data definitions for a data
   collection related to the Catalog module entities to be used in [Advanced Reporting](https://devdocs.magento.com/guides/v2.3/advanced-reporting/modules.html).
 
-'
+  '

--- a/src/_data/codebase/v2_4/mrg/ce/CatalogInventory.yml
+++ b/src/_data/codebase/v2_4/mrg/ce/CatalogInventory.yml
@@ -7,4 +7,4 @@ last_modified_at: '2014-12-12 12:14:06 -0800'
 content: 'Magento_CatalogInventory module allows retrieve and update stock attributes,
   such as status and quantity.
 
-'
+  '

--- a/src/_data/codebase/v2_4/mrg/ce/CatalogRule.yml
+++ b/src/_data/codebase/v2_4/mrg/ce/CatalogRule.yml
@@ -8,4 +8,4 @@ content: 'Magento_CatalogRule module is responsible for one of the types of pric
   rules in Magento. Catalog Rules are applied to products before they are added to
   the cart.
 
-'
+  '

--- a/src/_data/codebase/v2_4/mrg/ce/CatalogRuleConfigurable.yml
+++ b/src/_data/codebase/v2_4/mrg/ce/CatalogRuleConfigurable.yml
@@ -8,4 +8,4 @@ content: 'Magento_CatalogRuleConfigurable module is an extension of Magento_Cata
   and Magento_ConfigurableProduct modules that handle catalog rule indexer for configurable
   product
 
-'
+  '

--- a/src/_data/codebase/v2_4/mrg/ce/ConfigurableProductSales.yml
+++ b/src/_data/codebase/v2_4/mrg/ce/ConfigurableProductSales.yml
@@ -4,5 +4,6 @@ source_repo: magento2ce
 release: 2.4.0
 github_path: app/code/Magento/ConfigurableProductSales/README.md
 last_modified_at: '2017-07-14 16:51:00 +0300'
-content: 'Catalog. Returns true if the previously ordered item configuration is still
-  available. '
+content: "The Magento_ConfigurableProductSales module checks that the selected options
+  of order item are still presented in\nCatalog. Returns true if the previously ordered
+  item configuration is still available. "

--- a/src/_data/codebase/v2_4/mrg/ce/Contact.yml
+++ b/src/_data/codebase/v2_4/mrg/ce/Contact.yml
@@ -8,4 +8,4 @@ content: 'Magento_Contact module provides an implementation of "Contact Us" feat
   based on sending email message, allows to configure email recipients, email template,
   etc...
 
-'
+  '

--- a/src/_data/codebase/v2_4/mrg/ce/Cookie.yml
+++ b/src/_data/codebase/v2_4/mrg/ce/Cookie.yml
@@ -7,4 +7,4 @@ last_modified_at: '2015-01-28 16:50:13 -0600'
 content: 'Magento_Cookie module allows enabling and configuring HTTP cookie related
   settings for the store. These settings are available in the store administration.
 
-'
+  '

--- a/src/_data/codebase/v2_4/mrg/ce/CurrencySymbol.yml
+++ b/src/_data/codebase/v2_4/mrg/ce/CurrencySymbol.yml
@@ -18,3 +18,4 @@ content: |+
   ***CurrencySymbol\Controller\Adminhtml\System\Currencysymbol\Reset.php*** resets all custom currency symbols.
   ***CurrencySymbol\Controller\Adminhtml\System\Currencysymbol\Save.php*** creates custom currency symbols.
 
+...

--- a/src/_data/codebase/v2_4/mrg/ce/CustomerAnalytics.yml
+++ b/src/_data/codebase/v2_4/mrg/ce/CustomerAnalytics.yml
@@ -7,4 +7,4 @@ last_modified_at: '2019-08-06 14:40:28 -0500'
 content: 'The Magento_CustomerAnalytics module configures data definitions for a data
   collection related to the Customer module entities to be used in [Advanced Reporting](https://devdocs.magento.com/guides/v2.3/advanced-reporting/modules.html).
 
-'
+  '

--- a/src/_data/codebase/v2_4/mrg/ce/CustomerImportExport.yml
+++ b/src/_data/codebase/v2_4/mrg/ce/CustomerImportExport.yml
@@ -7,4 +7,4 @@ last_modified_at: '2014-10-31 09:04:08 -0700'
 content: 'The Magento_CustomerImportExport module handles the import and export of
   the customers data and related addresses.
 
-'
+  '

--- a/src/_data/codebase/v2_4/mrg/ce/Developer.yml
+++ b/src/_data/codebase/v2_4/mrg/ce/Developer.yml
@@ -7,4 +7,4 @@ last_modified_at: '2015-01-15 14:33:14 -0600'
 content: 'The Magento_Developer module provides functionality to make it easier to
   develop in Magento 2.
 
-'
+  '

--- a/src/_data/codebase/v2_4/mrg/ce/DownloadableImportExport.yml
+++ b/src/_data/codebase/v2_4/mrg/ce/DownloadableImportExport.yml
@@ -7,4 +7,4 @@ last_modified_at: '2015-08-10 11:16:49 +0300'
 content: 'The Magento_DownloadableImportExport module handles the import and export
   of the downloadable products.
 
-'
+  '

--- a/src/_data/codebase/v2_4/mrg/ce/EncryptionKey.yml
+++ b/src/_data/codebase/v2_4/mrg/ce/EncryptionKey.yml
@@ -7,4 +7,4 @@ last_modified_at: '2015-08-27 15:34:05 -0500'
 content: 'The Magento_EncryptionKey module provides an advanced encryption model to
   protect passwords and other sensitive data.
 
-'
+  '

--- a/src/_data/codebase/v2_4/mrg/ce/Fedex.yml
+++ b/src/_data/codebase/v2_4/mrg/ce/Fedex.yml
@@ -6,4 +6,4 @@ github_path: app/code/Magento/Fedex/README.md
 last_modified_at: '2014-10-31 09:04:08 -0700'
 content: 'The Magento_Fedex implements the integration with the FedEx shipping carrier.
 
-'
+  '

--- a/src/_data/codebase/v2_4/mrg/ce/GoogleAdwords.yml
+++ b/src/_data/codebase/v2_4/mrg/ce/GoogleAdwords.yml
@@ -6,4 +6,4 @@ github_path: app/code/Magento/GoogleAdwords/README.md
 last_modified_at: '2014-12-12 12:14:06 -0800'
 content: 'GoogleAdwords is a module designed for integration of Google Adwords service.
 
-'
+  '

--- a/src/_data/codebase/v2_4/mrg/ce/GoogleAnalytics.yml
+++ b/src/_data/codebase/v2_4/mrg/ce/GoogleAnalytics.yml
@@ -7,4 +7,4 @@ last_modified_at: '2014-12-12 12:14:06 -0800'
 content: 'Magento_GoogleAnalytics is a module for integration with Google Analytics
   service.
 
-'
+  '

--- a/src/_data/codebase/v2_4/mrg/ce/GroupedCatalogInventory.yml
+++ b/src/_data/codebase/v2_4/mrg/ce/GroupedCatalogInventory.yml
@@ -7,4 +7,4 @@ last_modified_at: '2018-11-27 16:04:57 -0600'
 content: 'Magento_GroupedCatalogInventory contains behavior related to the inventory
   status of items within grouped products.
 
-'
+  '

--- a/src/_data/codebase/v2_4/mrg/ce/LoginAsCustomer.yml
+++ b/src/_data/codebase/v2_4/mrg/ce/LoginAsCustomer.yml
@@ -7,4 +7,4 @@ last_modified_at: '2020-04-15 04:18:57 -0500'
 content: 'The Magento_LoginAsCustomer module is responsible for ability to login into
   customer account using the admin panel.
 
-'
+  '

--- a/src/_data/codebase/v2_4/mrg/ce/LoginAsCustomerAdminUi.yml
+++ b/src/_data/codebase/v2_4/mrg/ce/LoginAsCustomerAdminUi.yml
@@ -4,4 +4,6 @@ source_repo: magento2ce
 release: 2.4.0
 github_path: app/code/Magento/LoginAsCustomerAdminUi/README.md
 last_modified_at: '2020-05-21 22:39:24 -0500'
-content: ''
+content: 'The Magento_LoginAsCustomerAdminUi module provides UI for Admin Panel
+
+  '

--- a/src/_data/codebase/v2_4/mrg/ce/LoginAsCustomerApi.yml
+++ b/src/_data/codebase/v2_4/mrg/ce/LoginAsCustomerApi.yml
@@ -7,4 +7,4 @@ last_modified_at: '2020-04-27 20:39:08 -0500'
 content: 'The Magento_LoginAsCustomerApi module provides API for ability to login
   into customer account for an admin user.
 
-'
+  '

--- a/src/_data/codebase/v2_4/mrg/ce/LoginAsCustomerFrontendUi.yml
+++ b/src/_data/codebase/v2_4/mrg/ce/LoginAsCustomerFrontendUi.yml
@@ -4,4 +4,6 @@ source_repo: magento2ce
 release: 2.4.0
 github_path: app/code/Magento/LoginAsCustomerFrontendUi/README.md
 last_modified_at: '2020-05-21 22:39:24 -0500'
-content: ''
+content: 'The Magento_LoginAsCustomerFrontendUi module provides UI for Storefront
+
+  '

--- a/src/_data/codebase/v2_4/mrg/ce/LoginAsCustomerLog.yml
+++ b/src/_data/codebase/v2_4/mrg/ce/LoginAsCustomerLog.yml
@@ -4,4 +4,7 @@ source_repo: magento2ce
 release: 2.4.0
 github_path: app/code/Magento/LoginAsCustomerLog/README.md
 last_modified_at: '2020-05-04 17:44:22 +0300'
-content: ''
+content: 'The Magento_LoginAsCustomerLog module provides log for Login as Customer
+  functionality
+
+  '

--- a/src/_data/codebase/v2_4/mrg/ce/LoginAsCustomerPageCache.yml
+++ b/src/_data/codebase/v2_4/mrg/ce/LoginAsCustomerPageCache.yml
@@ -4,4 +4,7 @@ source_repo: magento2ce
 release: 2.4.0
 github_path: app/code/Magento/LoginAsCustomerPageCache/README.md
 last_modified_at: '2020-04-27 21:52:37 -0500'
-content: ''
+content: 'The Magento_LoginAsCustomerPageCache module provides adaptation to PageCache
+  functionality
+
+  '

--- a/src/_data/codebase/v2_4/mrg/ce/LoginAsCustomerQuote.yml
+++ b/src/_data/codebase/v2_4/mrg/ce/LoginAsCustomerQuote.yml
@@ -7,4 +7,4 @@ last_modified_at: '2020-05-21 22:39:24 -0500'
 content: 'The Magento_LoginAsCustomerQuote module is responsible for communication
   between Magento_LoginAsCustomer and shopping cart state.
 
-'
+  '

--- a/src/_data/codebase/v2_4/mrg/ce/LoginAsCustomerSales.yml
+++ b/src/_data/codebase/v2_4/mrg/ce/LoginAsCustomerSales.yml
@@ -7,4 +7,4 @@ last_modified_at: '2020-05-21 22:39:24 -0500'
 content: 'The Magento_LoginAsCustomerSales module is responsible for communication
   between Magento_LoginAsCustomer and order placement.
 
-'
+  '

--- a/src/_data/codebase/v2_4/mrg/ce/MediaContentCatalog.yml
+++ b/src/_data/codebase/v2_4/mrg/ce/MediaContentCatalog.yml
@@ -5,6 +5,8 @@ release: 2.4.0
 github_path: app/code/Magento/MediaContentCatalog/README.md
 last_modified_at: '2020-04-01 21:43:19 +0100'
 content: |
+  The Magento_MediaContentCatalog provides the implementation of MediaContent functionality for Magento_Catalog module
+
   ## Extensibility
 
   Extension developers can interact with the Magento_MediaContent module. For more information about the Magento extension mechanism, see [Magento plug-ins](https://devdocs.magento.com/guides/v2.3/extension-dev-guide/plugins.html).

--- a/src/_data/codebase/v2_4/mrg/ce/MediaContentCms.yml
+++ b/src/_data/codebase/v2_4/mrg/ce/MediaContentCms.yml
@@ -5,6 +5,8 @@ release: 2.4.0
 github_path: app/code/Magento/MediaContentCms/README.md
 last_modified_at: '2020-04-01 21:43:19 +0100'
 content: |
+  The Magento_MediaContentCms provides the implementation of MediaContent functionality for Magento_Cms module
+
   ## Extensibility
 
   Extension developers can interact with the Magento_MediaContent module. For more information about the Magento extension mechanism, see [Magento plug-ins](https://devdocs.magento.com/guides/v2.3/extension-dev-guide/plugins.html).

--- a/src/_data/codebase/v2_4/mrg/ce/MediaGalleryCatalog.yml
+++ b/src/_data/codebase/v2_4/mrg/ce/MediaGalleryCatalog.yml
@@ -5,6 +5,8 @@ release: 2.4.0
 github_path: app/code/Magento/MediaGalleryCatalog/README.md
 last_modified_at: '2020-04-09 11:17:22 +0100'
 content: |
+  The Magento_MediaGalleryCatalog module is responsible for for catalog gallery processor delete operation handling
+
   ## Installation details
 
   For information about module installation in Magento 2, see [Enable or disable modules](https://devdocs.magento.com/guides/v2.3/install-gde/install/cli/install-cli-subcommands-enable.html).

--- a/src/_data/codebase/v2_4/mrg/ce/MediaStorage.yml
+++ b/src/_data/codebase/v2_4/mrg/ce/MediaStorage.yml
@@ -7,4 +7,4 @@ last_modified_at: '2015-02-26 14:04:15 +0200'
 content: 'The Magento_MediaStorage module implements functionality related with upload
   media files and synchronize it by database.
 
-'
+  '

--- a/src/_data/codebase/v2_4/mrg/ce/Newsletter.yml
+++ b/src/_data/codebase/v2_4/mrg/ce/Newsletter.yml
@@ -8,4 +8,4 @@ content: 'Magento_Newsletter module allows clients to subscribe for information 
   new promotions and discounts and allows store administrators to send newsletters
   to clients subscribed for them.
 
-'
+  '

--- a/src/_data/codebase/v2_4/mrg/ce/OfflineShipping.yml
+++ b/src/_data/codebase/v2_4/mrg/ce/OfflineShipping.yml
@@ -11,3 +11,4 @@ content: |+
   *Table Rates
   *Store Pickup
 
+...

--- a/src/_data/codebase/v2_4/mrg/ce/ProductAlert.yml
+++ b/src/_data/codebase/v2_4/mrg/ce/ProductAlert.yml
@@ -7,4 +7,4 @@ last_modified_at: '2014-10-31 09:04:08 -0700'
 content: 'The Magento_ProductAlert module enables product alerts, which allow customers
   to sign up for emails about product price or stock status change.
 
-'
+  '

--- a/src/_data/codebase/v2_4/mrg/ce/ProductVideo.yml
+++ b/src/_data/codebase/v2_4/mrg/ce/ProductVideo.yml
@@ -7,4 +7,4 @@ last_modified_at: '2015-09-11 16:19:20 +0300'
 content: 'The Magento_ProductVideo module implements functionality related with linking
   video files from external resources to product.
 
-'
+  '

--- a/src/_data/codebase/v2_4/mrg/ce/QuoteAnalytics.yml
+++ b/src/_data/codebase/v2_4/mrg/ce/QuoteAnalytics.yml
@@ -7,4 +7,4 @@ last_modified_at: '2019-08-06 14:40:28 -0500'
 content: 'The Magento_QuoteAnalytics module configures data definitions for a data
   collection related to the Quote module entities to be used in [Advanced Reporting](https://devdocs.magento.com/guides/v2.3/advanced-reporting/modules.html).
 
-'
+  '

--- a/src/_data/codebase/v2_4/mrg/ce/Review.yml
+++ b/src/_data/codebase/v2_4/mrg/ce/Review.yml
@@ -6,4 +6,4 @@ github_path: app/code/Magento/Review/README.md
 last_modified_at: '2014-12-12 12:14:06 -0800'
 content: 'Magento_Review module functionality allows to write reviews for products.
 
-'
+  '

--- a/src/_data/codebase/v2_4/mrg/ce/ReviewAnalytics.yml
+++ b/src/_data/codebase/v2_4/mrg/ce/ReviewAnalytics.yml
@@ -7,4 +7,4 @@ last_modified_at: '2019-08-06 14:40:28 -0500'
 content: 'The Magento_ReviewAnalytics module configures data definitions for a data
   collection related to the Review module entities to be used in [Advanced Reporting](https://devdocs.magento.com/guides/v2.3/advanced-reporting/modules.html).
 
-'
+  '

--- a/src/_data/codebase/v2_4/mrg/ce/Rss.yml
+++ b/src/_data/codebase/v2_4/mrg/ce/Rss.yml
@@ -7,4 +7,4 @@ last_modified_at: '2014-12-12 12:14:06 -0800'
 content: 'Magento_Rss module is responsible for processing all RSS feeds of the application
   and allows to turn on/off RSS centrally.
 
-'
+  '

--- a/src/_data/codebase/v2_4/mrg/ce/Rule.yml
+++ b/src/_data/codebase/v2_4/mrg/ce/Rule.yml
@@ -8,4 +8,4 @@ content: 'Magento_Rule module provides abstract implementation of rules and rule
   that are extended by other modules, in particular by: Magento_SalesRule, Magento_CatalogRule,
   etc...
 
-'
+  '

--- a/src/_data/codebase/v2_4/mrg/ce/SalesAnalytics.yml
+++ b/src/_data/codebase/v2_4/mrg/ce/SalesAnalytics.yml
@@ -7,4 +7,4 @@ last_modified_at: '2019-08-06 14:40:28 -0500'
 content: 'The Magento_SalesAnalytics module configures data definitions for a data
   collection related to the Sales module entities to be used in [Advanced Reporting](https://devdocs.magento.com/guides/v2.3/advanced-reporting/modules.html).
 
-'
+  '

--- a/src/_data/codebase/v2_4/mrg/ce/SalesInventory.yml
+++ b/src/_data/codebase/v2_4/mrg/ce/SalesInventory.yml
@@ -7,4 +7,4 @@ last_modified_at: '2016-09-21 16:39:44 +0300'
 content: 'Magento_SalesInventory module allows retrieve and update stock attributes
   related to Magento_Sales, such as status and quantity.
 
-'
+  '

--- a/src/_data/codebase/v2_4/mrg/ce/Search.yml
+++ b/src/_data/codebase/v2_4/mrg/ce/Search.yml
@@ -7,4 +7,4 @@ last_modified_at: '2014-12-12 12:14:06 -0800'
 content: 'Magento_Search module introduces basic search functionality and provides
   interfaces that allow to implement search for specific module.
 
-'
+  '

--- a/src/_data/codebase/v2_4/mrg/ce/SendFriend.yml
+++ b/src/_data/codebase/v2_4/mrg/ce/SendFriend.yml
@@ -8,4 +8,4 @@ content: 'The Magento_SendFriend implements the functionality behind the "Email 
   a Friend" link on a product page, which allows to share favorite products with others
   by clicking the link.
 
-'
+  '

--- a/src/_data/codebase/v2_4/mrg/ce/Ups.yml
+++ b/src/_data/codebase/v2_4/mrg/ce/Ups.yml
@@ -7,4 +7,4 @@ last_modified_at: '2014-10-31 09:04:08 -0700'
 content: 'The Magento_Ups module implements integration with the United Parcel Service
   shipping carrier.
 
-'
+  '

--- a/src/_data/codebase/v2_4/mrg/ce/UrlRewrite.yml
+++ b/src/_data/codebase/v2_4/mrg/ce/UrlRewrite.yml
@@ -7,4 +7,4 @@ last_modified_at: '2014-12-12 12:14:06 -0800'
 content: 'Magento_UrlRewrite module provides ability to customize website URLs by
   creating custom URL rewrite rules.
 
-'
+  '

--- a/src/_data/codebase/v2_4/mrg/ce/Usps.yml
+++ b/src/_data/codebase/v2_4/mrg/ce/Usps.yml
@@ -7,4 +7,4 @@ last_modified_at: '2014-10-31 09:04:08 -0700'
 content: 'The Magento_Usps module provides integration with the United States Postal
   Service shipping carrier.
 
-'
+  '

--- a/src/_data/codebase/v2_4/mrg/ce/Variable.yml
+++ b/src/_data/codebase/v2_4/mrg/ce/Variable.yml
@@ -7,4 +7,4 @@ last_modified_at: '2015-02-10 10:11:24 -0600'
 content: 'Magento\Variable Allows to create custom variables and then use them in
   email templates or in WYSIWYG editor for editing description of system entities.
 
-'
+  '

--- a/src/_data/codebase/v2_4/mrg/ce/Vault.yml
+++ b/src/_data/codebase/v2_4/mrg/ce/Vault.yml
@@ -7,4 +7,4 @@ last_modified_at: '2015-12-02 14:06:21 +0200'
 content: 'The Magento_Vault module implements the integration with the Vault payment
   gateway and makes the latter available as a payment method in Magento.
 
-'
+  '

--- a/src/_data/codebase/v2_4/mrg/ce/Version.yml
+++ b/src/_data/codebase/v2_4/mrg/ce/Version.yml
@@ -6,4 +6,4 @@ github_path: app/code/Magento/Version/README.md
 last_modified_at: '2015-01-29 16:15:56 -0600'
 content: 'Magento\Version Allows to get Magento version and edition by HTTP GET request
 
-'
+  '

--- a/src/_data/codebase/v2_4/mrg/ce/WishlistAnalytics.yml
+++ b/src/_data/codebase/v2_4/mrg/ce/WishlistAnalytics.yml
@@ -7,4 +7,4 @@ last_modified_at: '2019-08-06 14:40:28 -0500'
 content: 'The Magento_WishlistAnalytics module configures data definitions for a data
   collection related to the Wishlist module entities to be used in [Advanced Reporting](https://devdocs.magento.com/guides/v2.3/advanced-reporting/modules.html).
 
-'
+  '

--- a/src/_data/codebase/v2_4/mrg/ee/GiftCardAccount.yml
+++ b/src/_data/codebase/v2_4/mrg/ee/GiftCardAccount.yml
@@ -8,4 +8,4 @@ content: 'The Magento_GiftCardAccount module is responsible for gift card balanc
   for both gift cards created by a store administrator and gift cards sold as gift
   card products.
 
-'
+  '

--- a/src/_data/codebase/v2_4/mrg/ee/GoogleTagManager.yml
+++ b/src/_data/codebase/v2_4/mrg/ee/GoogleTagManager.yml
@@ -7,4 +7,4 @@ last_modified_at: '2015-06-22 19:55:26 +0300'
 content: 'Magento_GoogleTagManager is a module for integration with Google Tag Manager
   service.
 
-'
+  '

--- a/src/_data/codebase/v2_4/mrg/ee/Invitation.yml
+++ b/src/_data/codebase/v2_4/mrg/ee/Invitation.yml
@@ -7,4 +7,4 @@ last_modified_at: '2014-12-17 18:31:49 +0000'
 content: 'The Magento_Invitation module enables invitation sending, referral tracking
   and generating invitation reports.
 
-'
+  '

--- a/src/_data/codebase/v2_4/mrg/ee/MediaContentCatalogStaging.yml
+++ b/src/_data/codebase/v2_4/mrg/ee/MediaContentCatalogStaging.yml
@@ -5,6 +5,8 @@ release: 2.4.0
 github_path: app/code/Magento/MediaContentCatalogStaging/README.md
 last_modified_at: '2020-04-29 00:24:11 -0500'
 content: |
+  The Magento_MediaContentCatalogStaging provides the implementation of MediaContent functionality for Magento_Catalog module
+
   ## Extensibility
 
   Extension developers can interact with the Magento_MediaContentStaging module. For more information about the Magento extension mechanism, see [Magento plug-ins](https://devdocs.magento.com/guides/v2.3/extension-dev-guide/plugins.html).

--- a/src/_data/codebase/v2_4/mrg/ee/PricePermissions.yml
+++ b/src/_data/codebase/v2_4/mrg/ee/PricePermissions.yml
@@ -7,4 +7,4 @@ last_modified_at: '2014-12-17 18:31:49 +0000'
 content: 'Magento_PricePermissions module allows to restrict such admin rights as
   changing or reading product price, changing product status.
 
-'
+  '

--- a/src/_data/codebase/v2_4/mrg/ee/Reminder.yml
+++ b/src/_data/codebase/v2_4/mrg/ee/Reminder.yml
@@ -7,4 +7,4 @@ last_modified_at: '2014-12-17 18:31:49 +0000'
 content: 'Magento_Reminder module provides functionality for sending reminder emails
   to customers according to pre-configured rules.
 
-'
+  '

--- a/src/_data/codebase/v2_4/mrg/ee/Support.yml
+++ b/src/_data/codebase/v2_4/mrg/ee/Support.yml
@@ -7,4 +7,4 @@ last_modified_at: '2015-07-31 14:51:10 +0300'
 content: 'Magento_Support module is used for generation of system reports, which provide
   detailed information about the system environment and Magento instance configuration.
 
-'
+  '

--- a/src/_data/codebase/v2_4/mrg/ee/TargetRule.yml
+++ b/src/_data/codebase/v2_4/mrg/ee/TargetRule.yml
@@ -7,4 +7,4 @@ last_modified_at: '2014-12-17 18:31:49 +0000'
 content: 'Magento_TargetRule module allows to configure the rules for showing related
   products.
 
-'
+  '

--- a/src/_data/codebase/v2_4/mrg/msi/InventoryInStorePickupSalesApi.yml
+++ b/src/_data/codebase/v2_4/mrg/msi/InventoryInStorePickupSalesApi.yml
@@ -21,3 +21,4 @@ content: |+
   The `InventoryInStorePickupSalesApi` module contains extension points and APIs that 3rd-party developers
   can use to provide customization of In-Store Pickup functionality
 
+...

--- a/src/_data/codebase/v2_4/mrg/msi/InventoryInStorePickupWebapiExtension.yml
+++ b/src/_data/codebase/v2_4/mrg/msi/InventoryInStorePickupWebapiExtension.yml
@@ -4,9 +4,9 @@ source_repo: inventory
 release: 1.2.0
 github_path: InventoryInStorePickupWebapiExtension/README.md
 last_modified_at: '2019-09-17 09:16:51 +0300'
-content: "# InventoryInStorePickupWebapiExtension module (Abandoned)\n\nThe `InventoryInStorePickupWebapiExtension`
-  \ is a part of `InStorePickup` implementation.\n\nThis module is part of the new
-  inventory infrastructure. The\n[Inventory Management overview](https://devdocs.magento.com/guides/v2.3/inventory/index.html)\ndescribes
+content: "The `InventoryInStorePickupWebapiExtension`  is a part of `InStorePickup`
+  implementation.\n\nThis module is part of the new inventory infrastructure. The\n[Inventory
+  Management overview](https://devdocs.magento.com/guides/v2.3/inventory/index.html)\ndescribes
   the MSI (Multi-Source Inventory) project in more detail.\nThe module provide fix
   for usage of extension attributes as parameter for get endpoint in web API.\nThe
   module is abandoned and will be removed as soon as fix for the described issue will

--- a/src/_data/codebase/v2_4/mrg/msi/InventoryProductAlert.yml
+++ b/src/_data/codebase/v2_4/mrg/msi/InventoryProductAlert.yml
@@ -19,3 +19,4 @@ content: |+
 
   There are no extension points or service contracts for this module.
 
+...


### PR DESCRIPTION
## Purpose of this pull request

This pull request (PR) adds missing text to the Module Reference Guide topics in the 2.4 documentation.

The text was missing because of a bug in the MRG generation tool.

## Affected DevDocs pages

<!-- REQUIRED List the affected pages on devdocs.magento.com (URLs). Not needed for large numbers of files. -->

-  multiple topics at the https://devdocs.magento.com/guides/v2.4/mrg/intro.html