### PR TITLE
Enable Xdebug. Console command quick fix

### DIFF
--- a/src/cloud/docker/docker-development-debug.md
+++ b/src/cloud/docker/docker-development-debug.md
@@ -23,7 +23,7 @@ If you use Microsoft Windows, take the following steps before continuing:
 1. To enable Xdebug for your Docker environment, generate the Docker Compose configuration file in developer mode with the `--with-xdebug` option and any other required options, for example.
 
    ```bash
-   vendor/bin/ece-docker build:compose --mode --sync-engine="mutagen" developer --with-xdebug
+   vendor/bin/ece-docker build:compose --mode developer --sync-engine="mutagen" --with-xdebug
    ```
 
    This command adds the Xdebug configuration to your `docker-compose.yml` file.
@@ -38,7 +38,7 @@ If you use Microsoft Windows, take the following steps before continuing:
        volumes:
          - 'mymagento-magento-sync:/app:nocopy'
        environment:
-         - 'PHP_EXTENSIONS=bcmath bz2 calendar exif gd gettext intl mysqli pcntl pdo_mysql soap    socketssysvmsg    sysvsem sysvshm opcache zip redis xsl sodium'
+         - 'PHP_EXTENSIONS=bcmath bz2 calendar exif gd gettext intl mysqli pcntl pdo_mysql soap socketssysvmsg sysvsem sysvshm opcache zip redis xsl sodium'
        networks:
          magento:
            aliases:


### PR DESCRIPTION
## Purpose of this pull request

Fix console command to generate 'Docker Compose' config with the xdebug

## Affected DevDocs pages

https://devdocs.magento.com/cloud/docker/docker-development-debug.html
<!--
If you are fixing a GitHub issue, note it using GitHub keyword format (https://help.github.com/en/articles/closing-issues-using-keywords#closing-an-issue-in-a-different-repository) to close the issue when this pull request is merged. Example: `Fixes #1234`

`master` is the default branch. Merged pull requests to `master` go live on the site automatically. Any requested changes to content on the `master` branch must be related to the released codebase. Any content related to future releases goes in the `develop` branch.

See Contribution guidelines (https://github.com/magento/devdocs/blob/master/.github/CONTRIBUTING.md) for more information.
-->
