### PR TITLE
Change Marketplace link text on home page

### DIFF
--- a/src/guides/v2.3/index.html
+++ b/src/guides/v2.3/index.html
@@ -50,6 +50,7 @@ layout: home
         <li><a href="{{ page.baseurl }}/rest/bk-rest.html">REST API Reference (Static)</a></li>
         <li><a href="{{ page.baseurl }}/rest/generate-local.html">REST API Reference (Local)</a></li>
         <li><a href="{{ page.baseurl }}/graphql/index.html">GraphQL Developer Guide (New!)</a></li>
+        <li><a href="{{ site.baseurl }}/marketplace/eqp/v1/api.html">Marketplace EQP API Reference</a></li>
       </ul>
     </div>
 
@@ -58,7 +59,9 @@ layout: home
       <ul>
         <li><a href="{{ site.baseurl }}/community/resources/resources.html">Community Resources</a></li>
         <li><a href="{{ site.baseurl }}/contributor-guide/contributing.html">Contributor Guide</a></li>
+        <li><a href="{{ site.baseurl }}/contributor-guide/contributors.html">Contributors and Maintainers</a></li>
         <li><a href="{{ site.baseurl }}/contributor-guide/contributing_dod.html">Magento Definition of Done</a></li>
+        <li><a href="{{ site.baseurl }}/marketplace/sellers/getting-started.html">Marketplace Developer Guide</a></li>
       </ul>
     </div>
 

--- a/src/index.html
+++ b/src/index.html
@@ -64,7 +64,7 @@ guide_version: '2.4'
         <li><a href="{{ site.baseurl }}/contributor-guide/contributing.html">Contributor Guide</a></li>
         <li><a href="{{ site.baseurl }}/contributor-guide/contributors.html">Contributors and Maintainers</a></li>
         <li><a href="{{ site.baseurl }}/contributor-guide/contributing_dod.html">Magento Definition of Done</a></li>
-        <li><a href="{{ site.baseurl }}/marketplace/sellers/getting-started.html">Magento Marketplace</a></li>
+        <li><a href="{{ site.baseurl }}/marketplace/sellers/getting-started.html">Marketplace Developer Guide</a></li>
       </ul>
     </div>
 


### PR DESCRIPTION
## Purpose of this pull request

This pull request (PR) updates the link text for the marketplace docs on the home page per internal request.

It also syncs changes from the latest home page version (2.4.x) with the 2.3.x home page.

## Affected DevDocs pages

- https://devdocs.magento.com/
- https://devdocs.magento.com/guides/v2.3/