### PR TITLE
GraphQL: Update availableStores query

### DIFF
--- a/src/guides/v2.4/graphql/queries/available-stores.md
+++ b/src/guides/v2.4/graphql/queries/available-stores.md
@@ -3,14 +3,15 @@ group: graphql
 title: availableStores query
 ---
 
-The `availableStores` query returns configuration information about all store views that have the same parent website. Use this query to implement a store switcher.
+The `availableStores` query returns configuration information about multiple store views. Use this query to implement a store switcher.
 
-{:.bs-callout-tip}
 Specify the [Store header]({{ page.baseurl }}/graphql/send-request.html) to determine the scope of the call.
+
+If the `useCurrentGroup` input argument is set to `true`, then the `availableStores` query returns configuration information about store views that have the same parent _store_. If the input argument is not specified or is set to `false`, the query returns values for all store views with the same parent _website_.
 
 ## Syntax
 
-`availableStores: [StoreConfig]`
+`availableStores(useCurrentGroup: Boolean): [StoreConfig]`
 
 ## Example usage
 
@@ -54,6 +55,12 @@ query {
   }
 }
 ```
+
+## Input attributes
+
+Attribute | Data type | Description
+--- | --- | ---
+useCurrentGroup | Boolean | Filter store views by current store group
 
 ## Output attributes
 

--- a/src/guides/v2.4/graphql/queries/available-stores.md
+++ b/src/guides/v2.4/graphql/queries/available-stores.md
@@ -5,9 +5,9 @@ title: availableStores query
 
 The `availableStores` query returns configuration information about multiple store views. Use this query to implement a store switcher.
 
-Specify the [Store header]({{ page.baseurl }}/graphql/send-request.html) to determine the scope of the call.
-
 If the `useCurrentGroup` input argument is set to `true`, then the `availableStores` query returns configuration information about store views that have the same parent _store_. If the input argument is not specified or is set to `false`, the query returns values for all store views with the same parent _website_.
+
+Specify the [Store header]({{ page.baseurl }}/graphql/send-request.html) to determine the scope of the call. Without this header, the query returns values for the default store view and other store views with the same parent _store_.
 
 ## Syntax
 
@@ -21,7 +21,7 @@ The following query returns information about the store's catalog configuration.
 
 ```graphql
 query {
-  availableStores {
+  availableStores(useCurrentGroup: true) {
     id
     code
     locale
@@ -60,7 +60,7 @@ query {
 
 Attribute | Data type | Description
 --- | --- | ---
-useCurrentGroup | Boolean | Filter store views by current store group
+`useCurrentGroup` | Boolean | Filter store views by current store group
 
 ## Output attributes
 


### PR DESCRIPTION
## Purpose of this pull request

This pull request (PR) adds the `useCurrentGroup` input parameter to the `availableStores` query.

Related ticket: PWA-805

## Affected DevDocs pages

<!-- REQUIRED List the affected pages on devdocs.magento.com (URLs). Not needed for large numbers of files. -->

-  https://devdocs.magento.com/guides/v2.4/graphql/queries/available-stores.html

## Links to Magento source code

<!--  OPTIONAL - REMOVE THIS SECTION IF NOT USED. If this pull request references a file in a Magento codebase repository, add it here. -->

-  ...

<!--
If you are fixing a GitHub issue, note it using GitHub keyword format (https://help.github.com/en/articles/closing-issues-using-keywords#closing-an-issue-in-a-different-repository) to close the issue when this pull request is merged. Example: `Fixes #1234`

`master` is the default branch. Merged pull requests to `master` go live on the site automatically. Any requested changes to content on the `master` branch must be related to the released codebase. Any content related to future releases goes in the `develop` branch.

See Contribution guidelines (https://github.com/magento/devdocs/blob/master/.github/CONTRIBUTING.md) for more information.
-->

whatsnew
Added the `useCurrentGroup` input parameter to the [`availableStores` query](https://devdocs.magento.com/guides/v2.4/graphql/queries/available-stores.html).