### PR TITLE
Add a contributor to What's New entries

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -153,7 +153,7 @@ GEM
     unicode-display_width (1.7.0)
     verbal_expressions (0.1.5)
     wdm (0.1.1)
-    whatsup_github (0.3.0)
+    whatsup_github (0.3.1)
       netrc (~> 0.10)
       octokit (~> 4.14)
       thor (~> 0.20)

--- a/src/whats-new.md
+++ b/src/whats-new.md
@@ -19,14 +19,39 @@ title: What's new on DevDocs
 
 ## {{ group.name }}
 
-Description | Versions | Type | Date
----|---|---|---{% for item in group.items %}
-{{ item.description }} | {{ item.versions }} | {{ item.type }} |
-{%- if item.link -%}
-[{{ item.date | date: "%B&nbsp;%e" }}]({{ item.link }})
-{%- else -%}
-{{ item.date | date: "%B&nbsp;%e" }}
-{%- endif -%}
-{% endfor %}
+<table>
+  <thead>
+    <tr>
+      <th>Description</th>
+      <th>Versions</th>
+      <th>Type</th>
+      <th>Date</th>
+    </tr>
+  </thead>
+  <tbody>
+  {% for item in group.items %}
+    <tr>
+      <td><p>
+          {{ item.description | markdownify }}
+          </p>
+          {%- if item.contributor -%}
+          <p>
+          Contributed by <a href="{{ item.profile }}">{{ item.contributor }}</a>.
+          </p>
+          {% endif %}
+      </td>
+      <td>{{ item.versions }}</td>
+      <td>{{ item.type }}</td>
+      <td>
+          {%- if item.link -%}
+              <a href="{{ item.link }}">{{ item.date | date: "%B&nbsp;%e" }}</a>
+          {%- else -%}
+              {{ item.date | date: "%B&nbsp;%e" }}
+          {%- endif -%}
+      </td>
+    </tr>
+  {% endfor %}
+  </tbody>
+</table>
 
 {% endfor %}


### PR DESCRIPTION
## Purpose of this pull request

This pull request (PR) adds a contributor to entries at [What's new on DevDocs](https://devdocs.magento.com/whats-new.html).

## Affected DevDocs pages

<!-- REQUIRED List the affected pages on devdocs.magento.com (URLs). Not needed for large numbers of files. -->

-  https://devdocs.magento.com/whats-new.html

Example:

![Screen Shot 2020-08-07 at 18 54 07](https://user-images.githubusercontent.com/12731225/89696912-6f9ba780-d8df-11ea-809b-309f617f50a0.png)
