### PR TITLE
Fix wrong file name > nginx.conf.sample

### DIFF
--- a/src/guides/v2.3/config-guide/secy/secy-cron.md
+++ b/src/guides/v2.3/config-guide/secy/secy-cron.md
@@ -133,7 +133,7 @@ Consult one of the following resources to create a password file before continui
 
 Magento provides an optimized sample nginx configuration file out of the box. We recommend modifying it to secure cron.
 
-1. Add the following to your Magento [`nginx.sample.conf`]({{ site.mage2bloburl }}/{{ page.guide_version }}/nginx.conf.sample){:target="_blank"} file:
+1. Add the following to your Magento [`nginx.conf.sample`]({{ site.mage2bloburl }}/{{ page.guide_version }}/nginx.conf.sample){:target="_blank"} file:
 
    ```conf
    #Securing cron


### PR DESCRIPTION
## Purpose of this pull request

The purpose is to fix the wrong file name **nginx.conf.sample**.

## Affected DevDocs pages

<!-- REQUIRED List the affected pages on devdocs.magento.com (URLs). Not needed for large numbers of files. -->

-  https://devdocs.magento.com/guides/v2.4/config-guide/secy/secy-cron.html#secure-cron-in-nginxconfsample
-  https://devdocs.magento.com/guides/v2.3/config-guide/secy/secy-cron.html#secure-cron-in-nginxconfsample

## Links to Magento source code

<!--  OPTIONAL - REMOVE THIS SECTION IF NOT USED. If this pull request references a file in a Magento codebase repository, add it here. -->

-  https://github.com/magento/magento2/blob/2.3/nginx.conf.sample
<!--
If you are fixing a GitHub issue, note it using GitHub keyword format (https://help.github.com/en/articles/closing-issues-using-keywords#closing-an-issue-in-a-different-repository) to close the issue when this pull request is merged. Example: `Fixes #1234`

`master` is the default branch. Merged pull requests to `master` go live on the site automatically. Any requested changes to content on the `master` branch must be related to the released codebase. Any content related to future releases goes in the `develop` branch.

See Contribution guidelines (https://github.com/magento/devdocs/blob/master/.github/CONTRIBUTING.md) for more information.
-->
