### PR TITLE
fix(xdebug, docker): fixes a typo in xdebug yaml

### DIFF
--- a/src/cloud/docker/docker-development-debug.md
+++ b/src/cloud/docker/docker-development-debug.md
@@ -38,7 +38,7 @@ If you use Microsoft Windows, take the following steps before continuing:
        volumes:
          - 'mymagento-magento-sync:/app:nocopy'
        environment:
-         - 'PHP_EXTENSIONS=bcmath bz2 calendar exif gd gettext intl mysqli pcntl pdo_mysql soap socketssysvmsg sysvsem sysvshm opcache zip redis xsl sodium'
+         - 'PHP_EXTENSIONS=bcmath bz2 calendar exif gd gettext intl mysqli pcntl pdo_mysql soap sockets sysvmsg sysvsem sysvshm opcache zip redis xsl sodium'
        networks:
          magento:
            aliases:


### PR DESCRIPTION
## Purpose of this pull request

Fixed spacing error in the `docker-compose.yml` code sample.

## Affected DevDocs pages

- https://devdocs.magento.com/cloud/docker/docker-development-debug.html
