### PR TITLE
Fix missing "\" in new implementation example

### DIFF
--- a/src/guides/v2.4/config-guide/redis/redis-pg-cache.md
+++ b/src/guides/v2.4/config-guide/redis/redis-pg-cache.md
@@ -104,7 +104,7 @@ As of Magento 2.3.5, it is recommended to use the extended Redis cache implement
 'cache' => [
     'frontend' => [
         'default' => [
-            'backend' => '\\Magento\\Framework\\Cache\\Backend\Redis',
+            'backend' => '\\Magento\\Framework\\Cache\\Backend\\Redis',
             'backend_options' => [
                 'server' => '127.0.0.1',
                 'database' => '0',


### PR DESCRIPTION
## Purpose of this pull request

Fix documentation mis-type on Redis configuration. Code example was missing double-backslash in code example

## Affected DevDocs pages

-  https://devdocs.magento.com/guides/v2.4/config-guide/redis/redis-pg-cache.html
