### PR TITLE
Improve Apply Patch page

### DIFF
--- a/src/_data/toc/software-update-guide.yml
+++ b/src/_data/toc/software-update-guide.yml
@@ -101,9 +101,21 @@ pages:
       url: /comp-mgr/patching.html
       children:
 
-       - label: MQP release notes
-         url: /quality-patches/release-notes.html
-         versionless: true
+       - label: Magento Quality Patches
+         url: /comp-mgr/patching/mqp.html
+         children:
+
+           - label: MQP release notes
+             url: /quality-patches/release-notes.html
+             versionless: true
+
+       - label: Command Line
+         url: /comp-mgr/patching/command-line.html
+         children:
+
+       - label: Composer
+         url: /comp-mgr/patching/composer.html
+         children:
 
     - label: Update the updater application
       url: /comp-mgr/updater/update-updater.html

--- a/src/cloud/project/project-patch.md
+++ b/src/cloud/project/project-patch.md
@@ -14,7 +14,7 @@ functional_areas:
 Both packages improve the integration of all {{site.data.var.ee}} versions with Cloud environments and support quick delivery of critical, optional, and custom fixes. You can use these packages to apply, revert, and view general information about all individual patches that are available for Magento.
 
 {:.bs-callout-tip}
-You can use the [Magento Quality Patches]({{ site.baseurl }}/guides/v2.4/comp-mgr/patching.html#mqp) and [{{ site.data.var.mcp-prod }}](#standalone) packages as stand-alone packages for {{ site.data.var.ce }} and {{ site.data.var.ee }} projects. We recommend using the Magento Quality Patches package for non-Cloud projects.
+You can use the [Magento Quality Patches]({{ site.baseurl }}/guides/v2.4/comp-mgr/patching/mqp.html#mqp) and [{{ site.data.var.mcp-prod }}](#standalone) packages as stand-alone packages for {{ site.data.var.ce }} and {{ site.data.var.ee }} projects. We recommend using the Magento Quality Patches package for non-Cloud projects.
 
 When you deploy changes to the remote environment, `{{site.data.var.ct}}` uses {{ site.data.var.mcp-package }} and `magento/quality-patches` to check for pending patches and applies them automatically in the following order:
 
@@ -205,7 +205,7 @@ To apply and test a custom patch on a Cloud environment:
 
 ## Apply patches to a non-Cloud project {#standalone}
 
-Use the [Magento Quality Patches]({{ site.baseurl }}/guides/v2.4/comp-mgr/patching.html#mqp) package for {{ site.data.var.ce }} and {{ site.data.var.ee }} projects.
+Use the [Magento Quality Patches]({{ site.baseurl }}/guides/v2.4/comp-mgr/patching/mqp.html#mqp) package for {{ site.data.var.ce }} and {{ site.data.var.ee }} projects.
 
 ## Revert a patch in a local environment
 

--- a/src/cloud/project/project-patch.md
+++ b/src/cloud/project/project-patch.md
@@ -83,22 +83,22 @@ The status table contains the following types of information:
 
 -  **Type**:
 
-   -  `Optional`—All patches from the MQP package and the [Magento Cloud Patches]({{ site.baseurl }}/cloud/project/project-patch.html) package are optional for {{ site.data.var.ee }} and {{ site.data.var.ce }} installations. For {{ site.data.var.ece }}, all MQP patches are optional.
-   -  `Required`—All patches from the {{ site.data.var.mcp-prod }} package are required for Cloud customers.
-   -  `Deprecated`—The individual patch is marked as deprecated by Magento and we recommend reverting it if you have applied it. After you revert a deprecated patch, it will no longer be displayed in the status table.
-   -  `Custom`—All patches from the 'm2-hotfixes' directory.
+  -  `Optional`—All patches from the MQP package and the [Magento Cloud Patches]({{ site.baseurl }}/cloud/project/project-patch.html) package are optional for {{ site.data.var.ee }} and {{ site.data.var.ce }} installations. For {{ site.data.var.ece }}, all MQP patches are optional.
+  -  `Required`—All patches from the {{ site.data.var.mcp-prod }} package are required for Cloud customers.
+  -  `Deprecated`—The individual patch is marked as deprecated by Magento and we recommend reverting it if you have applied it. After you revert a deprecated patch, it will no longer be displayed in the status table.
+  -  `Custom`—All patches from the 'm2-hotfixes' directory.
 
 -  **Status**:
 
-   -  `Applied`—The patch has been applied.
-   -  `Not applied`—The patch has not been applied.
-   -  `N/A`—The status of the patch cannot be defined due to conflicts.
+  -  `Applied`—The patch has been applied.
+  -  `Not applied`—The patch has not been applied.
+  -  `N/A`—The status of the patch cannot be defined due to conflicts.
 
 -  **Details**:
 
-   -  `Affected components`—The list of affected Magento modules.
-   -  `Required patches`—The list of required patches (dependencies).
-   -  `Recommended replacement`—The patch that is a recommended replacement for a deprecated patch.
+  -  `Affected components`—The list of affected Magento modules.
+  -  `Required patches`—The list of required patches (dependencies).
+  -  `Recommended replacement`—The patch that is a recommended replacement for a deprecated patch.
 
 ## Apply a patch in a local environment
 

--- a/src/cloud/project/project-patch.md
+++ b/src/cloud/project/project-patch.md
@@ -82,23 +82,20 @@ Magento 2 Enterprise Edition, version 2.3.5.0
 The status table contains the following types of information:
 
 -  **Type**:
-
-  -  `Optional`—All patches from the MQP package and the [Magento Cloud Patches]({{ site.baseurl }}/cloud/project/project-patch.html) package are optional for {{ site.data.var.ee }} and {{ site.data.var.ce }} installations. For {{ site.data.var.ece }}, all MQP patches are optional.
-  -  `Required`—All patches from the {{ site.data.var.mcp-prod }} package are required for Cloud customers.
-  -  `Deprecated`—The individual patch is marked as deprecated by Magento and we recommend reverting it if you have applied it. After you revert a deprecated patch, it will no longer be displayed in the status table.
-  -  `Custom`—All patches from the 'm2-hotfixes' directory.
+   -  `Optional`—All patches from the MQP package and the [Magento Cloud Patches]({{ site.baseurl }}/cloud/project/project-patch.html) package are optional for {{ site.data.var.ee }} and {{ site.data.var.ce }} installations. For {{ site.data.var.ece }}, all MQP patches are optional.
+   -  `Required`—All patches from the {{ site.data.var.mcp-prod }} package are required for Cloud customers.
+   -  `Deprecated`—The individual patch is marked as deprecated by Magento and we recommend reverting it if you have applied it. After you revert a deprecated patch, it will no longer be displayed in the status table.
+   -  `Custom`—All patches from the 'm2-hotfixes' directory.
 
 -  **Status**:
-
-  -  `Applied`—The patch has been applied.
-  -  `Not applied`—The patch has not been applied.
-  -  `N/A`—The status of the patch cannot be defined due to conflicts.
+   -  `Applied`—The patch has been applied.
+   -  `Not applied`—The patch has not been applied.
+   -  `N/A`—The status of the patch cannot be defined due to conflicts.
 
 -  **Details**:
-
-  -  `Affected components`—The list of affected Magento modules.
-  -  `Required patches`—The list of required patches (dependencies).
-  -  `Recommended replacement`—The patch that is a recommended replacement for a deprecated patch.
+   -  `Affected components`—The list of affected Magento modules.
+   -  `Required patches`—The list of required patches (dependencies).
+   -  `Recommended replacement`—The patch that is a recommended replacement for a deprecated patch.
 
 ## Apply a patch in a local environment
 

--- a/src/cloud/project/project-patch.md
+++ b/src/cloud/project/project-patch.md
@@ -81,21 +81,21 @@ Magento 2 Enterprise Edition, version 2.3.5.0
 
 The status table contains the following types of information:
 
--  **Type**:
-    -  `Optional`—All patches from the MQP package and the [Magento Cloud Patches]({{ site.baseurl }}/cloud/project/project-patch.html) package are optional for {{ site.data.var.ee }} and {{ site.data.var.ce }} installations. For {{ site.data.var.ece }}, all MQP patches are optional.
-    -  `Required`—All patches from the {{ site.data.var.mcp-prod }} package are required for Cloud customers.
-    -  `Deprecated`—The individual patch is marked as deprecated by Magento and we recommend reverting it if you have applied it. After you revert a deprecated patch, it will no longer be displayed in the status table.
-    -  `Custom`—All patches from the 'm2-hotfixes' directory.
+- **Type**:
+  - `Optional`—All patches from the MQP package and the [Magento Cloud Patches]({{ site.baseurl }}/cloud/project/project-patch.html) package are optional for {{ site.data.var.ee }} and {{ site.data.var.ce }} installations. For {{ site.data.var.ece }}, all MQP patches are optional.
+  - `Required`—All patches from the {{ site.data.var.mcp-prod }} package are required for Cloud customers.
+  - `Deprecated`—The individual patch is marked as deprecated by Magento and we recommend reverting it if you have applied it. After you revert a deprecated patch, it will no longer be displayed in the status table.
+  - `Custom`—All patches from the 'm2-hotfixes' directory.
 
--  **Status**:
-    -  `Applied`—The patch has been applied.
-    -  `Not applied`—The patch has not been applied.
-    -  `N/A`—The status of the patch cannot be defined due to conflicts.
+- **Status**:
+  - `Applied`—The patch has been applied.
+  - `Not applied`—The patch has not been applied.
+  - `N/A`—The status of the patch cannot be defined due to conflicts.
 
--  **Details**:
-    -  `Affected components`—The list of affected Magento modules.
-    -  `Required patches`—The list of required patches (dependencies).
-    -  `Recommended replacement`—The patch that is a recommended replacement for a deprecated patch.
+- **Details**:
+  - `Affected components`—The list of affected Magento modules.
+  - `Required patches`—The list of required patches (dependencies).
+  - `Recommended replacement`—The patch that is a recommended replacement for a deprecated patch.
 
 ## Apply a patch in a local environment
 
@@ -121,7 +121,6 @@ To apply individual patches in a local development environment:
    ```
 
    The `ece-patches apply` command applies patches in the following order:
-
    -  Required patches
    -  Optional individual patches
    -  Custom patches from the `/m2-hotfixes` directory

--- a/src/cloud/project/project-patch.md
+++ b/src/cloud/project/project-patch.md
@@ -14,7 +14,7 @@ functional_areas:
 Both packages improve the integration of all {{site.data.var.ee}} versions with Cloud environments and support quick delivery of critical, optional, and custom fixes. You can use these packages to apply, revert, and view general information about all individual patches that are available for Magento.
 
 {:.bs-callout-tip}
-You can use the [Magento Quality Patches]({{ site.baseurl }}/guides/v2.4/comp-mgr/patching/mqp.html#mqp) and [{{ site.data.var.mcp-prod }}](#standalone) packages as stand-alone packages for {{ site.data.var.ce }} and {{ site.data.var.ee }} projects. We recommend using the Magento Quality Patches package for non-Cloud projects.
+You can use the [Magento Quality Patches]({{ site.baseurl }}/guides/v2.4/comp-mgr/patching/mqp.html) and [{{ site.data.var.mcp-prod }}](#standalone) packages as stand-alone packages for {{ site.data.var.ce }} and {{ site.data.var.ee }} projects. We recommend using the Magento Quality Patches package for non-Cloud projects.
 
 When you deploy changes to the remote environment, `{{site.data.var.ct}}` uses {{ site.data.var.mcp-package }} and `magento/quality-patches` to check for pending patches and applies them automatically in the following order:
 

--- a/src/cloud/project/project-patch.md
+++ b/src/cloud/project/project-patch.md
@@ -82,20 +82,20 @@ Magento 2 Enterprise Edition, version 2.3.5.0
 The status table contains the following types of information:
 
 - **Type**:
-  - `Optional`—All patches from the MQP package and the [Magento Cloud Patches]({{ site.baseurl }}/cloud/project/project-patch.html) package are optional for {{ site.data.var.ee }} and {{ site.data.var.ce }} installations. For {{ site.data.var.ece }}, all MQP patches are optional.
-  - `Required`—All patches from the {{ site.data.var.mcp-prod }} package are required for Cloud customers.
-  - `Deprecated`—The individual patch is marked as deprecated by Magento and we recommend reverting it if you have applied it. After you revert a deprecated patch, it will no longer be displayed in the status table.
-  - `Custom`—All patches from the 'm2-hotfixes' directory.
+  -  `Optional`—All patches from the MQP package and the [Magento Cloud Patches]({{ site.baseurl }}/cloud/project/project-patch.html) package are optional for {{ site.data.var.ee }} and {{ site.data.var.ce }} installations. For {{ site.data.var.ece }}, all MQP patches are optional.
+  -  `Required`—All patches from the {{ site.data.var.mcp-prod }} package are required for Cloud customers.
+  -  `Deprecated`—The individual patch is marked as deprecated by Magento and we recommend reverting it if you have applied it. After you revert a deprecated patch, it will no longer be displayed in the status table.
+  -  `Custom`—All patches from the 'm2-hotfixes' directory.
 
 - **Status**:
-  - `Applied`—The patch has been applied.
-  - `Not applied`—The patch has not been applied.
-  - `N/A`—The status of the patch cannot be defined due to conflicts.
+  -  `Applied`—The patch has been applied.
+  -  `Not applied`—The patch has not been applied.
+  -  `N/A`—The status of the patch cannot be defined due to conflicts.
 
 - **Details**:
-  - `Affected components`—The list of affected Magento modules.
-  - `Required patches`—The list of required patches (dependencies).
-  - `Recommended replacement`—The patch that is a recommended replacement for a deprecated patch.
+  -  `Affected components`—The list of affected Magento modules.
+  -  `Required patches`—The list of required patches (dependencies).
+  -  `Recommended replacement`—The patch that is a recommended replacement for a deprecated patch.
 
 ## Apply a patch in a local environment
 

--- a/src/cloud/project/project-patch.md
+++ b/src/cloud/project/project-patch.md
@@ -82,20 +82,20 @@ Magento 2 Enterprise Edition, version 2.3.5.0
 The status table contains the following types of information:
 
 -  **Type**:
-   -  `Optional`—All patches from the MQP package and the [Magento Cloud Patches]({{ site.baseurl }}/cloud/project/project-patch.html) package are optional for {{ site.data.var.ee }} and {{ site.data.var.ce }} installations. For {{ site.data.var.ece }}, all MQP patches are optional.
-   -  `Required`—All patches from the {{ site.data.var.mcp-prod }} package are required for Cloud customers.
-   -  `Deprecated`—The individual patch is marked as deprecated by Magento and we recommend reverting it if you have applied it. After you revert a deprecated patch, it will no longer be displayed in the status table.
-   -  `Custom`—All patches from the 'm2-hotfixes' directory.
+    -  `Optional`—All patches from the MQP package and the [Magento Cloud Patches]({{ site.baseurl }}/cloud/project/project-patch.html) package are optional for {{ site.data.var.ee }} and {{ site.data.var.ce }} installations. For {{ site.data.var.ece }}, all MQP patches are optional.
+    -  `Required`—All patches from the {{ site.data.var.mcp-prod }} package are required for Cloud customers.
+    -  `Deprecated`—The individual patch is marked as deprecated by Magento and we recommend reverting it if you have applied it. After you revert a deprecated patch, it will no longer be displayed in the status table.
+    -  `Custom`—All patches from the 'm2-hotfixes' directory.
 
 -  **Status**:
-   -  `Applied`—The patch has been applied.
-   -  `Not applied`—The patch has not been applied.
-   -  `N/A`—The status of the patch cannot be defined due to conflicts.
+    -  `Applied`—The patch has been applied.
+    -  `Not applied`—The patch has not been applied.
+    -  `N/A`—The status of the patch cannot be defined due to conflicts.
 
 -  **Details**:
-   -  `Affected components`—The list of affected Magento modules.
-   -  `Required patches`—The list of required patches (dependencies).
-   -  `Recommended replacement`—The patch that is a recommended replacement for a deprecated patch.
+    -  `Affected components`—The list of affected Magento modules.
+    -  `Required patches`—The list of required patches (dependencies).
+    -  `Recommended replacement`—The patch that is a recommended replacement for a deprecated patch.
 
 ## Apply a patch in a local environment
 

--- a/src/cloud/project/project-patch.md
+++ b/src/cloud/project/project-patch.md
@@ -201,7 +201,7 @@ To apply and test a custom patch on a Cloud environment:
 
 ## Apply patches to a non-Cloud project {#standalone}
 
-Use the [Magento Quality Patches]({{ site.baseurl }}/guides/v2.4/comp-mgr/patching/mqp.html#mqp) package for {{ site.data.var.ce }} and {{ site.data.var.ee }} projects.
+Use the [Magento Quality Patches]({{ site.baseurl }}/guides/v2.4/comp-mgr/patching/mqp.html) package for {{ site.data.var.ce }} and {{ site.data.var.ee }} projects.
 
 ## Revert a patch in a local environment
 

--- a/src/cloud/project/project-patch.md
+++ b/src/cloud/project/project-patch.md
@@ -81,21 +81,21 @@ Magento 2 Enterprise Edition, version 2.3.5.0
 
 The status table contains the following types of information:
 
-- **Type**:
-  -  `Optional`—All patches from the MQP package and the [Magento Cloud Patches]({{ site.baseurl }}/cloud/project/project-patch.html) package are optional for {{ site.data.var.ee }} and {{ site.data.var.ce }} installations. For {{ site.data.var.ece }}, all MQP patches are optional.
-  -  `Required`—All patches from the {{ site.data.var.mcp-prod }} package are required for Cloud customers.
-  -  `Deprecated`—The individual patch is marked as deprecated by Magento and we recommend reverting it if you have applied it. After you revert a deprecated patch, it will no longer be displayed in the status table.
-  -  `Custom`—All patches from the 'm2-hotfixes' directory.
+-  **Type**:
+   -  `Optional`—All patches from the MQP package and the [Magento Cloud Patches]({{ site.baseurl }}/cloud/project/project-patch.html) package are optional for {{ site.data.var.ee }} and {{ site.data.var.ce }} installations. For {{ site.data.var.ece }}, all MQP patches are optional.
+   -  `Required`—All patches from the {{ site.data.var.mcp-prod }} package are required for Cloud customers.
+   -  `Deprecated`—The individual patch is marked as deprecated by Magento and we recommend reverting it if you have applied it. After you revert a deprecated patch, it will no longer be displayed in the status table.
+   -  `Custom`—All patches from the 'm2-hotfixes' directory.
 
-- **Status**:
-  -  `Applied`—The patch has been applied.
-  -  `Not applied`—The patch has not been applied.
-  -  `N/A`—The status of the patch cannot be defined due to conflicts.
+-  **Status**:
+   -  `Applied`—The patch has been applied.
+   -  `Not applied`—The patch has not been applied.
+   -  `N/A`—The status of the patch cannot be defined due to conflicts.
 
-- **Details**:
-  -  `Affected components`—The list of affected Magento modules.
-  -  `Required patches`—The list of required patches (dependencies).
-  -  `Recommended replacement`—The patch that is a recommended replacement for a deprecated patch.
+-  **Details**:
+   -  `Affected components`—The list of affected Magento modules.
+   -  `Required patches`—The list of required patches (dependencies).
+   -  `Recommended replacement`—The patch that is a recommended replacement for a deprecated patch.
 
 ## Apply a patch in a local environment
 

--- a/src/guides/v2.3/comp-mgr/patching.md
+++ b/src/guides/v2.3/comp-mgr/patching.md
@@ -28,7 +28,7 @@ There are three types of patches:
 
 Hotfixes are patches that contain high-impact security or quality fixes that affect a large number of Magento merchants. These fixes are applied to the next patch release for the applicable Magento minor version. Magento releases hot fixes as needed.
 
-You can find hotfixes in the [Magento Security Center][]. Follow the instructions on the page to download the patch file, depending on your Magento version and installation type. Use the [command line](#command-line) or [Composer](#composer) to apply hot fix patches.
+You can find hotfixes in the [Magento Security Center][]. Follow the instructions on the page to download the patch file, depending on your Magento version and installation type. Use the [command line][] or [Composer][] to apply hot fix patches.
 
 {:.bs-callout-info}
 Hot fixes can contain backward incompatible changes.
@@ -37,7 +37,7 @@ Hot fixes can contain backward incompatible changes.
 
 Individual patches contain low-impact quality fixes for a specific issue. These fixes are applied to the most recently supported minor version of Magento (for example, 2.4.x), but could be missing from the previous supported minor version of Magento (for example, 2.3.x). Magento releases individual patches as needed.
 
-Use the [Magento Quality Patches (MQP) package](#mqp) to apply individual patches.
+Use the [Magento Quality Patches (MQP) package][MQP] to apply individual patches.
 
 {:.bs-callout-info}
 Individual patches do not contain backward incompatible changes.
@@ -46,7 +46,7 @@ Individual patches do not contain backward incompatible changes.
 
 Sometimes it takes a while for the Magento Engineering Team to include a bug fix made on GitHub in a Magento 2 Composer release. In the meantime, you can create a patch from GitHub and use the [`cweagans/composer-patches`][1] plugin to apply it to your Composer-based Magento 2 installation.
 
-Use the [command line](#command-line) or [Composer](#composer) to apply custom patches.
+Use the [command line][] or [Composer][] to apply custom patches.
 
 There are many ways to create custom patch files. The following example focuses on creating a patch from a known git commit.
 
@@ -81,276 +81,15 @@ index c8a6fef58d31..7d01c195791e 100644
 
 You can apply patches using any of the following methods:
 
--  Magento Quality Patch (MQP) package
--  Command line
--  Composer
+-  [Magento Quality Patch (MQP) package][MQP]
+-  [Command line][]
+-  [Composer][]
 
 {:.bs-callout-info}
 To apply a patch to a {{site.data.var.ece}} project, see [Apply patches][].
 
-### Magento Quality Patch (MQP) package {#mqp}
-
-The [MQP package][] delivers individual patches developed by Magento and allows you to apply, revert, and view general information about all individual patches that are available for the installed version of {{ site.data.var.ee }} or {{ site.data.var.ce }}.
-
-{:.bs-callout-warning}
-We do not recommend using the MQP package to apply large numbers of patches because it increases the complexity of your code, which makes upgrading to a new version of Magento more difficult.
-
-#### Install the MQP package
-
-{:.bs-callout-info}
-If it is not already installed, you must install [Git](https://github.com/git-guides/install-git) before installing the MQP package.
-
-Add the `magento/quality-patches` Composer package to your `composer.json` file:
-
-```bash
-composer require magento/quality-patches
-```
-
-#### View individual patches
-
-To view the list of individual patches available for your version of Magento:
-
-```bash
-./vendor/bin/magento-patches status
-```
-
-You will see output similar to the following:
-
-```terminal
-╔════════════════╤═════════════════════════════════════════════════╤══════════╤═════════════╤═════════════════════════════════╗
-║ Id             │ Title                                           │ Type     │ Status      │ Details                         ║
-╠════════════════╪═════════════════════════════════════════════════╪══════════╪═════════════╪═════════════════════════════════╣
-║ MAGECLOUD-5069 │ FPC is getting disabled during deployments      │ Optional │ Not applied │ Affected components:            ║
-║                │                                                 │          │             │  - magento/module-page-cache    ║
-╟────────────────┼─────────────────────────────────────────────────┼──────────┼─────────────┼─────────────────────────────────╢
-║ MCLOUD-5650    │ Hold deployment config after reading from file  │ Optional │ Not applied │ Affected components:            ║
-║                │                                                 │          │             │  - magento/framework            ║
-╟────────────────┼─────────────────────────────────────────────────┼──────────┼─────────────┼─────────────────────────────────╢
-║ MCLOUD-5684    │ Pagination Not working - product_list_limit=all │ Optional │ Not applied │ Affected components:            ║
-║                │                                                 │          │             │  - magento/module-elasticsearch ║
-╟────────────────┼─────────────────────────────────────────────────┼──────────┼─────────────┼─────────────────────────────────╢
-║ MCLOUD-5837    │ Fix load balancer issue                         │Deprecated│ Applied     │ Recommended replacement: MC-1   ║
-║                │                                                 │          │             │ Affected components:            ║
-║                │                                                 │          │             │  - magento/framework            ║
-╟────────────────┼─────────────────────────────────────────────────┼──────────┼─────────────┼─────────────────────────────────╢
-║ BUNDLE-2554    │ Set Payment info bug                            │ Optional │ Not applied │ Affected components:            ║
-║                │                                                 │          │             │  - amzn/amazon-pay-module       ║
-╟────────────────┼─────────────────────────────────────────────────┼──────────┼─────────────┼─────────────────────────────────╢
-║ MC-1           │ Fixes issue 1                                   │ Optional │ Applied     │ Affected components:            ║
-║                │                                                 │          │             │  - magento/module-cms           ║
-╟────────────────┼─────────────────────────────────────────────────┼──────────┼─────────────┼─────────────────────────────────╢
-║ MC-2           │ Fixes issue 2                                   │ Optional │ Not applied │ Affected components:            ║
-║                │                                                 │          │             │  - magento/module-cms           ║
-╟────────────────┼─────────────────────────────────────────────────┼──────────┼─────────────┼─────────────────────────────────╢
-║ MC-3           │ Fixes issue 3                                   │ Optional │ Not applied │ Required patches:               ║
-║                │                                                 │          │             │  - MC-2                         ║
-║                │                                                 │          │             │ Affected components:            ║
-║                │                                                 │          │             │  - magento/module-cms           ║
-╟────────────────┼─────────────────────────────────────────────────┼──────────┼─────────────┼─────────────────────────────────╢
-║ MC-3-V2        │ Updated fix for issue 3, replaces MC-3 patch    │ Optional │ N/A         │ Affected components:            ║
-║                │                                                 │          │             │  - magento/module-cms           ║
-╚════════════════╧═════════════════════════════════════════════════╧══════════╧═════════════╧═════════════════════════════════╝
-Magento 2 Enterprise Edition, version 2.3.5.0
-```
-
-The status table contains the following types of information:
-
--  **Type**:
-
-   -  `Optional`—All patches from the MQP package and the [Magento Cloud Patches]({{ site.baseurl }}/cloud/project/project-patch.html) package are optional for {{ site.data.var.ee }} and {{ site.data.var.ce }} installations.
-   -  `Deprecated`—Magento has deprecated the individual patch. If you have applied the patch, we recommend that you revert it. The revert operation also removes the patch from the status table.
-
--  **Status**:
-
-   -  `Applied`—The patch has been applied.
-   -  `Not applied`—The patch has not been applied.
-   -  `N/A`—The status of the patch cannot be defined due to conflicts.
-
--  **Details**:
-
-   -  `Affected components`—The list of affected Magento modules.
-   -  `Required patches`—The list of patches that must be applied for an indicated patch to work properly (dependencies).
-   -  `Recommended replacement`—The patch that is a recommended replacement for a deprecated patch.
-
-{:.bs-callout-info}
-After upgrading to a new version of Magento, you must re-apply patches if the patches are not included in the new version. See [Re-apply patches after an upgrade](#upgrade).
-
-#### Apply individual patches
-
-{:.bs-callout-warning}
-We strongly recommend testing all patches in a staging or development environment before deploying to production. We also strongly recommend backing up your data before applying a patch. See [Back up and roll back the file system][].
-
-To apply a single patch, run the following command where `MAGETWO-XXXX` is the patch ID specified in the status table:
-
-```bash
-./vendor/bin/magento-patches apply MAGETWO-XXXX
-```
-
-Also, you can apply several patches at the same time by separating each additional patch ID with a space:
-
-```bash
-./vendor/bin/magento-patches apply MAGETWO-XXXX MAGETWO-YYYY
-```
-
-You must clean the cache after applying patches to see changes in the Magento application:
-
-```bash
-./bin/magento cache:clean
-```
-
-{:.bs-callout-info}
-Consider keeping a list of applied patches in a separate location. You might need to re-apply some of them after upgrading to a new version of Magento. See [Re-apply patches after an upgrade](#upgrade).
-
-#### Revert individual patches
-
-{:.bs-callout-warning}
-We strongly recommend testing all patches in a staging or development environment before deploying to production. We also strongly recommend backing up your data before applying a patch. See [Back up and roll back the file system][].
-
-To revert a single patch, run the following command where `MAGETWO-XXXX` is the patch ID specified in the status table:
-
-```bash
-./vendor/bin/magento-patches revert MAGETWO-XXXX
-```
-
-Also, you can revert several patches at the same time by separating each additional patch ID with a space:
-
-```bash
-./vendor/bin/magento-patches revert MAGETWO-XXXX MAGETWO-YYYY
-```
-
-To revert all applied patches:
-
-```bash
-./vendor/bin/magento-patches revert --all
-```
-
-You must clean the cache after reverting patches to see changes in the Magento application:
-
-```bash
-./bin/magento cache:clean
-```
-
-#### Get updates
-
-Magento periodically releases new individual patches. You must update the MQP package to get new individual patches:
-
-```bash
-composer update magento/quality-patches
-```
-
-View the added patches:
-
-{:.bs-callout-tip}
-New add patches display at the bottom of the table.
-
-```bash
-./vendor/bin/magento-patches status
-```
-
-#### Re-apply patches after an upgrade {#upgrade}
-
-When you upgrade to a new version of Magento, you must re-apply patches if the patches are not included in the new version.
-
-{:procedure}
-To re-apply patches:
-
-1. Update the MQP package:
-
-   ```bash
-   composer update magento/quality-patches.
-   ```
-
-1. Open the list of previously applied patches, which was recommended in [Apply individual patches](#apply-individual-patches).
-
-1. Apply the patches:
-
-   ```bash
-   ./vendor/bin/magento-patches apply MAGETWO-XXXX
-   ```
-
-   The best practice is to apply patches one at a time.
-
-1. Clean the cache:
-
-   ```bash
-   ./bin/magento cache:clean
-   ```
-
-   {:.bs-callout-info}
-   When you run the `status` command, the patches that where included in the new version are no longer displayed in the table of available patches.
-
-#### Logging
-
-The MQP package logs all operations in the `<Magento_root>/var/log/patch.log` file.
-
-### Command line
-
-1. Upload the local file into the `<Magento_root>` on the server using FTP, SFTP, SSH or your normal transport method.
-1. Log into the server as the [Magento admin user][] and verify the file is in the correct directory.
-1. In the command line interface, run the following commands according to the patch extension:
-
-   ```bash
-   patch < patch_file_name.patch
-   ```
-
-   The command assumes the file to be patched is located relative to the patch file.
-
-    {:.bs-callout-info}
-   If the command line shows: `File to patch:`, it means it cannot locate the intended file, even if the path seems correct. In the box displayed in the command line terminal, the first line shows the file to be patched. Copy the file path and paste it into the `File to patch:` prompt and press `Enter` and the patch should complete.
-
-1. For the changes to be reflected, refresh the cache in the Admin under **System** > Tools > **Cache Management**.
-
-  Alternatively, the patch can be applied locally with the same command, then committed and pushed normally.
-
-### Composer
-
-{:.bs-callout-warning}
-Always perform comprehensive testing before deploying any custom patch.
-
-To apply a custom patch using Composer:
-
-1. Open your command line application and navigate to your project directory.
-1. Add the `cweagans/composer-patches` plugin to the `composer.json` file.
-
-   ```bash
-   composer require cweagans/composer-patches
-   ```
-
-1. Edit the `composer.json` file and add the following section to specify:
-   -  **Module:** *\"magento/module-payment\"*
-   -  **Title:** *\"MAGETWO-56934: Checkout page freezes when ordering with Authorize.net with invalid credit card\"*
-   -  **Path to patch:** *\"patches/composer/github-issue-6474.diff\"*
-
-   For example:
-
-   ```json
-     "extra": {
-         "composer-exit-on-patch-failure": true,
-         "patches": {
-             "magento/module-payment": {
-                 "MAGETWO-56934: Checkout page freezes when ordering with Authorize.net with invalid credit card": "patches/composer/github-issue-6474.diff"
-             }
-         }
-     }
-   ```
-
-    If a patch affects multiple modules, you must create multiple patch files targeting multiple modules.
-
-1. Apply the patch. Use the `-v` option only if you want to see debugging information.
-
-   ```bash
-   composer -v install
-   ```
-
-1. Update the `composer.lock` file. The lock file tracks which patches have been applied to each Composer package in an object.
-
-   ```bash
-   composer update --lock
-   ```
-
 <!-- Link Definitions -->
 
-[MQP package]:https://github.com/magento/quality-patches
 [Magento Security Center]:https://magento.com/security/patches
 [-p1 instead of -p0]:http://man7.org/linux/man-pages/man1/patch.1.html
 [Back up and roll back the file system]:{{ page.baseurl }}/install-gde/install/cli/install-cli-backup.html
@@ -362,3 +101,6 @@ To apply a custom patch using Composer:
 [3]: https://github.com/magento/magento2/issues/6474
 [4]: https://github.com/magento/magento2/commit/2d31571f1bacd11aa2ec795180abf682e0e9aede.diff
 [Apply patches]:{{ site.baseurl }}/cloud/project/project-patch.html
+[Command line]:{{ page.baseurl }}/comp-mgr/patching/command-line.html
+[Composer]:{{ page.baseurl }}/comp-mgr/patching/composer.html
+[MQP]: {{ page.baseurl }}/comp-mgr/patching/mqp.html

--- a/src/guides/v2.3/comp-mgr/patching/command-line.md
+++ b/src/guides/v2.3/comp-mgr/patching/command-line.md
@@ -22,7 +22,7 @@ functional_areas:
 
 1. For the changes to be reflected, refresh the cache in the Admin under **System** > Tools > **Cache Management**.
 
-Alternatively, the patch can be applied locally with the same command, then committed and pushed normally.
+   Alternatively, the patch can be applied locally with the same command, then committed and pushed normally.
   
 <!-- Link Definitions -->
 

--- a/src/guides/v2.3/comp-mgr/patching/command-line.md
+++ b/src/guides/v2.3/comp-mgr/patching/command-line.md
@@ -8,7 +8,7 @@ functional_areas:
 {:.procedure}
 To apply patches from the command line:
 
-1. Upload the local file into the `<Magento_root>` on the server using FTP, SFTP, SSH or your normal transport method.
+1. Upload the local file into the `<Magento_root>` directory on the server using FTP, SFTP, SSH or your normal transport method.
 1. Log into the server as the [Magento admin user][] and verify the file is in the correct directory.
 1. In the command line interface, run the following commands according to the patch extension:
 

--- a/src/guides/v2.3/comp-mgr/patching/command-line.md
+++ b/src/guides/v2.3/comp-mgr/patching/command-line.md
@@ -1,0 +1,29 @@
+---
+group: software-update-guide
+title: Apply patches using Command Line tools
+functional_areas:
+  - Upgrade
+---
+
+### Command line
+
+1. Upload the local file into the `<Magento_root>` on the server using FTP, SFTP, SSH or your normal transport method.
+1. Log into the server as the [Magento admin user][] and verify the file is in the correct directory.
+1. In the command line interface, run the following commands according to the patch extension:
+
+   ```bash
+   patch < patch_file_name.patch
+   ```
+
+   The command assumes the file to be patched is located relative to the patch file.
+
+    {:.bs-callout-info}
+   If the command line shows: `File to patch:`, it means it cannot locate the intended file, even if the path seems correct. In the box displayed in the command line terminal, the first line shows the file to be patched. Copy the file path and paste it into the `File to patch:` prompt and press `Enter` and the patch should complete.
+
+1. For the changes to be reflected, refresh the cache in the Admin under **System** > Tools > **Cache Management**.
+
+  Alternatively, the patch can be applied locally with the same command, then committed and pushed normally.
+  
+<!-- Link Definitions -->
+
+[Magento Admin user]:{{ page.baseurl }}/config-guide/cli/config-cli.html#config-install-cli-first

--- a/src/guides/v2.3/comp-mgr/patching/command-line.md
+++ b/src/guides/v2.3/comp-mgr/patching/command-line.md
@@ -22,7 +22,7 @@ functional_areas:
 
 1. For the changes to be reflected, refresh the cache in the Admin under **System** > Tools > **Cache Management**.
 
-  Alternatively, the patch can be applied locally with the same command, then committed and pushed normally.
+Alternatively, the patch can be applied locally with the same command, then committed and pushed normally.
   
 <!-- Link Definitions -->
 

--- a/src/guides/v2.3/comp-mgr/patching/command-line.md
+++ b/src/guides/v2.3/comp-mgr/patching/command-line.md
@@ -23,7 +23,7 @@ functional_areas:
 1. For the changes to be reflected, refresh the cache in the Admin under **System** > Tools > **Cache Management**.
 
    Alternatively, the patch can be applied locally with the same command, then committed and pushed normally.
-  
+
 <!-- Link Definitions -->
 
 [Magento Admin user]:{{ page.baseurl }}/config-guide/cli/config-cli.html#config-install-cli-first

--- a/src/guides/v2.3/comp-mgr/patching/command-line.md
+++ b/src/guides/v2.3/comp-mgr/patching/command-line.md
@@ -5,7 +5,8 @@ functional_areas:
   - Upgrade
 ---
 
-### Command line
+{:.procedure}
+To apply patches from the command line:
 
 1. Upload the local file into the `<Magento_root>` on the server using FTP, SFTP, SSH or your normal transport method.
 1. Log into the server as the [Magento admin user][] and verify the file is in the correct directory.

--- a/src/guides/v2.3/comp-mgr/patching/composer.md
+++ b/src/guides/v2.3/comp-mgr/patching/composer.md
@@ -9,6 +9,7 @@ functional_areas:
 {:.bs-callout-warning}
 Always perform comprehensive testing before deploying any custom patch.
 
+{.:procedure}
 To apply a custom patch using Composer:
 
 1. Open your command line application and navigate to your project directory.

--- a/src/guides/v2.3/comp-mgr/patching/composer.md
+++ b/src/guides/v2.3/comp-mgr/patching/composer.md
@@ -5,7 +5,6 @@ functional_areas:
   - Upgrade
 ---
 
-### Composer
 
 {:.bs-callout-warning}
 Always perform comprehensive testing before deploying any custom patch.

--- a/src/guides/v2.3/comp-mgr/patching/composer.md
+++ b/src/guides/v2.3/comp-mgr/patching/composer.md
@@ -1,0 +1,52 @@
+---
+group: software-update-guide
+title: Apply patches using Composer
+functional_areas:
+  - Upgrade
+---
+
+### Composer
+
+{:.bs-callout-warning}
+Always perform comprehensive testing before deploying any custom patch.
+
+To apply a custom patch using Composer:
+
+1. Open your command line application and navigate to your project directory.
+1. Add the `cweagans/composer-patches` plugin to the `composer.json` file.
+
+   ```bash
+   composer require cweagans/composer-patches
+   ```
+
+1. Edit the `composer.json` file and add the following section to specify:
+   -  **Module:** *\"magento/module-payment\"*
+   -  **Title:** *\"MAGETWO-56934: Checkout page freezes when ordering with Authorize.net with invalid credit card\"*
+   -  **Path to patch:** *\"patches/composer/github-issue-6474.diff\"*
+
+   For example:
+
+   ```json
+     "extra": {
+         "composer-exit-on-patch-failure": true,
+         "patches": {
+             "magento/module-payment": {
+                 "MAGETWO-56934: Checkout page freezes when ordering with Authorize.net with invalid credit card": "patches/composer/github-issue-6474.diff"
+             }
+         }
+     }
+   ```
+
+    If a patch affects multiple modules, you must create multiple patch files targeting multiple modules.
+
+1. Apply the patch. Use the `-v` option only if you want to see debugging information.
+
+   ```bash
+   composer -v install
+   ```
+
+1. Update the `composer.lock` file. The lock file tracks which patches have been applied to each Composer package in an object.
+
+   ```bash
+   composer update --lock
+   ```

--- a/src/guides/v2.3/comp-mgr/patching/mqp.md
+++ b/src/guides/v2.3/comp-mgr/patching/mqp.md
@@ -73,20 +73,20 @@ The status table contains the following types of information:
 
 -  **Type**:
 
-   -  `Optional`—All patches from the MQP package and the [Magento Cloud Patches]({{ site.baseurl }}/cloud/project/project-patch.html) package are optional for {{ site.data.var.ee }} and {{ site.data.var.ce }} installations.
-   -  `Deprecated`—Magento has deprecated the individual patch. If you have applied the patch, we recommend that you revert it. The revert operation also removes the patch from the status table.
+  -  `Optional`—All patches from the MQP package and the [Magento Cloud Patches]({{ site.baseurl }}/cloud/project/project-patch.html) package are optional for {{ site.data.var.ee }} and {{ site.data.var.ce }} installations.
+  -  `Deprecated`—Magento has deprecated the individual patch. If you have applied the patch, we recommend that you revert it. The revert operation also removes the patch from the status table.
 
 -  **Status**:
 
-   -  `Applied`—The patch has been applied.
-   -  `Not applied`—The patch has not been applied.
-   -  `N/A`—The status of the patch cannot be defined due to conflicts.
+  -  `Applied`—The patch has been applied.
+  -  `Not applied`—The patch has not been applied.
+  -  `N/A`—The status of the patch cannot be defined due to conflicts.
 
 -  **Details**:
 
-   -  `Affected components`—The list of affected Magento modules.
-   -  `Required patches`—The list of patches that must be applied for an indicated patch to work properly (dependencies).
-   -  `Recommended replacement`—The patch that is a recommended replacement for a deprecated patch.
+  -  `Affected components`—The list of affected Magento modules.
+  -  `Required patches`—The list of patches that must be applied for an indicated patch to work properly (dependencies).
+  -  `Recommended replacement`—The patch that is a recommended replacement for a deprecated patch.
 
 {:.bs-callout-info}
 After upgrading to a new version of Magento, you must re-apply patches if the patches are not included in the new version. See [Re-apply patches after an upgrade](#upgrade).

--- a/src/guides/v2.3/comp-mgr/patching/mqp.md
+++ b/src/guides/v2.3/comp-mgr/patching/mqp.md
@@ -72,18 +72,18 @@ Magento 2 Enterprise Edition, version 2.3.5.0
 The status table contains the following types of information:
 
 - **Type**:
-  - `Optional`—All patches from the MQP package and the [Magento Cloud Patches]({{ site.baseurl }}/cloud/project/project-patch.html) package are optional for {{ site.data.var.ee }} and {{ site.data.var.ce }} installations.
-  - `Deprecated`—Magento has deprecated the individual patch. If you have applied the patch, we recommend that you revert it. The revert operation also removes the patch from the status table.
+  -  `Optional`—All patches from the MQP package and the [Magento Cloud Patches]({{ site.baseurl }}/cloud/project/project-patch.html) package are optional for {{ site.data.var.ee }} and {{ site.data.var.ce }} installations.
+  -  `Deprecated`—Magento has deprecated the individual patch. If you have applied the patch, we recommend that you revert it. The revert operation also removes the patch from the status table.
 
 - **Status**:
-  - `Applied`—The patch has been applied.
-  - `Not applied`—The patch has not been applied.
-  - `N/A`—The status of the patch cannot be defined due to conflicts.
+  -  `Applied`—The patch has been applied.
+  -  `Not applied`—The patch has not been applied.
+  -  `N/A`—The status of the patch cannot be defined due to conflicts.
 
 - **Details**:
-  - `Affected components`—The list of affected Magento modules.
-  - `Required patches`—The list of patches that must be applied for an indicated patch to work properly (dependencies).
-  - `Recommended replacement`—The patch that is a recommended replacement for a deprecated patch.
+  -  `Affected components`—The list of affected Magento modules.
+  -  `Required patches`—The list of patches that must be applied for an indicated patch to work properly (dependencies).
+  -  `Recommended replacement`—The patch that is a recommended replacement for a deprecated patch.
 
 {:.bs-callout-info}
 After upgrading to a new version of Magento, you must re-apply patches if the patches are not included in the new version. See [Re-apply patches after an upgrade](#upgrade).

--- a/src/guides/v2.3/comp-mgr/patching/mqp.md
+++ b/src/guides/v2.3/comp-mgr/patching/mqp.md
@@ -72,21 +72,18 @@ Magento 2 Enterprise Edition, version 2.3.5.0
 The status table contains the following types of information:
 
 -  **Type**:
-
-  -  `Optional`—All patches from the MQP package and the [Magento Cloud Patches]({{ site.baseurl }}/cloud/project/project-patch.html) package are optional for {{ site.data.var.ee }} and {{ site.data.var.ce }} installations.
-  -  `Deprecated`—Magento has deprecated the individual patch. If you have applied the patch, we recommend that you revert it. The revert operation also removes the patch from the status table.
+   -  `Optional`—All patches from the MQP package and the [Magento Cloud Patches]({{ site.baseurl }}/cloud/project/project-patch.html) package are optional for {{ site.data.var.ee }} and {{ site.data.var.ce }} installations.
+   -  `Deprecated`—Magento has deprecated the individual patch. If you have applied the patch, we recommend that you revert it. The revert operation also removes the patch from the status table.
 
 -  **Status**:
-
-  -  `Applied`—The patch has been applied.
-  -  `Not applied`—The patch has not been applied.
-  -  `N/A`—The status of the patch cannot be defined due to conflicts.
+   -  `Applied`—The patch has been applied.
+   -  `Not applied`—The patch has not been applied.
+   -  `N/A`—The status of the patch cannot be defined due to conflicts.
 
 -  **Details**:
-
-  -  `Affected components`—The list of affected Magento modules.
-  -  `Required patches`—The list of patches that must be applied for an indicated patch to work properly (dependencies).
-  -  `Recommended replacement`—The patch that is a recommended replacement for a deprecated patch.
+   -  `Affected components`—The list of affected Magento modules.
+   -  `Required patches`—The list of patches that must be applied for an indicated patch to work properly (dependencies).
+   -  `Recommended replacement`—The patch that is a recommended replacement for a deprecated patch.
 
 {:.bs-callout-info}
 After upgrading to a new version of Magento, you must re-apply patches if the patches are not included in the new version. See [Re-apply patches after an upgrade](#upgrade).

--- a/src/guides/v2.3/comp-mgr/patching/mqp.md
+++ b/src/guides/v2.3/comp-mgr/patching/mqp.md
@@ -71,19 +71,19 @@ Magento 2 Enterprise Edition, version 2.3.5.0
 
 The status table contains the following types of information:
 
-- **Type**:
-  -  `Optional`—All patches from the MQP package and the [Magento Cloud Patches]({{ site.baseurl }}/cloud/project/project-patch.html) package are optional for {{ site.data.var.ee }} and {{ site.data.var.ce }} installations.
-  -  `Deprecated`—Magento has deprecated the individual patch. If you have applied the patch, we recommend that you revert it. The revert operation also removes the patch from the status table.
+-  **Type**:
+   -  `Optional`—All patches from the MQP package and the [Magento Cloud Patches]({{ site.baseurl }}/cloud/project/project-patch.html) package are optional for {{ site.data.var.ee }} and {{ site.data.var.ce }} installations.
+   -  `Deprecated`—Magento has deprecated the individual patch. If you have applied the patch, we recommend that you revert it. The revert operation also removes the patch from the status table.
 
-- **Status**:
-  -  `Applied`—The patch has been applied.
-  -  `Not applied`—The patch has not been applied.
-  -  `N/A`—The status of the patch cannot be defined due to conflicts.
+-  **Status**:
+   -  `Applied`—The patch has been applied.
+   -  `Not applied`—The patch has not been applied.
+   -  `N/A`—The status of the patch cannot be defined due to conflicts.
 
-- **Details**:
-  -  `Affected components`—The list of affected Magento modules.
-  -  `Required patches`—The list of patches that must be applied for an indicated patch to work properly (dependencies).
-  -  `Recommended replacement`—The patch that is a recommended replacement for a deprecated patch.
+-  **Details**:
+   -  `Affected components`—The list of affected Magento modules.
+   -  `Required patches`—The list of patches that must be applied for an indicated patch to work properly (dependencies).
+   -  `Recommended replacement`—The patch that is a recommended replacement for a deprecated patch.
 
 {:.bs-callout-info}
 After upgrading to a new version of Magento, you must re-apply patches if the patches are not included in the new version. See [Re-apply patches after an upgrade](#upgrade).

--- a/src/guides/v2.3/comp-mgr/patching/mqp.md
+++ b/src/guides/v2.3/comp-mgr/patching/mqp.md
@@ -1,0 +1,204 @@
+---
+group: software-update-guide
+title: Apply patches using Magento Quality Patches Tool (MQP)
+functional_areas:
+  - Upgrade
+---
+
+### Magento Quality Patch (MQP) package {#mqp}
+
+The [MQP package][] delivers individual patches developed by Magento and allows you to apply, revert, and view general information about all individual patches that are available for the installed version of {{ site.data.var.ee }} or {{ site.data.var.ce }}.
+
+{:.bs-callout-warning}
+We do not recommend using the MQP package to apply large numbers of patches because it increases the complexity of your code, which makes upgrading to a new version of Magento more difficult.
+
+#### Install the MQP package
+
+{:.bs-callout-info}
+If it is not already installed, you must install [Git](https://github.com/git-guides/install-git) before installing the MQP package.
+Add the `magento/quality-patches` Composer package to your `composer.json` file:
+
+```bash
+composer require magento/quality-patches
+```
+
+#### View individual patches
+
+To view the list of individual patches available for your version of Magento:
+
+```bash
+./vendor/bin/magento-patches status
+```
+
+You will see output similar to the following:
+
+```terminal
+╔════════════════╤═════════════════════════════════════════════════╤══════════╤═════════════╤═════════════════════════════════╗
+║ Id             │ Title                                           │ Type     │ Status      │ Details                         ║
+╠════════════════╪═════════════════════════════════════════════════╪══════════╪═════════════╪═════════════════════════════════╣
+║ MAGECLOUD-5069 │ FPC is getting disabled during deployments      │ Optional │ Not applied │ Affected components:            ║
+║                │                                                 │          │             │  - magento/module-page-cache    ║
+╟────────────────┼─────────────────────────────────────────────────┼──────────┼─────────────┼─────────────────────────────────╢
+║ MCLOUD-5650    │ Hold deployment config after reading from file  │ Optional │ Not applied │ Affected components:            ║
+║                │                                                 │          │             │  - magento/framework            ║
+╟────────────────┼─────────────────────────────────────────────────┼──────────┼─────────────┼─────────────────────────────────╢
+║ MCLOUD-5684    │ Pagination Not working - product_list_limit=all │ Optional │ Not applied │ Affected components:            ║
+║                │                                                 │          │             │  - magento/module-elasticsearch ║
+╟────────────────┼─────────────────────────────────────────────────┼──────────┼─────────────┼─────────────────────────────────╢
+║ MCLOUD-5837    │ Fix load balancer issue                         │Deprecated│ Applied     │ Recommended replacement: MC-1   ║
+║                │                                                 │          │             │ Affected components:            ║
+║                │                                                 │          │             │  - magento/framework            ║
+╟────────────────┼─────────────────────────────────────────────────┼──────────┼─────────────┼─────────────────────────────────╢
+║ BUNDLE-2554    │ Set Payment info bug                            │ Optional │ Not applied │ Affected components:            ║
+║                │                                                 │          │             │  - amzn/amazon-pay-module       ║
+╟────────────────┼─────────────────────────────────────────────────┼──────────┼─────────────┼─────────────────────────────────╢
+║ MC-1           │ Fixes issue 1                                   │ Optional │ Applied     │ Affected components:            ║
+║                │                                                 │          │             │  - magento/module-cms           ║
+╟────────────────┼─────────────────────────────────────────────────┼──────────┼─────────────┼─────────────────────────────────╢
+║ MC-2           │ Fixes issue 2                                   │ Optional │ Not applied │ Affected components:            ║
+║                │                                                 │          │             │  - magento/module-cms           ║
+╟────────────────┼─────────────────────────────────────────────────┼──────────┼─────────────┼─────────────────────────────────╢
+║ MC-3           │ Fixes issue 3                                   │ Optional │ Not applied │ Required patches:               ║
+║                │                                                 │          │             │  - MC-2                         ║
+║                │                                                 │          │             │ Affected components:            ║
+║                │                                                 │          │             │  - magento/module-cms           ║
+╟────────────────┼─────────────────────────────────────────────────┼──────────┼─────────────┼─────────────────────────────────╢
+║ MC-3-V2        │ Updated fix for issue 3, replaces MC-3 patch    │ Optional │ N/A         │ Affected components:            ║
+║                │                                                 │          │             │  - magento/module-cms           ║
+╚════════════════╧═════════════════════════════════════════════════╧══════════╧═════════════╧═════════════════════════════════╝
+Magento 2 Enterprise Edition, version 2.3.5.0
+```
+
+The status table contains the following types of information:
+
+-  **Type**:
+
+   -  `Optional`—All patches from the MQP package and the [Magento Cloud Patches]({{ site.baseurl }}/cloud/project/project-patch.html) package are optional for {{ site.data.var.ee }} and {{ site.data.var.ce }} installations.
+   -  `Deprecated`—Magento has deprecated the individual patch. If you have applied the patch, we recommend that you revert it. The revert operation also removes the patch from the status table.
+
+-  **Status**:
+
+   -  `Applied`—The patch has been applied.
+   -  `Not applied`—The patch has not been applied.
+   -  `N/A`—The status of the patch cannot be defined due to conflicts.
+
+-  **Details**:
+
+   -  `Affected components`—The list of affected Magento modules.
+   -  `Required patches`—The list of patches that must be applied for an indicated patch to work properly (dependencies).
+   -  `Recommended replacement`—The patch that is a recommended replacement for a deprecated patch.
+
+{:.bs-callout-info}
+After upgrading to a new version of Magento, you must re-apply patches if the patches are not included in the new version. See [Re-apply patches after an upgrade](#upgrade).
+
+#### Apply individual patches
+
+{:.bs-callout-warning}
+We strongly recommend testing all patches in a staging or development environment before deploying to production. We also strongly recommend backing up your data before applying a patch. See [Back up and roll back the file system][].
+
+To apply a single patch, run the following command where `MAGETWO-XXXX` is the patch ID specified in the status table:
+
+```bash
+./vendor/bin/magento-patches apply MAGETWO-XXXX
+```
+
+Also, you can apply several patches at the same time by separating each additional patch ID with a space:
+
+```bash
+./vendor/bin/magento-patches apply MAGETWO-XXXX MAGETWO-YYYY
+```
+
+You must clean the cache after applying patches to see changes in the Magento application:
+
+```bash
+./bin/magento cache:clean
+```
+
+{:.bs-callout-info}
+Consider keeping a list of applied patches in a separate location. You might need to re-apply some of them after upgrading to a new version of Magento. See [Re-apply patches after an upgrade](#upgrade).
+
+#### Revert individual patches
+
+{:.bs-callout-warning}
+We strongly recommend testing all patches in a staging or development environment before deploying to production. We also strongly recommend backing up your data before applying a patch. See [Back up and roll back the file system][].
+
+To revert a single patch, run the following command where `MAGETWO-XXXX` is the patch ID specified in the status table:
+
+```bash
+./vendor/bin/magento-patches revert MAGETWO-XXXX
+```
+
+Also, you can revert several patches at the same time by separating each additional patch ID with a space:
+
+```bash
+./vendor/bin/magento-patches revert MAGETWO-XXXX MAGETWO-YYYY
+```
+
+To revert all applied patches:
+
+```bash
+./vendor/bin/magento-patches revert --all
+```
+
+You must clean the cache after reverting patches to see changes in the Magento application:
+
+```bash
+./bin/magento cache:clean
+```
+
+#### Get updates
+
+Magento periodically releases new individual patches. You must update the MQP package to get new individual patches:
+
+```bash
+composer update magento/quality-patches
+```
+
+View the added patches:
+
+{:.bs-callout-tip}
+New add patches display at the bottom of the table.
+
+```bash
+./vendor/bin/magento-patches status
+```
+
+#### Re-apply patches after an upgrade {#upgrade}
+
+When you upgrade to a new version of Magento, you must re-apply patches if the patches are not included in the new version.
+
+{:procedure}
+To re-apply patches:
+
+1. Update the MQP package:
+
+   ```bash
+   composer update magento/quality-patches.
+   ```
+
+1. Open the list of previously applied patches, which was recommended in [Apply individual patches](#apply-individual-patches).
+
+1. Apply the patches:
+
+   ```bash
+   ./vendor/bin/magento-patches apply MAGETWO-XXXX
+   ```
+
+   The best practice is to apply patches one at a time.
+
+1. Clean the cache:
+
+   ```bash
+   ./bin/magento cache:clean
+   ```
+
+   {:.bs-callout-info}
+   When you run the `status` command, the patches that where included in the new version are no longer displayed in the table of available patches.
+
+#### Logging
+
+The MQP package logs all operations in the `<Magento_root>/var/log/patch.log` file.
+
+<!-- Link Definitions -->
+
+[MQP package]: https://github.com/magento/quality-patches

--- a/src/guides/v2.3/comp-mgr/patching/mqp.md
+++ b/src/guides/v2.3/comp-mgr/patching/mqp.md
@@ -15,7 +15,7 @@ We do not recommend using the MQP package to apply large numbers of patches be
 #### Install the MQP package
 
 {:.bs-callout-info}
-If it is not already installed, you must install [Git](https://github.com/git-guides/install-git) before installing the MQP package.
+If it is not already installed, you must install [Git](https://github.com/git-guides/install-git) or [Patch](https://man7.org/linux/man-pages/man1/patch.1.html) before installing the MQP package.
 Add the `magento/quality-patches` Composer package to your `composer.json` file:
 
 ```bash

--- a/src/guides/v2.3/comp-mgr/patching/mqp.md
+++ b/src/guides/v2.3/comp-mgr/patching/mqp.md
@@ -71,19 +71,19 @@ Magento 2 Enterprise Edition, version 2.3.5.0
 
 The status table contains the following types of information:
 
--  **Type**:
-    -  `Optional`—All patches from the MQP package and the [Magento Cloud Patches]({{ site.baseurl }}/cloud/project/project-patch.html) package are optional for {{ site.data.var.ee }} and {{ site.data.var.ce }} installations.
-    -  `Deprecated`—Magento has deprecated the individual patch. If you have applied the patch, we recommend that you revert it. The revert operation also removes the patch from the status table.
+- **Type**:
+  - `Optional`—All patches from the MQP package and the [Magento Cloud Patches]({{ site.baseurl }}/cloud/project/project-patch.html) package are optional for {{ site.data.var.ee }} and {{ site.data.var.ce }} installations.
+  - `Deprecated`—Magento has deprecated the individual patch. If you have applied the patch, we recommend that you revert it. The revert operation also removes the patch from the status table.
 
--  **Status**:
-    -  `Applied`—The patch has been applied.
-    -  `Not applied`—The patch has not been applied.
-    -  `N/A`—The status of the patch cannot be defined due to conflicts.
+- **Status**:
+  - `Applied`—The patch has been applied.
+  - `Not applied`—The patch has not been applied.
+  - `N/A`—The status of the patch cannot be defined due to conflicts.
 
--  **Details**:
-    -  `Affected components`—The list of affected Magento modules.
-    -  `Required patches`—The list of patches that must be applied for an indicated patch to work properly (dependencies).
-    -  `Recommended replacement`—The patch that is a recommended replacement for a deprecated patch.
+- **Details**:
+  - `Affected components`—The list of affected Magento modules.
+  - `Required patches`—The list of patches that must be applied for an indicated patch to work properly (dependencies).
+  - `Recommended replacement`—The patch that is a recommended replacement for a deprecated patch.
 
 {:.bs-callout-info}
 After upgrading to a new version of Magento, you must re-apply patches if the patches are not included in the new version. See [Re-apply patches after an upgrade](#upgrade).

--- a/src/guides/v2.3/comp-mgr/patching/mqp.md
+++ b/src/guides/v2.3/comp-mgr/patching/mqp.md
@@ -196,4 +196,4 @@ The MQP package logs all operations in the `<Magento_root>/var/log/patch.log` fi
 
 <!-- Link Definitions -->
 
-[MQP package]: https://github.com/magento/quality-patches
+[Magento Quality Package (MQP) package]: https://github.com/magento/quality-patches

--- a/src/guides/v2.3/comp-mgr/patching/mqp.md
+++ b/src/guides/v2.3/comp-mgr/patching/mqp.md
@@ -5,9 +5,7 @@ functional_areas:
   - Upgrade
 ---
 
-### Magento Quality Patch (MQP) package {#mqp}
-
-The [MQP package][] delivers individual patches developed by Magento and allows you to apply, revert, and view general information about all individual patches that are available for the installed version of {{ site.data.var.ee }} or {{ site.data.var.ce }}.
+The [Magento Quality Package (MQP) package][] delivers individual patches developed by Magento and allows you to apply, revert, and view general information about all individual patches that are available for the installed version of {{ site.data.var.ee }} or {{ site.data.var.ce }}.
 
 {:.bs-callout-warning}
 We do not recommend using the MQP package to apply large numbers of patches because it increases the complexity of your code, which makes upgrading to a new version of Magento more difficult.

--- a/src/guides/v2.3/comp-mgr/patching/mqp.md
+++ b/src/guides/v2.3/comp-mgr/patching/mqp.md
@@ -72,18 +72,18 @@ Magento 2 Enterprise Edition, version 2.3.5.0
 The status table contains the following types of information:
 
 -  **Type**:
-   -  `Optional`—All patches from the MQP package and the [Magento Cloud Patches]({{ site.baseurl }}/cloud/project/project-patch.html) package are optional for {{ site.data.var.ee }} and {{ site.data.var.ce }} installations.
-   -  `Deprecated`—Magento has deprecated the individual patch. If you have applied the patch, we recommend that you revert it. The revert operation also removes the patch from the status table.
+    -  `Optional`—All patches from the MQP package and the [Magento Cloud Patches]({{ site.baseurl }}/cloud/project/project-patch.html) package are optional for {{ site.data.var.ee }} and {{ site.data.var.ce }} installations.
+    -  `Deprecated`—Magento has deprecated the individual patch. If you have applied the patch, we recommend that you revert it. The revert operation also removes the patch from the status table.
 
 -  **Status**:
-   -  `Applied`—The patch has been applied.
-   -  `Not applied`—The patch has not been applied.
-   -  `N/A`—The status of the patch cannot be defined due to conflicts.
+    -  `Applied`—The patch has been applied.
+    -  `Not applied`—The patch has not been applied.
+    -  `N/A`—The status of the patch cannot be defined due to conflicts.
 
 -  **Details**:
-   -  `Affected components`—The list of affected Magento modules.
-   -  `Required patches`—The list of patches that must be applied for an indicated patch to work properly (dependencies).
-   -  `Recommended replacement`—The patch that is a recommended replacement for a deprecated patch.
+    -  `Affected components`—The list of affected Magento modules.
+    -  `Required patches`—The list of patches that must be applied for an indicated patch to work properly (dependencies).
+    -  `Recommended replacement`—The patch that is a recommended replacement for a deprecated patch.
 
 {:.bs-callout-info}
 After upgrading to a new version of Magento, you must re-apply patches if the patches are not included in the new version. See [Re-apply patches after an upgrade](#upgrade).

--- a/src/guides/v2.4/comp-mgr/patching/command-line.md
+++ b/src/guides/v2.4/comp-mgr/patching/command-line.md
@@ -1,0 +1,1 @@
+../../../v2.3/comp-mgr/patching/command-line.md

--- a/src/guides/v2.4/comp-mgr/patching/composer.md
+++ b/src/guides/v2.4/comp-mgr/patching/composer.md
@@ -1,0 +1,1 @@
+../../../v2.3/comp-mgr/patching/composer.md

--- a/src/guides/v2.4/comp-mgr/patching/mqp.md
+++ b/src/guides/v2.4/comp-mgr/patching/mqp.md
@@ -1,0 +1,1 @@
+../../../v2.3/comp-mgr/patching/mqp.md

--- a/src/quality-patches/release-notes.md
+++ b/src/quality-patches/release-notes.md
@@ -16,7 +16,7 @@ The [Magento Quality Patches](https://github.com/magento/quality-patches) packag
 -  {:.bug}Known issues -->
 
 {:.bs-callout-info}
-See [Apply patches]({{ site.baseurl }}/guides/v2.4/comp-mgr/patching.html#mqp) for instructions on applying patches to your Magento projects.
+See [Apply patches]({{ site.baseurl }}/guides/v2.4/comp-mgr/patching/mqp.html#mqp) for instructions on applying patches to your Magento projects.
 See [Patches available in MQP tool](https://support.magento.com/hc/en-us/sections/360010506631-Patches-available-in-MQP-tool-) for additional patch details.
 
 ## v1.0.6

--- a/src/quality-patches/release-notes.md
+++ b/src/quality-patches/release-notes.md
@@ -16,7 +16,7 @@ The [Magento Quality Patches](https://github.com/magento/quality-patches) packag
 -  {:.bug}Known issues -->
 
 {:.bs-callout-info}
-See [Apply patches]({{ site.baseurl }}/guides/v2.4/comp-mgr/patching/mqp.html#mqp) for instructions on applying patches to your Magento projects.
+See [Apply patches]({{ site.baseurl }}/guides/v2.4/comp-mgr/patching/mqp.html) for instructions on applying patches to your Magento projects.
 See [Patches available in MQP tool](https://support.magento.com/hc/en-us/sections/360010506631-Patches-available-in-MQP-tool-) for additional patch details.
 
 ## v1.0.6


### PR DESCRIPTION
## Purpose of this pull request

This pull request (PR) is to separate patch application methods from one single page to individual pages.
MQP section is rather large and it would be nice to have it on a separate page, alongside the composer and command line patch application methods.

The work was done in the scope of the JIRA story: https://jira.corp.magento.com/browse/MC-37903

Certain Help Center pages are currently pointing to the https://devdocs.magento.com/guides/v2.4/comp-mgr/patching.html and https://devdocs.magento.com/guides/v2.4/comp-mgr/patching.html#mpq, the change should not break the links, but I will work on updating the related articles to point directly to the new MQP page after the PR is merged.


## Affected DevDocs pages

<!-- REQUIRED List the affected pages on devdocs.magento.com (URLs). Not needed for large numbers of files. -->

- https://devdocs.magento.com/guides/v2.4/comp-mgr/patching.html
- https://devdocs.magento.com/quality-patches/release-notes.html
- https://devdocs.magento.com/cloud/project/project-patch.html

<!--
If you are fixing a GitHub issue, note it using GitHub keyword format (https://help.github.com/en/articles/closing-issues-using-keywords#closing-an-issue-in-a-different-repository) to close the issue when this pull request is merged. Example: `Fixes #1234`

`master` is the default branch. Merged pull requests to `master` go live on the site automatically. Any requested changes to content on the `master` branch must be related to the released codebase. Any content related to future releases goes in the `develop` branch.

See Contribution guidelines (https://github.com/magento/devdocs/blob/master/.github/CONTRIBUTING.md) for more information.
-->
