### PR TITLE
Facilitate rake update tasks

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -17,6 +17,9 @@ require 'colorator'
 # Require helper methods from the 'lib' directory
 Dir.glob('lib/**/*.rb') { |file| require_relative(file) }
 
+# Instantiate Docfile data for usage in tasks
+@content_map = DocConfig.new.content_map
+
 desc "Same as 'rake', 'rake preview'"
 task default: %w[preview]
 

--- a/rakelib/multirepo.rake
+++ b/rakelib/multirepo.rake
@@ -7,8 +7,7 @@ namespace :multirepo do
   desc 'Create a file tree for devdocs website and get all required content'
   task :init do
     protocol = ENV['token'] ? "https://#{ENV['token']}@github.com/" : 'git@github.com:'
-    content_map = DocConfig.new.content_map
-    content_map.each do |subrepo|
+    @content_map.each do |subrepo|
       repo_url = protocol + subrepo['repository'] + '.git'
       add_subrepo(subrepo['directory'], repo_url , subrepo['branch'], subrepo['filter'])
     end
@@ -16,8 +15,7 @@ namespace :multirepo do
 
   desc 'Reinitialize subrepositories. CAUTION: This will remove directories and associated git repositories listed in Docfile'
   task reinit: %w[clean] do
-    content_map = DocConfig.new.content_map
-    content_map.each do |subrepo|
+    @content_map.each do |subrepo|
       if subrepo['directory']
         puts "Removing #{subrepo['directory']}".yellow
         sh 'rm', '-rf', subrepo['directory']

--- a/rakelib/update.rake
+++ b/rakelib/update.rake
@@ -49,14 +49,21 @@ namespace :update do
   task all: %w[devdocs subrepos]
 
   desc 'Update subrepositories only'
-  task subrepos: %w[mbi pb pbm mftf]
+  task :subrepos do
+    @content_map.each do |subrepo|
+      update_dir subrepo['directory']
+    end
+  end
 end
 
 def update_dir(dir)
   abort "Cannot find the #{dir} directory. You can run 'rake init' to create it and rerun 'rake update:all' again.".red unless Dir.exist? dir
   Dir.chdir dir do
+    puts "Updating #{dir}:".magenta
+
+    next warn "No branch to update" if `git status -sb`.include? 'no branch'
     sh 'git remote -v'
-    sh 'git pull'
+    sh 'git pull --no-recurse-submodules'
     sh 'git status -sb'
   end
 end


### PR DESCRIPTION
## Purpose of this pull request

This pull request (PR) updates rake update tasks:
- Omits pulling updates for submodules at subrepos
- Reads directories with subrepos from Docfile instead of hardcoded
- Instantiates content map only once and reuses it in tasks

### How to test

Run `rake update:subrepos` (or `rake update:all`)

- The result should report about all the directories listed in the Docfile
- No failures caused by submodules at subrepos