### PR TITLE
Add storageConfig entry to data provider of admin grid doc

### DIFF
--- a/src/guides/v2.3/extension-dev-guide/admin-grid.md
+++ b/src/guides/v2.3/extension-dev-guide/admin-grid.md
@@ -114,6 +114,9 @@ The UI component `dev_grid_category_listing` must be defined separately in a fil
        <argument name="data" xsi:type="array">
          <item name="config" xsi:type="array">
            <item name="update_url" xsi:type="url" path="mui/index/render"/>
+           <item name="storageConfig" xsi:type="array">
+             <item name="indexField" xsi:type="string">entity_id</item>
+           </item>
          </item>
        </argument>
    </argument>


### PR DESCRIPTION
## Purpose of this pull request

Without storage config the filter clearing leads to a bug. The solution is found at https://magento.stackexchange.com/a/132130/31734.

Credits to [Tony Bartiloro](https://magento.stackexchange.com/users/43467/tony-bartiloro)

## Affected DevDocs pages

- https://devdocs.magento.com/guides/v2.3/extension-dev-guide/admin-grid.html
- https://devdocs.magento.com/guides/v2.4/extension-dev-guide/admin-grid.html
