### PR TITLE
Update elasticsearch.md

### DIFF
--- a/src/guides/v2.4/install-gde/prereq/elasticsearch.md
+++ b/src/guides/v2.4/install-gde/prereq/elasticsearch.md
@@ -25,7 +25,7 @@ As of Magento 2.4, all installations must be configured to use [Elasticsearch][]
 
 You must install and configure Elasticsearch 7.6.x before upgrading to Magento 2.4.x.
 
-Be aware, that Magento 2.4.x is only tested with Elasticsearch 7.6.x at the moment. You can use other (7.x) versions at your discretion, but we recommend using the tested version of Elasticsearch.
+Magento 2.4.x is tested with Elasticsearch 7.6.x only. You can use other 7.x versions at your discretion, but we recommend using the tested version of Elasticsearch.
 
 {:.bs-callout-info}
 Magento does not support Elasticsearch 2.x, 5.x, and 6.x.

--- a/src/guides/v2.4/install-gde/prereq/elasticsearch.md
+++ b/src/guides/v2.4/install-gde/prereq/elasticsearch.md
@@ -23,7 +23,7 @@ As of Magento 2.4, all installations must be configured to use [Elasticsearch][]
 
 ## Supported versions {#es-spt-versions}
 
-You must install and configure Elasticsearch 7.x before upgrading to Magento 2.4.x.
+You must install and configure Elasticsearch 7.6.x before upgrading to Magento 2.4.x.
 
 {:.bs-callout-info}
 Magento does not support Elasticsearch 2.x, 5.x, and 6.x.

--- a/src/guides/v2.4/install-gde/prereq/elasticsearch.md
+++ b/src/guides/v2.4/install-gde/prereq/elasticsearch.md
@@ -23,7 +23,7 @@ As of Magento 2.4, all installations must be configured to use [Elasticsearch][]
 
 ## Supported versions {#es-spt-versions}
 
-You must install and configure Elasticsearch 7.6.x before upgrading to Magento 2.4.0.
+You must install and configure Elasticsearch 7.x before upgrading to Magento 2.4.x.
 
 {:.bs-callout-info}
 Magento does not support Elasticsearch 2.x, 5.x, and 6.x.
@@ -75,14 +75,14 @@ The tasks discussed in this section require the following:
 
 *  [Firewall and SELinux](#firewall-selinux)
 *  [Install the Java Software Development Kit (JDK)](#prereq-java)
-*  [Install Elasticsearch](#es-install-es6)
+*  [Install Elasticsearch](#es-install-es7)
 *  [Upgrading Elasticsearch](#es-upgrade6)
 
 {% include config/solr-elastic-selinux.md %}
 
 {% include config/install-java8.md %}
 
-### Install Elasticsearch  {#es-install-es6}
+### Install Elasticsearch  {#es-install-es7}
 
 Follow [Installing Elasticsearch][] for your platform-specific steps.
 

--- a/src/guides/v2.4/install-gde/prereq/elasticsearch.md
+++ b/src/guides/v2.4/install-gde/prereq/elasticsearch.md
@@ -25,6 +25,8 @@ As of Magento 2.4, all installations must be configured to use [Elasticsearch][]
 
 You must install and configure Elasticsearch 7.6.x before upgrading to Magento 2.4.x.
 
+Be aware, that Magento 2.4.x is only tested with Elasticsearch 7.6.x at the moment. You can use other (7.x) versions at your discretion, but we recommend using the tested version of Elasticsearch.
+
 {:.bs-callout-info}
 Magento does not support Elasticsearch 2.x, 5.x, and 6.x.
 


### PR DESCRIPTION
Clarified Elasticsearch documentation

## Purpose of this pull request

As Elasticsearch has no relevant breaking changes between minor versions (see https://www.elastic.co/guide/en/beats/libbeat/current/breaking-changes.html ), Elasticsearch 7.x should generally be remanded instead of 7.6.

I also renamed the html anchor to match Elasticsearch version.

## Affected DevDocs pages

https://devdocs.magento.com/guides/v2.4/install-gde/prereq/elasticsearch.html

