### PR TITLE
Remove the 'Contributed by' attribution from What's New template

### DIFF
--- a/src/whats-new.md
+++ b/src/whats-new.md
@@ -31,15 +31,7 @@ title: What's new on DevDocs
   <tbody>
   {% for item in group.items %}
     <tr>
-      <td><p>
-          {{ item.description | markdownify }}
-          </p>
-          {%- if item.contributor -%}
-          <p>
-          Contributed by <a href="{{ item.profile }}">{{ item.contributor }}</a>.
-          </p>
-          {% endif %}
-      </td>
+      <td>{{ item.description | markdownify }}</td>
       <td>{{ item.versions }}</td>
       <td>{{ item.type }}</td>
       <td>


### PR DESCRIPTION
## Purpose of this pull request

This pull request (PR) removes _Contributed by_ attribution from the What's New on DevDocs table until further decisions from @magento/devdocs-team .

## Affected DevDocs pages

<!-- REQUIRED List the affected pages on devdocs.magento.com (URLs). Not needed for large numbers of files. -->

-  https://devdocs.magento.com/whats-new.html