### PR TITLE
Added missing TOC links

### DIFF
--- a/src/_data/toc/ui-components-guide.yml
+++ b/src/_data/toc/ui-components-guide.yml
@@ -279,6 +279,12 @@ pages:
         - label: Update the page URL type
           url: /ui_comp_guide/howto/update-url-type.html
 
+        - label: Render prices on the frontend
+          url: /ui_comp_guide/howto/price_rendering.html
+
+        - label: Declare a custom UI component
+          url: /ui_comp_guide/howto/new_component_declaration.html
+
     - label: Troubleshoot
       children:
 


### PR DESCRIPTION
## Purpose of this pull request

This pull request (PR) adds the two missing links in the sidebar of https://devdocs.magento.com/guides/v2.4/ui_comp_guide/howto/add_category_attribute.html under the 'How Tos' sub heading. The missing pages are https://devdocs.magento.com/guides/v2.4/ui_comp_guide/howto/price_rendering.html and https://devdocs.magento.com/guides/v2.4/ui_comp_guide/howto/new_component_declaration.html

## Affected DevDocs pages

-  TOC in pages under Development > UI Components Guide