### PR TITLE
Added example for date column and filter to admin grid guide

### DIFF
--- a/src/guides/v2.3/extension-dev-guide/admin-grid.md
+++ b/src/guides/v2.3/extension-dev-guide/admin-grid.md
@@ -197,6 +197,13 @@ The UI component `dev_grid_category_listing` must be defined separately in a fil
          <label translate="true">Name</label>
       </settings>
     </column>
+    <column name="created_at" class="Magento\Ui\Component\Listing\Columns\Date" component="Magento_Ui/js/grid/columns/date">
+      <settings>
+        <filter>dateRange</filter>
+        <dataType>date</dataType>
+        <label translate="true">Created</label>
+      </settings>
+    </column>
     <actionsColumn name="actions" class="Dev\Grid\Ui\Component\Category\Listing\Column\Actions" sortOrder="200">
        <argument name="data" xsi:type="array">
           <item name="config" xsi:type="array">


### PR DESCRIPTION
## Purpose of this pull request

It is very common to show dates in a grid. The example should make it easier for developers to find out how it works.

## Affected DevDocs pages

- https://devdocs.magento.com/guides/v2.3/extension-dev-guide/admin-grid.html
- https://devdocs.magento.com/guides/v2.4/extension-dev-guide/admin-grid.html

## Notes

If you like this PR, I'd be happy if you could add the "[hacktoberfest-accepted](https://hacktoberfest.digitalocean.com/details#details)" label to the PR.