### PR TITLE
Reference DB Entrypoint Volume Option

### DIFF
--- a/src/cloud/docker/docker-manage-database.md
+++ b/src/cloud/docker/docker-manage-database.md
@@ -163,7 +163,7 @@ To import a database dump into the Docker environment:
 
 1. Place the resulting SQL file into the `.docker/mysql/docker-entrypoint-initdb.d` folder.
 
-   The `{{site.data.var.ct}}` package imports and processes the SQL file the next time you build and start the Docker environment using the `docker-compose up` command.
+   The `{{site.data.var.ct}}` package imports and processes the SQL file the next time you build and start the Docker environment using the `docker-compose up` command. It is required the `docker-compose.yml` file be built with the `--with-entrypoint` option when running the `ece-docker build:compose` command in order for the SQL file to be recorgnized correctly: `./vendor/bin/ece-docker build:compose --with-entrypoint`. 
 
 {:.bs-callout-tip}
 Although it is a more complex approach, you can use GZIP to import the database by _sharing_ the `.sql.gz` file using the `.docker/mnt` directory and import it inside the Docker container.

--- a/src/cloud/docker/docker-manage-database.md
+++ b/src/cloud/docker/docker-manage-database.md
@@ -163,7 +163,7 @@ To import a database dump into the Docker environment:
 
 1. Place the resulting SQL file into the `.docker/mysql/docker-entrypoint-initdb.d` folder.
 
-   The `{{site.data.var.ct}}` package imports and processes the SQL file the next time you build and start the Docker environment using the `docker-compose up` command. It is required the `docker-compose.yml` file be built with the `--with-entrypoint` option when running the `ece-docker build:compose` command in order for the SQL file to be recorgnized correctly: `./vendor/bin/ece-docker build:compose --with-entrypoint`. 
+   The `{{site.data.var.ct}}` package imports and processes the SQL file the next time you build and start the Docker environment using the `docker-compose up` command. It is required the `docker-compose.yml` file be built with the `--with-entrypoint` option when running the `ece-docker build:compose` command in order for the SQL file to be recorgnized correctly: `./vendor/bin/ece-docker build:compose --with-entrypoint`.
 
 {:.bs-callout-tip}
 Although it is a more complex approach, you can use GZIP to import the database by _sharing_ the `.sql.gz` file using the `.docker/mnt` directory and import it inside the Docker container.

--- a/src/cloud/docker/docker-manage-database.md
+++ b/src/cloud/docker/docker-manage-database.md
@@ -163,7 +163,7 @@ To import a database dump into the Docker environment:
 
 1. Place the resulting SQL file into the `.docker/mysql/docker-entrypoint-initdb.d` folder.
 
-   The `{{site.data.var.ct}}` package imports and processes the SQL file the next time you build and start the Docker environment using the `docker-compose up` command. It is required the `docker-compose.yml` file be built with the `--with-entrypoint` option when running the `ece-docker build:compose` command in order for the SQL file to be recorgnized correctly: `./vendor/bin/ece-docker build:compose --with-entrypoint`.
+   The `{{site.data.var.ct}}` package imports and processes the SQL file the next time you build and start the Docker environment using the `docker-compose up` command. When you build, you must add the `--with-entrypoint` option to the `ece-docker build:compose` command. This option configures the directories for the imported database. See [Service configuration options][].
 
 {:.bs-callout-tip}
 Although it is a more complex approach, you can use GZIP to import the database by _sharing_ the `.sql.gz` file using the `.docker/mnt` directory and import it inside the Docker container.
@@ -195,3 +195,5 @@ See [Docker service containers][Docker database container] for details about the
 [Add the Magento encryption key]: {{ site.baseurl}}/cloud/setup/first-time-setup-import-import.html#encryption-key
 [Docker database container]: https://devdocs.magento.com/cloud/docker/docker-containers-service.html#database-container
 [mysqldump]: https://dev.mysql.com/doc/refman/8.0/en/mysqldump.html
+[Service configuration options]: {{ site.baseurl }}/cloud/docker/docker-containers.html#service-configuration-options
+


### PR DESCRIPTION
Reference the required entry point build compose option when teaching the user to import a DB via the `.docker/mysql/docker-entrypoint-initdb.d` directory.

## Purpose of this pull request

Add additional information about a required step to import a database through the `.docker/mysql/docker-entrypoint-initdb.d` directory. 

## Affected DevDocs pages

<!-- REQUIRED List the affected pages on devdocs.magento.com (URLs). Not needed for large numbers of files. -->

-  https://devdocs.magento.com/cloud/docker/docker-manage-database.html

- I suggest a similar addition be done on: 
    * https://devdocs.magento.com/cloud/docker/docker-containers-service.html#database-container

 

<!--
If you are fixing a GitHub issue, note it using GitHub keyword format (https://help.github.com/en/articles/closing-issues-using-keywords#closing-an-issue-in-a-different-repository) to close the issue when this pull request is merged. Example: `Fixes #1234`

`master` is the default branch. Merged pull requests to `master` go live on the site automatically. Any requested changes to content on the `master` branch must be related to the released codebase. Any content related to future releases goes in the `develop` branch.

See Contribution guidelines (https://github.com/magento/devdocs/blob/master/.github/CONTRIBUTING.md) for more information.
-->
