### PR TITLE
Update content related lazyload section for theme images

### DIFF
--- a/src/guides/v2.4/frontend-dev-guide/themes/theme-images.md
+++ b/src/guides/v2.4/frontend-dev-guide/themes/theme-images.md
@@ -186,15 +186,12 @@ Variables may be used within the scope of modules than the defined one.
 
 ### Image lazy loading {#lazy_loading}
 
-When saving products, images are resized based on different properties including the `frame` variable `product_image_white_borders` in `view.xml`.
+When saving products, images are resized based on different properties including the `frame` and variable `product_image_white_borders` defined in `view.xml`.
 By default, all images have frames. Magento calculates the required frame size and then it allocates the image to it.
 If the image is small, the white frame will be bigger.
 
 The variable `product_image_white_borders` can be overwritten in a custom theme. If it is not defined in a custom theme, it can also be set in `app/code/Magento/Catalog/etc/view.xml`.
-Variables defined in the theme `view.xml` have a higher priority. If the same variable is in a module's and also in the theme's `view.xml`, the module variable will be overwritten by the theme variable.
+Variables defined in the theme can set at `etc/view.xml` in each theme directory will have a higher priority. If the same variable is in a module's and also in the theme's `view.xml`, the module variable will be overwritten by the theme variable.
 
 If the `frame` property is enabled in the configuration file, native lazy-loading is enabled on the category product page, checkout shopping cart, and customer wish list.
-If the `frame` property is disabled, image lazy-loading is also disabled, unless the variable `enable_lazy_loading_for_images_without_borders` is enabled in `view.xml`.
-This is done to prevent small images from being stretched and distorted.
-
-If you have images within frames, and you are sure your images are correctly sized, you can enable lazy-loading by setting `enable_lazy_loading_for_images_without_borders` to `1` in `view.xml`.
+If the `frame` property is disabled, image lazy-loading is also disabled.


### PR DESCRIPTION
## Purpose of this pull request

This pull request (PR) will update content for lazy-load section in theme images topic.
Magento core will no longer use variable `enable_lazy_loading_for_images_without_borders` mentioned in docs. Clean docs to avoid confusing for devs

## Affected DevDocs pages

<!-- REQUIRED List the affected pages on devdocs.magento.com (URLs). Not needed for large numbers of files. -->

https://devdocs.magento.com/guides/v2.4/frontend-dev-guide/themes/theme-images.html#lazy_loading

## Links to Magento source code

<!--  OPTIONAL - REMOVE THIS SECTION IF NOT USED. If this pull request references a file in a Magento codebase repository, add it here. -->


<!--
If you are fixing a GitHub issue, note it using GitHub keyword format (https://help.github.com/en/articles/closing-issues-using-keywords#closing-an-issue-in-a-different-repository) to close the issue when this pull request is merged. Example: `Fixes #1234`

`master` is the default branch. Merged pull requests to `master` go live on the site automatically. Any requested changes to content on the `master` branch must be related to the released codebase. Any content related to future releases goes in the `develop` branch.

See Contribution guidelines (https://github.com/magento/devdocs/blob/master/.github/CONTRIBUTING.md) for more information.
-->
