### PR TITLE
GraphQL: Update same_as_shipping description

### DIFF
--- a/src/guides/v2.3/graphql/mutations/set-billing-address.md
+++ b/src/guides/v2.3/graphql/mutations/set-billing-address.md
@@ -112,7 +112,7 @@ Attribute |  Data Type | Description
 --- | --- | ---
 `address` | [CartAddressInput](#CartAddressInput) | The billing address for the cart
 `customer_address_id` | Int | The unique ID that identifies the customer's address
-`same_as_shipping` | Boolean | Specifies whether to use the billing address for the shipping address (`True`/`False`)
+`same_as_shipping` | Boolean | Specifies whether to use the shipping address for the billing address
 `use_for_shipping` | Boolean | Deprecated. Use `same_as_shipping` instead
 
 ### CartAddressInput object {#CartAddressInput}

--- a/src/guides/v2.4/graphql/mutations/set-billing-address.md
+++ b/src/guides/v2.4/graphql/mutations/set-billing-address.md
@@ -110,7 +110,7 @@ Attribute |  Data Type | Description
 --- | --- | ---
 `address` | [CartAddressInput](#CartAddressInput) | The billing address for the cart
 `customer_address_id` | Int | The unique ID that identifies the customer's address
-`same_as_shipping` | Boolean | Specifies whether to use the billing address for the shipping address (`True`/`False`)
+`same_as_shipping` | Boolean | Specifies whether to use the shipping address for the billing address
 `use_for_shipping` | Boolean | Deprecated. Use `same_as_shipping` instead
 
 ### CartAddressInput object {#CartAddressInput}


### PR DESCRIPTION
## Purpose of this pull request

This pull request (PR) updates the description of the `same_as_shipping` attribute in the `setBillingAddressOnCart` mutation topic.

## Affected DevDocs pages

<!-- REQUIRED List the affected pages on devdocs.magento.com (URLs). Not needed for large numbers of files. -->

-  https://devdocs.magento.com/guides/v2.3/graphql/mutations/set-billing-address.html
- https://devdocs.magento.com/guides/v2.4/graphql/mutations/set-billing-address.html

## Links to Magento source code

<!--  OPTIONAL - REMOVE THIS SECTION IF NOT USED. If this pull request references a file in a Magento codebase repository, add it here. -->

-  ...

<!--
If you are fixing a GitHub issue, note it using GitHub keyword format (https://help.github.com/en/articles/closing-issues-using-keywords#closing-an-issue-in-a-different-repository) to close the issue when this pull request is merged. Example: `Fixes #1234`

`master` is the default branch. Merged pull requests to `master` go live on the site automatically. Any requested changes to content on the `master` branch must be related to the released codebase. Any content related to future releases goes in the `develop` branch.

See Contribution guidelines (https://github.com/magento/devdocs/blob/master/.github/CONTRIBUTING.md) for more information.
-->
