### PR TITLE
Fix Cloud services list alignment to correct broken list

### DIFF
--- a/src/cloud/project/project-conf-files_services.md
+++ b/src/cloud/project/project-conf-files_services.md
@@ -166,7 +166,7 @@ The following table lists the services used in {{site.data.var.ece}} and their v
 {:.error-table}
 Service   |  Magento 2.4  |Magento 2.3  | Magento 2.2
 --------- | ------------- |-------------| ------------
-`elasticsearch` | 7.7.x | **Magento version 2.3.5 and later**— 5.2, 6.5, 6.8, 7.5, 7.6, 7.7<br>**Magento version 2.3.1 to 2.3.4**— 5.2, 6.5<br>**Magento version 2.3.0**— 5.2  | **Magento version 2.2.8 and later**— 5.2, 6.5 <br>**Magento version 2.2.0 to 2.2.7**— 5.2
+`elasticsearch` | 7.7 | **Magento version 2.3.5 and later**— 5.2, 6.5, 6.8, 7.5, 7.6, 7.7<br>**Magento version 2.3.1 to 2.3.4**— 5.2, 6.5<br>**Magento version 2.3.0**— 5.2  | **Magento version 2.2.8 and later**— 5.2, 6.5 <br>**Magento version 2.2.0 to 2.2.7**— 5.2
 `mariadb` | 10.2, 10.3, 10.4 | **Magento version 2.3.0 to 2.3.5**–10.1 to 10.2<br> | 10.1 to 10.2
 `nginx`   | | 1.9           | 1.9
 `node`    | | 6, 8, 10, 11  | 6, 8, 10, 11

--- a/src/cloud/project/project-conf-files_services.md
+++ b/src/cloud/project/project-conf-files_services.md
@@ -282,12 +282,12 @@ To downgrade a service version by renaming an existing service:
        database: "mysql:mysql"
    ```
 
-  > Updated `.magento.app.yaml` configuration
+   > Updated `.magento.app.yaml` configuration
 
-  ```yaml
-  relationships:
-      database: "mysql2:mysql"
-  ```
+   ```yaml
+   relationships:
+       database: "mysql2:mysql"
+   ```
 
 1. Add, commit, and push your code changes.
 


### PR DESCRIPTION
There is a spacing problem that affected a numbered list in the [Services topic](https://devdocs.magento.com/cloud/project/project-conf-files_services.html#downgrade-version).