### PR TITLE
MCLOUD-6394: Help with running MFTF test generation commands

### DIFF
--- a/src/cloud/docker/docker-containers-service.md
+++ b/src/cloud/docker/docker-containers-service.md
@@ -182,6 +182,14 @@ docker-compose run --rm redis redis-cli -h redis
 
 The Selenium container, based on the [selenium/standalone-chrome/](https://hub.docker.com/r/selenium/standalone-chrome/h), enables the [Magento Functional Testing Framework (MFTF)](https://devdocs.magento.com/mftf/docs/introduction.html) for Magento application testing in the Cloud Docker environment. See [Magento application testing]({{site.baseurl}}/cloud/docker/docker-test-app-mftf.html).
 
+## Test container
+
+**Container name**: test<br/>
+**Docker base image**: [magento/magento-cloud-docker-php][php-cloud], which is based on the [php](https://hub.docker.com/_/php) Docker image<br/>
+**Ports exposed**: None<br/>
+
+The Test container, based on the [magento/magento-cloud-docker-php][php-cloud] has writable file system and using for Magento application testing in the Cloud Docker environment. See [Magento application testing]({{site.baseurl}}/cloud/docker/docker-test-app-mftf.html).
+
 ## TLS container
 
 **Container name**: tls<br/>

--- a/src/cloud/docker/docker-containers-service.md
+++ b/src/cloud/docker/docker-containers-service.md
@@ -188,7 +188,7 @@ The Selenium container, based on the [selenium/standalone-chrome/](https://hub.d
 **Docker base image**: [magento/magento-cloud-docker-php][php-cloud], which is based on the [php](https://hub.docker.com/_/php) Docker image<br/>
 **Ports exposed**: None<br/>
 
-The Test container, based on the [magento/magento-cloud-docker-php][php-cloud] has writable file system and using for Magento application testing in the Cloud Docker environment. See [Magento application testing]({{site.baseurl}}/cloud/docker/docker-test-app-mftf.html).
+The Test container, based on the [magento/magento-cloud-docker-php][php-cloud] has a writable file system and is used for Magento application testing in the Cloud Docker environment. See [Magento application testing]({{site.baseurl}}/cloud/docker/docker-test-app-mftf.html).
 
 ## TLS container
 

--- a/src/cloud/docker/docker-containers-service.md
+++ b/src/cloud/docker/docker-containers-service.md
@@ -188,7 +188,7 @@ The Selenium container, based on the [selenium/standalone-chrome/](https://hub.d
 **Docker base image**: [magento/magento-cloud-docker-php][php-cloud], which is based on the [php](https://hub.docker.com/_/php) Docker image<br/>
 **Ports exposed**: None<br/>
 
-The Test container, based on the [magento/magento-cloud-docker-php][php-cloud] has a writable file system and is used for Magento application testing in the Cloud Docker environment. See [Magento application testing]({{site.baseurl}}/cloud/docker/docker-test-app-mftf.html).
+The Test container, based on the [magento/magento-cloud-docker-php][php-cloud] Docker image has a writable file system and is used for Magento application testing in the Cloud Docker environment. See [Magento application testing]({{site.baseurl}}/cloud/docker/docker-test-app-mftf.html).
 
 ## TLS container
 

--- a/src/cloud/docker/docker-containers.md
+++ b/src/cloud/docker/docker-containers.md
@@ -49,7 +49,7 @@ The following table shows the options to customize service container configurati
 | [rabbitmq][rabbitmq-container]| RabbitMQ | `--rmq` | 3.5, 3.7, 3.8 |
 | [redis][redis-container] | Redis     | `--redis` | 3.2, 4.0, 5.0 |   Standard redis container
 | [selenium][selenium-container]| Selenium | `--with-selenium`<br>`--selenium-version`<br>`--selenium-image`| Any | Enables Magento application testing using the Magento Functional Testing Framework (MFTF)
-| [test][test-container]| PHP CLI | `--with-test`| Any | Creates PHP CLI based container with writable file system for test running
+| [test][test-container]| PHP CLI | `--with-test`| Any | Creates PHP CLI based container with writable file system for running tests
 | [tls][tls-container] | SSL Endpoint |  |   |  Terminates SSL, can be configured to pass to varnish or nginx
 | [varnish][varnish-container] | Varnish | `--no-varnish` | 4, 6.2 | Varnish is provisioned by default. Use the `--no-varnish` option to skip Varnish service installation
 | [web][web-container] | NGINX | `--nginx` | 1.9, latest |

--- a/src/cloud/docker/docker-containers.md
+++ b/src/cloud/docker/docker-containers.md
@@ -49,6 +49,7 @@ The following table shows the options to customize service container configurati
 | [rabbitmq][rabbitmq-container]| RabbitMQ | `--rmq` | 3.5, 3.7, 3.8 |
 | [redis][redis-container] | Redis     | `--redis` | 3.2, 4.0, 5.0 |   Standard redis container
 | [selenium][selenium-container]| Selenium | `--with-selenium`<br>`--selenium-version`<br>`--selenium-image`| Any | Enables Magento application testing using the Magento Functional Testing Framework (MFTF)
+| [test][test-container]| PHP CLI | `--with-test`| Any | Creates PHP CLI based container with writable file system for test running
 | [tls][tls-container] | SSL Endpoint |  |   |  Terminates SSL, can be configured to pass to varnish or nginx
 | [varnish][varnish-container] | Varnish | `--no-varnish` | 4, 6.2 | Varnish is provisioned by default. Use the `--no-varnish` option to skip Varnish service installation
 | [web][web-container] | NGINX | `--nginx` | 1.9, latest |
@@ -157,6 +158,7 @@ Now you can see all requests that are passing through the TLS container and chec
 [fpm-container]: {{site.baseurl}}/cloud/docker/docker-containers-service.html#fpm-container
 [redis-container]: {{site.baseurl}}/cloud/docker/docker-containers-service.html#redis-container
 [selenium-container]: {{site.baseurl}}/cloud/docker/docker-containers-service.html#selenium-container
+[test-container]: {{site.baseurl}}/cloud/docker/docker-containers-service.html#test-container
 [tls-container]: {{site.baseurl}}/cloud/docker/docker-containers-service.html#tls-container
 [varnish-container]: {{site.baseurl}}/cloud/docker/docker-containers-service.html#varnish-container
 [web-container]: {{site.baseurl}}/cloud/docker/docker-containers-service.html#web-container

--- a/src/cloud/docker/docker-containers.md
+++ b/src/cloud/docker/docker-containers.md
@@ -49,7 +49,7 @@ The following table shows the options to customize service container configurati
 | [rabbitmq][rabbitmq-container]| RabbitMQ | `--rmq` | 3.5, 3.7, 3.8 |
 | [redis][redis-container] | Redis     | `--redis` | 3.2, 4.0, 5.0 |   Standard redis container
 | [selenium][selenium-container]| Selenium | `--with-selenium`<br>`--selenium-version`<br>`--selenium-image`| Any | Enables Magento application testing using the Magento Functional Testing Framework (MFTF)
-| [test][test-container]| PHP CLI | `--with-test`| Any | Creates PHP CLI based container with writable file system for running tests
+| [test][test-container]| PHP CLI | `--with-test`| Any | Container with a writable file system for running tests
 | [tls][tls-container] | SSL Endpoint |  |   |  Terminates SSL, can be configured to pass to varnish or nginx
 | [varnish][varnish-container] | Varnish | `--no-varnish` | 4, 6.2 | Varnish is provisioned by default. Use the `--no-varnish` option to skip Varnish service installation
 | [web][web-container] | NGINX | `--nginx` | 1.9, latest |

--- a/src/cloud/docker/docker-test-app-mftf.md
+++ b/src/cloud/docker/docker-test-app-mftf.md
@@ -36,7 +36,7 @@ To set up and run MFTF tests in a Cloud Docker environment:
 1. Generate the `docker-compose.yml` file.
 
    ```bash
-   ./vendor/bin/ece-docker build:compose --with-selenium
+   ./vendor/bin/ece-docker build:compose --with-selenium --with-test
    ```
 
 1. Start the {{site.data.var.mcd-prod}} environment. Optionally, you can set up {{site.data.var.mcd-prod}} to work in [Developer Mode].


### PR DESCRIPTION
## Purpose of this pull request

This pull request (PR) will add information about `test` container and `--with-test` option for `build:compose` command

## Affected DevDocs pages

<!-- REQUIRED List the affected pages on devdocs.magento.com (URLs). Not needed for large numbers of files. -->

-  https://devdocs.magento.com/cloud/docker/docker-containers-service.html
- https://devdocs.magento.com/cloud/docker/docker-containers.html


whatsnew
Added information about the test container  created by adding the `--with-test` option to the Docker `build:compose` when testing Magento Commerce in a Cloud Docker environment. See [Magento application testing](https://devdocs.magento.com/cloud/docker/docker-test-app-mftf.html) in the _Cloud Guide_.