### PR TITLE
Removed "A branch name of Sprint2 and sprint2 are just fine." #7825

### DIFF
--- a/src/cloud/reference/git-integration.md
+++ b/src/cloud/reference/git-integration.md
@@ -27,7 +27,7 @@ Not everyone remembers [Git](https://git-scm.com/docs) commands with ease. If yo
 In addition to Git's requirements for [valid branch names](https://www.kernel.org/pub/software/scm/git/docs/git-check-ref-format.html), {{site.data.var.ece}} adds two additional requirements:
 
 *  The `/` character isn't allowed in a branch name.
-*  Branch names must be case-insensitively unique. In other words, the names must be entirely unique regardless of the case you use. For example, if you have a branch named `Sprint`, you cannot create another branch named `sprint`.
+*  Branch names are not case-sensitive. Each name must be unique regardless of the case used for each letter. For example, if you have a branch named `Sprint`, you cannot create another branch named `sprint`.
 
 ## Git branching {#branching}
 

--- a/src/cloud/reference/git-integration.md
+++ b/src/cloud/reference/git-integration.md
@@ -27,7 +27,7 @@ Not everyone remembers [Git](https://git-scm.com/docs) commands with ease. If yo
 In addition to Git's requirements for [valid branch names](https://www.kernel.org/pub/software/scm/git/docs/git-check-ref-format.html), {{site.data.var.ece}} adds two additional requirements:
 
 *  The `/` character isn't allowed in a branch name.
-*  Branch names must be case-insensitively unique. In other words, the names must be entirely unique regardless of the case you use. For example, if you have a branch named `Sprint`, you cannot create another branch named `sprint`. A branch name of `Sprint2` and `sprint2` are just fine.
+*  Branch names must be case-insensitively unique. In other words, the names must be entirely unique regardless of the case you use. For example, if you have a branch named `Sprint`, you cannot create another branch named `sprint`.
 
 ## Git branching {#branching}
 


### PR DESCRIPTION
Fixes #7825 

## Purpose of this pull request

Clarified instructions for branch naming convention.

## Affected DevDocs pages

-  https://devdocs.magento.com/cloud/reference/git-integration.html
