### PR TITLE
Added link to custom cron reference

### DIFF
--- a/src/guides/v2.3/config-guide/cli/config-cli-subcommands-cron.md
+++ b/src/guides/v2.3/config-guide/cli/config-cli-subcommands-cron.md
@@ -92,3 +92,7 @@ content='All cron data is also written to the `cron_schedule` table in the Magen
 
 To see records in the table, log in to the Magento database on the command line and enter `SELECT * from cron_schedule;`.'
 %}
+
+## Related topics
+
+[Custom cron job and cron group reference]({{ page.baseurl }}/config-guide/cron/custom-cron-ref.html)

--- a/src/guides/v2.4/config-guide/cli/config-cli-subcommands-cron.md
+++ b/src/guides/v2.4/config-guide/cli/config-cli-subcommands-cron.md
@@ -92,3 +92,7 @@ content='All cron data is also written to the `cron_schedule` table in the Magen
 
 To see records in the table, log in to the Magento database on the command line and enter `SELECT * from cron_schedule;`.'
 %}
+
+## Related topics
+
+[Custom cron job and cron group reference]({{ page.baseurl }}/config-guide/cron/custom-cron-ref.html)


### PR DESCRIPTION
## Purpose of this pull request

People may be directed to the documentation on how to use the cli subcommand 'cron', when they are using a search engine to find out how to create cron jobs. But on that page it is not explained about how to add custom cron jobs.

So I have added a link to the page where more information can be found. This makes it easier to navigate through the docs.

## Affected DevDocs pages

- https://devdocs.magento.com/guides/v2.3/config-guide/cli/config-cli-subcommands-cron.html
- https://devdocs.magento.com/guides/v2.4/config-guide/cli/config-cli-subcommands-cron.html
