### PR TITLE
Fix list of allowed attributes in escaper

### DIFF
--- a/src/guides/v2.3/extension-dev-guide/xss-protection.md
+++ b/src/guides/v2.3/extension-dev-guide/xss-protection.md
@@ -93,7 +93,7 @@ let settings = <?= $myJson ?>
 
 You can pass in an optional array of allowed tags that will not be escaped.
 
-If a tag is allowed, the following attributes will not be escaped: `id`, `class`, `href`, `target`, `style` and `title`. Any other attribute for that allowed tag will be escaped.
+If a tag is allowed, the following attributes will not be escaped: `id`, `class`, `href`, `style` and `title`. Any other attribute for that allowed tag will be escaped.
 
 `embed`, `iframe`, `video`, `source`, `object`, `audio`, `script` and `img` tags are not allowed, regardless of the content of this array.
 

--- a/src/guides/v2.4/extension-dev-guide/xss-protection.md
+++ b/src/guides/v2.4/extension-dev-guide/xss-protection.md
@@ -94,7 +94,7 @@ let settings = <?= $myJson ?>
 
 Pass in an optional array of allowed tags that will not be escaped.
 
-If a tag is allowed, the following attributes will not be escaped: `id`, `class`, `href`, `target`, `style` and `title`. Any other attribute for that allowed tag will be escaped.
+If a tag is allowed, the following attributes will not be escaped: `id`, `class`, `href`, `style` and `title`. Any other attribute for that allowed tag will be escaped.
 
 `embed`, `iframe`, `video`, `source`, `object`, `audio`, `script` and `img` tags are not allowed, regardless of the content of this array.
 


### PR DESCRIPTION
## Purpose of this pull request

Removed `target` as this attribute is not allowed by the escaper. List of allowed attributes can be found here: https://github.com/magento/magento2/blob/2.4-develop/lib/internal/Magento/Framework/Escaper.php#L45

## Affected DevDocs pages

- https://devdocs.magento.com/guides/v2.4/extension-dev-guide/xss-protection.html

## Links to Magento source code

- https://github.com/magento/magento2/blob/2.4-develop/lib/internal/Magento/Framework/Escaper.php