### PR TITLE
Added validation rules to the system.xml reference

### DIFF
--- a/src/guides/v2.3/config-guide/prod/config-reference-systemxml.md
+++ b/src/guides/v2.3/config-guide/prod/config-reference-systemxml.md
@@ -358,12 +358,12 @@ The following validation rules are available:
 
 | Rule                            | Description                                                                                                             |
 |---------------------------------|-------------------------------------------------------------------------------------------------------------------------|
-| `alphanumeric`                  | Allows letters, numbers, spaces or underscores only                                                                     |
-| `integer`                       | Enter a positive or negative non-decimal number                                                                         |
-| `letters-only`                  | Allows letters only. For example, abcABC                                                                                |
+| `alphanumeric`                  | Allows letters, numbers, spaces or underscores only.                                                                     |
+| `integer`                       | Enter a positive or negative non-decimal number.                                                                         |
+| `letters-only`                  | Allows letters only. For example, `abcABC`.                                                                                |
 | `no-whitespace`                 | Disallows white spaces.                                                                                                 |
-| `time`                          | Allows a valid time in 24-hour format, between 00:00 and 23:59. For example 15, 15:05 or 15:05:48                                         |
-| `time12h`                       | Allows a valid time in 12-hour format, between 12:00 am and 11:59:59 pm. For example 3 am, 11:30 pm, 02:15:00 pm          |
+| `time`                          | Allows a valid time in 24-hour format, between 00:00 and 23:59. For example `15`, `15:05` or `15:05:48`                                         |
+| `time12h`                       | Allows a valid time in 12-hour format, between 12:00 am and 11:59:59 pm. For example `3 am`, `11:30 pm`, `02:15:00 pm`.          |
 | `validate-no-html-tags`         | HTML tags are not allowed.                                                                                              |
 | `validate-select`               | Select an option.                                                                                                       |
 | `validate-no-empty`             | Empty Value                                                                                                             |

--- a/src/guides/v2.3/config-guide/prod/config-reference-systemxml.md
+++ b/src/guides/v2.3/config-guide/prod/config-reference-systemxml.md
@@ -358,6 +358,12 @@ The following validation rules are available:
 
 | Rule                            | Description                                                                                                             |
 |---------------------------------|-------------------------------------------------------------------------------------------------------------------------|
+| `alphanumeric`                  | Allows letters, numbers, spaces or underscores only                                                                     |
+| `integer`                       | Enter a positive or negative non-decimal number                                                                         |
+| `letters-only`                  | Allows letters only. For example, fooBAR                                                                                |
+| `no-whitespace`                 | Disallows white spaces.                                                                                                 |
+| `time`                          | Allows a valid time, between 00:00 and 23:59. For example 15, 15:05 or 15:05:48                                         |
+| `time12h`                       | Allows a valid time in 12 hours format, between 00:00 am and 12:00 pm. For example 3 am, 11:30 pm, 02:15:00 pm          |
 | `validate-no-html-tags`         | HTML tags are not allowed.                                                                                              |
 | `validate-select`               | Select an option.                                                                                                       |
 | `validate-no-empty`             | Empty Value                                                                                                             |

--- a/src/guides/v2.3/config-guide/prod/config-reference-systemxml.md
+++ b/src/guides/v2.3/config-guide/prod/config-reference-systemxml.md
@@ -360,10 +360,10 @@ The following validation rules are available:
 |---------------------------------|-------------------------------------------------------------------------------------------------------------------------|
 | `alphanumeric`                  | Allows letters, numbers, spaces or underscores only                                                                     |
 | `integer`                       | Enter a positive or negative non-decimal number                                                                         |
-| `letters-only`                  | Allows letters only. For example, fooBAR                                                                                |
+| `letters-only`                  | Allows letters only. For example, abcABC                                                                                |
 | `no-whitespace`                 | Disallows white spaces.                                                                                                 |
-| `time`                          | Allows a valid time, between 00:00 and 23:59. For example 15, 15:05 or 15:05:48                                         |
-| `time12h`                       | Allows a valid time in 12 hours format, between 00:00 am and 12:00 pm. For example 3 am, 11:30 pm, 02:15:00 pm          |
+| `time`                          | Allows a valid time in 24-hour format, between 00:00 and 23:59. For example 15, 15:05 or 15:05:48                                         |
+| `time12h`                       | Allows a valid time in 12-hour format, between 12:00 am and 11:59:59 pm. For example 3 am, 11:30 pm, 02:15:00 pm          |
 | `validate-no-html-tags`         | HTML tags are not allowed.                                                                                              |
 | `validate-select`               | Select an option.                                                                                                       |
 | `validate-no-empty`             | Empty Value                                                                                                             |

--- a/src/guides/v2.4/config-guide/prod/config-reference-systemxml.md
+++ b/src/guides/v2.4/config-guide/prod/config-reference-systemxml.md
@@ -358,12 +358,12 @@ The following validation rules are available:
 
 | Rule                            | Description                                                                                                             |
 |---------------------------------|-------------------------------------------------------------------------------------------------------------------------|
-| `alphanumeric`                  | Allows letters, numbers, spaces or underscores only                                                                     |
-| `integer`                       | Enter a positive or negative non-decimal number                                                                         |
-| `letters-only`                  | Allows letters only. For example, abcABC                                                                                |
+| `alphanumeric`                  | Allows letters, numbers, spaces or underscores only.                                                                    |
+| `integer`                       | Enter a positive or negative non-decimal number.                                                                         |
+| `letters-only`                  | Allows letters only. For example, `abcABC`.                                                                                |
 | `no-whitespace`                 | Disallows white spaces.                                                                                                 |
-| `time`                          | Allows a valid time in 24-hour format, between 00:00 and 23:59. For example 15, 15:05 or 15:05:48                                         |
-| `time12h`                       | Allows a valid time in 12-hour format, between 12:00 am and 11:59:59 pm. For example 3 am, 11:30 pm, 02:15:00 pm          |
+| `time`                          | Allows a valid time in 24-hour format, between 00:00 and 23:59. For example `15`, `15:05` or `15:05:48`.                                        |
+| `time12h`                       | Allows a valid time in 12-hour format, between 12:00 am and 11:59:59 pm. For example `3 am`, `11:30 pm`, `02:15:00 pm`.          |
 | `validate-no-html-tags`         | HTML tags are not allowed.                                                                                              |
 | `validate-select`               | Select an option.                                                                                                       |
 | `validate-no-empty`             | Empty Value                                                                                                             |

--- a/src/guides/v2.4/config-guide/prod/config-reference-systemxml.md
+++ b/src/guides/v2.4/config-guide/prod/config-reference-systemxml.md
@@ -358,6 +358,12 @@ The following validation rules are available:
 
 | Rule                            | Description                                                                                                             |
 |---------------------------------|-------------------------------------------------------------------------------------------------------------------------|
+| `alphanumeric`                  | Allows letters, numbers, spaces or underscores only                                                                     |
+| `integer`                       | Enter a positive or negative non-decimal number                                                                         |
+| `letters-only`                  | Allows letters only. For example, fooBAR                                                                                |
+| `no-whitespace`                 | Disallows white spaces.                                                                                                 |
+| `time`                          | Allows a valid time, between 00:00 and 23:59. For example 15, 15:05 or 15:05:48                                         |
+| `time12h`                       | Allows a valid time in 12 hours format, between 00:00 am and 12:00 pm. For example 3 am, 11:30 pm, 02:15:00 pm          |
 | `validate-no-html-tags`         | HTML tags are not allowed.                                                                                              |
 | `validate-select`               | Select an option.                                                                                                       |
 | `validate-no-empty`             | Empty Value                                                                                                             |

--- a/src/guides/v2.4/config-guide/prod/config-reference-systemxml.md
+++ b/src/guides/v2.4/config-guide/prod/config-reference-systemxml.md
@@ -363,7 +363,7 @@ The following validation rules are available:
 | `letters-only`                  | Allows letters only. For example, fooBAR                                                                                |
 | `no-whitespace`                 | Disallows white spaces.                                                                                                 |
 | `time`                          | Allows a valid time, between 00:00 and 23:59. For example 15, 15:05 or 15:05:48                                         |
-| `time12h`                       | Allows a valid time in 12 hours format, between 00:00 am and 12:00 pm. For example 3 am, 11:30 pm, 02:15:00 pm          |
+| `time12h`                       | Allows a valid time in 12-hour format, between 12:00 am and 11:59:59 pm. For example 3 am, 11:30 pm, 02:15:00 pm          |
 | `validate-no-html-tags`         | HTML tags are not allowed.                                                                                              |
 | `validate-select`               | Select an option.                                                                                                       |
 | `validate-no-empty`             | Empty Value                                                                                                             |

--- a/src/guides/v2.4/config-guide/prod/config-reference-systemxml.md
+++ b/src/guides/v2.4/config-guide/prod/config-reference-systemxml.md
@@ -360,9 +360,9 @@ The following validation rules are available:
 |---------------------------------|-------------------------------------------------------------------------------------------------------------------------|
 | `alphanumeric`                  | Allows letters, numbers, spaces or underscores only                                                                     |
 | `integer`                       | Enter a positive or negative non-decimal number                                                                         |
-| `letters-only`                  | Allows letters only. For example, fooBAR                                                                                |
+| `letters-only`                  | Allows letters only. For example, abcABC                                                                                |
 | `no-whitespace`                 | Disallows white spaces.                                                                                                 |
-| `time`                          | Allows a valid time, between 00:00 and 23:59. For example 15, 15:05 or 15:05:48                                         |
+| `time`                          | Allows a valid time in 24-hour format, between 00:00 and 23:59. For example 15, 15:05 or 15:05:48                                         |
 | `time12h`                       | Allows a valid time in 12-hour format, between 12:00 am and 11:59:59 pm. For example 3 am, 11:30 pm, 02:15:00 pm          |
 | `validate-no-html-tags`         | HTML tags are not allowed.                                                                                              |
 | `validate-select`               | Select an option.                                                                                                       |


### PR DESCRIPTION
## Purpose of this pull request

The current reference for the validation rules is very incomplete. Some imported rules that were missing have been added:

* alphanumeric
* integer
* letters-only
* no-whitespace
* time
* time12h

The rules can be found in /path/to/magento-root/app/code/Magento/Ui/view/base/web/js/lib/validation/rules.js

## Affected DevDocs pages

* https://devdocs.magento.com/guides/v2.3/config-guide/prod/config-reference-systemxml.html
* https://devdocs.magento.com/guides/v2.4/config-guide/prod/config-reference-systemxml.html

## Links to Magento source code

- https://github.com/magento/magento2/blob/2.3/app/code/Magento/Ui/view/base/web/js/lib/validation/rules.js

whatsnew
Added missing field validation rules to the  [system.xml reference](https://devdocs.magento.com/guides/v2.3/config-guide/prod/config-reference-systemxml.html) in the _Magento Configuration Guide_.

## Notes

If you like this PR, I'd be happy if you could add the "[hacktoberfest-accepted](https://hacktoberfest.digitalocean.com/details#details)" label to the PR.