### PR TITLE
MCLOUD-7072: Add CLI command for generating .magento.env.yaml

### DIFF
--- a/src/cloud/project/magento-env-yaml.md
+++ b/src/cloud/project/magento-env-yaml.md
@@ -77,15 +77,13 @@ php ./vendor/bin/ece-tools cloud:config:create     # Creates a new configuration
 php ./vendor/bin/ece-tools cloud:config:update     # Updates values in the configuration file
 ```
 
-Both commands accept one argument - configured in JSON format.
-
-For example, the next command :
+Both commands require a single argument, a JSON-formatted array that specifies a value for at least one build, deploy, or post-deploy variable. For example, the following command sets values for the `SCD_THREADS` and `CLEAN_STATIC_FILES` variables.
 
 ```bash
 php vendor/bin/ece-tools cloud:config:create '{"stage":{"build":{"SCD_THREADS":5}, "deploy":{"CLEAN_STATIC_FILES":false}}}'
 ```
 
-will create a new configuration file `.magento.env.yaml`
+This command creates a new .magento.env.yaml file with the following settings:
 
 ```yaml
 stage:
@@ -95,13 +93,13 @@ stage:
     CLEAN_STATIC_FILES: false
 ```
 
-If after that you run `cloud:config:update` command :
+You can use the cloud:config:update command to update the new file. For example, the following command changes the `SCD_THREADS` value and adds the `SCD_COMPRESSION_TIMEOUT` configuration:
 
 ```bash
 php vendor/bin/ece-tools cloud:config:update '{"stage":{"build":{"SCD_THREADS":3, "SCD_COMPRESSION_TIMEOUT":1000}}}'
 ```
 
-The configuration file will contain updated values :
+The updated file contains the following configuration:
 
 ```yaml
 stage:

--- a/src/cloud/project/magento-env-yaml.md
+++ b/src/cloud/project/magento-env-yaml.md
@@ -70,22 +70,22 @@ Make any corrections, commit, and push the changes. If you do not receive an err
 
 ## Create configuration file from CLI
 
-Sometimes it requires to generate the configuration file `.magento.env.yaml` from CLI, for this purpose `ece-tools` contains two CLI commands.
+Sometimes it is required to generate the configuration file `.magento.env.yaml` from CLI, for this purpose `ece-tools` contains two CLI commands.
 
 ```bash
 php ./vendor/bin/ece-tools cloud:config:create     # Creates a new configuration file
 php ./vendor/bin/ece-tools cloud:config:update     # Updates values in the configuration file
 ```
 
-Both commands accepts one argument - configuration in JSON format.
+Both commands accept one argument - configured in JSON format.
 
-For example, the next command
+For example, the next command :
 
 ```bash
 php vendor/bin/ece-tools cloud:config:create '{"stage":{"build":{"SCD_THREADS":5}, "deploy":{"CLEAN_STATIC_FILES":false}}}'
 ```
 
-will create the next configuration file `.magento.env.yaml`
+will create a new configuration file `.magento.env.yaml`
 
 ```yaml
 stage:
@@ -95,13 +95,13 @@ stage:
     CLEAN_STATIC_FILES: false
 ```
 
-If after that you run `cloud:config:update` command 
+If after that you run `cloud:config:update` command :
 
 ```bash
 php vendor/bin/ece-tools cloud:config:update '{"stage":{"build":{"SCD_THREADS":3, "SCD_COMPRESSION_TIMEOUT":1000}}}'
 ```
 
-The configuration file will contain updated values
+The configuration file will contain updated values :
 
 ```yaml
 stage:

--- a/src/cloud/project/magento-env-yaml.md
+++ b/src/cloud/project/magento-env-yaml.md
@@ -70,7 +70,7 @@ Make any corrections, commit, and push the changes. If you do not receive an err
 
 ## Create configuration file from CLI
 
-Sometimes it is required to generate the configuration file `.magento.env.yaml` from CLI, for this purpose `ece-tools` contains two CLI commands.
+You can use the following `ece-tools` CLI commands to generate a `.magento.env.yaml` configuration file for a Cloud environment.
 
 ```bash
 php ./vendor/bin/ece-tools cloud:config:create     # Creates a new configuration file

--- a/src/cloud/project/magento-env-yaml.md
+++ b/src/cloud/project/magento-env-yaml.md
@@ -67,3 +67,47 @@ When a failure occurs because of an unexpected value in the `.magento.env.yaml` 
 ```
 
 Make any corrections, commit, and push the changes. If you do not receive an error message, then the changes to your configuration file pass the validation.
+
+## Create configuration file from CLI
+
+Sometimes it requires to generate the configuration file `.magento.env.yaml` from CLI, for this purpose `ece-tools` contains two CLI commands.
+
+```bash
+php ./vendor/bin/ece-tools cloud:config:create     # Creates a new configuration file
+php ./vendor/bin/ece-tools cloud:config:update     # Updates values in the configuration file
+```
+
+Both commands accepts one argument - configuration in JSON format.
+
+For example, the next command
+
+```bash
+php vendor/bin/ece-tools cloud:config:create '{"stage":{"build":{"SCD_THREADS":5}, "deploy":{"CLEAN_STATIC_FILES":false}}}'
+```
+
+will create the next configuration file `.magento.env.yaml`
+
+```yaml
+stage:
+  build:
+    SCD_THREADS: 5
+  deploy:
+    CLEAN_STATIC_FILES: false
+```
+
+If after that you run `cloud:config:update` command 
+
+```bash
+php vendor/bin/ece-tools cloud:config:update '{"stage":{"build":{"SCD_THREADS":3, "SCD_COMPRESSION_TIMEOUT":1000}}}'
+```
+
+The configuration file will contain updated values
+
+```yaml
+stage:
+  build:
+    SCD_THREADS: 3
+    SCD_COMPRESSION_TIMEOUT: 1000
+  deploy:
+    CLEAN_STATIC_FILES: false
+```

--- a/src/cloud/reference/ece-tools-reference.md
+++ b/src/cloud/reference/ece-tools-reference.md
@@ -37,14 +37,14 @@ Available commands:
   cloud:config:create      Create .magento.env.yaml file from provided configuration. Overwrite file if it exists
   cloud:config:update      Update .magento.env.yaml file with provided configuration. Create file if it does not exist
  config
-  config:dump              [dump] Dump configuration for static content deployment.
+  config:dump              [dump] Dump configuration for static content deployment
  cron
   cron:disable             Disable all Magento cron processes and kills currently running
   cron:enable              Enable Magento cron processes
   cron:kill                Kill all Magento cron processes
-  cron:unlock              Unlock cron jobs that stuck in "running" state.
+  cron:unlock              Unlock cron jobs that stuck in "running" state
  dev
-  dev:git:update-composer  Updates composer for deployment from git.
+  dev:git:update-composer  Updates composer for deployment from git
  env
   env:config:show          Display encoded cloud configuration environment variables
  error

--- a/src/cloud/reference/ece-tools-reference.md
+++ b/src/cloud/reference/ece-tools-reference.md
@@ -20,7 +20,7 @@ php ./vendor/bin/ece-tools list
 ```terminal
 Available commands:
   build                    Builds application
-  db-dump                  Creates backup of database
+  db-dump                  Creates backups of databases
   deploy                   Deploys application
   help                     Displays help for a command
   list                     Lists commands
@@ -33,6 +33,9 @@ Available commands:
  build
   build:generate           Generates all necessary files for build stage
   build:transfer           Transfer generated files into init directory
+ cloud
+  cloud:config:create      Create .magento.env.yaml file from provided configuration. Overwrite file if exists.
+  cloud:config:update      Update .magento.env.yaml file with provided configuration. Create file if not exists.
  config
   config:dump              [dump] Dump configuration for static content deployment.
  cron
@@ -44,14 +47,19 @@ Available commands:
   dev:git:update-composer  Updates composer for deployment from git.
  env
   env:config:show          Display encoded cloud configuration environment variables
+ error
+  error:show               Display info about error by error id or info about all errors from the last deployment
  module
   module:refresh           Refresh config to enable newly added modules
+ schema
+  schema:generate          Generate the schema dist file
  wizard
   wizard:ideal-state       Verifies ideal state of configuration
   wizard:master-slave      Verifies master-slave configuration
   wizard:scd-on-build      Verifies SCD on build configuration
   wizard:scd-on-demand     Verifies SCD on demand configuration
   wizard:scd-on-deploy     Verifies SCD on deploy configuration
+  wizard:split-db-state    Verifies ability to split DB and whether DB was already split or not.
 ```
 {:.no-copy}
 

--- a/src/cloud/reference/ece-tools-reference.md
+++ b/src/cloud/reference/ece-tools-reference.md
@@ -19,45 +19,45 @@ php ./vendor/bin/ece-tools list
 
 ```terminal
 Available commands:
-  build                    Builds application
-  db-dump                  Creates backups of databases
-  deploy                   Deploys application
-  help                     Displays help for a command
-  list                     Lists commands
-  patch                    Applies custom patches
-  post-deploy              Performs after deploy operations
-  run                      Execute scenario(s)
+  build                    Builds application.
+  db-dump                  Creates database backups.
+  deploy                   Deploys application.
+  help                     Displays help for a command.
+  list                     Lists commands.
+  patch                    Applies custom patches.
+  post-deploy              Performs after deploy operations.
+  run                      Execute scenario(s).
  backup
-  backup:list              Shows the list of backup files
+  backup:list              Shows the list of backup files.
   backup:restore           Restore important configuration files. Run backup:list to show the list of backup files
- build
-  build:generate           Generates all necessary files for build stage
-  build:transfer           Transfer generated files into init directory
+ build.
+  build:generate           Generates all necessary files for build stage.
+  build:transfer           Transfers generated files into init directory.
  cloud
-  cloud:config:create      Create .magento.env.yaml file from provided configuration. Overwrite file if it exists
-  cloud:config:update      Update .magento.env.yaml file with provided configuration. Create file if it does not exist
+  cloud:config:create      Creates a `.magento.env.yaml` file with the specified build, deploy, and post-deploy variable configuration. Overwrites any existing `.magento,.env.yaml` file.
+  cloud:config:update      Updates the existing `.magento.env.yaml` file with the specified configuration. Creates `.magento.env.yaml` file if it does not exist.
  config
-  config:dump              [dump] Dump configuration for static content deployment
+  config:dump              [dump] Dump configuration for static content deployment.
  cron
-  cron:disable             Disable all Magento cron processes and kills currently running
-  cron:enable              Enable Magento cron processes
-  cron:kill                Kill all Magento cron processes
-  cron:unlock              Unlock cron jobs that stuck in "running" state
+  cron:disable             Disable all Magento cron processes and kills currently running.
+  cron:enable              Enable Magento cron processes.
+  cron:kill                Kill all Magento cron processes.
+  cron:unlock              Unlock cron jobs that stuck in "running" state.
  dev
-  dev:git:update-composer  Updates composer for deployment from git
+  dev:git:update-composer  Updates composer for deployment from git.
  env
-  env:config:show          Display encoded cloud configuration environment variables
+  env:config:show          Display encoded cloud configuration environment variables.
  error
-  error:show               Display info about error by error id or info about all errors from the last deployment
+  error:show               Display info about error by error id or info about all errors from the last deployment.
  module
-  module:refresh           Refresh config to enable newly added modules
+  module:refresh           Refresh config to enable newly added modules.
  wizard
-  wizard:ideal-state       Verifies ideal state of configuration
-  wizard:master-slave      Verifies master-slave configuration
-  wizard:scd-on-build      Verifies SCD on build configuration
-  wizard:scd-on-demand     Verifies SCD on demand configuration
-  wizard:scd-on-deploy     Verifies SCD on deploy configuration
-  wizard:split-db-state    Verifies ability to split DB and whether DB was already split or not
+  wizard:ideal-state       Verifies ideal state of configuration.
+  wizard:master-slave      Verifies master-slave configuration.
+  wizard:scd-on-build      Verifies SCD on build configuration.
+  wizard:scd-on-demand     Verifies SCD on demand configuration.
+  wizard:scd-on-deploy     Verifies SCD on deploy configuration.
+  wizard:split-db-state    Verifies ability to split DB and whether DB was already split or not.
 ```
 {:.no-copy}
 

--- a/src/cloud/reference/ece-tools-reference.md
+++ b/src/cloud/reference/ece-tools-reference.md
@@ -25,7 +25,7 @@ Available commands:
   help                     Displays help for a command
   list                     Lists commands
   patch                    Applies custom patches
-  post-deploy              Performs after deploy operations.
+  post-deploy              Performs after deploy operations
   run                      Execute scenario(s)
  backup
   backup:list              Shows the list of backup files
@@ -34,8 +34,8 @@ Available commands:
   build:generate           Generates all necessary files for build stage
   build:transfer           Transfer generated files into init directory
  cloud
-  cloud:config:create      Create .magento.env.yaml file from provided configuration. Overwrite file if exists.
-  cloud:config:update      Update .magento.env.yaml file with provided configuration. Create file if not exists.
+  cloud:config:create      Create .magento.env.yaml file from provided configuration. Overwrite file if it exists
+  cloud:config:update      Update .magento.env.yaml file with provided configuration. Create file if it does not exist
  config
   config:dump              [dump] Dump configuration for static content deployment.
  cron
@@ -51,15 +51,13 @@ Available commands:
   error:show               Display info about error by error id or info about all errors from the last deployment
  module
   module:refresh           Refresh config to enable newly added modules
- schema
-  schema:generate          Generate the schema dist file
  wizard
   wizard:ideal-state       Verifies ideal state of configuration
   wizard:master-slave      Verifies master-slave configuration
   wizard:scd-on-build      Verifies SCD on build configuration
   wizard:scd-on-demand     Verifies SCD on demand configuration
   wizard:scd-on-deploy     Verifies SCD on deploy configuration
-  wizard:split-db-state    Verifies ability to split DB and whether DB was already split or not.
+  wizard:split-db-state    Verifies ability to split DB and whether DB was already split or not
 ```
 {:.no-copy}
 


### PR DESCRIPTION
## Purpose of this pull request

This pull request (PR) will add information about new `ece-tools` commands.

## Affected DevDocs pages

<!-- REQUIRED List the affected pages on devdocs.magento.com (URLs). Not needed for large numbers of files. -->

-  https://devdocs.magento.com/cloud/project/magento-env-yaml.html
-  https://devdocs.magento.com/cloud/reference/ece-tools-reference.html

whatsnew
Added documentation for the following ece-tools CLI commands to create and update the `.magento.env.yaml` file with a specified configuration that can include one or more build, deploy, and post-deploy variables: `cloud:config:create` and `cloud:config:update`. See [Create configuration file from CLI](https://devdocs.magento.com/cloud/project/magento-env-yaml.html).
