### PR TITLE
Update BrainTree Statement

### DIFF
--- a/src/guides/v2.4/release-notes/release-notes-2-4-0-commerce.md
+++ b/src/guides/v2.4/release-notes/release-notes-2-4-0-commerce.md
@@ -89,8 +89,6 @@ The following platform upgrades help enhance website security and performance. S
 
 *  **Removal of the core integration of the Signifyd fraud protection code**. This core feature is no longer supported. Merchants should migrate to the [Signifyd Fraud & Chargeback Protection extension](https://marketplace.magento.com/signifyd-module-connect.html) that is available on the Magento Marketplace.
 
-*  The **core Braintree module has been removed from the code base**. The Braintree Payments module now provides the same feature set. See [Braintree Payments](https://marketplace.magento.com/paypal-module-braintree.html).
-
 *  The Internet Explorer 11.x browser is no longer supported.
 
 ### Infrastructure improvements
@@ -221,9 +219,6 @@ This release includes:
 *  Ability to do multiple authorizations for a multi-item order
 *  Support for Japanese addresses
 
-#### Braintree Payments
-
-This bundled extension replaces our core Braintree integration, which has been removed in this release. See [Braintree Payments](https://marketplace.magento.com/paypal-module-braintree.html).
 
 #### Klarna
 


### PR DESCRIPTION
This is a contradictory statement to the following on this page itself. It is also not included in this blog post. URL: https://community.magento.com/t5/Magento-DevBlog/Deprecation-of-Magento-core-payment-integrations/ba-p/426445?_ga=2.145131826.704475700.1602302487-695246737.1590919082

This bundled extension replaces our core Braintree integration, which has been removed in this release. See Braintree Payments.
This is also on the same page