### PR TITLE
Move clean up instructions earlier in the upgrade procedure

### DIFF
--- a/src/guides/v2.4/comp-mgr/cli/cli-upgrade.md
+++ b/src/guides/v2.4/comp-mgr/cli/cli-upgrade.md
@@ -148,16 +148,6 @@ composer require magento/product-community-edition=2.3.3-p1 --no-update
    composer update
    ```
 
-1. Clean the Magento cache.
-
-   ```bash
-   bin/magento cache:clean
-   ```
-
-## Clean up
-
-Manually clear caches and generated content.
-
 1. Clear the `var/` and `generated/` subdirectories:
 
    ```bash


### PR DESCRIPTION
## Purpose of this pull request

This pull request (PR) moves the "clean up" info up in the procedure to prevent upgrade issues per internal ticket MC-37662.

## Affected DevDocs pages

- https://devdocs.magento.com/guides/v2.4/comp-mgr/cli/cli-upgrade.html