### PR TITLE
Missing space in Magento and CSP section

### DIFF
--- a/src/guides/v2.4/extension-dev-guide/security/content-security-policies.md
+++ b/src/guides/v2.4/extension-dev-guide/security/content-security-policies.md
@@ -27,7 +27,7 @@ Magento also permits configuring unique CSPs for specific pages.
 
 CSP can work in two modes:
 
-*  `report-only` - In this mode, Magento reports policy violations but does not interfere. This mode isuseful for debugging.  By default, CSP violations are written to the browser console, but they can be configured to be reported to an endpoint as an HTTP request to collect logs. There are a number of services that will collect, store, and sort your store's CSP violations reports for you.
+*  `report-only` - In this mode, Magento reports policy violations but does not interfere. This mode is useful for debugging.  By default, CSP violations are written to the browser console, but they can be configured to be reported to an endpoint as an HTTP request to collect logs. There are a number of services that will collect, store, and sort your store's CSP violations reports for you.
 
 *  `restrict mode` - In this mode, Magento acts on any policy violations.
 


### PR DESCRIPTION
Fixes #7755

## Purpose of this pull request

This pull request (PR) fixes #7755 and adds a space where one was missing in the Magento and CSP section.

## Affected DevDocs pages

<!-- REQUIRED List the affected pages on devdocs.magento.com (URLs). Not needed for large numbers of files. -->

-  https://devdocs.magento.com/guides/v2.4/extension-dev-guide/security/content-security-policies.html

## Links to Magento source code

<!--  OPTIONAL - REMOVE THIS SECTION IF NOT USED. If this pull request references a file in a Magento codebase repository, add it here. -->

-  ...

<!--
If you are fixing a GitHub issue, note it using GitHub keyword format (https://help.github.com/en/articles/closing-issues-using-keywords#closing-an-issue-in-a-different-repository) to close the issue when this pull request is merged. Example: `Fixes #1234`

`master` is the default branch. Merged pull requests to `master` go live on the site automatically. Any requested changes to content on the `master` branch must be related to the released codebase. Any content related to future releases goes in the `develop` branch.

See Contribution guidelines (https://github.com/magento/devdocs/blob/master/.github/CONTRIBUTING.md) for more information.
-->
