### PR TITLE
Update the Marketplace EQP API "Help" section

### DIFF
--- a/src/marketplace/eqp/v1/help.md
+++ b/src/marketplace/eqp/v1/help.md
@@ -22,7 +22,7 @@ Use these resources if you need additional help.
 **Websites:**
 
 -  [Marketplace Developer Portal](https://developer.magento.com)
--  [sandbox](https://developer-stg.magento.com)
+-  [Sandbox Marketplace Developer Portal](https://developer-stg.magento.com)
 -  [Magento Marketplace](https://marketplace.magento.com)
 -  [Magento Account](https://account.magento.com)
 
@@ -30,5 +30,5 @@ Use these resources if you need additional help.
 
 |Environment|Base Url|
 |-----------|--------|
-|sandbox    | `https://developer-stg-api.magento.com` |
 |production | `https://developer-api.magento.com`     |
+|sandbox    | `https://developer-stg-api.magento.com` |


### PR DESCRIPTION

## Purpose of this pull request

* make it more obvious what is the link to **sandbox**  --> "Sandbox Marketplace Developer Portal"
* For the base URLs, list "production" before "sandbox" since everyone can access **production** but access to **sandbox** is limited

## Affected DevDocs pages

<!-- REQUIRED List the affected pages on devdocs.magento.com (URLs). Not needed for large numbers of files. -->

-  src/marketplace/eqp/v1/help.md
