### PR TITLE
Minor change to wrong dir

### DIFF
--- a/src/guides/v2.4/install-gde/prereq/nginx.md
+++ b/src/guides/v2.4/install-gde/prereq/nginx.md
@@ -289,7 +289,7 @@ We recommend setting the memory limit to 2G when testing Magento. Refer to [Requ
 1. Uncomment the session path directory and set the path:
 
    ```conf
-   session.save_path = "/var/lib/php/session"
+   session.save_path = "/var/lib/php/sessions"
    ```
 
 1. Save and exit the editor.


### PR DESCRIPTION
/var/lib/php/session doesn't exist, the correct is /var/lib/php/sessions as stated in default php.ini file
