### PR TITLE
MCLOUD-6896: Add possibility to pass ECE-Tools environment variables

### DIFF
--- a/src/cloud/docker/docker-config.md
+++ b/src/cloud/docker/docker-config.md
@@ -48,14 +48,14 @@ The mode option for the `ece-docker build:compose` command does not affect the M
 
 ## Set the environment variables
 
-You can launch a Docker with predefined environment variable by passing them in `--env-vars` option.
+You can launch a Cloud Docker environment with predefined environment variables by adding the `--env-vars` option to the `ece-docker build:compose` command.
 
 For example,
 ```
 bin/ece-docker build:compose --env-vars="{\"MAGENTO_CLOUD_VARIABLES\":{\"LOCK_PROVIDER\":\"db\",\"CRON_CONSUMERS_RUNNER\":{\"cron_run\":\"true\",\"max_messages\":5000,\"consumers\":[\"test\"]}}}"
 ```
 
-Use the next php script to generate value for `--env-vars` option:
+You must escape special characters when specifying the value for the `--env-vars` option. Use the following PHP script to generate the escaped value. Update the example with the values required for your Cloud Docker environment configuration.
 ```php
 <?php
 

--- a/src/cloud/docker/docker-config.md
+++ b/src/cloud/docker/docker-config.md
@@ -56,6 +56,7 @@ bin/ece-docker build:compose --env-vars="{\"MAGENTO_CLOUD_VARIABLES\":{\"LOCK_PR
 ```
 
 You must escape special characters when specifying the value for the `--env-vars` option. Use the following PHP script to generate the escaped value. Update the example with the values required for your Cloud Docker environment configuration.
+
 ```php
 <?php
 

--- a/src/cloud/docker/docker-config.md
+++ b/src/cloud/docker/docker-config.md
@@ -46,6 +46,31 @@ To skip the interactive mode, use the `-n, --no-interaction` option.
 {:.bs-callout-info}
 The mode option for the `ece-docker build:compose` command does not affect the Magento mode. It determines the {{site.data.var.ece}} file system installation and read-only or read-write behavior.
 
+## Set the environment variables
+
+You can launch a Docker with predefined environment variable by passing them in `--env-vars` option.
+
+For example,
+```
+bin/ece-docker build:compose --env-vars="{\"MAGENTO_CLOUD_VARIABLES\":{\"LOCK_PROVIDER\":\"db\",\"CRON_CONSUMERS_RUNNER\":{\"cron_run\":\"true\",\"max_messages\":5000,\"consumers\":[\"test\"]}}}"
+```
+
+Use the next php script to generate value for `--env-vars` option:
+```php
+<?php
+
+echo addslashes(json_encode([
+   'MAGENTO_CLOUD_VARIABLES' => [
+       'LOCK_PROVIDER' => 'db',
+       'CRON_CONSUMERS_RUNNER' => [
+           'cron_run' => 'true',
+           'max_messages' => 5000,
+           'consumers' => ['test'],
+       ],
+   ]
+]));
+```
+
 ## Stop and start containers
 
 You can stop containers and restore them afterwards using the following methods.


### PR DESCRIPTION
## Purpose of this pull request

This pull request (PR)  will add info on how to configure environment variables for docker containers.

## Affected DevDocs pages

<!-- REQUIRED List the affected pages on devdocs.magento.com (URLs). Not needed for large numbers of files. -->

-  https://devdocs.magento.com/cloud/docker/docker-config.html

<!--
If you are fixing a GitHub issue, note it using GitHub keyword format (https://help.github.com/en/articles/closing-issues-using-keywords#closing-an-issue-in-a-different-repository) to close the issue when this pull request is merged. Example: `Fixes #1234`

`master` is the default branch. Merged pull requests to `master` go live on the site automatically. Any requested changes to content on the `master` branch must be related to the released codebase. Any content related to future releases goes in the `develop` branch.

See Contribution guidelines (https://github.com/magento/devdocs/blob/master/.github/CONTRIBUTING.md) for more information.
-->
