### PR TITLE
fix typo and link update

### DIFF
--- a/src/guides/v2.4/security/security-txt.md
+++ b/src/guides/v2.4/security/security-txt.md
@@ -15,8 +15,8 @@ Magento merchants can enter their contact information for [security issue report
 -  Contains a router to match application action class for requests to the `well-known/security.txt` and `.well-known/security.txt.sig` files.
 -  Serves the content of the `.well-known/security.txt` and `.well-known/security.txt.sig` files.
 
-{:.bs-calllout-info}
-**Magento Community Contribution** - Magento thanks [Kalpesh Mehta](https://github.com/kalpmehta) of [Corra](https://partners.magento.com/portal/details/partner/id/70/) for contributing this feature as part of the Magento Community Engineering program.
+{:.bs-callout-info}
+**Magento Community Contribution** - Magento thanks [Kalpesh Mehta](http://ka.lpe.sh/) of [Corra](https://partners.magento.com/portal/details/partner/id/70/) for contributing this feature as part of the Magento Community Engineering program.
 
 A valid `security.txt` file might look like the following:
 


### PR DESCRIPTION
## Purpose of this pull request

This pull request (PR) fixes the typo in the recognition call out and updates contributor's link to the blog page instead of github page.

## Affected DevDocs pages

<!-- REQUIRED List the affected pages on devdocs.magento.com (URLs). Not needed for large numbers of files. -->

-  Security.txt (https://devdocs.magento.com/guides/v2.4/security/security-txt.html)

<!--
If you are fixing a GitHub issue, note it using GitHub keyword format (https://help.github.com/en/articles/closing-issues-using-keywords#closing-an-issue-in-a-different-repository) to close the issue when this pull request is merged. Example: `Fixes #1234`

`master` is the default branch. Merged pull requests to `master` go live on the site automatically. Any requested changes to content on the `master` branch must be related to the released codebase. Any content related to future releases goes in the `develop` branch.

See Contribution guidelines (https://github.com/magento/devdocs/blob/master/.github/CONTRIBUTING.md) for more information.
-->
