### PR TITLE
MCLOUD-6430: Xdebug not working on Magento Cloud Docker 1.1

### DIFF
--- a/src/cloud/docker/docker-development-debug.md
+++ b/src/cloud/docker/docker-development-debug.md
@@ -23,8 +23,14 @@ If you use Microsoft Windows, take the following steps before continuing:
 1. To enable Xdebug for your Docker environment, generate the Docker Compose configuration file in developer mode with the `--with-xdebug` option and any other required options, for example.
 
    ```bash
-   vendor/bin/ece-docker build:compose --mode --sync-engine="mutagen" developer --with-xdebug
+   vendor/bin/ece-docker build:compose --mode="developer" --sync-engine="mutagen" --with-xdebug
    ```
+   
+   For Linux system also need to be added option `--set-docker-host` for automatically adding `host.docker.internal` into `/etc/hosts` of `fpm_xdebug` container.
+   
+      ```bash
+      vendor/bin/ece-docker build:compose --mode="developer" --with-xdebug --set-docker-host
+      ```
 
    This command adds the Xdebug configuration to your `docker-compose.yml` file.
 

--- a/src/cloud/docker/docker-development-debug.md
+++ b/src/cloud/docker/docker-development-debug.md
@@ -26,7 +26,7 @@ If you use Microsoft Windows, take the following steps before continuing:
    vendor/bin/ece-docker build:compose --mode="developer" --sync-engine="mutagen" --with-xdebug
    ```
    
-   For Linux system also need to be added option `--set-docker-host` for automatically adding `host.docker.internal` into `/etc/hosts` of `fpm_xdebug` container.
+   For Linux systems, the option `--set-docker-host` also needs to be added for automatically adding `host.docker.internal` into the `/etc/hosts` for the `fpm_xdebug` container.
    
       ```bash
       vendor/bin/ece-docker build:compose --mode="developer" --with-xdebug --set-docker-host

--- a/src/cloud/docker/docker-development-debug.md
+++ b/src/cloud/docker/docker-development-debug.md
@@ -26,7 +26,7 @@ If you use Microsoft Windows, take the following steps before continuing:
    vendor/bin/ece-docker build:compose --mode="developer" --sync-engine="mutagen" --with-xdebug
    ```
    
-   For Linux systems, the option `--set-docker-host` also needs to be added for automatically adding `host.docker.internal` into the `/etc/hosts` for the `fpm_xdebug` container.
+   For Linux systems, you must use the `--set-docker-host` option to add the `host.docker.internal` entry to the `/etc/hosts` file for the `fpm_xdebug` container.
    
       ```bash
       vendor/bin/ece-docker build:compose --mode="developer" --with-xdebug --set-docker-host


### PR DESCRIPTION
## Purpose of this pull request

This pull request (PR) will update information on how to use xdebug with docker on Linux systems

## Affected DevDocs pages

<!-- REQUIRED List the affected pages on devdocs.magento.com (URLs). Not needed for large numbers of files. -->

-  https://devdocs.magento.com/cloud/docker/docker-development-debug.html

whatsnew
Added [instructions](https://devdocs.magento.com/cloud/docker/docker-development-debug.html) for using Xdebug with Docker on Linux systems.