### PR TITLE
Remove Magento-Doc-Feedback email address

### DIFF
--- a/.github/CODE_OF_CONDUCT.md
+++ b/.github/CODE_OF_CONDUCT.md
@@ -55,7 +55,7 @@ further defined and clarified by project maintainers.
 ## Enforcement
 
 Instances of abusive, harassing, or otherwise unacceptable behavior may be
-reported by contacting the project team at DL-Magento-Doc-Feedback@magento.com. All
+reported by contacting the project team in [Slack](https://magentocommeng.slack.com/messages/CAN932A3H). All
 complaints will be reviewed and investigated and will result in a response that
 is deemed necessary and appropriate to the circumstances. The project team is
 obligated to maintain confidentiality with regard to the reporter of an incident.

--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -151,6 +151,5 @@ Have a question? Need help? Magento DevDocs, Maintainers, and other Contributors
 
 -  [Slack](https://magentocommeng.slack.com/messages/CAN932A3H) ([Join us](http://tinyurl.com/engcom-slack))
 -  [Twitter @MagentoDevDocs](https://twitter.com/MagentoDevDocs)
--  [E-mail](mailto:DL-Magento-Doc-Feedback@magento.com)
 
 Thank you for contributing your brilliance to Magento DevDocs!!

--- a/README.md
+++ b/README.md
@@ -169,4 +169,3 @@ If you have questions, open an issue and ask us. We're looking forward to hearin
 
 -  [Visit our wiki](https://github.com/magento/devdocs/wiki)
 -  <a href="https://twitter.com/MagentoDevDocs" class="twitter-follow-button" data-show-count="false">Follow @MagentoDevDocs</a>
--  [E-mail us](mailto:DL-Magento-Doc-Feedback@magento.com)

--- a/src/guides/v2.3/bk-get-started-magento.md
+++ b/src/guides/v2.3/bk-get-started-magento.md
@@ -29,11 +29,6 @@ by creating pull requests, or open a discussion by creating an issue.
 
 For more information, see our [Contributors Guide](https://github.com/magento/devdocs/blob/master/.github/CONTRIBUTING.md).
 
-## Contact us {#contact-us}
-
-Feel free to contact the documentation team directly at
-[DL-Magento-Doc-Feedback@magento.com](mailto:DL-Magento-Doc-Feedback@magento.com)
-
 {:.ref-header}
 Related topics
 


### PR DESCRIPTION
## Purpose of this pull request

This pull request (PR) removes references to the Magento-Doc-Feedback email address because we only receive spam. Preferred contact method is Slack or directly through the GitHub repo.