### PR TITLE
Add a warning about the `REDIS_USE_SLAVE_CONNECTION` deploy variable

### DIFF
--- a/src/cloud/env/variables-deploy.md
+++ b/src/cloud/env/variables-deploy.md
@@ -408,6 +408,9 @@ If you specify `\Magento\Framework\Cache\Backend\RemoteSynchronizedCache` as the
 -  **Default**—`false`
 -  **Version**—Magento 2.1.16 and later
 
+{:.bs-callout-warning}
+You should not enable this on scaled architecture (split architecture) projects because it will cause Redis connection errors. Redis slaves are still active but will not be used for Redis reads. As an alternative for scaled architecture, we recommend using Magento 2.3.5 or later, implementing a new Redis backend configuration, and implementing L2 caching for Redis.
+
 Magento can read multiple Redis instances asynchronously. Set to `true` to automatically use a _read-only_ connection to a Redis instance to receive read-only traffic on a non-master node. This improves performance through load balancing, because only one node needs to handle read-write traffic. Set to `false` to remove any existing read-only connection array from the `env.php` file.
 
 ```yaml

--- a/src/cloud/env/variables-deploy.md
+++ b/src/cloud/env/variables-deploy.md
@@ -409,7 +409,7 @@ If you specify `\Magento\Framework\Cache\Backend\RemoteSynchronizedCache` as the
 -  **Version**—Magento 2.1.16 and later
 
 {:.bs-callout-warning}
-You should not enable this on scaled architecture (split architecture) projects because it will cause Redis connection errors. Redis slaves are still active but will not be used for Redis reads. As an alternative for scaled architecture, we recommend using Magento 2.3.5 or later, implementing a new Redis backend configuration, and implementing L2 caching for Redis.
+Do not enable this variable on scaled architecture (split architecture) projects because it will cause Redis connection errors. Redis slaves are still active but will not be used for Redis reads. As an alternative, we recommend the following: use Magento 2.3.5 or later on Cloud projects with a scaled architecture, implement a new Redis backend configuration, and implement L2 caching for Redis.
 
 Magento can read multiple Redis instances asynchronously. Set to `true` to automatically use a _read-only_ connection to a Redis instance to receive read-only traffic on a non-master node. This improves performance through load balancing, because only one node needs to handle read-write traffic. Set to `false` to remove any existing read-only connection array from the `env.php` file.
 

--- a/src/cloud/env/variables-deploy.md
+++ b/src/cloud/env/variables-deploy.md
@@ -409,7 +409,7 @@ If you specify `\Magento\Framework\Cache\Backend\RemoteSynchronizedCache` as the
 -  **Version**—Magento 2.1.16 and later
 
 {:.bs-callout-warning}
-Do not enable this variable on scaled architecture (split architecture) projects because it will cause Redis connection errors. Redis slaves are still active but will not be used for Redis reads. As an alternative, we recommend the following: use Magento 2.3.5 or later on Cloud projects with a scaled architecture, implement a new Redis backend configuration, and implement L2 caching for Redis.
+Do not enable this variable on scaled architecture (split architecture) projects. It causes Redis connection errors. Redis slaves are still active but will not be used for Redis reads. As an alternative, we recommend the following: use Magento 2.3.5 or later on Cloud projects with a scaled architecture, implement a new Redis backend configuration, and implement L2 caching for Redis.
 
 Magento can read multiple Redis instances asynchronously. Set to `true` to automatically use a _read-only_ connection to a Redis instance to receive read-only traffic on a non-master node. This improves performance through load balancing, because only one node needs to handle read-write traffic. Set to `false` to remove any existing read-only connection array from the `env.php` file.
 


### PR DESCRIPTION
## Purpose of this pull request

This pull request (PR) adds a warning about enabling the `REDIS_USE_SLAVE_CONNECTION` deploy variable for cloud projects that use split architecture.

For Scaled Architecture (Split Architecture), Redis Slave Connections ‘SHOULD NOT’ be enabled.

We received a complaint from a partner that there is no warning about this in the docs.

## Affected DevDocs pages

- https://devdocs.magento.com/cloud/env/variables-deploy.html#redis_use_slave_connection

whatsnew
Added a [warning](https://devdocs.magento.com/cloud/env/variables-deploy.html#redis_use_slave_connection) about enabling the `REDIS_USE_SLAVE_CONNECTION` deploy variable for Cloud projects that use split architecture.