### PR TITLE
Fix a link in the Configuration Guide

### DIFF
--- a/src/guides/v2.3/config-guide/config/config-create.md
+++ b/src/guides/v2.3/config-guide/config/config-create.md
@@ -131,4 +131,4 @@ Related topics
 
 *  [Module configuration files]({{ page.baseurl }}/config-guide/config/config-php.html)
 *  [Configuration file merge]({{ page.baseurl }}/config-guide/config/config-files.html#config-files-load-merge-merge)
-*  [Magento's deployment configuration]({{ page.baseurl }}/config-guide/config/config-php.html)
+*  [Magento's deployment configuration]({{ page.baseurl }}/config-guide/config/config-files.html)


### PR DESCRIPTION
## Purpose of this pull request

This pull request (PR) fixes a link in the config guide.

## Affected DevDocs pages

- https://devdocs.magento.com/guides/v2.3/config-guide/config/config-create.html
- https://devdocs.magento.com/guides/v2.4/config-guide/config/config-create.html
