### PR TITLE
Update GraphQL release notes

### DIFF
--- a/src/guides/v2.4/graphql/release-notes.md
+++ b/src/guides/v2.4/graphql/release-notes.md
@@ -3,17 +3,20 @@ group: graphql
 title: Release Notes
 ---
 
-*Release notes published January 2020.*
+*Release notes published October 2020.*
 
 GraphQL is a flexible and performant API that allows you to build custom front-ends, including headless storefronts, [Progressive Web Apps](https://github.com/magento/pwa-studio) (PWA), and mobile apps for Magento.
 
-The **[Magento GraphQL](https://github.com/magento/graphql-ce) project** is a Magento Community Engineering special project open to contributors.
-To take part and contribute, see the [Magento GraphQL](https://github.com/magento/graphql-ce) repository and [wiki](https://github.com/magento/graphql-ce/wiki) to get started. Join us in our [Slack](https://magentocommeng.slack.com/messages/C8076E0KS) channel (or [self signup](https://tinyurl.com/engcom-slack)) to discuss the project.
+To take part and contribute, see the [Magento 2](https://github.com/magento/magento2) repository and look for issues with the `Project: GraphQL` tag. Join us in our [Slack](https://magentocommeng.slack.com/messages/C8076E0KS) channel (or [self signup](https://tinyurl.com/engcom-slack)) to discuss the project.
 
 These release notes can include:
 
 -  {:.new}New features
 -  {:.fix}Fixes and improvements
+
+## {{site.data.var.ee}} and {{site.data.var.ce}} 2.4.1
+
+As of version 2.4.1, the [Magento Open Source 2.4.1 Release Notes]({{page.baseurl}}/release-notes/open-source-2-4-1.html) and [Magento Commerce 2.4.1 Release Notes]({{page.baseurl}}/release-notes/commerce-2-4-1.html) describe the new GraphQL features and bug fixes.
 
 ## {{site.data.var.ee}} and {{site.data.var.ce}} 2.4.0
 
@@ -22,6 +25,8 @@ These release notes can include:
 -  {:.new} **Added the [`categories` query]({{page.baseurl}}/graphql/queries/categories.html) returns a list of categories that match a specified filter.** This query differs from the `categoryList` query in that it supports pagination.
 
 -  {:.new} **Added the [`pickupLocations` query]({{page.baseurl}}/graphql/queries/pickup-locations.html).** When the Inventory in-store pickup feature is enabled, this query allows the shopper to select a pickup location. The `pickup_location_code` attribute has been added to the [`setShippingAddressesOnCart` mutation]({{page.baseurl}}/graphql/mutations/set-shipping-address.html) to specify which source will serve as the pickup location.
+
+The [Magento Open Source 2.4.0 Release Notes]({{page.baseurl}}/release-notes/release-notes-2-4-0-open-source.html#graphql-1) and [Magento Commerce 2.4.0 Release Notes]({{page.baseurl}}/release-notes/release-notes-2-4-0-commerce.html#graphql-1) list the bug fixes.
 
 ## {{site.data.var.ee}} and {{site.data.var.ce}} 2.3.5
 


### PR DESCRIPTION
## Purpose of this pull request

This pull request (PR) updates the GraphQL release notes page for 2.4.1.

## Affected DevDocs pages

<!-- REQUIRED List the affected pages on devdocs.magento.com (URLs). Not needed for large numbers of files. -->

-  https://devdocs.magento.com/guides/v2.4/graphql/release-notes.html

## Links to Magento source code

<!--  OPTIONAL - REMOVE THIS SECTION IF NOT USED. If this pull request references a file in a Magento codebase repository, add it here. -->

-  ...

<!--
If you are fixing a GitHub issue, note it using GitHub keyword format (https://help.github.com/en/articles/closing-issues-using-keywords#closing-an-issue-in-a-different-repository) to close the issue when this pull request is merged. Example: `Fixes #1234`

`master` is the default branch. Merged pull requests to `master` go live on the site automatically. Any requested changes to content on the `master` branch must be related to the released codebase. Any content related to future releases goes in the `develop` branch.

See Contribution guidelines (https://github.com/magento/devdocs/blob/master/.github/CONTRIBUTING.md) for more information.
-->
