### PR TITLE
Fix typo in extension dev guide

### DIFF
--- a/src/guides/v2.3/extension-dev-guide/cache/page-caching/private-content.md
+++ b/src/guides/v2.3/extension-dev-guide/cache/page-caching/private-content.md
@@ -62,7 +62,7 @@ All properties are available in the template.
 
 Specify actions that trigger cache invalidation for private content blocks in a `sections.xml` configuration file in the `Vendor/ModuleName/etc/frontend` directory. Magento invalidates the cache on a POST or PUT request.
 
-Customer sections was designed to cache private data in browser storage. This means that any customer section will no be updated until proper action was made.
+Customer sections was designed to cache private data in browser storage. This means that any customer section will not be updated until proper action was made.
 
 The are some exception cases:
 


### PR DESCRIPTION
## Purpose of this pull request

This pull request (PR) fixes a typo reported in chat.

## Affected DevDocs pages

https://devdocs.magento.com/guides/v2.4/extension-dev-guide/cache/page-caching/private-content.html#invalidate-private-content

3rd sentence in the section:
“This means that any customer section will --no-- be updated until proper action was made.”
“no” should be changed to be “not”