### PR TITLE
Added Cloud Patches 1.0.7 release notes

### DIFF
--- a/src/_data/var.yml
+++ b/src/_data/var.yml
@@ -28,7 +28,7 @@ ct-repo: magento/ece-tools
 ct-release: 2002.1.2
 mcp-prod: Magento Cloud Patches
 mcp-package: magento/magento-cloud-patches
-mcp-release: 1.0.6
+mcp-release: 1.0.7
 mcd-package: magento/magento-cloud-docker
 mcd-prod: Magento Cloud Docker
 mcd-release: 1.1.2

--- a/src/cloud/release-notes/cloud-tools.md
+++ b/src/cloud/release-notes/cloud-tools.md
@@ -14,9 +14,9 @@ This release information details the latest improvements to the {{site.data.var.
 | Release notes | Version | Description | Package source |
 | --- | --- | --- | --- |
 | [`{{site.data.var.ct}}` release notes] | {{site.data.var.ct-release}}<br/>2002.0.23| A set of scripts and tools designed to manage and deploy Cloud projects | [{{site.data.var.ct}}][ece package] |
-| [`{{site.data.var.mcp-prod}}` release notes] | {{site.data.var.mcp-release}} | A set of patches which improve the integration of all Magento versions with Cloud environments. This package includes Magento patches and available hotfixes that are applied when you use `{{site.data.var.ct}}` to deploy | [{{site.data.var.mcp}}][Patches package] |
-| [`{{site.data.var.mcd-prod}}` release notes] | {{site.data.var.mcd-release}} | Functionality and configuration files for Docker images to deploy Magento Commerce to a local Cloud environment | [{{site.data.var.mcd}}][Docker package] |
-| [`{{site.data.var.mcc-prod}}` release notes] | {{site.data.var.mcc-release}} | Extended Magento Commerce core functionality for sites deployed on the Cloud platform | [{{site.data.var.mcc}}][Components package] |
+| [`{{site.data.var.mcp-prod}}` release notes] | {{site.data.var.mcp-release}} | A set of patches which improve the integration of all Magento versions with Cloud environments. This package includes Magento patches and available hotfixes that are applied when you use `{{site.data.var.ct}}` to deploy | [{{site.data.var.mcp-package}}][Patches package] |
+| [`{{site.data.var.mcd-prod}}` release notes] | {{site.data.var.mcd-release}} | Functionality and configuration files for Docker images to deploy Magento Commerce to a local Cloud environment | [{{site.data.var.mcd-package}}][Docker package] |
+| [`{{site.data.var.mcc-prod}}` release notes] | {{site.data.var.mcc-release}} | Extended Magento Commerce core functionality for sites deployed on the Cloud platform | [{{site.data.var.mcc-package}}][Components package] |
 
 When you update to `{{site.data.var.ct}}` 2002.1.0 or later, you automatically update to the latest versions of the other packages, which are dependencies for `{{site.data.var.ct}}`.
 

--- a/src/cloud/release-notes/mcp-release-notes.md
+++ b/src/cloud/release-notes/mcp-release-notes.md
@@ -19,6 +19,17 @@ To ensure that your project has all required patches, update to the [latest vers
 {:.bs-callout-info}
 See [Apply patches]({{site.baseurl}}/cloud/project/project-patch.html) for instructions on applying patches to your Magento projects.
 
+<!--Add release notes below-->
+
+## v1.0.7
+*Release date: October 13, 2020*<br/>
+
+-  **Redis patches for Magento 2.3.0 - 2.3.5, 2.4.0**–Updated the Redis patches to support adding products to a category when implementing a Level 2 cache. <!--MCLOUD-6659-->
+
+-  **Braintree VBE patch**–Fixes an issue that generated an error when an Administrator tried to view a Braintree Settlement Report. <!--MCLOUD-6684-->
+
+-  Changed the Magento Quality Patches (MQP) package dependency in the `composer.json` file from a required dependency to a suggested one. The MQP package is no longer required when installing `{{ site.data.var.mcp-package }}` as a stand-alone package. <!--MCLOUD-6910-->
+
 ## v1.0.6
 *Release date: {{ site.data.var.ece-release-date }}*<br/>
 

--- a/src/cloud/release-notes/mcp-release-notes.md
+++ b/src/cloud/release-notes/mcp-release-notes.md
@@ -28,7 +28,7 @@ See [Apply patches]({{site.baseurl}}/cloud/project/project-patch.html) for instr
 
 -  **Braintree VBE patch**–Fixes an issue that generated an error when an Administrator tried to view a Braintree Settlement Report. <!--MCLOUD-6684-->
 
--  Now, the `ece-patches apply` command uses the Unix Patch command to apply patches if Git is not available on the host system. <!--MCLOUD-7069-->
+-  Now, the `ece-patches apply` command uses the Unix `patch` command to apply patches if Git is not available on the host system. <!--MCLOUD-7069-->
 
 ## v1.0.6
 *Release date: {{ site.data.var.ece-release-date }}*<br/>

--- a/src/cloud/release-notes/mcp-release-notes.md
+++ b/src/cloud/release-notes/mcp-release-notes.md
@@ -24,7 +24,7 @@ See [Apply patches]({{site.baseurl}}/cloud/project/project-patch.html) for instr
 ## v1.0.7
 *Release date: October 14, 2020*<br/>
 
--  **Redis patches for Magento 2.3.0 - 2.3.5, 2.4.0**–Updated the Redis patches to support adding products to a category when implementing a Level 2 cache. <!--MCLOUD-6659-->
+-  **Redis patches for Magento 2.3.0 to 2.3.5, 2.4.0**–Updated the Redis patches to support adding products to a category when implementing a Level 2 cache. <!--MCLOUD-6659-->
 
 -  **Braintree VBE patch**–Fixes an issue that generated an error when an Administrator tried to view a Braintree Settlement Report. <!--MCLOUD-6684-->
 

--- a/src/cloud/release-notes/mcp-release-notes.md
+++ b/src/cloud/release-notes/mcp-release-notes.md
@@ -27,6 +27,7 @@ See [Apply patches]({{site.baseurl}}/cloud/project/project-patch.html) for instr
 -  **Redis patches for Magento 2.3.0 - 2.3.5, 2.4.0**–Updated the Redis patches to support adding products to a category when implementing a Level 2 cache. <!--MCLOUD-6659-->
 
 -  **Braintree VBE patch**–Fixes an issue that generated an error when an Administrator tried to view a Braintree Settlement Report. <!--MCLOUD-6684-->
+
 -  Now, the `ece-patches apply` command uses the Unix Patch command to apply patches if Git is not available on the host system. <!--MCLOUD-7069-->
 
 ## v1.0.6

--- a/src/cloud/release-notes/mcp-release-notes.md
+++ b/src/cloud/release-notes/mcp-release-notes.md
@@ -22,7 +22,7 @@ See [Apply patches]({{site.baseurl}}/cloud/project/project-patch.html) for instr
 <!--Add release notes below-->
 
 ## v1.0.7
-*Release date: October 13, 2020*<br/>
+*Release date: October 14, 2020*<br/>
 
 -  **Redis patches for Magento 2.3.0 - 2.3.5, 2.4.0**–Updated the Redis patches to support adding products to a category when implementing a Level 2 cache. <!--MCLOUD-6659-->
 

--- a/src/cloud/release-notes/mcp-release-notes.md
+++ b/src/cloud/release-notes/mcp-release-notes.md
@@ -27,8 +27,7 @@ See [Apply patches]({{site.baseurl}}/cloud/project/project-patch.html) for instr
 -  **Redis patches for Magento 2.3.0 - 2.3.5, 2.4.0**–Updated the Redis patches to support adding products to a category when implementing a Level 2 cache. <!--MCLOUD-6659-->
 
 -  **Braintree VBE patch**–Fixes an issue that generated an error when an Administrator tried to view a Braintree Settlement Report. <!--MCLOUD-6684-->
-
--  Changed the Magento Quality Patches (MQP) package dependency in the `composer.json` file from a required dependency to a suggested one. The MQP package is no longer required when installing `{{ site.data.var.mcp-package }}` as a stand-alone package. <!--MCLOUD-6910-->
+-  Now, the `ece-patches apply` command uses the Unix Patch command to apply patches if Git is not available on the host system. <!--MCLOUD-7069-->
 
 ## v1.0.6
 *Release date: {{ site.data.var.ece-release-date }}*<br/>


### PR DESCRIPTION
## Purpose of this pull request

Added release notes for Magento Cloud Patches package version 1.0.7.

## Affected DevDocs pages

- https://devdocs.magento.com/cloud/release-notes/cloud-tools.html
- https://devdocs.magento.com/cloud/release-notes/mcp-release-notes.html

## Links to Magento source code

[Magento Cloud Patches v1.0.7 PRs](https://github.com/magento/magento-cloud-patches/pulls?q=is%3Apr+label%3A%22Release%3A+1.0.7%22+is%3Aclosed)

whatsnew
Added release notes for Magento Cloud Patches version 1.0.7.