### PR TITLE
magento/devdocs#: Get Redis version on Cloud environments

### DIFF
--- a/src/cloud/project/services-redis.md
+++ b/src/cloud/project/services-redis.md
@@ -63,3 +63,26 @@ Assuming your Redis relationship is named `redis`, you can access it using the `
    ```bash
    redis-cli -h redis.internal
    ```
+
+## Get installed Redis version
+
+Use the following command to get the Redis version installed on an Integration environment:
+
+```bash
+redis-cli -h redis.internal info | grep version
+```
+
+```terminal
+redis_version:5.0.0
+gcc_version:6.3.0
+```
+
+To get the Redis version installed on a Staging or Production environment, use the `redis-server` command:
+
+```bash
+redis-server -v
+```
+
+```terminal
+Redis server v=5.0.5 sha=947ee0b5:0 malloc=jemalloc-5.1.0 bits=64 build=c1ca234caf5bd678
+```


### PR DESCRIPTION
## Purpose of this pull request

This pull request (PR) adds information how a Redis version may be retrieved on Cloud instances.

## Affected DevDocs pages

<!-- REQUIRED List the affected pages on devdocs.magento.com (URLs). Not needed for large numbers of files. -->

-  https://devdocs.magento.com/cloud/project/services-redis.html

## Links to Magento source code

<!--  OPTIONAL - REMOVE THIS SECTION IF NOT USED. If this pull request references a file in a Magento codebase repository, add it here. -->

<img width="372" alt="redis" src="https://user-images.githubusercontent.com/13585327/95512202-31933080-09c1-11eb-9a6a-6a10c61adb5a.png">


<!--
If you are fixing a GitHub issue, note it using GitHub keyword format (https://help.github.com/en/articles/closing-issues-using-keywords#closing-an-issue-in-a-different-repository) to close the issue when this pull request is merged. Example: `Fixes #1234`

`master` is the default branch. Merged pull requests to `master` go live on the site automatically. Any requested changes to content on the `master` branch must be related to the released codebase. Any content related to future releases goes in the `develop` branch.

See Contribution guidelines (https://github.com/magento/devdocs/blob/master/.github/CONTRIBUTING.md) for more information.
-->

Thank you!