### PR TITLE
Update php extensions template to include ext-sockets

### DIFF
--- a/src/_includes/install/php-extensions-template.md
+++ b/src/_includes/install/php-extensions-template.md
@@ -7,6 +7,7 @@
   {% endif %}
 {% endfor %}
 {% unless page.guide_version == '2.3' %}
+
 *  ext-sockets
 
 {% else %}

--- a/src/_includes/install/php-extensions-template.md
+++ b/src/_includes/install/php-extensions-template.md
@@ -13,5 +13,5 @@
 {% else %}
 
 {:.bs-callout-warning}
-If you install Magento via cloning from the [GitHub](https://github.com/magento/magento2) repository then make sure you have the [ext-sockets](https://github.com/php-amqplib/php-amqplib/blob/master/CHANGELOG.md#281---2018-11-13) installed on your instance.
+If you install Magento by cloning from the [GitHub](https://github.com/magento/magento2) repository, you must have the [ext-sockets](https://github.com/php-amqplib/php-amqplib/blob/master/CHANGELOG.md#281---2018-11-13) installed on your instance.
 {% endunless %}

--- a/src/_includes/install/php-extensions-template.md
+++ b/src/_includes/install/php-extensions-template.md
@@ -6,3 +6,10 @@
 *  {{ item[0] }}
   {% endif %}
 {% endfor %}
+{% unless page.guide_version == '2.3' %}
+*  ext-sockets
+{% else %}
+
+{:.bs-callout-warning}
+If you install Magento via cloning from the [GitHub](https://github.com/magento/magento2) repository then make sure you have the [ext-sockets](https://github.com/php-amqplib/php-amqplib/blob/master/CHANGELOG.md#281---2018-11-13) installed on your instance.
+{% endunless %}

--- a/src/_includes/install/php-extensions-template.md
+++ b/src/_includes/install/php-extensions-template.md
@@ -8,6 +8,7 @@
 {% endfor %}
 {% unless page.guide_version == '2.3' %}
 *  ext-sockets
+
 {% else %}
 
 {:.bs-callout-warning}

--- a/src/_includes/install/php-extensions-template.md
+++ b/src/_includes/install/php-extensions-template.md
@@ -10,8 +10,4 @@
 
 *  ext-sockets
 
-{% else %}
-
-{:.bs-callout-warning}
-If you install Magento by cloning from the [GitHub](https://github.com/magento/magento2) repository, you must have the [ext-sockets](https://github.com/php-amqplib/php-amqplib/blob/master/CHANGELOG.md#281---2018-11-13) installed on your instance.
 {% endunless %}

--- a/src/guides/v2.4/install-gde/prereq/php-settings.md
+++ b/src/guides/v2.4/install-gde/prereq/php-settings.md
@@ -41,9 +41,6 @@ Magento requires a set of extensions to be installed:
 <!--{% assign packages = site.data.codebase.v2_4.open-source.composer_lock.packages %}-->
 {% include install/php-extensions-template.md %}
 
-{:.bs-callout-warning}
-If you install Magento 2.3 by cloning the [magento/magento2](https://github.com/magento/magento2) GitHub repository, you must have the [ext-sockets](https://github.com/php-amqplib/php-amqplib/blob/master/CHANGELOG.md#281---2018-11-13) extension installed on your system. The `ext-sockets` extension is required for Magento 2.4.
-
 {:.procedure}
 To verify installed extensions:
 


### PR DESCRIPTION
## Purpose of this pull request

Update the PHP extensions template to include `ext-sockets` requirements in v2.3 and 2.4.

## Affected DevDocs pages

- https://devdocs.magento.com/guides/v2.4/install-gde/prereq/php-settings.html#verify-installed-extensions
- https://devdocs.magento.com/guides/v2.3/install-gde/prereq/php-settings.html
