### PR TITLE
Updates to VERBOSE_COMMANDS deploy and build variable description

### DIFF
--- a/src/cloud/env/variables-build.md
+++ b/src/cloud/env/variables-build.md
@@ -207,7 +207,7 @@ stage:
 -  **Default**—_Not set_
 -  **Version**—Magento 2.1.4 and later
 
-Enable or disable the [Symfony](https://symfony.com/doc/current/console/verbosity.html) debug verbosity level for `bin/magento` CLI commands executed from the deployment script.
+Enable or disable the [Symfony](https://symfony.com/doc/current/console/verbosity.html) debug verbosity level for `bin/magento` CLI commands performed during the deployment phase.
 
 To change the verbosity of the output from _successful_ `bin/magento` CLI commands, you must also set the [MIN_LOGGING_LEVEL]({{ site.baseurl }}/cloud/env/variables-global.html#min_logging_level) to `debug`.
 

--- a/src/cloud/env/variables-build.md
+++ b/src/cloud/env/variables-build.md
@@ -207,7 +207,9 @@ stage:
 -  **Default**—_Not set_
 -  **Version**—Magento 2.1.4 and later
 
- Enables or disables the [Symfony](https://symfony.com/doc/current/console/verbosity.html) debug verbosity level for your logs. Choose the level of detail provided in the logs: `-v`, `-vv`, or `-vvv`.
+Enable or disable the [Symfony](https://symfony.com/doc/current/console/verbosity.html) debug verbosity level for `bin/magento` CLI commands executed from the deployment script. 
+To change verbosity of the output from _successful_ `bin/magento` CLI commands, you must set the `MIN_LOGGING_LEVEL` to `debug`.
+Use the following options to set the level of detail provided in the logs: `-v`, `-vv`, or `-vvv`.
 
 ```yaml
 stage:

--- a/src/cloud/env/variables-build.md
+++ b/src/cloud/env/variables-build.md
@@ -209,7 +209,7 @@ stage:
 
 Enable or disable the [Symfony](https://symfony.com/doc/current/console/verbosity.html) debug verbosity level for `bin/magento` CLI commands performed during the deployment phase.
 
-To change the verbosity of the output from _successful_ `bin/magento` CLI commands, you must also set the [MIN_LOGGING_LEVEL]({{ site.baseurl }}/cloud/env/variables-global.html#min_logging_level) to `debug`.
+The [MIN_LOGGING_LEVEL]({{ site.baseurl }}/cloud/env/variables-global.html#min_logging_level) must be set to `debug` for the most useful output.
 
 Choose the level of detail provided in the logs: `-v`, `-vv`, or `-vvv`.
 

--- a/src/cloud/env/variables-build.md
+++ b/src/cloud/env/variables-build.md
@@ -207,9 +207,11 @@ stage:
 -  **Default**—_Not set_
 -  **Version**—Magento 2.1.4 and later
 
-Enable or disable the [Symfony](https://symfony.com/doc/current/console/verbosity.html) debug verbosity level for `bin/magento` CLI commands executed from the deployment script. 
-To change verbosity of the output from _successful_ `bin/magento` CLI commands, you must set the `MIN_LOGGING_LEVEL` to `debug`.
-Use the following options to set the level of detail provided in the logs: `-v`, `-vv`, or `-vvv`.
+Enable or disable the [Symfony](https://symfony.com/doc/current/console/verbosity.html) debug verbosity level for `bin/magento` CLI commands executed from the deployment script.
+
+To change the verbosity of the output from _successful_ `bin/magento` CLI commands, you must also set the [MIN_LOGGING_LEVEL]({{ site.baseurl }}/cloud/env/variables-global.html#min_logging_level) to `debug`.
+
+Choose the level of detail provided in the logs: `-v`, `-vv`, or `-vvv`.
 
 ```yaml
 stage:

--- a/src/cloud/env/variables-build.md
+++ b/src/cloud/env/variables-build.md
@@ -209,7 +209,8 @@ stage:
 
 Enable or disable the [Symfony](https://symfony.com/doc/current/console/verbosity.html) debug verbosity level for `bin/magento` CLI commands performed during the deployment phase.
 
-The [MIN_LOGGING_LEVEL]({{ site.baseurl }}/cloud/env/variables-global.html#min_logging_level) must be set to `debug` for the most useful output.
+{:.bs-callout}
+To use VERBOSE_COMMANDS to control the detail in command output for both successful and failed `bin/magento` CLI commands, you must set [MIN_LOGGING_LEVEL]({{ site.baseurl }}/cloud/env/variables-global.html#min_logging_level) `debug`.
 
 Choose the level of detail provided in the logs: `-v`, `-vv`, or `-vvv`.
 

--- a/src/cloud/env/variables-deploy.md
+++ b/src/cloud/env/variables-deploy.md
@@ -645,7 +645,8 @@ stage:
 
 Enable or disable the [Symfony](https://symfony.com/doc/current/console/verbosity.html) debug verbosity level for `bin/magento` CLI commands performed during the deployment phase.
 
-The [MIN_LOGGING_LEVEL]({{ site.baseurl }}/cloud/env/variables-global.html#min_logging_level) must be set to `debug` for the most useful output.
+{:.bs-callout}
+To use the VERBOSE_COMMANDS setting to control the detail in command output for both successful and failed `bin/magento` CLI commands, you must set [MIN_LOGGING_LEVEL]({{ site.baseurl }}/cloud/env/variables-global.html#min_logging_level) `debug`.
 
 Choose the level of detail provided in the logs: `-v`, `-vv`, or `-vvv`.
 

--- a/src/cloud/env/variables-deploy.md
+++ b/src/cloud/env/variables-deploy.md
@@ -643,9 +643,9 @@ stage:
 -  **Default**—_Not set_
 -  **Version**—Magento 2.1.4 and later
 
-Enable or disable the [Symfony](https://symfony.com/doc/current/console/verbosity.html) debug verbosity level for `bin/magento` CLI commands executed from the deployment script.
+Enable or disable the [Symfony](https://symfony.com/doc/current/console/verbosity.html) debug verbosity level for `bin/magento` CLI commands performed during the deployment phase.
 
-To change the verbosity of the output from _successful_ `bin/magento` CLI commands, you must also set the [MIN_LOGGING_LEVEL]({{ site.baseurl }}/cloud/env/variables-global.html#min_logging_level) to `debug`.
+The [MIN_LOGGING_LEVEL]({{ site.baseurl }}/cloud/env/variables-global.html#min_logging_level) must be set to `debug` for the most useful output.
 
 Choose the level of detail provided in the logs: `-v`, `-vv`, or `-vvv`.
 

--- a/src/cloud/env/variables-deploy.md
+++ b/src/cloud/env/variables-deploy.md
@@ -643,9 +643,11 @@ stage:
 -  **Default**—_Not set_
 -  **Version**—Magento 2.1.4 and later
 
-Enable or disable the [Symfony](https://symfony.com/doc/current/console/verbosity.html) debug verbosity level for `bin/magento` CLI commands executed from the deployment script. 
-To change verbosity of the output from _successful_ `bin/magento` CLI commands, you must set the `MIN_LOGGING_LEVEL` to `debug`.
-Use the following options to set the level of detail provided in the logs: `-v`, `-vv`, or `-vvv`.
+Enable or disable the [Symfony](https://symfony.com/doc/current/console/verbosity.html) debug verbosity level for `bin/magento` CLI commands executed from the deployment script.
+
+To change the verbosity of the output from _successful_ `bin/magento` CLI commands, you must also set the [MIN_LOGGING_LEVEL]({{ site.baseurl }}/cloud/env/variables-global.html#min_logging_level) to `debug`.
+
+Choose the level of detail provided in the logs: `-v`, `-vv`, or `-vvv`.
 
 ```yaml
 stage:

--- a/src/cloud/env/variables-deploy.md
+++ b/src/cloud/env/variables-deploy.md
@@ -643,7 +643,9 @@ stage:
 -  **Default**—_Not set_
 -  **Version**—Magento 2.1.4 and later
 
- Enables or disables the [Symfony](https://symfony.com/doc/current/console/verbosity.html) debug verbosity level for your logs. Choose the level of detail provided in the logs: `-v`, `-vv`, or `-vvv`.
+Enable or disable the [Symfony](https://symfony.com/doc/current/console/verbosity.html) debug verbosity level for `bin/magento` CLI commands executed from the deployment script. 
+To change verbosity of the output from _successful_ `bin/magento` CLI commands, you must set the `MIN_LOGGING_LEVEL` to `debug`.
+Use the following options to set the level of detail provided in the logs: `-v`, `-vv`, or `-vvv`.
 
 ```yaml
 stage:


### PR DESCRIPTION
Merges changes from PR #7708

## Purpose of this pull request

Updated the VERBOSE_COMMANDS deploy and build variable description to clarify that MIN_LOG_LEVEL=`debug` must be set to control verbosity level of successful command.

## Affected DevDocs pages

- https://devdocs.magento.com/cloud/env/variables-build.html#verbose_commands
- https://devdocs.magento.com/cloud/env/variables-deploy.html#verbose_commands