### PR TITLE
Marketplace format fix

### DIFF
--- a/src/marketplace/sellers/profile-company.md
+++ b/src/marketplace/sellers/profile-company.md
@@ -6,7 +6,7 @@ redirect_from: /marketplace/sellers/company-profile.html
 
 Your company profile provides the information about your business and brand that appears in your Magento Marketplace listing. During the initial interview, the Company Profile page appears after you choose the “Business” type of account. In your account, the Company Profile is located on the Developer Portal tab under My Information.
 
-![]({{ site.baseurl }}/marketplace/sellers/images/developer-portal-company-profile.png){: .zoom}
+![Company profile]({{ site.baseurl }}/marketplace/sellers/images/developer-portal-company-profile.png){: .zoom}
 _Company Profile_
 
 The following instructions walk you through the process of completing your company profile. All fields are required, unless marked “Optional”.
@@ -19,8 +19,8 @@ Prepare an image for your company profile that is 255 pixels square. Then, save 
 
 1. Select the checkbox at the top of the form if you want to use your company profile—rather than your personal profile—as the default.
 
-   ![]({{ site.baseurl }}/marketplace/sellers/images/account-company-profile-name.png){: .zoom}
-   _Company Profile_
+   ![Company background]({{ site.baseurl }}/marketplace/sellers/images/account-company-profile-name.png){: .zoom}
+   _Company Background_
 
 1. Enter your **Legal Company Name**.
 
@@ -45,7 +45,7 @@ Prepare an image for your company profile that is 255 pixels square. Then, save 
    This unique identifier is used to identify your Marketplace vendor account, and must exactly match the Vendor Name in your company profile.
    </div>
 
-   ![]({{ site.baseurl }}/marketplace/sellers/images/account-company-profile-contact-info.png){: .zoom}
+   ![Contact information]({{ site.baseurl }}/marketplace/sellers/images/account-company-profile-contact-info.png){: .zoom}
       _Contact Information_
 
 ## Step 4: Enter your company address
@@ -59,7 +59,7 @@ Prepare an image for your company profile that is 255 pixels square. Then, save 
 
 1. To complete the **Phone Number**, choose the flag for your country code. Then, enter the area code and phone number.
 
-   ![]({{ site.baseurl }}/marketplace/sellers/images/account-company-profile-address.png){: .zoom}
+   ![Company address]({{ site.baseurl }}/marketplace/sellers/images/account-company-profile-address.png){: .zoom}
    _Company Address_
 
 ## Step 5: Link to your social networks (optional)
@@ -72,7 +72,7 @@ Enter the link to each professional social network that you want to include in y
 -  Facebook
 -  LinkedIn
 
-![]({{ site.baseurl }}/marketplace/sellers/images/account-profile-social-networks.png){: .zoom}
+![Social networks]({{ site.baseurl }}/marketplace/sellers/images/account-profile-social-networks.png){: .zoom}
 _Social Networks_
 
 ## Step 6: Activate your account
@@ -90,7 +90,6 @@ _Social Networks_
 
 ## Field Descriptions
 
-{: .fields-table }
 |Field|Description|
 |---|---|
 |Use as my default profile|Mark the checkbox to use your company profile as the default.|

--- a/src/marketplace/sellers/profile-company.md
+++ b/src/marketplace/sellers/profile-company.md
@@ -11,16 +11,16 @@ _Company Profile_
 
 The following instructions walk you through the process of completing your company profile. All fields are required, unless marked “Optional”.
 
-## Before you begin
+## Step 1: Before you begin
 
 Prepare an image for your company profile that is 255 pixels square. Then, save it as one of the following file types: JPG, GIF, or PNG.
 
-### Step 1: Complete your company background
+## Step 2: Complete your company background
 
 1. Select the checkbox at the top of the form if you want to use your company profile—rather than your personal profile—as the default.
 
-    ![]({{ site.baseurl }}/marketplace/sellers/images/account-company-profile-name.png){: .zoom}
-    _Company Profile_
+   ![]({{ site.baseurl }}/marketplace/sellers/images/account-company-profile-name.png){: .zoom}
+   _Company Profile_
 
 1. Enter your **Legal Company Name**.
 
@@ -28,10 +28,10 @@ Prepare an image for your company profile that is 255 pixels square. Then, save 
 
 1. To upload the image that you have prepared to your company profile, do one of the following:
 
--  Drag the image to the box.
--  Click <span class="btn">Update Image</span>. Then, navigate to the image in your file system and upload it to your profile.
+   -  Drag the image to the box.
+   -  Click <span class="btn">Update Image</span>. Then, navigate to the image in your file system and upload it to your profile.
 
-### Step 2: Enter your contact information
+## Step 3: Enter your contact information
 
 1. Enter the URL of your **Company Website**.
 
@@ -39,30 +39,30 @@ Prepare an image for your company profile that is 255 pixels square. Then, save 
 
 1. In the **Vendor Name** field, enter the `vendor-name` part of the `Name` field from your `composer.json` file.
 
-    `Name: <vendor-name> / <package-name>`
+   `Name: <vendor-name> / <package-name>`
 
-    <div class="bs-callout bs-callout-info" markdown="1">
-    This unique identifier is used to identify your Marketplace vendor account, and must exactly match the Vendor Name in your company profile.
-    </div>
+   <div class="bs-callout bs-callout-info" markdown="1">
+   This unique identifier is used to identify your Marketplace vendor account, and must exactly match the Vendor Name in your company profile.
+   </div>
 
-    ![]({{ site.baseurl }}/marketplace/sellers/images/account-company-profile-contact-info.png){: .zoom}
-    _Contact Information_
+   ![]({{ site.baseurl }}/marketplace/sellers/images/account-company-profile-contact-info.png){: .zoom}
+      _Contact Information_
 
-### Step 3: Enter your company address
+## Step 4: Enter your company address
 
 1. Complete the following fields that make up your company address:
 
--  Country
--  Street Address, Apt/Suite
--  ZIP, City, State / Province
--  Phone Number
+   -  Country
+   -  Street Address, Apt/Suite
+   -  ZIP, City, State / Province
+   -  Phone Number
 
 1. To complete the **Phone Number**, choose the flag for your country code. Then, enter the area code and phone number.
 
-    ![]({{ site.baseurl }}/marketplace/sellers/images/account-company-profile-address.png){: .zoom}
-    _Company Address_
+   ![]({{ site.baseurl }}/marketplace/sellers/images/account-company-profile-address.png){: .zoom}
+   _Company Address_
 
-### Step 4: Link to your social networks (optional)
+## Step 5: Link to your social networks (optional)
 
 Enter the link to each professional social network that you want to include in your company profile.
 
@@ -75,14 +75,14 @@ Enter the link to each professional social network that you want to include in y
 ![]({{ site.baseurl }}/marketplace/sellers/images/account-profile-social-networks.png){: .zoom}
 _Social Networks_
 
-### Step 5: Activate your account
+## Step 6: Activate your account
 
 1. When the required fields are complete, click <span class="btn">Save</span>.
 
 1. When prompted, enter your **PayPal Email** address.
 
-    {: .bs-callout .bs-callout-info}
-    **Important:** This payment information is required of all developers, even those who make their extensions available at no charge. Magento sends your revenue share on a monthly basis to PayPal account.
+   {: .bs-callout .bs-callout-info}
+   **Important:** This payment information is required of all developers, even those who make their extensions available at no charge. Magento sends your revenue share on a monthly basis to PayPal account.
 
 1. Watch for a confirmation email sent to the email address associated with the account.
 
@@ -98,9 +98,8 @@ _Social Networks_
 |Company Bio|A description of your company’s background, products, and services. You might begin with a couple of sentences to give a brief overview, and finish it later with a more detailed description. If you use a word processor to compose and spell check your bio, make sure to save it as plain text before pasting it into your profile. Make sure to convert all URLs to working hyperlinks. Maximum characters: 1500, including spaces.|
 |Update Image|Your company profile image represents your brand in Magento Marketplace, and appears on your developer profile and product pages. The image must have a professional presentation, and must not be derived from, or include the Magento logo. To learn more, see the Magento Extension Distribution and Service Agreement. <br/>Size: 255 x 255 pixels <br/>Supported file types: JPG / GIF / PNG|
 
-### Contact information
+#### Contact information
 
-{: .fields-table }
 |Field|Description|
 |--- |--- |
 |Company Website|The URL of your company website.|
@@ -108,9 +107,8 @@ _Social Networks_
 |Company Support Email|The email address that customers can use to contact your company for technical support.|
 |Vendor Name|A unique identifier that identifies your Marketplace account. The vendor name can be based on your company name, and must be lowercase alphanumeric characters, and can include dashes. <br/><br/>**_Important:_** For all Magento 2.x packages submitted to Marketplace, the Vendor Name must match the name field in the Vendor section of the composer.json file.|
 
-### Company address
+#### Company address
 
-{: .fields-table }
 |Field|Description|
 |--- |--- |
 |Country|The country where your company is legally registered to conduct business.|
@@ -121,9 +119,8 @@ _Social Networks_
 |State/Province|The state or province where your company is located.|
 |Phone Number|The primary phone number used by your company. The area code and phone number are automatically formatted as: (999) 999-9999|
 
-### Social networks
+#### Social networks
 
-{: .fields-table }
 |Field|Description|
 |--- |--- |
 |GitHub|(Optional) The user name associated with your company’s GitHub account. For example: http://github.com/username|

--- a/src/marketplace/sellers/profile-company.md
+++ b/src/marketplace/sellers/profile-company.md
@@ -98,7 +98,7 @@ _Social Networks_
 |Company Bio|A description of your company’s background, products, and services. You might begin with a couple of sentences to give a brief overview, and finish it later with a more detailed description. If you use a word processor to compose and spell check your bio, make sure to save it as plain text before pasting it into your profile. Make sure to convert all URLs to working hyperlinks. Maximum characters: 1500, including spaces.|
 |Update Image|Your company profile image represents your brand in Magento Marketplace, and appears on your developer profile and product pages. The image must have a professional presentation, and must not be derived from, or include the Magento logo. To learn more, see the Magento Extension Distribution and Service Agreement. <br/>Size: 255 x 255 pixels <br/>Supported file types: JPG / GIF / PNG|
 
-#### Contact information
+### Contact information
 
 |Field|Description|
 |--- |--- |
@@ -107,7 +107,7 @@ _Social Networks_
 |Company Support Email|The email address that customers can use to contact your company for technical support.|
 |Vendor Name|A unique identifier that identifies your Marketplace account. The vendor name can be based on your company name, and must be lowercase alphanumeric characters, and can include dashes. <br/><br/>**_Important:_** For all Magento 2.x packages submitted to Marketplace, the Vendor Name must match the name field in the Vendor section of the composer.json file.|
 
-#### Company address
+### Company address
 
 |Field|Description|
 |--- |--- |
@@ -119,7 +119,7 @@ _Social Networks_
 |State/Province|The state or province where your company is located.|
 |Phone Number|The primary phone number used by your company. The area code and phone number are automatically formatted as: (999) 999-9999|
 
-#### Social networks
+### Social networks
 
 |Field|Description|
 |--- |--- |

--- a/src/marketplace/sellers/profile-information.md
+++ b/src/marketplace/sellers/profile-information.md
@@ -12,7 +12,7 @@ Your contact information includes your address, phone number, and PayPal email a
 ![]({{ site.baseurl }}/marketplace/sellers/images/account-information.png){: .zoom}
 _Contact Information_
 
-### Account Information 
+### Account Information
 
 |Field|Description|
 |--- |--- |
@@ -65,7 +65,7 @@ Your Marketplace Profile contains information you entered during account setup, 
 ![]({{ site.baseurl }}/marketplace/sellers/images/marketplace-profile.png){: .zoom}
 _Marketplace Profile_
 
-### Account Information 
+### Account Information
 
 | Field | Description |
 |----------

--- a/src/marketplace/sellers/profile-information.md
+++ b/src/marketplace/sellers/profile-information.md
@@ -11,8 +11,8 @@ Your contact information includes your address, phone number, and PayPal email a
 
 ![]({{ site.baseurl }}/marketplace/sellers/images/account-information.png){: .zoom}
 _Contact Information_
- 
-### Field Descriptions - personal
+
+### Account Information 
 
 |Field|Description|
 |--- |--- |
@@ -22,7 +22,7 @@ _Contact Information_
 |Login Credentials|Clicking <span class="btn">Go to My Account</span> takes you to your Magento account information.|
 |PayPal Email|You must enter a valid PayPal account email, even if  your extensions are available for free on Magento Marketplace. Magento sends your revenue share payment to your PayPal account.|
 
-### Field Descriptions - company
+### Company
 
 |Field|Description|
 |--- |--- |
@@ -50,8 +50,8 @@ For more technical information, see [Get your authentication keys][2] in the dev
 
 1. In the Basic Access Key Information dialog, enter an **Access Key Name** (max of 32 characters) to identify the access key. Then, click <span class="btn">Continue</span>.
 
-    ![]({{ site.baseurl }}/marketplace/sellers/images/basic-access-key-information.png){: .zoom}
-    _Basic Access Key Information_
+   ![]({{ site.baseurl }}/marketplace/sellers/images/basic-access-key-information.png){: .zoom}
+   _Basic Access Key Information_
 
 Your new access key appears in the list, and can now be used to authorize downloads of Magento updates, extensions, and themes.
 
@@ -64,6 +64,8 @@ Your Marketplace Profile contains information you entered during account setup, 
 
 ![]({{ site.baseurl }}/marketplace/sellers/images/marketplace-profile.png){: .zoom}
 _Marketplace Profile_
+
+### Account Information 
 
 | Field | Description |
 |----------

--- a/src/marketplace/sellers/profile-information.md
+++ b/src/marketplace/sellers/profile-information.md
@@ -9,7 +9,7 @@ Your profile tracks and provides all information for your Marketplace Developer 
 
 Your contact information includes your address, phone number, and PayPal email address. As part of the registration process, you must enter a valid PayPal email, even if your extensions are available for free on Magento Marketplace. Magento sends your revenue share payment to your PayPal account.
 
-![]({{ site.baseurl }}/marketplace/sellers/images/account-information.png){: .zoom}
+![Contact information]({{ site.baseurl }}/marketplace/sellers/images/account-information.png){: .zoom}
 _Contact Information_
 
 ### Account Information
@@ -50,19 +50,19 @@ For more technical information, see [Get your authentication keys][2] in the dev
 
 1. In the Basic Access Key Information dialog, enter an **Access Key Name** (max of 32 characters) to identify the access key. Then, click <span class="btn">Continue</span>.
 
-   ![]({{ site.baseurl }}/marketplace/sellers/images/basic-access-key-information.png){: .zoom}
+   ![Basic access key information]({{ site.baseurl }}/marketplace/sellers/images/basic-access-key-information.png){: .zoom}
    _Basic Access Key Information_
 
 Your new access key appears in the list, and can now be used to authorize downloads of Magento updates, extensions, and themes.
 
-![]({{ site.baseurl }}/marketplace/sellers/images/access-keys.png){: .zoom}
+![Access key added to account]({{ site.baseurl }}/marketplace/sellers/images/access-keys.png){: .zoom}
 _Access Key Added to Your Account_
 
 ## Marketplace Profile
 
 Your Marketplace Profile contains information you entered during account setup, lets you enter social media links, and gives you the option to upgrade your partner status.
 
-![]({{ site.baseurl }}/marketplace/sellers/images/marketplace-profile.png){: .zoom}
+![Marketplace profile]({{ site.baseurl }}/marketplace/sellers/images/marketplace-profile.png){: .zoom}
 _Marketplace Profile_
 
 ### Account Information
@@ -81,14 +81,14 @@ _Marketplace Profile_
 
 Marketplace policy requires all providers to submit business information to ensure the efficient processing of transactions and payments. Here you can download the necessary form for your tax status, and click <span class="btn">Email Tax Forms</span> to open an email in your default email client.
 
-![]({{ site.baseurl }}/marketplace/sellers/images/tax-forms.png){: .zoom}
+![Tax forms]({{ site.baseurl }}/marketplace/sellers/images/tax-forms.png){: .zoom}
 _Tax Forms_
 
 ## Partner Portal
 
 Click **Partner Portal** to open the Magento Partner Portal dashboard.
 
-![]({{ site.baseurl }}/marketplace/sellers/images/partner-portal.png){: .zoom}
+![Partner portal]({{ site.baseurl }}/marketplace/sellers/images/partner-portal.png){: .zoom}
 _Partner Portal_
 
 [1]: http://docs.magento.com/m2/ce/user_guide/system/encryption-key.html

--- a/src/marketplace/sellers/profile-personal.md
+++ b/src/marketplace/sellers/profile-personal.md
@@ -31,7 +31,6 @@ Prepare an image for your personal profile that is 255 pixels square, and saved 
    ![Personal Profile - Name]({{ site.baseurl }}/marketplace/sellers/images/account-personal-profile-name.png){: .zoom}
    _Personal Profile - Name_
 
-
 ## Step 3: Enter your contact information
 
 1. Enter the URL of your **Personal Website**.

--- a/src/marketplace/sellers/profile-personal.md
+++ b/src/marketplace/sellers/profile-personal.md
@@ -6,7 +6,7 @@ redirect_from: /marketplace/sellers/personal-profile.html
 
 The information in your personal profile identifies you as a vendor in Magento Marketplace, and includes your background, image, contact information, and social network addresses. The Personal Profile page initially appears when you set up your Marketplace account as an individual. From your Marketplace account, the Personal Profile is located on the Developer Portal tab under My Information.
 
-![]({{ site.baseurl }}/marketplace/sellers/images/developer-portal-personal-profile.png){: .zoom}
+![Personal profile]({{ site.baseurl }}/marketplace/sellers/images/developer-portal-personal-profile.png){: .zoom}
 _Personal Profile_
 
 The following instructions walk you through the process of completing your personal profile. All fields are required, unless marked “Optional”.
@@ -28,7 +28,9 @@ Prepare an image for your personal profile that is 255 pixels square, and saved 
 
 1. Enter a brief description of your background as a Magento developer in the **Bio** box. To change the height of the text box, drag the lower-right corner into position.
 
-   ![]({{ site.baseurl }}/marketplace/sellers/images/account-personal-profile-name.png){: .zoom}
+   ![Personal Profile - Name]({{ site.baseurl }}/marketplace/sellers/images/account-personal-profile-name.png){: .zoom}
+   _Personal Profile - Name_
+
 
 ## Step 3: Enter your contact information
 
@@ -45,7 +47,7 @@ Prepare an image for your personal profile that is 255 pixels square, and saved 
    {: .bs-callout .bs-callout-info}
    This unique identifier is used to identify your Marketplace vendor account, and must exactly match the Vendor Name in your personal profile.
 
-![]({{ site.baseurl }}/marketplace/sellers/images/account-company-profile-contact-info.png){: .zoom}
+![Contact information]({{ site.baseurl }}/marketplace/sellers/images/account-company-profile-contact-info.png){: .zoom}
 _Contact Information_
 
 ## Step 4: Enter your personal address
@@ -59,7 +61,7 @@ Complete the following fields that make up your personal address:
 
 To complete the **Phone Number**, choose the flag for your country code. Then, enter the area code and phone number.
 
-![]({{ site.baseurl }}/marketplace/sellers/images/account-personal-profile-address.png){: .zoom}
+![Personal address]({{ site.baseurl }}/marketplace/sellers/images/account-personal-profile-address.png){: .zoom}
 _Personal Address_
 
 ## Step 5: Link to your social networks (optional)
@@ -72,7 +74,7 @@ Enter the link to each professional social network that you want to include in y
 -  Facebook
 -  LinkedIn
 
-![]({{ site.baseurl }}/marketplace/sellers/images/account-profile-social-networks.png){: .zoom}
+![Social networks]({{ site.baseurl }}/marketplace/sellers/images/account-profile-social-networks.png){: .zoom}
 _Social Networks_
 
 ## Step 6: Activate your account

--- a/src/marketplace/sellers/profile-personal.md
+++ b/src/marketplace/sellers/profile-personal.md
@@ -11,26 +11,26 @@ _Personal Profile_
 
 The following instructions walk you through the process of completing your personal profile. All fields are required, unless marked “Optional”.
 
-## Before you begin
+## Step 1: Before you begin
 
 Prepare an image for your personal profile that is 255 pixels square, and saved as one of the following file types: JPG, GIF, or PNG.
 
-### Step 1: Complete your personal background
+## Step 2: Complete your personal background
 
 1. Enter your **First Name** and **Last Name**.
 
 1. To upload the image that you have prepared to your personal profile, do one of the following:
 
-    -  Drag the image to the box.
-    -  Click <span class="btn">Update Image</span>. Then, navigate to the image in your file system, and upload it to your profile.
+   -  Drag the image to the box.
+   -  Click <span class="btn">Update Image</span>. Then, navigate to the image in your file system, and upload it to your profile.
 
 1. Take note that a unique **Magento ID** is assigned to your account.
 
 1. Enter a brief description of your background as a Magento developer in the **Bio** box. To change the height of the text box, drag the lower-right corner into position.
 
-    ![]({{ site.baseurl }}/marketplace/sellers/images/account-personal-profile-name.png){: .zoom}
+   ![]({{ site.baseurl }}/marketplace/sellers/images/account-personal-profile-name.png){: .zoom}
 
-### Step 2: Enter your contact information
+## Step 3: Enter your contact information
 
 1. Enter the URL of your **Personal Website**.
 
@@ -40,15 +40,15 @@ Prepare an image for your personal profile that is 255 pixels square, and saved 
 
 1. In the **Vendor Name** field, enter the `vendor-name` part of the `Name` field from your `composer.json` file.
 
-    `Name: <vendor-name> / <package-name>`
+   `Name: <vendor-name> / <package-name>`
 
-    {: .bs-callout .bs-callout-info}
-    This unique identifier is used to identify your Marketplace vendor account, and must exactly match the Vendor Name in your personal profile.
+   {: .bs-callout .bs-callout-info}
+   This unique identifier is used to identify your Marketplace vendor account, and must exactly match the Vendor Name in your personal profile.
 
 ![]({{ site.baseurl }}/marketplace/sellers/images/account-company-profile-contact-info.png){: .zoom}
 _Contact Information_
 
-### Step 3: Enter your personal address
+## Step 4: Enter your personal address
 
 Complete the following fields that make up your personal address:
 
@@ -62,7 +62,7 @@ To complete the **Phone Number**, choose the flag for your country code. Then, e
 ![]({{ site.baseurl }}/marketplace/sellers/images/account-personal-profile-address.png){: .zoom}
 _Personal Address_
 
-### Step 4: Link to your social networks (optional)
+## Step 5: Link to your social networks (optional)
 
 Enter the link to each professional social network that you want to include in your personal profile.
 
@@ -75,16 +75,16 @@ Enter the link to each professional social network that you want to include in y
 ![]({{ site.baseurl }}/marketplace/sellers/images/account-profile-social-networks.png){: .zoom}
 _Social Networks_
 
-### Step 5: Activate your account
+## Step 6: Activate your account
 
 1. When the required fields are complete, click <span class="btn">Save</span>.
 
 1. When prompted, enter your **PayPal Email** address.
 
-    {: .bs-callout .bs-callout-info}
-    **Important:** This payment information is required of all developers, even those who make their extensions available at no charge. Magento sends your revenue share on a monthly basis to PayPal account.
+   {: .bs-callout .bs-callout-info}
+   **Important:** This payment information is required of all developers, even those who make their extensions available at no charge. Magento sends your revenue share on a monthly basis to PayPal account.
 
-    Look for the confirmation email that is sent to the email address associated with the account. To activate your account and gain access to the Developer Portal, click the link in the email.
+   Look for the confirmation email that is sent to the email address associated with the account. To activate your account and gain access to the Developer Portal, click the link in the email.
 
 ## Field Descriptions
 
@@ -95,7 +95,11 @@ _Social Networks_
 |Update Image|The image for your Marketplace personal profile can be dragged to your profile. <br/>Size - 255 x 255 pixels <br/>Supported file types: JPG, GIF, or PNG|
 |Mage ID|Your Magento ID is an automatically assigned when your account is created and identifies you throughout the Magento system.|
 |Bio|A brief description of your expertise and interests. You might begin with a couple of sentences to give a brief overview, and finish it later with a more detailed description of your background, expertise, and experience. If you use a word processor to compose and spell check your bio, make sure to save it as text before pasting it into your profile. Maximum characters - 1,958, including spaces.|
-|**_Contact information_**||
+
+### Contact Information
+
+|Field|Description|
+|--- |--- |
 |Personal Website|The URL of your personal website.|
 |Personal Email|Your personal email address.|
 |Screen Name|The name that you want to use when communicating with others on Magento.com.|
@@ -107,7 +111,11 @@ _Social Networks_
 |City|The city where you reside.|
 |State|The state or province where you reside.|
 |Phone|Your personal phone number. Choose the  flag for your country code. Then, enter the area code and phone number.|
-|**_Social Networks_**||
+
+### Social Networks
+
+|Field|Description|
+|--- |--- |
 |GitHub|(Optional) The user name that is associated with your GitHub account.|
 |Stack Exchange|(Optional) The URL of your Stack Exchange profile. For example: `http://username.stackexchange.com`|
 |Twitter|(Optional) The user name associated with your Twitter account.|


### PR DESCRIPTION
## Purpose of this pull request

This pull request (PR) standardizes the formatting of the pages that are used as examples in the Marketplace tutorial. I made the headings consistent and added missing captions and alt text.

## Affected DevDocs pages

[Profile Information](https://devdocs.magento.com/marketplace/sellers/profile-information.html)
[Company Profile](https://devdocs.magento.com/marketplace/sellers/profile-company.html)
[Personal Profile](https://devdocs.magento.com/marketplace/sellers/profile-personal.html)

## Additional information

Staging: #2150
