### PR TITLE
Update Marketplace EQP API's auth.md

### DIFF
--- a/src/marketplace/eqp/v1/auth.md
+++ b/src/marketplace/eqp/v1/auth.md
@@ -47,15 +47,17 @@ You must specify the grant type in the request body:
 
 ```json
 {
-   "grant_type": "session"
+   "grant_type": "session",
+   "expires_in": 7200
 }
 ```
 
 Field details:
 
-|Field|Type|Description|
-|-----|----|-----------|
-|grant_type|string|The API only supports the `session` grant type; other values will give an error.|
+|Field|Type|Required|Description|
+|-----|----|----|-----------|
+|grant_type|string|yes| The API only supports the `session` grant type; other values will give an error.|
+|expires_in|int|no| Requested time in seconds that the session token will be valid. If the requested time exceeds the system's maximum allowed, the system's maximum limit will be used instead. |
 
 **Request:**
 

--- a/src/marketplace/eqp/v1/auth.md
+++ b/src/marketplace/eqp/v1/auth.md
@@ -57,7 +57,7 @@ Field details:
 |Field|Type|Required|Description|
 |-----|----|----|-----------|
 |grant_type|string|yes| The API only supports the `session` grant type; other values will give an error.|
-|expires_in|int|no| Requested time in seconds that the session token will be valid. If the requested time exceeds the system's maximum allowed, the system's maximum limit will be used instead. |
+|expires_in|int|no| Specifies the number of seconds that the session token will be valid. If the requested time exceeds the system's maximum allowed, the system's maximum limit will be used instead. |
 
 **Request:**
 


### PR DESCRIPTION
## Purpose of this pull request

* reveal the optional "expires_in" field that can be used when requesting a user session token

## Affected DevDocs pages

* .../src/marketplace/eqp/v1/auth.md
