### PR TITLE
Add Security.txt feature attribution to community member

### DIFF
--- a/src/guides/v2.4/security/security-txt.md
+++ b/src/guides/v2.4/security/security-txt.md
@@ -15,6 +15,9 @@ Magento merchants can enter their contact information for [security issue report
 -  Contains a router to match application action class for requests to the `well-known/security.txt` and `.well-known/security.txt.sig` files.
 -  Serves the content of the `.well-known/security.txt` and `.well-known/security.txt.sig` files.
 
+{:.bs-calllout-info}
+**Magento Community Contribution** - Magento thanks [Kalpesh Mehta](https://github.com/kalpmehta) of [Corra](https://partners.magento.com/portal/details/partner/id/70/) for contributing this feature as part of the Magento Community Engineering program.
+
 A valid `security.txt` file might look like the following:
 
  ```bash


### PR DESCRIPTION
## Purpose of this pull request

This pull request (PR) adds a note attributing the security.txt feature to the community member [kalpmehta](https://github.com/kalpmehta) who contributed it to the Magento 2 code base.

A previous PR (#7615) attributed the new devdocs topic to the community member, but the community member also contributed the code. I confirmed with Magento Community Engineering.

We've recognized code contributions like this no devdocs before. See [Google reCAPTCHA](https://devdocs.magento.com/guides/v2.4/security/google-recaptcha.html) for an example.

## Affected DevDocs pages

- https://devdocs.magento.com/guides/v2.4/security/security-txt.html

## Links to Magento source code

- https://github.com/magento/security-package/pull/1