### PR TITLE
Add links to the Magento Marketplace docs on the home page

### DIFF
--- a/src/_data/main-nav.yml
+++ b/src/_data/main-nav.yml
@@ -193,7 +193,7 @@
     - label: Checkout
       url: /howdoi/checkout/checkout_overview.html
 
-    - label: Extensions Marketplace
+    - label: Magento Marketplace
       url: /marketplace/sellers/getting-started.html
       versionless: true
 

--- a/src/index.html
+++ b/src/index.html
@@ -53,6 +53,7 @@ guide_version: '2.4'
         <li><a href="{{ page.baseurl }}/rest/bk-rest.html">REST API Reference (Static)</a></li>
         <li><a href="{{ page.baseurl }}/rest/generate-local.html">REST API Reference (Local)</a></li>
         <li><a href="{{ page.baseurl }}/graphql/index.html">GraphQL Developer Guide</a></li>
+        <li><a href="{{ site.baseurl }}/marketplace/eqp/v1/api.html">Marketplace EQP API Reference</a></li>
       </ul>
     </div>
 
@@ -63,6 +64,7 @@ guide_version: '2.4'
         <li><a href="{{ site.baseurl }}/contributor-guide/contributing.html">Contributor Guide</a></li>
         <li><a href="{{ site.baseurl }}/contributor-guide/contributors.html">Contributors and Maintainers</a></li>
         <li><a href="{{ site.baseurl }}/contributor-guide/contributing_dod.html">Magento Definition of Done</a></li>
+        <li><a href="{{ site.baseurl }}/marketplace/sellers/getting-started.html">Magento Marketplace</a></li>
       </ul>
     </div>
 


### PR DESCRIPTION
## Purpose of this pull request

This pull request (PR) adds links to the Magento Marketplace docs to the home page and changes the name of the _Extensions Marketplace_ guide to _Magento Marketplace_. 

## Affected DevDocs pages

- https://devdocs.magento.com