### PR TITLE
Update privatelink-service.md

### DIFF
--- a/src/cloud/project/privatelink-service.md
+++ b/src/cloud/project/privatelink-service.md
@@ -25,7 +25,7 @@ The PrivateLink service integration for {{site.data.var.ece}} projects includes 
 -  You cannot establish SSH connections using PrivateLink. For SSH, use the Magento SSH capabilities. See [Enable SSH keys][].
 -  Magento support does not cover troubleshooting AWS PrivateLink issues beyond initial enablement.
 -  Customers are responsible for costs associated with managing their own VPC.
--  Connecting to Magento Commerce Cloud with HTTP(S) over Private Link is not supported.
+-  You cannot use the HTTPS protocol to connect to Magento Commerce over PrivateLink.
 
 ## PrivateLink connection types
 

--- a/src/cloud/project/privatelink-service.md
+++ b/src/cloud/project/privatelink-service.md
@@ -25,6 +25,7 @@ The PrivateLink service integration for {{site.data.var.ece}} projects includes 
 -  You cannot establish SSH connections using PrivateLink. For SSH, use the Magento SSH capabilities. See [Enable SSH keys][].
 -  Magento support does not cover troubleshooting AWS PrivateLink issues beyond initial enablement.
 -  Customers are responsible for costs associated with managing their own VPC.
+-  Connecting to Magento Commerce Cloud with HTTP(S) over Private Link is not supported.
 
 ## PrivateLink connection types
 


### PR DESCRIPTION
## Purpose of this pull request

Updated Privatelink limitations to mention restriction on HTTPS connections to Magento Commerce Cloud.

## Affected DevDocs pages

- https://devdocs.magento.com/cloud/project/privatelink-service.html#limitations

whatsnew
Added PrivateLink limitation on establishing HTTPS connections to Magento. See  [PrivateLink limitations](https://devdocs.magento.com/cloud/project/privatelink-service.html#limitations) topic in the _Cloud Guide_ .
