### PR TITLE
Updated supported php versions in composer.json examples

### DIFF
--- a/src/guides/v2.3/frontend-dev-guide/themes/theme-create.md
+++ b/src/guides/v2.3/frontend-dev-guide/themes/theme-create.md
@@ -99,7 +99,7 @@ Example of a theme `composer.json` file:
         "sort-packages": true
     },
     "require": {
-        "php": "~7.1.3||~7.2.0",
+        "php": "~7.2.0||~7.3.0",
         "magento/framework": "*",
         "magento/theme-frontend-blank": "*"
     },

--- a/src/guides/v2.3/get-started/create-integration.md
+++ b/src/guides/v2.3/get-started/create-integration.md
@@ -92,7 +92,7 @@ To develop a module, you must:
         "name": "Vendor1_Module1",
         "description": "create integration from config",
         "require": {
-           "php": "~7.1.3|~7.2.0|~7.3.0",
+           "php": "~7.2.0|~7.3.0",
            "magento/framework": "2.0.0",
            "magento/module-integration": "2.0.0"
         },

--- a/src/guides/v2.4/extension-dev-guide/build/create_component.md
+++ b/src/guides/v2.4/extension-dev-guide/build/create_component.md
@@ -46,7 +46,7 @@ Refer to [Module version dependencies]({{ page.baseurl }}/extension-dev-guide/ve
     "name": "your-name/module-Acme",
     "description": "Test component for Magento 2",
     "require": {
-        "php": "~7.1.3||~7.2.0",
+        "php": "~7.3.0||~7.4.0",
         "magento/module-store": "102.1",
         "magento/module-catalog": "102.1",
         "magento/module-catalog-inventory": "102.1",


### PR DESCRIPTION
## Purpose of this pull request

This pull request (PR) : Updating supported php versions in composer.json examples.

## Affected DevDocs pages

<!-- REQUIRED List the affected pages on devdocs.magento.com (URLs). Not needed for large numbers of files. -->

-  https://devdocs.magento.com/guides/v2.3/frontend-dev-guide/themes/theme-create.html
-  https://devdocs.magento.com/guides/v2.3/get-started/create-integration.html
- https://devdocs.magento.com/guides/v2.4/extension-dev-guide/build/create_component.md

