### PR TITLE
Removed orphaned page - nothing ever linked to this

### DIFF
--- a/src/guides/v2.3/javascript-dev-guide/back_to_guide.md
+++ b/src/guides/v2.3/javascript-dev-guide/back_to_guide.md
@@ -1,7 +1,0 @@
----
-group: javascript
-subgroup: Back to JavaScript section
-title: Modal widget
----
-
-Go back to [JavaScript section of the Frontend Developer Guide]({{page.baseurl}}/javascript-dev-guide/javascript/js_overview.html).

--- a/src/guides/v2.4/javascript-dev-guide/back_to_guide.md
+++ b/src/guides/v2.4/javascript-dev-guide/back_to_guide.md
@@ -1,1 +1,0 @@
-../../v2.3/javascript-dev-guide/back_to_guide.md


### PR DESCRIPTION
## Purpose of this pull request

This pull request (PR) fixes issue #7435 

This page has no real content and there is not link to it anywhere.

## Affected DevDocs pages
https://devdocs.magento.com/guides/v2.3/javascript-dev-guide/back_to_guide.html
https://devdocs.magento.com/guides/v2.4/javascript-dev-guide/back_to_guide.html
