### PR TITLE
Updated supported and recommended elasticsearch version

### DIFF
--- a/src/_includes/cloud/cloud-elasticsearch-client-compatibility.md
+++ b/src/_includes/cloud/cloud-elasticsearch-client-compatibility.md
@@ -4,4 +4,4 @@ Elasticsearch service   |  Elasticsearch composer package | Status
 --------- | ------------- | -------------------------
 5.2.x | 5.x.x | default versions for {{ site.data.var.ee }} versions 2.2.x to 2.2.7 and 2.3.0
 6.8 | 6.7.x | recommended, default version for {{ site.data.var.ee }} versions 2.2.8 and 2.3.4
-7.5, 7.6, 7.7 | 7.x | recommended versions for {{ site.data.var.ee }} versions 2.3.5 and later
+7.7 | 7.x | recommended versions for {{ site.data.var.ee }} 2.3.5 and later versions, 2.4 and later versions

--- a/src/_includes/cloud/cloud-elasticsearch-client-compatibility.md
+++ b/src/_includes/cloud/cloud-elasticsearch-client-compatibility.md
@@ -3,5 +3,5 @@ The following table lists compatible versions of the Elasticsearch software supp
 Elasticsearch service   |  Elasticsearch composer package | Status
 --------- | ------------- | -------------------------
 5.2.x | 5.x.x | default versions for {{ site.data.var.ee }} versions 2.2.x to 2.2.7 and 2.3.0
-6.8 | 6.7.x | recommended, default version for {{ site.data.var.ee }} versions 2.2.8 and 2.3.4
+6.8 | 6.7.x | recommended, default versions for {{ site.data.var.ee }} versions 2.2.8 and 2.3.4
 7.7 | 7.x | recommended versions for {{ site.data.var.ee }} 2.3.5 and later versions, 2.4 and later versions

--- a/src/_includes/cloud/cloud-elasticsearch-client-compatibility.md
+++ b/src/_includes/cloud/cloud-elasticsearch-client-compatibility.md
@@ -4,4 +4,4 @@ Elasticsearch service   |  Elasticsearch composer package | Status
 --------- | ------------- | -------------------------
 5.2.x | 5.x.x | default versions for {{ site.data.var.ee }} versions 2.2.x to 2.2.7 and 2.3.0
 6.8 | 6.7.x | recommended, default versions for {{ site.data.var.ee }} versions 2.2.8 and 2.3.4
-7.7 | 7.x | recommended versions for {{ site.data.var.ee }} 2.3.5 and later versions, 2.4 and later versions
+7.7 | 7.x | recommended, default versions for {{ site.data.var.ee }} versions 2.3.5 and 2.4.x

--- a/src/cloud/project/project-conf-files_services.md
+++ b/src/cloud/project/project-conf-files_services.md
@@ -166,7 +166,7 @@ The following table lists the services used in {{site.data.var.ece}} and their v
 {:.error-table}
 Service   |  Magento 2.4  |Magento 2.3  | Magento 2.2
 --------- | ------------- |-------------| ------------
-`elasticsearch` | 7.5.x, 7.6.x, 7.7.x | **Magento version 2.3.5 and later**— 5.2, 6.5, 6.8, 7.5, 7.6, 7.7<br>**Magento version 2.3.1 to 2.3.4**— 5.2, 6.5<br>**Magento version 2.3.0**— 5.2  | **Magento version 2.2.8 and later**— 5.2, 6.5 <br>**Magento version 2.2.0 to 2.2.7**— 5.2
+`elasticsearch` | 7.7.x | **Magento version 2.3.5 and later**— 5.2, 6.5, 6.8, 7.5, 7.6, 7.7<br>**Magento version 2.3.1 to 2.3.4**— 5.2, 6.5<br>**Magento version 2.3.0**— 5.2  | **Magento version 2.2.8 and later**— 5.2, 6.5 <br>**Magento version 2.2.0 to 2.2.7**— 5.2
 `mariadb` | 10.2, 10.3, 10.4 | **Magento version 2.3.0 to 2.3.5**–10.1 to 10.2<br> | 10.1 to 10.2
 `nginx`   | | 1.9           | 1.9
 `node`    | | 6, 8, 10, 11  | 6, 8, 10, 11


### PR DESCRIPTION
## Purpose of this pull request

Updated the Elastiicsearch version compatibility and software version compatibility matrices to show Elasticsearch 7.7.x as the supported and recommended version for Magento Commerce on the Cloud platform.

## Affected DevDocs pages

- https://devdocs.magento.com/cloud/project/project-conf-files_services-elastic.html
- https://devdocs.magento.com/cloud/project/project-conf-files_services.html

whatsnew
Updated the Elastiicsearch version compatibility and software version compatibility matrices to show Elasticsearch 7.7.x as the supported and recommended version for Magento Commerce on the Cloud platform.