### PR TITLE
GraphQL: Reorganize storeConfig attributes

### DIFF
--- a/src/guides/v2.4/graphql/queries/store-config.md
+++ b/src/guides/v2.4/graphql/queries/store-config.md
@@ -237,138 +237,91 @@ The following query returns enumeration values that indicate the store's fixed p
 
 ## Output attributes
 
-### Supported storeConfig attributes
-
-Use the `storeConfig` attributes to retrieve information about the store's configuration; such as, locale, currency codes, and secure and unsecure URLs.
-
-Attribute |  Data Type | Description | Example
+Attribute | Data Type | Description | Default or example value
 --- | --- | --- | ---
+`absolute_footer` | String | Contains scripts that must be included in the HTML before the closing `<body>` tag | null
+`allow_items` | String | Allows gift messages for order items. Possible values: 1 (Yes) and 0 (No). <br/>Configuration path: sales/gift_options/allow_items | 0
+`allow_order` | String | Allows gift messages at the order level. Possible values: 1 (Yes) and 0 (No). <br/>Configuration path: sales/gift_options/allow_order | 0
+`autocomplete_on_storefront` | Boolean | Enable autocomplete on login and forgot password forms. <br/>Configuration path: customer/password/autocomplete_on_storefront | true
 `base_currency_code` | String | The code representing the currency in which Magento processes all payment transactions | `USD`
 `base_link_url` | String | A fully-qualified URL that is used to create relative links to the `base_url` | `http://magentohost.example.com/`
-`base_static_url` | String | The fully-qualified URL that specifies the location of static view files | `http://magentohost.example.com/pub/static/`
 `base_media_url` | String | The fully-qualified URL that specifies the location of user media files | `http://magentohost.example.com/pub/media/`
+`base_static_url` | String | The fully-qualified URL that specifies the location of static view files | `http://magentohost.example.com/pub/static/`
 `base_url` | String | The store's fully-qualified base URL | `http://magentohost.example.com/`
+`catalog_default_sort_by` | String | The default sort order of the search results list | `position`
+`category_fixed_product_tax_display_setting` | [FixedProductTaxDisplaySettings](#FixedProductTaxDisplaySettings) | Corresponds to the **Display Prices In Product Lists** field. It indicates how Fixed Product Tax information is displayed on category pages | FPT_DISABLED
+`category_url_suffix` | String | The suffix applied to category pages, such as `.htm` or `.html` | `.html`
+`cms_home_page` | String | Returns the name of the CMS page that identifies the home page for the store | `home`
+`cms_no_cookies` | String | Identifies a specific CMS page that appears when cookies are not enabled for the browser | `enable-cookies`
+`cms_no_route` | String | Identifies a specific CMS page that you want to appear when a 404 “Page Not Found” error occurs | `no-route`
 `code` | String | A unique identifier for the store | `default`
+`copyright` | String | The copyright statement that appears at the bottom of each page | Copyright &#169; 2013-present Magento, Inc. All rights reserved.
+`default_description` | String | The description that provides a summary of your site for search engine listings and should not be more than 160 characters in length | null
 `default_display_currency_code` | String | The code representing the currency displayed on the store | `USD`
-`id` | Integer | The ID number assigned to the store | `1`
+`default_keywords` | String | A series of keywords that describe your store, each separated by a comma | `Magento, Varien, E-commerce`
+`default_title` | String | The title that appears at the title bar of each page when viewed in a browser | Magento Enterprise Edition
+`demonotice` | Int | Controls the display of the demo store notice at the top of the page. Options: `0` (No) or `1` (Yes) | 0
+`front` | String | Indicates the landing page that is associated with the base URL | `cms`
+`grid_per_page` | Int | The default number of products per page in Grid View | `9`
+`grid_per_page_values` | String | A list of numbers that define how many products can be displayed in List View  | `9,15,30`
+`head_includes` | String | Contains scripts that must be included in the HTML before the closing `<head>` tag | `<link  rel=\"stylesheet\" type=\"text/css\"  media=\"all\" href=\"{{MEDIA_URL}}styles.css\" />`
+`head_shortcut_icon` | String | Uploads the small graphic image that appears in the address bar and tab of the browser | null
+`header_logo_src` | String | The path to the logo that appears in the header | null
+`id` | Int | The ID number assigned to the store | `1`
+`list_mode` | String  | The format of the search results list | `grid-list`
+`list_per_page` | Int | The default number of products per page in List View | `10`
+`list_per_page_values` | String | A list of numbers that define how many products can be displayed in List View | `5,10,15,20,25`
 `locale` | String | The store's locale | `en_US`
+`logo_alt` | String | The Alt text that is associated with the logo | null
+`logo_height` | Int | The height of your logo image in pixels | null
+`logo_width` | Int | The width of your logo image in pixels | null
+`magento_reward_general_is_enabled_on_front` | String | Indicates whether reward points functionality is enabled on the storefront | `1` (enabled)
+`magento_reward_general_is_enabled` | String | Indicates whether reward points are enabled. | `1` (enabled)
+`magento_reward_general_min_points_balance` | String | The minimum point balance customers must have before they can redeem them. A null value indicates no minimum | null
+`magento_reward_general_publish_history` | String | When enabled, customers can see a detailed history of their reward points | `1` (enabled)
+`magento_reward_points_invitation_customer_limit` | String | The maximum number of registration referrals that qualify for rewards. A null value indicates no limit | null
+`magento_reward_points_invitation_customer` | String | The number of points for a referral when the invitee registers on the site | null
+`magento_reward_points_invitation_order_limit` | String | The number of order conversions that can earn points for the customer who sends the invitation. A null value indicates no limit | null
+`magento_reward_points_invitation_order` | String | The number of points for a referral when the invitee places their first order on the site | null
+`magento_reward_points_newsletter` | String | The number of points earned by registered customers who subscribe to a newsletter | null
+`magento_reward_points_order` | String | Indicates whether customers earn points for shopping according to the reward point exchange rate. In Luma, this also controls whether to show a message in the shopping cart about the rewards points earned for the purchase, as well as the customer’s current reward point balance | null
+`magento_reward_points_register` | String | The number of points a customer gets for registering | null
+`magento_reward_points_review_limit` | String | The maximum number of reviews that qualify for  rewards. A null value indicates no limit | null
+`magento_reward_points_review` | String | The number of points for writing a review | null
+`minimum_password_length` | String | The minimum number of characters required for a valid password. <br/>Configuration path: customer/password/minimum_password_length | 6
+`no_route` | String | Contains the URL of the default page that you want to appear when if a 404 “Page not Found” error occurs | `cms/noroute/index`
+`product_fixed_product_tax_display_setting` | [FixedProductTaxDisplaySettings](#FixedProductTaxDisplaySettings) | Corresponds to the **Display Prices On Product View Page** field. It indicates how Fixed Product Taxes information is displayed on product pages | FPT_DISABLED
+`product_url_suffix` | String | The suffix applied to product pages, such as `.htm` or `.html` | `.html`
+`required_character_classes_number` | String | The number of different character classes required in a password (lowercase, uppercase, digits, special characters). <br/>Configuration path: customer/password/required_character_classes_number | 2
+`root_category_id` | Int | The ID of the root category | 2
+`sales_fixed_product_tax_display_setting` | [FixedProductTaxDisplaySettings](#FixedProductTaxDisplaySettings) | Corresponds to the **Display Prices In Sales Modules** field. It indicates how Fixed Product Taxes information is displayed on cart, checkout, and order pages | FPT_DISABLED
 `secure_base_link_url` | String | A secure fully-qualified URL that is used to create relative links to the `base_url` | `https://magentohost.example.com/`
 `secure_base_media_url` | String | The secure fully-qualified URL that specifies the location of user media files | `https://magentohost.example.com/pub/media/`
 `secure_base_static_url` | String | The secure fully-qualified URL that specifies the location of static view files | `https://magentohost.example.com/pub/static/`
 `secure_base_url` | String | The store's fully-qualified secure base URL | `https://magentohost.example.com/`
-`send_friend` | SendFriendConfiguration | Email to a Friend configuration | Not applicable
+`send_friend` | [SendFriendConfiguration](#SendFriendConfiguration) | Email to a Friend configuration | Not applicable
+`show_cms_breadcrumbs` | Int | Determines if a breadcrumb trail appears on all CMS pages in the catalog. Options: `0` (No) or `1` (Yes) | 1
 `store_name` | String | The store's name | `My Store`
 `timezone` | String | The store's time zone | `America/Chicago`
+`title_prefix` | String | A prefix that appears before the title to create a two- or three-part title | null
+`title_separator` | String | Identifies the character that separates the category name and subcategory in the browser title bar | `-`
+`title_suffix` | String | A suffix that appears after the title to create a two-or three part title | null
 `website_id` | Integer | The ID number assigned to the parent website | `1`
 `weight_unit` | String | The weight unit for products | `lbs`, `kgs`, or similar
+`welcome` | String | Text that appears in the header of the page and includes the name of customers who are logged in | Default welcome msg!
 
-#### SendFriendConfiguration attributes
+### SendFriendConfiguration attributes {#SendFriendConfiguration}
 
 Attribute |  Data Type | Description
 --- | --- | ---
 `enabled_for_customers` | Boolean! | Indicates whether the Email to a Friend feature is enabled for customers
 `enabled_for_guests` | Boolean! | Indicates whether the Email to a Friend feature is enabled for guests
 
-### Supported theme attributes
+### FixedProductTaxDisplaySettings attributes {#FixedProductTaxDisplaySettings}
 
-Use the `theme` attributes to retrieve information about the store's thematic elements; such as, footer and header information, copyright text, and logo information. These attributes are defined in the `ThemeGraphQl` module.
+The **Stores** > Settings > **Configuration** > **Sales** > **Tax** > **Fixed Product Taxes** panel contains several fields that determine how to display fixed product tax (FPT) values and descriptions.
 
-Attribute |  Data Type | Description
---- | --- | ---
-`absolute_footer` | String | Contains scripts that must be included in the HTML before the closing `<body>` tag
-`copyright` | String | The copyright statement that appears at the bottom of each page
-`default_description` | String | The description that provides a summary of your site for search engine listings and should not be more than 160 characters in length
-`default_keywords` | String | A series of keywords that describe your store, each separated by a comma
-`default_title` | String | The title that appears at the title bar of each page when viewed in a browser
-`demonotice` | Int | Controls the display of the demo store notice at the top of the page. Options: `0` (No) or `1` (Yes)
-`head_includes` | String | Contains scripts that must be included in the HTML before the closing `<head>` tag
-`head_shortcut_icon` | String | Uploads the small graphic image that appears in the address bar and tab of the browser
-`header_logo_src` | String | The path to the logo that appears in the header
-`logo_alt` | String | The Alt text that is associated with the logo
-`logo_height` | Int | The height of your logo image in pixels
-`logo_width` | Int | The width of your logo image in pixels
-`title_prefix` | String | A prefix that appears before the title to create a two- or three-part title
-`title_suffix` | String | A suffix that appears after the title to create a two-or three part title
-`welcome` | String | Text that appears in the header of the page and includes the name of customers who are logged in
-
-### Supported CMS attributes
-
-Use the `cms` attributes to retrieve information about the store's default pages. These attributes are defined in the `CmsGraphQl` module.
-
-Attribute |  Data Type | Description
---- | --- | ---
-`cms_home_page` | String | Returns the name of the CMS page that identifies the home page for the store
-`cms_no_cookies` | String | Identifies a specific CMS page that appears when cookies are not enabled for the browser
-`cms_no_route` | String | Identifies a specific CMS page that you want to appear when a 404 “Page Not Found” error occurs
-`front` | String | Indicates the landing page that is associated with the base URL
-`no_route` | String | Contains the URL of the default page that you want to appear when if a 404 “Page not Found” error occurs
-`show_cms_breadcrumbs` | Int | Determines if a breadcrumb trail appears on all CMS pages in the catalog. Options: `0` (No) or `1` (Yes)
-
-### Supported Catalog attributes
-
-Use the `catalog` attributes to retrieve information about the store's catalog. These attributes are defined in the `CatalogGraphQl` module.
-
-Attribute |  Data Type | Description | Example
---- | --- | ---
-`catalog_default_sort_by` | String | The default sort order of the search results list | `position`
-`category_url_suffix` | String | The suffix applied to category pages, such as `.htm` or `.html` | `.html`
-`grid_per_page` | Int | The default number of products per page in Grid View | `9`
-`grid_per_page_values` | String | A list of numbers that define how many products can be displayed in List View  | `9,15,30`
-`list_mode` | String  | The format of the search results list | `grid-list`
-`list_per_page` | Int | The default number of products per page in List View | `10`
-`list_per_page_values` | String | A list of numbers that define how many products can be displayed in List View | `5,10,15,20,25`
-`product_url_suffix` | String | The suffix applied to product pages, such as `.htm` or `.html` | `.html`
-`root_category_id` | Int | The ID of the root category
-`title_separator` | String | Identifies the character that separates the category name and subcategory in the browser title bar | `-`
-
-### Supported catalog attributes
-
-Use the `customer` attributes to retrieve information about the store's customer settings. These attributes are defined in the `CustomerGraphQl` module.
-
-Attribute |  Data Type | Description | Configuration path | Default Value
---- | --- | ---
-`autocomplete_on_storefront` | Boolean | Enable autocomplete on login and forgot password forms. | customer/password/autocomplete_on_storefront | true
-`minimum_password_length` | String | The minimum number of characters required for a valid password. | customer/password/minimum_password_length | 6
-`required_character_classes_number` | String | The number of different character classes required in a password (lowercase, uppercase, digits, special characters). | customer/password/required_character_classes_number | 2
-
-### Supported gift message attributes
-
-These attributes retrieve information about the store's gift message settings. They are defined in the `GiftMessageGraphQl` module.
-
-Attribute |  Data Type | Description | Configuration path | Default Value
---- | --- | ---
-`allow_order` | String | Allows gift messages at the order level. Possible values: 1 (Yes) and 0 (No). | sales/gift_options/allow_order | 0
-`allow_items` | String | Allows gift messages for order items. Possible values: 1 (Yes) and 0 (No). | sales/gift_options/allow_items | 0
-
-### Supported reward points attributes
-
-Attribute |  Data Type | Description |  Default Value
---- | --- | ---
-`magento_reward_general_is_enabled` | String | Indicates whether reward points are enabled. | `1` (enabled)
-`magento_reward_general_is_enabled_on_front` | String | Indicates whether reward points functionality is enabled on the storefront | `1` (enabled)
-`magento_reward_general_min_points_balance` | String | The minimum point balance customers must have before they can redeem them. A null value indicates no minimum | null
-`magento_reward_general_publish_history` | String | When enabled, customers can see a detailed history of their reward points | `1` (enabled)
-`magento_reward_points_invitation_customer` | String | The number of points for a referral when the invitee registers on the site | null
-`magento_reward_points_invitation_customer_limit` | String | The maximum number of registration referrals that qualify for rewards. A null value indicates no limit | null
-`magento_reward_points_invitation_order` | String | The number of points for a referral when the invitee places their first order on the site | null
-`magento_reward_points_invitation_order_limit` | String | The number of order conversions that can earn points for the customer who sends the invitation. A null value indicates no limit | null
-`magento_reward_points_newsletter` | String | The number of points earned by registered customers who subscribe to a newsletter | null
-`magento_reward_points_order` | String | Indicates whether customers earn points for shopping according to the reward point exchange rate. In Luma, this also controls whether to show a message in the shopping cart about the rewards points earned for the purchase, as well as the customer’s current reward point balance | null
-`magento_reward_points_register` | String | The number of points a customer gets for registering | null
-`magento_reward_points_review` | String | The number of points for writing a review | null
-`magento_reward_points_review_limit` | String | The maximum number of reviews that qualify for  rewards. A null value indicates no limit | null
-
-### Supported WEEE (fixed product tax) attributes
-
-The **Stores** > Settings > **Configuration** > **Sales** > **Tax** > **Fixed Product Taxes** panel contains several fields that determine how to display fixed product tax (FPT) values and descriptions. Use the following attributes to determine the values of the **Fixed Product Taxes** fields. These attributes are defined in the `WeeeGraphQl` module.
-
-Attribute |  Data Type | Description
---- | --- | ---
-`category_fixed_product_tax_display_setting` | FixedProductTaxDisplaySettings | Corresponds to the **Display Prices In Product Lists** field. It indicates how FPT information is displayed on category pages
-`product_fixed_product_tax_display_setting` | FixedProductTaxDisplaySettings | Corresponds to the **Display Prices On Product View Page** field. It indicates how FPT information is displayed on product pages
-`sales_fixed_product_tax_display_setting` | FixedProductTaxDisplaySettings | Corresponds to the **Display Prices In Sales Modules** field. It indicates how FPT information is displayed on cart, checkout, and order pages
-
-The `FixedProductTaxDisplaySettings` data type is an enumeration that describes whether displayed prices include fixed product taxes and whether Magento separately displays detailed information about the FPTs.
+The `FixedProductTaxDisplaySettings` data type is an enumeration that describes whether displayed prices include fixed product taxes and whether Magento separately displays detailed information about the FPTs. These attributes are defined in the `WeeeGraphQl` module.
 
 Value | Description
 --- | ---
@@ -377,32 +330,3 @@ EXCLUDE_FPT_WITHOUT_DETAILS | The displayed price does not include the FPT amoun
 FPT_DISABLED | The FPT feature is not enabled. You can omit `ProductPrice.fixed_product_taxes` from your query
 INCLUDE_FPT_WITH_DETAILS | The displayed price includes the FPT amount while displaying the values of `ProductPrice.fixed_product_taxes` separately. This value corresponds to **Including FPT and FPT description**
 INCLUDE_FPT_WITHOUT_DETAILS | The displayed price includes the FPT amount without displaying the `ProductPrice.fixed_product_taxes` values. This value corresponds to **Including FPT only**
-
-## Extend configuration data
-
-You can add your own configuration to the `storeConfig` query within your own module.
-
-To do this, configure the constructor argument `extendedConfigData` in the `argument` node in your area-specific `etc/graphql/di.xml` file.
-
-The following example adds an array-item to the `extendedConfigData` array within the construct of the `StoreConfigDataProvider`.
-
-```xml
-<?xml version="1.0" ?>
-<config xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="urn:magento:framework:ObjectManager/etc/config.xsd">
-  <type name="Magento\StoreGraphQl\Model\Resolver\Store\StoreConfigDataProvider">
-    <arguments xsi:type="array">
-      <argument name="extendedConfigData">
-        <item name="section_group_field" xsi:type="string">section/group/field</item>
-      </argument>
-    </arguments>
-  </type>
-</config>
-```
-
-You must also extend the type `storeConfig` within in the `etc/schema.graphqls` file, as shown below:
-
-```graphql
-type StoreConfig {
-    section_group_field : String  @doc(description: "Extended Config Data - section/group/field")
-}
-```


### PR DESCRIPTION
## Purpose of this pull request

In the early days of GraphQL, the configuration parameters that we could query was limited to a few modules, like CMS, themes, and catalog. Now, we're accessing config parameters from many different parts of Magento, including Commerce and soon, B2B. It no longer makes sense to categorize the parameters by module. 

This PR sorts the queryable configuration alphabetically, without creating numerous subheads. The tables had different numbers of columns. The new giant table contains 4 columns. 

## Affected DevDocs pages

<!-- REQUIRED List the affected pages on devdocs.magento.com (URLs). Not needed for large numbers of files. -->

-  https://devdocs.magento.com/guides/v2.4/graphql/queries/store-config.html

## Links to Magento source code

<!--  OPTIONAL - REMOVE THIS SECTION IF NOT USED. If this pull request references a file in a Magento codebase repository, add it here. -->

-  ...

<!--
If you are fixing a GitHub issue, note it using GitHub keyword format (https://help.github.com/en/articles/closing-issues-using-keywords#closing-an-issue-in-a-different-repository) to close the issue when this pull request is merged. Example: `Fixes #1234`

`master` is the default branch. Merged pull requests to `master` go live on the site automatically. Any requested changes to content on the `master` branch must be related to the released codebase. Any content related to future releases goes in the `develop` branch.

See Contribution guidelines (https://github.com/magento/devdocs/blob/master/.github/CONTRIBUTING.md) for more information.
-->
