### PR TITLE
Fix super linter

### DIFF
--- a/.github/workflows/linter.yml
+++ b/.github/workflows/linter.yml
@@ -54,4 +54,4 @@ jobs:
           VALIDATE_ALL_CODEBASE: false
           DEFAULT_BRANCH: master
           VALIDATE_HTML: false
-          VALIDATE_MD: false
+          VALIDATE_MARKDOWN: false


### PR DESCRIPTION
## Purpose of this pull request

This pull request (PR) updates syntax to disable Markdown check for the Lint Code Base check. The SuperLinter syntax was changed just yesterday (https://github.com/github/super-linter/commit/b69b2b124b798c3040e265f63d6c965a81172b9a).

