### PR TITLE
MCLOUD-2981: Asses usefulness and necessity of option Verbosity

### DIFF
--- a/src/cloud/env/variables-build.md
+++ b/src/cloud/env/variables-build.md
@@ -207,7 +207,9 @@ stage:
 -  **Default**—_Not set_
 -  **Version**—Magento 2.1.4 and later
 
- Enables or disables the [Symfony](https://symfony.com/doc/current/console/verbosity.html) debug verbosity level for your logs. Choose the level of detail provided in the logs: `-v`, `-vv`, or `-vvv`.
+Enable or disable the [Symfony](https://symfony.com/doc/current/console/verbosity.html) debug verbosity level for `bin/magento` CLI commands executed from the deployment script. 
+To change verbosity of the output from _successful_ `bin/magento` CLI commands, you must set the `MIN_LOGGING_LEVEL` to `debug`.
+Use the following options to set the level of detail provided in the logs: `-v`, `-vv`, or `-vvv`.
 
 ```yaml
 stage:

--- a/src/cloud/env/variables-deploy.md
+++ b/src/cloud/env/variables-deploy.md
@@ -643,7 +643,9 @@ stage:
 -  **Default**—_Not set_
 -  **Version**—Magento 2.1.4 and later
 
- Enables or disables the [Symfony](https://symfony.com/doc/current/console/verbosity.html) debug verbosity level for your logs. Choose the level of detail provided in the logs: `-v`, `-vv`, or `-vvv`.
+Enable or disable the [Symfony](https://symfony.com/doc/current/console/verbosity.html) debug verbosity level for `bin/magento` CLI commands executed from the deployment script. 
+To change verbosity of the output from _successful_ `bin/magento` CLI commands, you must set the `MIN_LOGGING_LEVEL` to `debug`.
+Use the following options to set the level of detail provided in the logs: `-v`, `-vv`, or `-vvv`.
 
 ```yaml
 stage:


### PR DESCRIPTION
## Purpose of this pull request

This pull request (PR) specify information about `VERBOSE_COMMANDS` setting

## Affected DevDocs pages

<!-- REQUIRED List the affected pages on devdocs.magento.com (URLs). Not needed for large numbers of files. -->

- https://devdocs.magento.com/cloud/env/variables-build.html#verbose_commands
- https://devdocs.magento.com/cloud/env/variables-deploy.html#verbose_commands

<!--
If you are fixing a GitHub issue, note it using GitHub keyword format (https://help.github.com/en/articles/closing-issues-using-keywords#closing-an-issue-in-a-different-repository) to close the issue when this pull request is merged. Example: `Fixes #1234`

`master` is the default branch. Merged pull requests to `master` go live on the site automatically. Any requested changes to content on the `master` branch must be related to the released codebase. Any content related to future releases goes in the `develop` branch.

See Contribution guidelines (https://github.com/magento/devdocs/blob/master/.github/CONTRIBUTING.md) for more information.
-->
