### PR TITLE
Fixed the wrong links in the article "Private content"

### DIFF
--- a/src/guides/v2.3/extension-dev-guide/cache/page-caching/private-content.md
+++ b/src/guides/v2.3/extension-dev-guide/cache/page-caching/private-content.md
@@ -15,7 +15,7 @@ The section source class is responsible for retrieving data for the section. As 
 
 The public method `getSectionData` must return an array with data for a private block.
 
-[Example]({{ site.mage2bloburl }}/{{ page.guide_version }}/app/code/Magento/Catalog/CustomerData/CompareProducts.php#L45-L54){:target="_blank"}
+[Example]({{ site.mage2bloburl }}/{{ page.guide_version }}/app/code/Magento/Catalog/CustomerData/CompareProducts.php#L61-L70){:target="_blank"}
 
 Add the following to your component's [dependency injection](https://glossary.magento.com/dependency-injection) configuration (`di.xml`):
 
@@ -56,7 +56,7 @@ The UI component renders block data on the Magento [storefront](https://glossary
 
 All properties are available in the template.
 
-[Example of defining a UI component in a layout]({{ site.mage2bloburl }}/{{ page.guide_version }}/app/code/Magento/Catalog/view/frontend/layout/default.xml#L11-L32){:target="_blank"}
+[Example of defining a UI component in a layout]({{ site.mage2bloburl }}/{{ page.guide_version }}/app/code/Magento/Catalog/view/frontend/layout/default.xml#L11-L35){:target="_blank"}
 
 ## Invalidate private content
 


### PR DESCRIPTION
## Purpose of this pull request

This pull request (PR) fixes the wrong links in the article "Private content".
There some changes in module Magento_Catalog, that affect on the article. 

## Affected DevDocs pages

<!-- REQUIRED List the affected pages on devdocs.magento.com (URLs). Not needed for large numbers of files. -->

-  [Private content](https://devdocs.magento.com/guides/v2.4/extension-dev-guide/cache/page-caching/private-content.html)

## Links to Magento source code

<!--  OPTIONAL - REMOVE THIS SECTION IF NOT USED. If this pull request references a file in a Magento codebase repository, add it here. -->

-  [The commit that affects the first link named "Example"](https://github.com/magento/magento2/commit/68334c0b74664a41e6959b4e7e5d12b0b83e2eed#diff-21ae51cd159c2b7202a8bef42f9e3765)
-  [The commit that affects the second link named "Example of defining a UI component in a layout"](https://github.com/magento/magento2/commit/cd4a3eb409238de01508fc3afe5adf283f30ce98#diff-7dafece2e4a6b31b544b9391e77ac50b)

<!--
If you are fixing a GitHub issue, note it using GitHub keyword format (https://help.github.com/en/articles/closing-issues-using-keywords#closing-an-issue-in-a-different-repository) to close the issue when this pull request is merged. Example: `Fixes #1234`

`master` is the default branch. Merged pull requests to `master` go live on the site automatically. Any requested changes to content on the `master` branch must be related to the released codebase. Any content related to future releases goes in the `develop` branch.

See Contribution guidelines (https://github.com/magento/devdocs/blob/master/.github/CONTRIBUTING.md) for more information.
-->
