### PR TITLE
GraphQL: Add Commerce icons to left nav

### DIFF
--- a/src/_data/toc/graphql.yml
+++ b/src/_data/toc/graphql.yml
@@ -106,6 +106,7 @@ pages:
 
         - label: giftCardAccount query
           url: /graphql/queries/giftcard-account.html
+          edition: ee-only
 
         - label: isEmailAvailable query
           url: /graphql/queries/is-email-available.html
@@ -148,12 +149,14 @@ pages:
 
         - label: applyGiftCardToCart mutation
           url: /graphql/mutations/apply-giftcard.html
+          edition: ee-only
 
         - label: applyCouponToCart mutation
           url: /graphql/mutations/apply-coupon.html
 
         - label: applyStoreCreditToCart mutation
           url: /graphql/mutations/apply-store-credit.html
+          edition: ee-only
 
         - label: changeCustomerPassword mutation
           url: /graphql/mutations/change-customer-password.html
@@ -196,18 +199,21 @@ pages:
 
         - label: redeemGiftCardBalanceAsStoreCredit mutation
           url: /graphql/mutations/redeem-giftcard-balance.html
+          edition: ee-only
 
         - label: removeCouponFromCart mutation
           url: /graphql/mutations/remove-coupon.html
 
         - label: removeGiftCardFromCart mutation
           url: /graphql/mutations/remove-giftcard.html
+          edition: ee-only
 
         - label: removeItemFromCart mutation
           url: /graphql/mutations/remove-item.html
 
         - label: removeStoreCreditFromCart mutation
           url: /graphql/mutations/remove-store-credit.html
+          edition: ee-only
 
         - label: reorderItems mutation
           url: /graphql/mutations/reorder-items.html


### PR DESCRIPTION
## Purpose of this pull request

This pull request (PR) adds icons in the left navigation for mutations and queries that are specific to Magento Commerce. 

![Screen Shot 2020-08-11 at 7 03 35 PM](https://user-images.githubusercontent.com/11652541/89960760-8145bd80-dc05-11ea-8b3d-572af479c8cf.png)


## Affected DevDocs pages

<!-- REQUIRED List the affected pages on devdocs.magento.com (URLs). Not needed for large numbers of files. -->

-  ...

## Links to Magento source code

<!--  OPTIONAL - REMOVE THIS SECTION IF NOT USED. If this pull request references a file in a Magento codebase repository, add it here. -->

-  ...

<!--
If you are fixing a GitHub issue, note it using GitHub keyword format (https://help.github.com/en/articles/closing-issues-using-keywords#closing-an-issue-in-a-different-repository) to close the issue when this pull request is merged. Example: `Fixes #1234`

`master` is the default branch. Merged pull requests to `master` go live on the site automatically. Any requested changes to content on the `master` branch must be related to the released codebase. Any content related to future releases goes in the `develop` branch.

See Contribution guidelines (https://github.com/magento/devdocs/blob/master/.github/CONTRIBUTING.md) for more information.
-->
