### PR TITLE
Add an additional step to the before upgrade section

### DIFF
--- a/src/guides/v2.3/comp-mgr/cli/cli-upgrade.md
+++ b/src/guides/v2.3/comp-mgr/cli/cli-upgrade.md
@@ -35,7 +35,7 @@ Complete the following prerequisites to prepare your environment before starting
 
      {:.bs-callout-info}
     Optionally, you can create a [custom maintenance mode page].
--  **Check the status of the active running cron jobs**—To prevent various unexpected problems during the upgrade, wait for all active running Magento cron jobs to finish their work or stop them.
+-  **Check the status of cron jobs**—To prevent various unexpected problems during the upgrade, wait for all active running Magento cron jobs to finish or stop them.
 
 Using the more manual process of upgrading via the command line allows you to track and control exactly what is being changed in the upgrade.
 

--- a/src/guides/v2.4/comp-mgr/cli/cli-upgrade.md
+++ b/src/guides/v2.4/comp-mgr/cli/cli-upgrade.md
@@ -36,7 +36,7 @@ Complete the following prerequisites to prepare your environment before starting
 
      {:.bs-callout-info}
     Optionally, you can create a [custom maintenance mode page].
--  **Check the status of the active running cron jobs**—To prevent various unexpected problems during the upgrade, wait for all active running Magento cron jobs to finish their work or stop them.
+-  **Check the status of cron jobs**—To prevent various unexpected problems during the upgrade, wait for all active running Magento cron jobs to finish or stop them.
 -  **Install the Composer update plugin**—The [`magento/composer-root-update-plugin`][custom Composer plugin] Composer plugin resolves changes that need to be made to the root project `composer.json` file before updating to a new Magento product requirement.
 
    The plugin partially automates the manual upgrade by identifying and helping you resolve dependency conflicts instead of requiring you to identify and fix them them manually.


### PR DESCRIPTION
## Purpose of this pull request

Update the Magento upgrade documentation with additional information

## Affected DevDocs pages

<!-- REQUIRED List the affected pages on devdocs.magento.com (URLs). Not needed for large numbers of files. -->

-  https://devdocs.magento.com/guides/v2.4/comp-mgr/cli/cli-upgrade.html
-  https://devdocs.magento.com/guides/v2.3/comp-mgr/cli/cli-upgrade.html

<!--
If you are fixing a GitHub issue, note it using GitHub keyword format (https://help.github.com/en/articles/closing-issues-using-keywords#closing-an-issue-in-a-different-repository) to close the issue when this pull request is merged. Example: `Fixes #1234`

`master` is the default branch. Merged pull requests to `master` go live on the site automatically. Any requested changes to content on the `master` branch must be related to the released codebase. Any content related to future releases goes in the `develop` branch.

See Contribution guidelines (https://github.com/magento/devdocs/blob/master/.github/CONTRIBUTING.md) for more information.
-->

whatsnew
Added another step to help users avoid problems during [upgrades](https://devdocs.magento.com/guides/v2.4/comp-mgr/cli/cli-upgrade.html).