### PR TITLE
Remove abandoned Baler module

### DIFF
--- a/src/guides/v2.3/performance-best-practices/advanced-js-bundling.md
+++ b/src/guides/v2.3/performance-best-practices/advanced-js-bundling.md
@@ -7,13 +7,6 @@ functional_areas:
   - Setup
 ---
 
- {:.bs-callout-info}
-Magento's **[`baler`][]** module is now open for _Alpha testing_.
-This is a custom AMD module bundler and preloader for Magento 2.
-It is designed to provide optimal bundles and be less error-prone than the built-in Magento bundler.
-
-[`baler`]: https://github.com/magento/baler
-
 ## Introduction
 
 Bundling JavaScript modules for better performance is about reducing two things:


### PR DESCRIPTION
## Purpose of this pull request

Magento's "early Alpha" bundling solution `baler` has not been under development since the release of Magento v2.3.4, 7 months ago – I propose it be removed from the "Advanced JavaScript bundling" page masthead.

* Because of the staleness of the repository, [unresolved issues are cropping up](https://github.com/magento/baler/issues)
* Modern dependency versions [pose issues with the module](https://github.com/magento/baler/issues/62), and need to be manually downgraded and pinned
* The underlying M2 module [does not support PHP 7.4](https://github.com/magento/m2-baler/blob/c491c97b6f98567c7015290c6163d6e3f4a94a09/composer.json#L8), and is thus incompatible with Magento v2.4
* `baler`, in general, does not appear to have been tested whatsoever on modern Magento versions

I desperately hope development on `baler` is resuscitated. It's a fabulous tool, and better bundling _is_ needed on Magento. But recommending a stale, broken, unsupported, and undeveloped approach – even in an "alpha testing" way – does not seem wise!

Magento's "Magento Tech Tips," a resource that provides performance advice for Commerce Cloud clients, links out to this page. Clients should _not_ be seeing broken alpha software recommendations in the masthead. I've even had Commerce Cloud 
support reps recommend I test out `baler` to improve performance on clients. Another no-no.

Also see my issue on the `baler` repo proper: https://github.com/magento/baler/issues/70

## Affected DevDocs pages

- https://devdocs.magento.com/guides/v2.4/performance-best-practices/advanced-js-bundling.html
- https://devdocs.magento.com/guides/v2.3/performance-best-practices/advanced-js-bundling.html

## Links to Magento source code

- https://github.com/magento/baler
- https://github.com/magento/m2-baler