### PR TITLE
MCLOUD-6939: Errors occur running magento commands in composer cloud docker installation

### DIFF
--- a/src/cloud/env/variables-build.md
+++ b/src/cloud/env/variables-build.md
@@ -203,7 +203,7 @@ stage:
 
 ### `SKIP_COMPOSER_DUMP_AUTOLOAD`
 
-Skip executing of `composer dump-autoload` command.
+Do not run the composer dump-autoload command.
 
 -  **Default**— _Not set_
 -  **Version**—Magento 2.1.4 and later

--- a/src/cloud/env/variables-build.md
+++ b/src/cloud/env/variables-build.md
@@ -201,6 +201,19 @@ stage:
     SKIP_SCD: false
 ```
 
+### `SKIP_COMPOSER_DUMP_AUTOLOAD`
+
+Skip executing of `composer dump-autoload` command.
+
+-  **Default**— _Not set_
+-  **Version**—Magento 2.1.4 and later
+
+```yaml
+stage:
+   build:
+    SKIP_COMPOSER_DUMP_AUTOLOAD: true
+```
+
 ### `VERBOSE_COMMANDS`
 
 -  **Default**—_Not set_


### PR DESCRIPTION
## Purpose of this pull request

Added documentation for new Cloud build variable `SKIP_COMPOSER_DUMP_AUTOLOAD` to skip composer dump-autoload processing when deploying a Cloud project to the Cloud Docker environment. 

## Affected DevDocs pages

-  https://devdocs.magento.com/cloud/env/variables-build.html

## Magento source code

https://github.com/magento/ece-tools/pull/784