### PR TITLE
fix(xdebug,docker): accomodate linux differences

### DIFF
--- a/src/cloud/docker/docker-development-debug.md
+++ b/src/cloud/docker/docker-development-debug.md
@@ -63,6 +63,11 @@ If you use Microsoft Windows, take the following steps before continuing:
    ```bash
    XDEBUG_CONFIG='remote_host=host.docker.internal remote_port=9002'
    ```
+   
+   On Linux, you should instead use:
+   ```bash
+   XDEBUG_CONFIG=remote_host=host.docker.internal remote_port=9002
+   ```
 
 {:.procedure}
 To configure PhpStorm to work with Xdebug:

--- a/src/cloud/docker/docker-development-debug.md
+++ b/src/cloud/docker/docker-development-debug.md
@@ -65,6 +65,7 @@ If you use Microsoft Windows, take the following steps before continuing:
    ```
    
    On Linux systems, use the following command instead:
+   
    ```bash
    XDEBUG_CONFIG=remote_host=host.docker.internal remote_port=9002
    ```

--- a/src/cloud/docker/docker-development-debug.md
+++ b/src/cloud/docker/docker-development-debug.md
@@ -64,7 +64,7 @@ If you use Microsoft Windows, take the following steps before continuing:
    XDEBUG_CONFIG='remote_host=host.docker.internal remote_port=9002'
    ```
    
-   On Linux, you should instead use:
+   On Linux systems, use the following command instead:
    ```bash
    XDEBUG_CONFIG=remote_host=host.docker.internal remote_port=9002
    ```

--- a/src/cloud/docker/docker-development-debug.md
+++ b/src/cloud/docker/docker-development-debug.md
@@ -63,9 +63,7 @@ If you use Microsoft Windows, take the following steps before continuing:
    ```bash
    XDEBUG_CONFIG='remote_host=host.docker.internal remote_port=9002'
    ```
-   
    On Linux systems, use the following command instead:
-   
    ```bash
    XDEBUG_CONFIG=remote_host=host.docker.internal remote_port=9002
    ```


### PR DESCRIPTION
## Purpose of this pull request

Updated the `XDEBUG_CONFIG` command example to show command syntax for Linux systems.

## Affected DevDocs pages

- https://devdocs.magento.com/cloud/docker/docker-development-debug.html