### PR TITLE
Fixed a bookmark bug

### DIFF
--- a/src/guides/v2.3/extension-dev-guide/admin-grid.md
+++ b/src/guides/v2.3/extension-dev-guide/admin-grid.md
@@ -124,7 +124,7 @@ The UI component `dev_grid_category_listing` must be defined separately in a fil
    </argument>
   </dataSource>
   <listingToolbar name="listing_top">
-    <bookmarks name="bookmarks" class="Dev\Grid\Ui\Component\Category\Listing\Bookmark"/>
+    <bookmark name="bookmarks"/>
     <columnsControls name="columns_controls"/>
     <massaction name="listing_massaction">
       <argument name="data" xsi:type="array">


### PR DESCRIPTION
## Purpose of this pull request

This pull request (PR) fixes a bug reported here https://github.com/goivvy/admin-grid-tutorial/issues/1

## Affected DevDocs pages

<!-- REQUIRED List the affected pages on devdocs.magento.com (URLs). Not needed for large numbers of files. -->

-  https://devdocs.magento.com/guides/v2.4/extension-dev-guide/admin-grid.html
-  https://devdocs.magento.com/guides/v2.3/extension-dev-guide/admin-grid.html

## Links to Magento source code

<!--  OPTIONAL - REMOVE THIS SECTION IF NOT USED. If this pull request references a file in a Magento codebase repository, add it here. -->

<!--
If you are fixing a GitHub issue, note it using GitHub keyword format (https://help.github.com/en/articles/closing-issues-using-keywords#closing-an-issue-in-a-different-repository) to close the issue when this pull request is merged. Example: `Fixes #1234`

`master` is the default branch. Merged pull requests to `master` go live on the site automatically. Any requested changes to content on the `master` branch must be related to the released codebase. Any content related to future releases goes in the `develop` branch.

See Contribution guidelines (https://github.com/magento/devdocs/blob/master/.github/CONTRIBUTING.md) for more information.
-->
