### PR TITLE
Updates for bypass fastly cache

### DIFF
--- a/src/cloud/cdn/fastly-vcl-bypass-to-origin.md
+++ b/src/cloud/cdn/fastly-vcl-bypass-to-origin.md
@@ -8,7 +8,9 @@ functional_areas:
   - Setup
 ---
 
-You can create a custom VCL snippet to bypass Fastly caching and submit requests directly to the origin server, for example to determine whether site issues are caused by caching, or to troubleshoot headers. You can configure the snippet to bypass Fastly caching for requests from a specific IP address or URL.
+You can create a custom VCL snippet to bypass the Fastly cache so you can troubleshoot request traffic to the origin server, for example to determine whether site issues are caused by caching, or to troubleshoot headers.
+
+You can configure the snippet to bypass Fastly caching for requests from a specific IP address or URL.
 
 {:.bs-callout-info}
 We recommend testing custom VCL configurations in a Staging environment before merging them into a Production environment.

--- a/src/cloud/cdn/fastly-vcl-bypass-to-origin.md
+++ b/src/cloud/cdn/fastly-vcl-bypass-to-origin.md
@@ -13,13 +13,14 @@ You can create a custom VCL snippet to bypass Fastly caching and submit requests
 {:.bs-callout-info}
 We recommend testing custom VCL configurations in a Staging environment before merging them into a Production environment.
 
-{:.procedure}
-Prerequisites
+**Prerequisites:**
+
+Your environment must be configured to use the Fastly CDN. See [Set up Fastly]({{ site.baseurl }}/cloud/cdn/configure-fastly.html)
 
 {%include cloud/cloud-fastly-prereqs-custom-vcl.md%}
 
 {:.procedure}
-To bypass Fastly and submit requests to the origin server:
+To bypass Fastly cache based on IP address or URL:
 
 {% include cloud/admin-ui-login-step.md %}
 
@@ -64,6 +65,15 @@ To bypass Fastly and submit requests to the origin server:
 1. After the upload completes, refresh the cache according to the notification at the top of the page.
 
    Fastly validates the updated VCL version during the upload process. If the validation fails, edit your custom VCL snippet to fix any issues. Then, upload the VCL again.
+
+After you add the VCL snippet, you can use cURL commands to submit requests to the origin server from the specified IP address or URL as shown in the following example:
+
+```bash
+curl -svo /dev/null www.example.com/index.html
+```
+{:.no-copy}
+
+Then, inspect the response to troubleshoot issues with the uncached content.
 
 {% include cloud/cloud-fastly-manage-vcl-from-admin.md %}
 

--- a/src/cloud/cdn/trouble-fastly.md
+++ b/src/cloud/cdn/trouble-fastly.md
@@ -160,7 +160,7 @@ If the headers do not have the correct values, see the following information:
 
 ### Bypass Fastly cache to check Staging and Production sites {#cloud-test-stage}
 
-If the Fastly service returns incorrect headers, you can create a VCL snippet that allows you to submit API requests that bypass the Fastly cache. See [Bypass Fastly cache]({{site.baseurl}}/cloud/cdn/fastly-vcl-bypass-to-origin.html).
+If the Fastly service returns incorrect headers, you can create a VCL snippet that allows you to submit requests that bypass the Fastly cache. See [Bypass Fastly cache]({{site.baseurl}}/cloud/cdn/fastly-vcl-bypass-to-origin.html).
 
 After you add the VCL snippet, use cURL commands to submit requests to the origin server from the specified IP address. Then, check the responses for errors.
 

--- a/src/cloud/cdn/trouble-fastly.md
+++ b/src/cloud/cdn/trouble-fastly.md
@@ -139,7 +139,7 @@ To check the response headers:
    If you have not set a static route or completed the DNS configuration for the domains on your live site, use the `--resolve` flag, which bypasses DNS name resolution.
 
    ```bash
-   curl -svo /dev/null --resolve '<your_hostname>:443:<ip address of cache node>' <https URL>
+   curl -svo /dev/null --resolve '<your_hostname>:443:<IP-address-of-cache-node>' <https-URL>
    ```
 
    {:.bs-callout-info}

--- a/src/cloud/cdn/trouble-fastly.md
+++ b/src/cloud/cdn/trouble-fastly.md
@@ -33,7 +33,7 @@ You can use the same VCL for Production and Staging environments. See [How to co
 
 Use the following list to identify and troubleshoot issues related to the Fastly service configuration for your {{site.data.var.ece}} environment.
 
--  **Store menu does not display or work**—You might be using a link or temp link directly to the origin server instead of using the live site URL, or you used `-H "host:URL"` in a [cURL command](#curl). If you bypass Fastly to the origin server, the main menu does not work and incorrect headers display that allow caching on the browser side.
+-  **Store menu does not display or work**—You might be using a link or temp link directly to the origin server instead of using the live site URL, or you used `-H "host:URL"` in a [cURL command](#curl-live). If you bypass Fastly to the origin server, the main menu does not work and incorrect headers display that allow caching on the browser side.
 
 -  **Top level navigation does not work**—The top level navigation relies on Edge Side Includes (ESI) processing which is enabled when you upload the default Magento Fastly VCL snippets. If the navigation is not working, [upload the Fastly VCL]({{ site.baseurl }}/cloud/cdn/configure-fastly.html#upload-vcl-snippets) and recheck the site.
 
@@ -139,8 +139,11 @@ To check the response headers:
    If you have not set a static route or completed the DNS configuration for the domains on your live site, use the `--resolve` flag, which bypasses DNS name resolution.
 
    ```bash
-   curl https://<live URL> -vo /dev/null -H Fastly-Debug:1 [--resolve] <live URL hostname>:443:<live IP address>
+   curl -svo /dev/null --resolve '<your_hostname>:443:<ip address of cache node>' <https URL>
    ```
+
+   {:.bs-callout-info}
+   To use this command with the `--resolve` option, you must have TLS enabled with Fastly via a SSL/TLS certificate and find the IP address of the cache node.
 
 1. In the response, verify the [headers](#response-headers) to ensure that Fastly is working. You should see following unique headers in the response:
 
@@ -155,50 +158,11 @@ If the headers do not have the correct values, see the following information:
 
 -  [X-Cache contains only MISS, no HIT](#xcache-miss)
 
-### Bypass Fastly to check Staging and Production sites {#cloud-test-stage}
+### Bypass Fastly cache to check Staging and Production sites {#cloud-test-stage}
 
-If the Fastly service returns incorrect headers, you can create a VCL snippet that allows you to submit a Fastly API request directly to the origin server from a specified IP address, bypassing the Fastly CDN service. See [Bypass Fastly]({{site.baseurl}}/cloud/cdn/fastly-vcl-bypass-to-origin.html).
+If the Fastly service returns incorrect headers, you can create a VCL snippet that allows you to submit API requests that bypass the Fastly cache. See [Bypass Fastly cache]({{site.baseurl}}/cloud/cdn/fastly-vcl-bypass-to-origin.html).
 
-After you add the VCL snippet, you can use cURL commands to submit requests to the origin from the specified IP address.
-
-{:.procedure}
-To check the response headers:
-
-1. To get the response data, submit an API request to the origin server:
-
-   -  **Staging**
-
-      ```bash
-      curl http[s]://staging.<your domain>.c.<project ID>.ent.magento.cloud -H "Host:<URL>" -k -vo /dev/null -H Fastly-Debug:1
-      ```
-
-   -  **Production**
-
-      Submit the following request to test the load balancer:
-
-      ```bash
-      curl http[s]://<your domain>.c.<project ID>.ent.magento.cloud -H "Host:<URL>" -k -vo /dev/null -H Fastly-Debug:1
-      ```
-
-      Submit the following request to test a direct Origin node:
-
-      ```bash
-      curl http[s]:<your domain>.{1|2|3}.<project ID>.ent.magento.cloud -H "Host:<URL>" -k -vo /dev/null -H Fastly-Debug:1
-      ```
-
-      For example, if you have a public URL www.mymagento.biz, enter a command similar to the following to test the production site:
-
-      ```bash
-      curl -k https://www.mymagento.biz.c.sv7gVom4qrpek.ent.magento.cloud -H 'Host: www.mymagento.biz' -vo /dev/null -H Fastly-Debug:1
-      ```
-
-      If you have not completed the DNS configuration for the public hostname, remove the `"Host:<URL>"` option as shown in the following example:
-
-      ```bash
-      curl -k https://www.mymagento.biz.c.sv7gVom4qrpek.ent.magento.cloud -vo /dev/null -H Fastly-Debug:1
-      ```
-
-1. In the response, check for errors in the [cache HIT and MISS headers](#response-headers).
+After you add the VCL snippet, use cURL commands to submit requests to the origin server from the specified IP address. Then, check the responses for errors.
 
 ### Check cache HIT and MISS response headers {#response-headers}
 
@@ -290,7 +254,7 @@ If the `X-Cache` header contains `HIT` (`HIT, HIT` or `HIT, MISS`), it indicates
 
 If the `X-Cache` header is `MISS, MISS` and does not contain `HIT`, run the `curl` command again to make sure the page was not recently purged from the cache.
 
-If you get the same result, use the [`curl` commands](#curl) and verify the [response headers](#response-headers):
+If you get the same result, use the [`curl` commands](#curl-live) and verify the [response headers](#response-headers):
 
 -  `Pragma` is `cache`
 -  `X-Magento-Tags` exists
@@ -314,7 +278,7 @@ If the issue persists, another extension is likely resetting these headers. Repe
 
    -  Enable one extension at a time, save the configuration, and flush the Magento cache.
 
-   -  Run the [`curl` commands](#curl) to verify the [response headers](#response-headers).
+   -  Run the [`curl` commands](#curl-live) to verify the [response headers](#response-headers).
 
    Repeat this process for each extension. If the Fastly response headers no longer display, you have identified the extension causing issues with Fastly.
 

--- a/src/cloud/live/stage-prod-test.md
+++ b/src/cloud/live/stage-prod-test.md
@@ -16,7 +16,7 @@ Previous step
 
 [Migrate data and static files][]
 
-When your code, files, and data is successfully migrated to Staging or Production, use the environment URLs to test your site(s) and store(s). For a list of your URLs, see [Starter][] and [Pro][] access information.
+When your code, files, and data are successfully migrated to Staging or Production, use the environment URLs to test your site(s) and store(s). For a list of your URLs, see [Starter][] and [Pro][] access information.
 
 The following information provides information on verifying logs, testing Fastly configurations, user acceptance testing (UAT), and more.
 
@@ -40,53 +40,47 @@ Check the Magento configuration settings through the Admin panel including the B
 
 ## Check Fastly caching {#fastly}
 
-Verify Fastly is caching properly on Staging and Production. [Configuring Fastly][] requires careful attention to details, using the correct Fastly Service ID and Fastly API token, and a proper VCL snippet uploaded.
+[Configuring Fastly][] requires careful attention to detail–using the correct Fastly Service ID and Fastly API token credentials, uploading the Fastly VCL code, updating the DNS configuration, and applying the SSL/TLS certificates to your environments. If you have completed these tasks, you are ready to verify Fastly caching on Staging and Production environments.
 
-First, check for headers with a dig command to the URL. In a terminal application, enter `dig <url>` to verify Fastly services display in the headers. For additional `dig` tests, see Fastly's [Testing before changing DNS][].
+{:.procedure}
+To verify the Fastly service configuration:
 
-The following examples use Pro URLs. You can use any URL with the `dig` command.
+1. Log into the Magento Admin for Staging and Production using the URL with `/admin`, or the [updated Admin URL]({{ site.baseurl }}/cloud/env/environment-vars_magento.html#admin-url).
 
--  Staging: `dig http[s]://staging.<your domain>.c.<instanceid>.ent.magento.cloud`
--  Production: `dig http[s]://<your domain>.{1|2|3}.<project ID>.ent.magento.cloud`
-
-Next, use a `curl` command to verify X-Magento-Tags exist and additional header information. The format for the command is:
-
-```bash
-curl http[s]://<full site URL> -H "host: <url>" -k -vo /dev/null -HFastly-Debug:1
-```
-
-For Starter, enter the full site URL from your environment [Access info][] in the command to view the headers.
-
-For Pro Staging and Production, the command differs per server:
-
--  Staging: `curl http[s]://staging.<your domain>.c.<instanceid>.ent.magento.cloud -H "host: <url>" -k -vo /dev/null -HFastly-Debug:1`
--  Production:
-   -  The load balancer: `curl http[s]://<your domain>.c.<project ID>.ent.magento.cloud -H "host: <url>" -k -vo /dev/null -HFastly-Debug:1`
-   -  A direct Origin node: `curl http[s]://<your domain>.{1|2|3}.<project ID>.ent.magento.cloud -H "host: <url>" -k -vo /dev/null -HFastly-Debug:1`
-
-After you are live, you can also check your live site: `curl https://<your domain> -k -vo /dev/null -HFastly-Debug:1`. You can also add `--resolve` if your live URL is not set up with DNS.
-
-Check the returned response headers and values:
-
--  `Fastly-Magento-VCL-Uploaded` should be present
--  `X-Magento-Tags` should be returned
--  `Fastly-Module-Enabled` should be either `Yes` or the Fastly extension version number
--  `X-Cache` should be either `HIT` or `HIT, HIT`
--  `x-cache-hits` should be 1,1
--  [`Cache-Control: max-age`][] should be greater than 0
--  [`Pragma`][] should be `cache`
-
-To verify Fastly is enabled in Staging and Production, check the configuration in the Magento Admin for each environment:
-
-1. Log into the Admin console for Staging and Production using the URL with /admin (or the changed Admin URL).
 1. Navigate to **Stores** > **Settings** > **Configuration** > **Advanced** > **System**. Scroll and click **Full Page Cache**.
-1. Ensure Fastly CDN is selected.
+
+1. Ensure that the **Caching application** value is set to _Fastly CDN_ .
+
 1. Click on **Fastly Configuration**. Ensure the Fastly Service ID and Fastly API token are entered (your Fastly credentials). Verify you have the correct credentials entered for the Staging and Production environment. Click **Test credentials** to help.
 
-{:.bs-callout-warning}
-Make sure you entered the correct Fastly Service ID and API token in your Staging and Production environments. If you enter Staging credentials in your Production environment, you may not be able to upload your VCL snippets, caching will not work correctly, and your caching will be pointed to the wrong server and stores. Your Fastly credentials are created and mapped per service environment.
+   {:.bs-callout-warning}
+   Make sure that you entered the correct Fastly Service ID and API token in your Staging and Production environments. Fastly credentials are created and mapped per service environment. If you enter Staging credentials in your Production environment, you cannot upload your VCL snippets, caching does not work correctly, and your caching configuration points to the wrong server and stores.
 
-The module must be enabled to cache your site. If you have additional extensions enabled that affect headers, one of them could cause issues with Fastly. If you have further issues, see [Set up Fastly][] and [Fastly troubleshooting][].
+{:.procedure}
+To check Fastly caching behavior:
+
+1. Check for headers using the `dig` command-line utility to get information about the site configuration.
+
+   The following examples use Pro URLs. You can use any URL with the `dig` command.
+
+   -  Staging: `dig http[s]://mcstaging.<your-domain>.com`
+   -  Production: `dig http[s]://mcprod.<your-domain>.com`
+
+   For additional `dig` tests, see Fastly's [Testing before changing DNS][].
+
+1. Use `cURL` to verify the response header information:
+
+   ```bash
+   curl https://mcstaging.<your-domain>.com -H "host: mcstaging.<your-domain.com>" -k -vo /dev/null -H Fastly-Debug:1
+   ```
+
+   See [Check response headers][] for details about verifying the headers.
+
+1. After you are live, use the following command to check your live site:
+
+   ```curl
+   curl https://<your domain> -k -vo /dev/null -H Fastly-Debug:1
+   ```
 
 ## Complete UAT testing {#uat-testing}
 
@@ -230,22 +224,23 @@ We provide a free Security Scan Tool for your sites. To add your sites and run t
 
 <!--Link definitions-->
 
-[Migrate data and static files]: {{ site.baseurl }}/cloud/live/stage-prod-migrate.html
-[Starter]: {{ site.baseurl }}/cloud/live/stage-prod-migrate-prereq.html#starter-urls
-[Pro]: {{ site.baseurl }}/cloud/live/stage-prod-migrate-prereq.html#pro-urls
-[View logs]: {{ site.baseurl }}/cloud/project/log-locations
-[Configuring Fastly]: {{ site.baseurl }}/cloud/cdn/configure-fastly.html
-[Testing before changing DNS]: https://docs.fastly.com/en/guides/testing-setup-before-changing-domains
 [Access info]: {{ site.baseurl }}/cloud/live/stage-prod-migrate-prereq.html#starter-urls
+[Check response headers]: {{ site.baseurl }}/cloud/cdn/trouble-fastly.html#response-headers
+[Configuring Fastly]: {{ site.baseurl }}/cloud/cdn/configure-fastly.html
+[Fastly troubleshooting]: {{ site.baseurl }}/cloud/cdn/trouble-fastly.html
+[Jmeter]: https://jmeter.apache.org/
+[Magento Performance Toolkit]: {{ site.mage2bloburl }}/{{ site.version }}/setup/performance-toolkit
+[Magento Security Scan Tool]: {{ site.baseurl }}/cloud/live/live.html#security-scan
+[Magento application performance test]: {{ site.baseurl }}/cloud/env/variables-post-deploy.html#ttfb_tested_pages
+[Magento application testing]: {{site.baseurl}}/cloud/docker/docker-test-app-mftf.html
+[Migrate data and static files]: {{ site.baseurl }}/cloud/live/stage-prod-migrate.html
+[Pingdom]: https://www.pingdom.com/
+[Pro]: {{ site.baseurl }}/cloud/live/stage-prod-migrate-prereq.html#pro-urls
+[Set up Fastly]: {{ site.baseurl }}/cloud/cdn/cloud-fastly.html
+[Siege]: https://www.joedog.org/siege-home/
+[Starter]: {{ site.baseurl }}/cloud/live/stage-prod-migrate-prereq.html#starter-urls
+[Testing before changing DNS]: https://docs.fastly.com/en/guides/testing-setup-before-changing-domains
+[View logs]: {{ site.baseurl }}/cloud/project/log-locations
+[WebPageTest]: https://www.webpagetest.org/
 [`Cache-Control: max-age`]: https://www.w3.org/Protocols/rfc2616/rfc2616-sec14.html#sec14.9
 [`Pragma`]: https://www.w3.org/Protocols/rfc2616/rfc2616-sec14.html#sec14.32
-[Set up Fastly]: {{ site.baseurl }}/cloud/cdn/cloud-fastly.html
-[Fastly troubleshooting]: {{ site.baseurl }}/cloud/cdn/trouble-fastly.html
-[Magento Performance Toolkit]: {{ site.mage2bloburl }}/{{ site.version }}/setup/performance-toolkit
-[Magento application performance test]: {{ site.baseurl }}/cloud/env/variables-post-deploy.html#ttfb_tested_pages
-[Siege]: https://www.joedog.org/siege-home/
-[Jmeter]: https://jmeter.apache.org/
-[WebPageTest]: https://www.webpagetest.org/
-[Pingdom]: https://www.pingdom.com/
-[Magento application testing]: {{site.baseurl}}/cloud/docker/docker-test-app-mftf.html
-[Magento Security Scan Tool]: {{ site.baseurl }}/cloud/live/live.html#security-scan

--- a/src/cloud/live/stage-prod-test.md
+++ b/src/cloud/live/stage-prod-test.md
@@ -40,7 +40,7 @@ Check the Magento configuration settings through the Admin panel including the B
 
 ## Check Fastly caching {#fastly}
 
-[Configuring Fastly][] requires careful attention to detail–using the correct Fastly Service ID and Fastly API token credentials, uploading the Fastly VCL code, updating the DNS configuration, and applying the SSL/TLS certificates to your environments. If you have completed these tasks, you are ready to verify Fastly caching on Staging and Production environments.
+[Configuring Fastly][] requires careful attention to detail–using the correct Fastly Service ID and Fastly API token credentials, uploading the Fastly VCL code, updating the DNS configuration, and applying the SSL/TLS certificates to your environments. After completing these setup tasks, you can verify Fastly caching on Staging and Production environments.
 
 {:.procedure}
 To verify the Fastly service configuration:
@@ -51,7 +51,13 @@ To verify the Fastly service configuration:
 
 1. Ensure that the **Caching application** value is set to _Fastly CDN_ .
 
-1. Click on **Fastly Configuration**. Ensure the Fastly Service ID and Fastly API token are entered (your Fastly credentials). Verify you have the correct credentials entered for the Staging and Production environment. Click **Test credentials** to help.
+1. Test the Fastly credentials.
+
+   -  Click **Fastly Configuration**.
+
+   -  Verify that the values for the Fastly Service ID and Fastly API token credentials. See [Get Fastly credentials][].
+
+   -  Click **Test credentials**.
 
    {:.bs-callout-warning}
    Make sure that you entered the correct Fastly Service ID and API token in your Staging and Production environments. Fastly credentials are created and mapped per service environment. If you enter Staging credentials in your Production environment, you cannot upload your VCL snippets, caching does not work correctly, and your caching configuration points to the wrong server and stores.
@@ -63,8 +69,8 @@ To check Fastly caching behavior:
 
    The following examples use Pro URLs. You can use any URL with the `dig` command.
 
-   -  Staging: `dig http[s]://mcstaging.<your-domain>.com`
-   -  Production: `dig http[s]://mcprod.<your-domain>.com`
+   -  Staging: `dig https://mcstaging.<your-domain>.com`
+   -  Production: `dig https://mcprod.<your-domain>.com`
 
    For additional `dig` tests, see Fastly's [Testing before changing DNS][].
 
@@ -78,7 +84,7 @@ To check Fastly caching behavior:
 
 1. After you are live, use the following command to check your live site:
 
-   ```curl
+   ```bash
    curl https://<your domain> -k -vo /dev/null -H Fastly-Debug:1
    ```
 
@@ -228,6 +234,7 @@ We provide a free Security Scan Tool for your sites. To add your sites and run t
 [Check response headers]: {{ site.baseurl }}/cloud/cdn/trouble-fastly.html#response-headers
 [Configuring Fastly]: {{ site.baseurl }}/cloud/cdn/configure-fastly.html
 [Fastly troubleshooting]: {{ site.baseurl }}/cloud/cdn/trouble-fastly.html
+[Get Fastly credentials]: {{ site.baseurl }}/cloud/cdn/configure-fastly.html#cloud-fastly-creds
 [Jmeter]: https://jmeter.apache.org/
 [Magento Performance Toolkit]: {{ site.mage2bloburl }}/{{ site.version }}/setup/performance-toolkit
 [Magento Security Scan Tool]: {{ site.baseurl }}/cloud/live/live.html#security-scan

--- a/src/cloud/live/stage-prod-test.md
+++ b/src/cloud/live/stage-prod-test.md
@@ -67,14 +67,14 @@ To check Fastly caching behavior:
 
 1. Check for headers using the `dig` command-line utility to get information about the site configuration.
 
-   The following examples use Pro URLs. You can use any URL with the `dig` command.
+   You can use any URL with the `dig` command. The following examples use Pro URLs:
 
    -  Staging: `dig https://mcstaging.<your-domain>.com`
    -  Production: `dig https://mcprod.<your-domain>.com`
 
    For additional `dig` tests, see Fastly's [Testing before changing DNS][].
 
-1. Use `cURL` to verify the response header information:
+1. Use `cURL` to verify the response header information.
 
    ```bash
    curl https://mcstaging.<your-domain>.com -H "host: mcstaging.<your-domain.com>" -k -vo /dev/null -H Fastly-Debug:1
@@ -82,10 +82,10 @@ To check Fastly caching behavior:
 
    See [Check response headers][] for details about verifying the headers.
 
-1. After you are live, use the following command to check your live site:
+1. After you are live,  use `cURL` to check your live site.
 
    ```bash
-   curl https://<your domain> -k -vo /dev/null -H Fastly-Debug:1
+   curl https://<your-domain> -k -vo /dev/null -H Fastly-Debug:1
    ```
 
 ## Complete UAT testing {#uat-testing}

--- a/src/cloud/live/stage-prod-test.md
+++ b/src/cloud/live/stage-prod-test.md
@@ -16,7 +16,7 @@ Previous step
 
 [Migrate data and static files][]
 
-When your code, files, and data are successfully migrated to Staging or Production, use the environment URLs to test your site(s) and store(s). For a list of your URLs, see [Starter][] and [Pro][] access information.
+After a successful migration of your code, files, and data to Staging or Production, use the environment URLs to test your site(s) and store(s). For a list of your URLs, see [Starter][] and [Pro][] access information.
 
 The following information provides information on verifying logs, testing Fastly configurations, user acceptance testing (UAT), and more.
 


### PR DESCRIPTION
## Purpose of this pull request

Cleanup Test deployment and Custom bypass Fastly cache topics:

-   Remove direct origin URLs
-   Replaced inline links to "Check response" info with link to same info in troubleshooting topic
-   Replaced the instructions for bypass Fastly to check Staging and
-   Production sites with information about using custom VCL to bypass
-   Fastly cache instead of sending requests directly to origin server URL

## Affected DevDocs pages

- https://devdocs.magento.com/cloud/cdn/trouble-fastly.html#cloud-test-stage
- https://devdocs.magento.com/cloud/cdn/fastly-vcl-bypass-to-origin.html
- https://devdocs.magento.com/cloud/live/stage-prod-test.html
