### PR TITLE
GraphQL: Move section about custom config attributes

### DIFF
--- a/src/guides/v2.3/graphql/develop/extend-existing-schema.md
+++ b/src/guides/v2.3/graphql/develop/extend-existing-schema.md
@@ -98,6 +98,35 @@ class ProductAttributeSetNameResolver implements ResolverInterface
 }
 ```
 
+## Extend configuration data
+
+You can add your own configuration to the `storeConfig` query within your own module.
+
+To do this, configure the constructor argument `extendedConfigData` in the `argument` node in your area-specific `etc/graphql/di.xml` file.
+
+The following example adds an array-item to the `extendedConfigData` array within the construct of the `StoreConfigDataProvider`.
+
+```xml
+<?xml version="1.0" ?>
+<config xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="urn:magento:framework:ObjectManager/etc/config.xsd">
+  <type name="Magento\StoreGraphQl\Model\Resolver\Store\StoreConfigDataProvider">
+    <arguments xsi:type="array">
+      <argument name="extendedConfigData">
+        <item name="section_group_field" xsi:type="string">section/group/field</item>
+      </argument>
+    </arguments>
+  </type>
+</config>
+```
+
+You must also extend the type `storeConfig` within in the `etc/schema.graphqls` file, as shown below:
+
+```graphql
+type StoreConfig {
+    section_group_field : String  @doc(description: "Extended Config Data - section/group/field")
+}
+```
+
 ## Related topics
 
 -  [Define the GraphQL schema for a module]({{ page.baseurl }}/graphql/develop/create-graphqls-file.html)

--- a/src/guides/v2.3/graphql/queries/store-config.md
+++ b/src/guides/v2.3/graphql/queries/store-config.md
@@ -306,32 +306,3 @@ EXCLUDE_FPT_WITHOUT_DETAILS | The displayed price does not include the FPT amoun
 FPT_DISABLED | The FPT feature is not enabled. You can omit `ProductPrice.fixed_product_taxes` from your query
 INCLUDE_FPT_WITH_DETAILS | The displayed price includes the FPT amount while displaying the values of `ProductPrice.fixed_product_taxes` separately. This value corresponds to **Including FPT and FPT description**
 INCLUDE_FPT_WITHOUT_DETAILS | The displayed price includes the FPT amount without displaying the `ProductPrice.fixed_product_taxes` values. This value corresponds to **Including FPT only**
-
-## Extend configuration data
-
-You can add your own configuration to the `storeConfig` query within your own module.
-
-To do this, configure the constructor argument `extendedConfigData` in the `argument` node in your area-specific `etc/graphql/di.xml` file.
-
-The following example adds an array-item to the `extendedConfigData` array within the construct of the `StoreConfigDataProvider`.
-
-```xml
-<?xml version="1.0" ?>
-<config xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="urn:magento:framework:ObjectManager/etc/config.xsd">
-  <type name="Magento\StoreGraphQl\Model\Resolver\Store\StoreConfigDataProvider">
-    <arguments xsi:type="array">
-      <argument name="extendedConfigData">
-        <item name="section_group_field" xsi:type="string">section/group/field</item>
-      </argument>
-    </arguments>
-  </type>
-</config>
-```
-
-You must also extend the type `storeConfig` within in the `etc/schema.graphqls` file, as shown below:
-
-```graphql
-type StoreConfig {
-    section_group_field : String  @doc(description: "Extended Config Data - section/group/field")
-}
-```

--- a/src/guides/v2.4/graphql/queries/store-config.md
+++ b/src/guides/v2.4/graphql/queries/store-config.md
@@ -320,32 +320,3 @@ EXCLUDE_FPT_WITHOUT_DETAILS | The displayed price does not include the FPT amoun
 FPT_DISABLED | The FPT feature is not enabled. You can omit `ProductPrice.fixed_product_taxes` from your query
 INCLUDE_FPT_WITH_DETAILS | The displayed price includes the FPT amount while displaying the values of `ProductPrice.fixed_product_taxes` separately. This value corresponds to **Including FPT and FPT description**
 INCLUDE_FPT_WITHOUT_DETAILS | The displayed price includes the FPT amount without displaying the `ProductPrice.fixed_product_taxes` values. This value corresponds to **Including FPT only**
-
-## Extend configuration data
-
-You can add your own configuration to the `storeConfig` query within your own module.
-
-To do this, configure the constructor argument `extendedConfigData` in the `argument` node in your area-specific `etc/graphql/di.xml` file.
-
-The following example adds an array-item to the `extendedConfigData` array within the construct of the `StoreConfigDataProvider`.
-
-```xml
-<?xml version="1.0" ?>
-<config xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="urn:magento:framework:ObjectManager/etc/config.xsd">
-  <type name="Magento\StoreGraphQl\Model\Resolver\Store\StoreConfigDataProvider">
-    <arguments xsi:type="array">
-      <argument name="extendedConfigData">
-        <item name="section_group_field" xsi:type="string">section/group/field</item>
-      </argument>
-    </arguments>
-  </type>
-</config>
-```
-
-You must also extend the type `storeConfig` within in the `etc/schema.graphqls` file, as shown below:
-
-```graphql
-type StoreConfig {
-    section_group_field : String  @doc(description: "Extended Config Data - section/group/field")
-}
-```


### PR DESCRIPTION
## Purpose of this pull request

This pull request (PR) moves the section "Extend configuration data" in the `storeConfig` query to the "Extend an existing GraphQL schema" topic. This information does not belong in the query documentation, but at the time it was written, there was no place to put it.

## Affected DevDocs pages

<!-- REQUIRED List the affected pages on devdocs.magento.com (URLs). Not needed for large numbers of files. -->

-  https://devdocs.magento.com/guides/v2.3/graphql/queries/store-config.html
- https://devdocs.magento.com/guides/v2.3/graphql/develop/extend-existing-schema.html

## Links to Magento source code

<!--  OPTIONAL - REMOVE THIS SECTION IF NOT USED. If this pull request references a file in a Magento codebase repository, add it here. -->

-  ...

<!--
If you are fixing a GitHub issue, note it using GitHub keyword format (https://help.github.com/en/articles/closing-issues-using-keywords#closing-an-issue-in-a-different-repository) to close the issue when this pull request is merged. Example: `Fixes #1234`

`master` is the default branch. Merged pull requests to `master` go live on the site automatically. Any requested changes to content on the `master` branch must be related to the released codebase. Any content related to future releases goes in the `develop` branch.

See Contribution guidelines (https://github.com/magento/devdocs/blob/master/.github/CONTRIBUTING.md) for more information.
-->

whatsnew
The section "Extend configuration data" has been moved from the `storeConfig query` to the [Extend an existing GraphQL schema](https://devdocs.magento.com/guides/v2.3/graphql/develop/extend-existing-schema.html) topic.