### PR TITLE
fix `bin/magento app:config:dump scopes themes`

### DIFF
--- a/src/guides/v2.4/config-guide/cli/config-cli-subcommands-static-view.md
+++ b/src/guides/v2.4/config-guide/cli/config-cli-subcommands-static-view.md
@@ -328,8 +328,8 @@ You might want to run the deployment process in a separate, non-production, envi
 
 To do this, take the following steps:
 
-1. Run [`bin/magento app:config:dump`]({{ page.baseurl }}/config-guide/cli/config-cli-subcommands-config-mgmt-export.html) to export the configuration from your production system.
-1. Copy the exported files to the non-production code base.
+1. Run [`bin/magento app:config:dump scopes themes`]({{ page.baseurl }}/config-guide/cli/config-cli-subcommands-config-mgmt-export.html) to export the configuration from your production system.
+1. Copy the exported files to the non-production code base (`app/etc/env.php` must not exist, copy only `app/etc/config.php`)
 1. Run [`bin/magento setup:static-content:deploy`](#config-cli-subcommands-staticview).
 
 ## Troubleshooting the static view files deployment tool {#view-file-trouble}


### PR DESCRIPTION
- add missing arguments `scopes themes` to `app:config:dump` command to have only needed configuration, with full config setup:static-content:deploy fails,
- add better description which file should be copied and that env.php must not exist.

## Purpose of this pull request

Fix documentation

## Affected DevDocs pages

<!-- REQUIRED List the affected pages on devdocs.magento.com (URLs). Not needed for large numbers of files. -->

-  ...

## Links to Magento source code

<!--  OPTIONAL - REMOVE THIS SECTION IF NOT USED. If this pull request references a file in a Magento codebase repository, add it here. -->

-  ...

<!--
If you are fixing a GitHub issue, note it using GitHub keyword format (https://help.github.com/en/articles/closing-issues-using-keywords#closing-an-issue-in-a-different-repository) to close the issue when this pull request is merged. Example: `Fixes #1234`

`master` is the default branch. Merged pull requests to `master` go live on the site automatically. Any requested changes to content on the `master` branch must be related to the released codebase. Any content related to future releases goes in the `develop` branch.

See Contribution guidelines (https://github.com/magento/devdocs/blob/master/.github/CONTRIBUTING.md) for more information.
-->
