### PR TITLE
Update CLI tools reference

### DIFF
--- a/src/_includes/reference/cli-template.md
+++ b/src/_includes/reference/cli-template.md
@@ -7,7 +7,7 @@
 {% if app.version %}
 **Version**: {{ app.version }}
 {:style="color:gray; font-size: 120%"}
-{% endif %}
+{% endif %} <!-- app.version -->
 
 This reference contains {{ commands | size }} commands available through the `{{ tool }}` command-line tool.
 The initial list is auto generated using the `{{ tool }} list` command at the {{ edition }} edition.
@@ -40,8 +40,8 @@ This reference is generated from the Magento codebase. To change the content, yo
 {{ tool }} {{ usage }}
 ```
 
-{% endif %}
-{% endfor %}
+{% endif %} <!-- app.name -->
+{% endfor %} <!-- command.usage -->
 
 {% unless arguments.size == 0 %}
 
@@ -50,8 +50,6 @@ This reference is generated from the Magento codebase. To change the content, yo
 {% for argument in arguments %}
   {% for item in argument %}
     {% if item.name %}
-      {% if item.default == empty %}
-      {% endif %}
 
 ##### `{{ item.name }}`
 
@@ -73,6 +71,10 @@ This reference is generated from the Magento codebase. To change the content, yo
    {% endfor %}
    {% endfor %}
 
+{% endunless %} <!-- arguments.size -->
+
+{% unless options.size == 0 %}
+
 #### Options
 
  {% for option in options %}
@@ -83,15 +85,15 @@ This reference is generated from the Magento codebase. To change the content, yo
 -  Option: `{{ opt.name }}`
    {% if opt.shortcut contains '-' %}
 -  Shortcut: `{{ opt.shortcut }}`
-   {% endif %}
+   {% endif %} <!-- opt.shortcut -->
 -  Description: {{ opt.description | replace: '|', '\|'}}
    {% unless opt.default == nil %}
-   {% if opt.default == false or (opt.default == empty and opt.default != '') %}
+   {% if opt.default == false or opt.default == empty and opt.default != '' %}
 -  Default: `{{ opt.default | inspect }}`
    {% else %}
 -  Default: `{{ opt.default }}`
-   {% endif %}
-   {% endunless %}
+   {% endif %} <!-- opt.default -->
+   {% endunless %} <!-- opt.default -->
    {% if opt.is_value_required %}
 -  Requires a value
    {% elsif opt.accept_value and opt.is_multiple %}
@@ -100,14 +102,14 @@ This reference is generated from the Magento codebase. To change the content, yo
 -  Accepts a value
    {% else %}
 -  Does not accept a value
-   {% endif %}
-   {% endfor %}
+   {% endif %} <!-- opt.is_value_required -->
+   {% endfor %} <!-- options -->
 
-{% endunless %}
-{% endfor %}
+{% endunless %} <!-- options.size -->
+{% endfor %} <!-- commands -->
 
-{% else %}
+{% else %} <!-- file -->
 
 There is no data available for this reference at the moment.
 
-{% endif %}
+{% endif %} <!-- file -->

--- a/src/_includes/reference/cli-template.md
+++ b/src/_includes/reference/cli-template.md
@@ -53,7 +53,8 @@ This reference is generated from the Magento codebase. To change the content, yo
 
 ##### `{{ item.name }}`
 
--  Description: {{ item.description }}
+{{ item.description }}
+
    {% unless item.default == nil %}
    {% if item.default == false or (item.default == empty and item.default != '') %}
 -  Default: `{{ item.default | inspect }}`
@@ -68,8 +69,9 @@ This reference is generated from the Magento codebase. To change the content, yo
 -  Array
    {% endif %}
    {% endif %}
-   {% endfor %}
-   {% endfor %}
+
+  {% endfor %} <!-- argument -->
+{% endfor %} <!-- arguments -->
 
 {% endunless %} <!-- arguments.size -->
 
@@ -80,20 +82,23 @@ This reference is generated from the Magento codebase. To change the content, yo
  {% for option in options %}
  {% assign opt = option[1] %}
 
-##### `{{ option[0] }}`
+{% if opt.shortcut contains '-' %}
 
--  Option: `{{ opt.name }}`
-   {% if opt.shortcut contains '-' %}
--  Shortcut: `{{ opt.shortcut }}`
-   {% endif %} <!-- opt.shortcut -->
--  Description: {{ opt.description | replace: '|', '\|'}}
+##### `{{ opt.name }}`, `{{ opt.shortcut }}`
+{% else %}
+##### `{{ opt.name }}`
+
+{% endif %}
+
+{{ opt.description | replace: '|', '\|'}}
+
    {% unless opt.default == nil %}
    {% if opt.default == false or opt.default == empty and opt.default != '' %}
 -  Default: `{{ opt.default | inspect }}`
    {% else %}
 -  Default: `{{ opt.default }}`
-   {% endif %} <!-- opt.default -->
-   {% endunless %} <!-- opt.default -->
+   {% endif %}
+   {% endunless %}
    {% if opt.is_value_required %}
 -  Requires a value
    {% elsif opt.accept_value and opt.is_multiple %}
@@ -102,8 +107,9 @@ This reference is generated from the Magento codebase. To change the content, yo
 -  Accepts a value
    {% else %}
 -  Does not accept a value
-   {% endif %} <!-- opt.is_value_required -->
-   {% endfor %} <!-- options -->
+   {% endif %}
+
+{% endfor %} <!-- options -->
 
 {% endunless %} <!-- options.size -->
 {% endfor %} <!-- commands -->


### PR DESCRIPTION
## Purpose of this pull request

This pull request (PR) adds documentation to cover the `bin/magento` and `magento-cloud` commands options that were missing to tools.

## Affected DevDocs pages

<!-- REQUIRED List the affected pages on devdocs.magento.com (URLs). Not needed for large numbers of files. -->

- https://devdocs.magento.com/guides/v2.4/reference/cli/magento.html
- https://devdocs.magento.com/guides/v2.4/reference/cli/magento-commerce.html
- https://devdocs.magento.com/guides/v2.4/reference/cli/magento-cloud.html

- https://devdocs.magento.com/guides/v2.3/reference/cli/magento.html
- https://devdocs.magento.com/guides/v2.3/reference/cli/magento-commerce.html
- https://devdocs.magento.com/guides/v2.3/reference/cli/magento-cloud.html

## Additional information

This also updates formatting to facilitate user experience.

_Build: 2182_

whatsnew
Added missing documentation to _Options_ at the [CLI tools reference](https://devdocs.magento.com/guides/v2.4/reference/cli/magento.html).