### PR TITLE
Clarify Elasticsearch version support for 2.4.0

### DIFF
--- a/src/guides/v2.4/install-gde/system-requirements-tech.md
+++ b/src/guides/v2.4/install-gde/system-requirements-tech.md
@@ -8,7 +8,7 @@ functional_areas:
 ---
 
 {:.bs-calloout-info}
-If you are working on a {{site.data.var.ece}} project, see [Service versions]({{ site.baseurl }}/cloud/project/project-conf-files_services.html#service-versions).
+If you are working on a {{site.data.var.ece}} project, see [Service versions]({{ site.baseurl }}/cloud/project/project-conf-files_services.html#service-versions) in the _Cloud Guide_.
 
 ## Operating systems (Linux x86-64)
 

--- a/src/guides/v2.4/install-gde/system-requirements-tech.md
+++ b/src/guides/v2.4/install-gde/system-requirements-tech.md
@@ -66,7 +66,7 @@ For more information, see [Required PHP settings][].
 
 ## Elasticsearch
 
-As of Magento 2.4.0, MySQL is no longer used for search. You must use [Elasticsearch]({{page.baseurl}}/install-gde/prereq/elasticsearch.html). Magento supports Elasticsearch 7.6.x.
+As of Magento 2.4.0, MySQL is no longer used for search. You must use [Elasticsearch]({{page.baseurl}}/install-gde/prereq/elasticsearch.html). Magento is tested with Elasticsearch 7.6.x. You can use other versions at your discretion, but we recommend using the tested version of Elasticsearch.
 
 {:.bs-callout-warning}
 Magento no longer supports Elasticsearch [2.x, 5.x, and 6.x][].

--- a/src/guides/v2.4/install-gde/system-requirements-tech.md
+++ b/src/guides/v2.4/install-gde/system-requirements-tech.md
@@ -7,6 +7,9 @@ functional_areas:
   - Setup
 ---
 
+{:.bs-calloout-info}
+If you are working on a {{site.data.var.ece}} project, see [Service versions]({{ site.baseurl }}/cloud/project/project-conf-files_services.html#service-versions).
+
 ## Operating systems (Linux x86-64)
 
 Linux distributions, such as RedHat Enterprise Linux (RHEL), CentOS, Ubuntu, Debian, and similar.


### PR DESCRIPTION
## Purpose of this pull request

This pull request (PR) clarifies support for Elasticsearch 7.6.x in the 2.4.0 system requirements. We need to emphasize the fact that Magento is tested on ES 7.6.x.

It also adds a note at the top of the page redirecting cloud users to the Service versions section in the cloud guide since there can sometimes be differences between cloud and on-prem.

Fixes #7759 

## Affected DevDocs pages

- https://devdocs.magento.com/guides/v2.4/install-gde/system-requirements-tech.html#elasticsearch