### PR TITLE
add small block about redis configuration

### DIFF
--- a/src/guides/v2.3/config-guide/redis/config-redis.md
+++ b/src/guides/v2.3/config-guide/redis/config-redis.md
@@ -37,7 +37,7 @@ To optimize your Redis instance to your needs, you get best results when using a
 For sessions, it's recommended to enable persistence. This can either be done by regular RDB snapshots or by using the AOF persistence logs.
 You can get details of the advantages and disadvantages of RDB and AOF on the [Redis Persistence documentation](https://redis.io/topics/persistence).
 
-For the cache instance, you should make sure, the instance is set up big enough to store your whole Magento cache in it.
+For the cache instance, you should make sure the instance is set up to be large enough to store your whole Magento cache.
 The required size depends on different factors (like number of products and store views) but the required size of the file system cache gives you the order of
 magnitude. Persistence is not required here as the Magento cache can be restored. See also [Redis cache guide](https://redis.io/topics/lru-cache).
 

--- a/src/guides/v2.3/config-guide/redis/config-redis.md
+++ b/src/guides/v2.3/config-guide/redis/config-redis.md
@@ -37,14 +37,14 @@ To optimize your Redis instance to your needs, you get best results when using a
 For sessions, it's recommended to enable persistence. This can either be done by regular RDB snapshots or by using the AOF persistence logs.
 You can get the details advantages and disadvantages on the [Redis Persistence documentation](https://redis.io/topics/persistence).
 
-For the cache instance, you should make sure, the instance is set up big enough to store your whole Magento cache in it. 
+For the cache instance, you should make sure, the instance is set up big enough to store your whole Magento cache in it.
 The required size depends on different factors (like number of products and store views) but the required size of the file system cache gives you the order of
 magnitude. Persistence is not required here as the Magento cache can be restored. See also [Redis cache guide](https://redis.io/topics/lru-cache).
 
 For performance tuning you can also enable these settings for asynchronous deletion. This will not change the behavior of Redis (see also
 [redis news](http://antirez.com/news/93).
 
-```
+```ini
 lazyfree-lazy-eviction yes
 lazyfree-lazy-expire yes
 lazyfree-lazy-server-del yes
@@ -52,7 +52,7 @@ replica-lazy-flush yes
 ```
 From redis 6.x onwards, you can also set
 
-```
+```ini
 lazyfree-lazy-user-del yes
 ```
 

--- a/src/guides/v2.3/config-guide/redis/config-redis.md
+++ b/src/guides/v2.3/config-guide/redis/config-redis.md
@@ -37,6 +37,13 @@ To optimize your Redis instance to your needs, you get best results when using a
 For sessions, it's recommended to enable persistence. This can either be done by regular RDB snapshots or by using the AOF persistence logs.
 You can get details of the advantages and disadvantages of RDB and AOF on the [Redis Persistence documentation](https://redis.io/topics/persistence).
 
+RDB (Redis Database File) snapshots store the complete database in a dump file after a given time, when a minimum number of keys have changed since the last save.
+This can be configured with the `save` setting inside `redis.conf`.
+
+AOF (Append Only File) stores each write operation send to redis in a journal file. This file ẃill be read by Redis on restart to restore the the original dataset.
+
+It's possible, to enable both RDB ands AOF the same time.
+
 For the cache instance, you should make sure the instance is set up to be large enough to store your whole Magento cache.
 The required size depends on different factors (like number of products and store views) but the required size of the file system cache gives you the order of
 magnitude. Persistence is not required here as the Magento cache can be restored. See also [Redis cache guide](https://redis.io/topics/lru-cache).

--- a/src/guides/v2.3/config-guide/redis/config-redis.md
+++ b/src/guides/v2.3/config-guide/redis/config-redis.md
@@ -34,11 +34,14 @@ Depending on your installation, you can usually find your Redis configuration in
 
 To optimize the Redis instance for your requirements, you get best results by using a dedicated instance for each session, Magento cache and FPC.
 
-For sessions, we recommend that you enable persistence to copy Redis data to disk using either of the following persistence options: regular Redis Database Backup (RDB) snapshots, or Append Only File (AOF) persistence logs.
+For sessions, we recommend that you enable persistence to copy Redis data to disk using either of the following persistence options: regular Redis Database 
+Backup (RDB) snapshots, or Append Only File (AOF) persistence logs.
 
--  RDB (Redis Database Backup) snapshots store the complete database in a dump file after a given time, when a minimum number of keys have changed since the last save. Use the `save` setting inside the `redis.conf` file to configure this setting.
+* RDB (Redis Database Backup) snapshots store the complete database in a dump file after a given time, when a minimum number of keys have changed since the 
+last save. Use the `save` setting inside the `redis.conf` file to configure this setting.
 
--  AOF (Append Only File) stores each write operation sent to Redis in a journal file. Redis reads this file on restart only and uses it to restore the original dataset.
+* AOF (Append Only File) stores each write operation sent to Redis in a journal file. Redis reads this file on restart only and uses it to restore the 
+original dataset.
 
 You can also enable both the RDB and AOF options at the same time. For additional details including the advantages and disadvantages of the persistence options, see the [Redis Persistence documentation](https://redis.io/topics/persistence).
 

--- a/src/guides/v2.3/config-guide/redis/config-redis.md
+++ b/src/guides/v2.3/config-guide/redis/config-redis.md
@@ -16,7 +16,8 @@ Redis features include:
 *  Redis supports on-disk save and master/slave replication.
 
 {:.bs-callout-info}
-Starting in Magento 2.0.6, you can use either Redis or [memcached]({{ page.baseurl }}/config-guide/memcache/memcache.html) for session storage. Earlier issues with the Redis session handler and session locking have been resolved.
+Starting in Magento 2.0.6, you can use either Redis or [memcached]({{ page.baseurl }}/config-guide/memcache/memcache.html) for session storage. Earlier issues
+with the Redis session handler and session locking have been resolved.
 
 ## Install Redis {#config-redis-install}
 
@@ -27,7 +28,7 @@ Installing and configuring the Redis software is beyond the scope of this guide.
 *  [digitalocean](https://www.digitalocean.com/community/tutorials/how-to-install-and-use-redis)
 *  [Redis documentation page](http://redis.io/documentation)
 
-## Set up redis configuration
+## Set up redis configuration {#config-redis-setup}
 
 Depending on your installation, you can usually find your Redis configuration at /etc/redis/redis.conf or /etc/redis/`port`.conf
 
@@ -36,9 +37,12 @@ To optimize your Redis instance to your needs, you get best results when using a
 For sessions, it's recommended to enable persistence. This can either be done by regular RDB snapshots or by using the AOF persistence logs.
 You can get the details advantages and disadvantages on the [Redis Persistence documentation](https://redis.io/topics/persistence).
 
-For the cache instance, you should make sure, the instance is set up big enough to store your whole Magento cache in it. The required size depends on different factors (like number of products and store views) but the required size of the file system cache gives you the order of magnitude. Persistence is not required here as the Magento cache can be restored. See also [Redis cache guide](https://redis.io/topics/lru-cache).
+For the cache instance, you should make sure, the instance is set up big enough to store your whole Magento cache in it. 
+The required size depends on different factors (like number of products and store views) but the required size of the file system cache gives you the order of
+magnitude. Persistence is not required here as the Magento cache can be restored. See also [Redis cache guide](https://redis.io/topics/lru-cache).
 
-For performance tuning you can also enable these settings for asynchronous deletion. This will not change the behavior of Redis (see also [redis news](http://antirez.com/news/93).
+For performance tuning you can also enable these settings for asynchronous deletion. This will not change the behavior of Redis (see also
+[redis news](http://antirez.com/news/93).
 
 ```
 lazyfree-lazy-eviction yes

--- a/src/guides/v2.3/config-guide/redis/config-redis.md
+++ b/src/guides/v2.3/config-guide/redis/config-redis.md
@@ -46,7 +46,7 @@ For the cache instance, set up the instance so that it is large enough to store 
 Size requirements depend on different factors like the number of products and store views, but the size requirement for the the file system cache gives you the order of magnitude. Persistence is not required for the cache instance because the Magento cache can be restored. See also [Redis cache guide](https://redis.io/topics/lru-cache).
 
 For performance tuning, you can also enable the following settings for asynchronous deletion. These settings do not change the behavior of Redis.
-[redis news](http://antirez.com/news/93).
+See also [redis news](http://antirez.com/news/93) for details about asynchronous deletion.
 
 ```ini
 lazyfree-lazy-eviction yes

--- a/src/guides/v2.3/config-guide/redis/config-redis.md
+++ b/src/guides/v2.3/config-guide/redis/config-redis.md
@@ -42,7 +42,7 @@ This can be configured with the `save` setting inside `redis.conf`.
 
 AOF (Append Only File) stores each write operation sent to Redis in a journal file. This file ẃill be read by Redis on restart to restore the original dataset.
 
-It's possible, to enable both RDB ands AOF the same time.
+It's possible to enable both RDB and AOF at the same time.
 
 For the cache instance, you should make sure the instance is set up to be large enough to store your whole Magento cache.
 The required size depends on different factors (like number of products and store views) but the required size of the file system cache gives you the order of

--- a/src/guides/v2.3/config-guide/redis/config-redis.md
+++ b/src/guides/v2.3/config-guide/redis/config-redis.md
@@ -30,7 +30,7 @@ Installing and configuring the Redis software is beyond the scope of this guide.
 
 ## Set up redis configuration {#config-redis-setup}
 
-Depending on your installation, you can usually find your Redis configuration at /etc/redis/redis.conf or /etc/redis/`port`.conf
+Depending on your installation, you can usually find your Redis configuration in one of the following files: `/etc/redis/redis.conf` or `/etc/redis/<port>.conf`
 
 To optimize the Redis instance for your requirements, you get best results by using a dedicated instance for each session, Magento cache and FPC.
 

--- a/src/guides/v2.3/config-guide/redis/config-redis.md
+++ b/src/guides/v2.3/config-guide/redis/config-redis.md
@@ -42,7 +42,7 @@ For sessions, we recommend that you enable persistence to copy Redis data to dis
 You can also enable both the RDB and AOF options at the same time. For additional details including the advantages and disadvantages of the persistence options, see the [Redis Persistence documentation](https://redis.io/topics/persistence).
 
 For the cache instance, set up the instance so that it is large enough to store your entire Magento cache.
-Size requirements depend on different factors like the number of products and store views, but the size requirement for the the file system cache gives you the order of magnitude. Persistence is not required for the cache instance because the Magento cache can be restored. See also [Redis cache guide](https://redis.io/topics/lru-cache).
+Size requirements depend on different factors like the number of products and store views. When you have your Magento Cache previously put into your file system, you can check out the size of the cache folder for a good starting point to set up your Redis instance. For example, when you have a 5 GB 'var/cache' folder your Redis instance should have a similar size available. Persistence is not required for the cache instance because the Magento cache can be restored. See also [Redis cache guide](https://redis.io/topics/lru-cache).
 
 For performance tuning, you can also enable the following settings for asynchronous deletion. These settings do not change the behavior of Redis. See also [redis news](http://antirez.com/news/93) for details about asynchronous deletion.
 

--- a/src/guides/v2.3/config-guide/redis/config-redis.md
+++ b/src/guides/v2.3/config-guide/redis/config-redis.md
@@ -40,7 +40,7 @@ You can get details of the advantages and disadvantages of RDB and AOF on the [R
 RDB (Redis Database File) snapshots store the complete database in a dump file after a given time, when a minimum number of keys have changed since the last save.
 This can be configured with the `save` setting inside `redis.conf`.
 
-AOF (Append Only File) stores each write operation send to redis in a journal file. This file ẃill be read by Redis on restart to restore the the original dataset.
+AOF (Append Only File) stores each write operation sent to Redis in a journal file. This file ẃill be read by Redis on restart to restore the original dataset.
 
 It's possible, to enable both RDB ands AOF the same time.
 

--- a/src/guides/v2.3/config-guide/redis/config-redis.md
+++ b/src/guides/v2.3/config-guide/redis/config-redis.md
@@ -34,15 +34,13 @@ Depending on your installation, you can usually find your Redis configuration at
 
 To optimize the Redis instance for your requirements, you get best results by using a dedicated instance for each session, Magento cache and FPC.
 
-For sessions, it's recommended to enable persistence. This can either be done by regular RDB snapshots or by using the AOF persistence logs.
-You can get details of the advantages and disadvantages of RDB and AOF on the [Redis Persistence documentation](https://redis.io/topics/persistence).
+For sessions, we recommend that you enable persistence to copy Redis data to disk using either of the following persistence options: regular Redis Database Backup (RDB) snapshots, or Append Only File (AOF) persistence logs.
 
-RDB (Redis Database Backup) snapshots store the complete database in a dump file after a given time, when a minimum number of keys have changed since the last save.
-This can be configured with the `save` setting inside `redis.conf`.
+-  RDB (Redis Database Backup) snapshots store the complete database in a dump file after a given time, when a minimum number of keys have changed since the last save. Use the `save` setting inside the `redis.conf` file to configure this setting.
 
-AOF (Append Only File) stores each write operation sent to Redis in a journal file. This file ẃill be read by Redis on restart to restore the original dataset.
+-  AOF (Append Only File) stores each write operation sent to Redis in a journal file. Redis reads this file on restart only and uses it to restore the original dataset.
 
-It's possible to enable both RDB and AOF at the same time.
+You can also enable both the RDB and AOF options at the same time. For additional details including the advantages and disadvantages of the persistence options, see the [Redis Persistence documentation](https://redis.io/topics/persistence).
 
 For the cache instance, set up the instance so that it is large enough to store your entire Magento cache.
 Size requirements depend on different factors like the number of products and store views, but the size requirement for the the file system cache gives you the order of magnitude. Persistence is not required for the cache instance because the Magento cache can be restored. See also [Redis cache guide](https://redis.io/topics/lru-cache).

--- a/src/guides/v2.3/config-guide/redis/config-redis.md
+++ b/src/guides/v2.3/config-guide/redis/config-redis.md
@@ -16,7 +16,7 @@ Redis features include:
 *  Redis supports on-disk save and master/slave replication.
 
 {:.bs-callout-info}
-Starting in Magento 2.0.6, you can use either Redis or [memcached]({{ page.baseurl }}/config-guide/memcache/memcache.html) for session storage. Earlier issues
+Starting from Magento 2.0.6, you can use either Redis or [memcached]({{ page.baseurl }}/config-guide/memcache/memcache.html) for session storage. Earlier issues
 with the Redis session handler and session locking have been resolved.
 
 ## Install Redis {#config-redis-install}

--- a/src/guides/v2.3/config-guide/redis/config-redis.md
+++ b/src/guides/v2.3/config-guide/redis/config-redis.md
@@ -27,6 +27,31 @@ Installing and configuring the Redis software is beyond the scope of this guide.
 *  [digitalocean](https://www.digitalocean.com/community/tutorials/how-to-install-and-use-redis)
 *  [Redis documentation page](http://redis.io/documentation)
 
+## Set up redis configuration
+
+Depending on your installation, you can usually find your Redis configuration at /etc/redis/redis.conf or /etc/redis/`port`.conf
+
+To optimize your Redis instance to your needs, you get best results when using a dedicated instance for each sessions, Magento cache and FPC.
+
+For sessions, it's recommended to enable persistence. This can either be done by regular RDB snapshots or by using the AOF persistence logs.
+You can get the details advantages and disadvantages on the [Redis Persistence documentation](https://redis.io/topics/persistence).
+
+For the cache instance, you should make sure, the instance is set up big enough to store your whole Magento cache in it. The required size depends on different factors (like number of products and store views) but the required size of the file system cache gives you the order of magnitude. Persistence is not required here as the Magento cache can be restored. See also [Redis cache guide](https://redis.io/topics/lru-cache).
+
+For performance tuning you can also enable these settings for asynchronous deletion. This will not change the behavior of Redis (see also [redis news](http://antirez.com/news/93).
+
+```
+lazyfree-lazy-eviction yes
+lazyfree-lazy-expire yes
+lazyfree-lazy-server-del yes
+replica-lazy-flush yes
+```
+From redis 6.x onwards, you can also set
+
+```
+lazyfree-lazy-user-del yes
+```
+
 ## For more information
 
 You can find more information about configuring Redis from the following:

--- a/src/guides/v2.3/config-guide/redis/config-redis.md
+++ b/src/guides/v2.3/config-guide/redis/config-redis.md
@@ -16,8 +16,7 @@ Redis features include:
 *  Redis supports on-disk save and master/slave replication.
 
 {:.bs-callout-info}
-Starting from Magento 2.0.6, you can use either Redis or [memcached]({{ page.baseurl }}/config-guide/memcache/memcache.html) for session storage. Earlier issues
-with the Redis session handler and session locking have been resolved.
+Starting from Magento 2.0.6, you can use either Redis or [memcached]({{ page.baseurl }}/config-guide/memcache/memcache.html) for session storage. Earlier issues with the Redis session handler and session locking have been resolved.
 
 ## Install Redis {#config-redis-install}
 
@@ -34,8 +33,7 @@ Depending on your installation, you can usually find your Redis configuration in
 
 To optimize the Redis instance for your requirements, you get best results by using a dedicated instance for each session, Magento cache and FPC.
 
-For sessions, we recommend that you enable persistence to copy Redis data to disk using either of the following persistence options: regular Redis Database 
-Backup (RDB) snapshots, or Append Only File (AOF) persistence logs.
+For sessions, we recommend that you enable persistence to copy Redis data to disk using either of the following persistence options: regular Redis Database Backup (RDB) snapshots, or Append Only File (AOF) persistence logs.
 
 *  RDB (Redis Database Backup) snapshots store the complete database in a dump file after a given time, when a minimum number of keys have changed since the last save. Use the `save` setting inside the `redis.conf` file to configure this setting.
 
@@ -46,8 +44,7 @@ You can also enable both the RDB and AOF options at the same time. For additiona
 For the cache instance, set up the instance so that it is large enough to store your entire Magento cache.
 Size requirements depend on different factors like the number of products and store views, but the size requirement for the the file system cache gives you the order of magnitude. Persistence is not required for the cache instance because the Magento cache can be restored. See also [Redis cache guide](https://redis.io/topics/lru-cache).
 
-For performance tuning, you can also enable the following settings for asynchronous deletion. These settings do not change the behavior of Redis.
-See also [redis news](http://antirez.com/news/93) for details about asynchronous deletion.
+For performance tuning, you can also enable the following settings for asynchronous deletion. These settings do not change the behavior of Redis. See also [redis news](http://antirez.com/news/93) for details about asynchronous deletion.
 
 ```ini
 lazyfree-lazy-eviction yes

--- a/src/guides/v2.3/config-guide/redis/config-redis.md
+++ b/src/guides/v2.3/config-guide/redis/config-redis.md
@@ -32,7 +32,7 @@ Installing and configuring the Redis software is beyond the scope of this guide.
 
 Depending on your installation, you can usually find your Redis configuration at /etc/redis/redis.conf or /etc/redis/`port`.conf
 
-To optimize your Redis instance to your needs, you get best results when using a dedicated instance for each sessions, Magento cache and FPC.
+To optimize the Redis instance for your requirements, you get best results by using a dedicated instance for each session, Magento cache and FPC.
 
 For sessions, it's recommended to enable persistence. This can either be done by regular RDB snapshots or by using the AOF persistence logs.
 You can get details of the advantages and disadvantages of RDB and AOF on the [Redis Persistence documentation](https://redis.io/topics/persistence).

--- a/src/guides/v2.3/config-guide/redis/config-redis.md
+++ b/src/guides/v2.3/config-guide/redis/config-redis.md
@@ -57,7 +57,7 @@ lazyfree-lazy-expire yes
 lazyfree-lazy-server-del yes
 replica-lazy-flush yes
 ```
-From redis 6.x onwards, you can also set
+On Redis 6.x and later, you can also add the following value:
 
 ```ini
 lazyfree-lazy-user-del yes

--- a/src/guides/v2.3/config-guide/redis/config-redis.md
+++ b/src/guides/v2.3/config-guide/redis/config-redis.md
@@ -37,11 +37,9 @@ To optimize the Redis instance for your requirements, you get best results by us
 For sessions, we recommend that you enable persistence to copy Redis data to disk using either of the following persistence options: regular Redis Database 
 Backup (RDB) snapshots, or Append Only File (AOF) persistence logs.
 
-* RDB (Redis Database Backup) snapshots store the complete database in a dump file after a given time, when a minimum number of keys have changed since the 
-last save. Use the `save` setting inside the `redis.conf` file to configure this setting.
+*  RDB (Redis Database Backup) snapshots store the complete database in a dump file after a given time, when a minimum number of keys have changed since the last save. Use the `save` setting inside the `redis.conf` file to configure this setting.
 
-* AOF (Append Only File) stores each write operation sent to Redis in a journal file. Redis reads this file on restart only and uses it to restore the 
-original dataset.
+*  AOF (Append Only File) stores each write operation sent to Redis in a journal file. Redis reads this file on restart only and uses it to restore the original dataset.
 
 You can also enable both the RDB and AOF options at the same time. For additional details including the advantages and disadvantages of the persistence options, see the [Redis Persistence documentation](https://redis.io/topics/persistence).
 

--- a/src/guides/v2.3/config-guide/redis/config-redis.md
+++ b/src/guides/v2.3/config-guide/redis/config-redis.md
@@ -37,7 +37,7 @@ To optimize your Redis instance to your needs, you get best results when using a
 For sessions, it's recommended to enable persistence. This can either be done by regular RDB snapshots or by using the AOF persistence logs.
 You can get details of the advantages and disadvantages of RDB and AOF on the [Redis Persistence documentation](https://redis.io/topics/persistence).
 
-RDB (Redis Database File) snapshots store the complete database in a dump file after a given time, when a minimum number of keys have changed since the last save.
+RDB (Redis Database Backup) snapshots store the complete database in a dump file after a given time, when a minimum number of keys have changed since the last save.
 This can be configured with the `save` setting inside `redis.conf`.
 
 AOF (Append Only File) stores each write operation sent to Redis in a journal file. This file ẃill be read by Redis on restart to restore the original dataset.

--- a/src/guides/v2.3/config-guide/redis/config-redis.md
+++ b/src/guides/v2.3/config-guide/redis/config-redis.md
@@ -35,7 +35,7 @@ Depending on your installation, you can usually find your Redis configuration at
 To optimize your Redis instance to your needs, you get best results when using a dedicated instance for each sessions, Magento cache and FPC.
 
 For sessions, it's recommended to enable persistence. This can either be done by regular RDB snapshots or by using the AOF persistence logs.
-You can get the details advantages and disadvantages on the [Redis Persistence documentation](https://redis.io/topics/persistence).
+You can get details of the advantages and disadvantages of RDB and AOF on the [Redis Persistence documentation](https://redis.io/topics/persistence).
 
 For the cache instance, you should make sure, the instance is set up big enough to store your whole Magento cache in it.
 The required size depends on different factors (like number of products and store views) but the required size of the file system cache gives you the order of

--- a/src/guides/v2.3/config-guide/redis/config-redis.md
+++ b/src/guides/v2.3/config-guide/redis/config-redis.md
@@ -42,7 +42,7 @@ For sessions, we recommend that you enable persistence to copy Redis data to dis
 You can also enable both the RDB and AOF options at the same time. For additional details including the advantages and disadvantages of the persistence options, see the [Redis Persistence documentation](https://redis.io/topics/persistence).
 
 For the cache instance, set up the instance so that it is large enough to store your entire Magento cache.
-Size requirements depend on different factors like the number of products and store views. When you have your Magento Cache previously put into your file system, you can check out the size of the cache folder for a good starting point to set up your Redis instance. For example, when you have a 5 GB 'var/cache' folder your Redis instance should have a similar size available. Persistence is not required for the cache instance because the Magento cache can be restored. See also [Redis cache guide](https://redis.io/topics/lru-cache).
+Size requirements depend on different factors like the number of products and store views. As a starting point, you can use the size of the cache folder on your file system.  For example, if the `var/cache` folder on your file system is  5 GB, set up your Redis instance with at least 5 GB to start. Persistence is not required for the cache instance because the Magento cache can be restored. See also [Redis cache guide](https://redis.io/topics/lru-cache).
 
 For performance tuning, you can also enable the following settings for asynchronous deletion. These settings do not change the behavior of Redis. See also [redis news](http://antirez.com/news/93) for details about asynchronous deletion.
 

--- a/src/guides/v2.3/config-guide/redis/config-redis.md
+++ b/src/guides/v2.3/config-guide/redis/config-redis.md
@@ -44,11 +44,10 @@ AOF (Append Only File) stores each write operation sent to Redis in a journal fi
 
 It's possible to enable both RDB and AOF at the same time.
 
-For the cache instance, you should make sure the instance is set up to be large enough to store your whole Magento cache.
-The required size depends on different factors (like number of products and store views) but the required size of the file system cache gives you the order of
-magnitude. Persistence is not required here as the Magento cache can be restored. See also [Redis cache guide](https://redis.io/topics/lru-cache).
+For the cache instance, set up the instance so that it is large enough to store your entire Magento cache.
+Size requirements depend on different factors like the number of products and store views, but the size requirement for the the file system cache gives you the order of magnitude. Persistence is not required for the cache instance because the Magento cache can be restored. See also [Redis cache guide](https://redis.io/topics/lru-cache).
 
-For performance tuning you can also enable these settings for asynchronous deletion. This will not change the behavior of Redis (see also
+For performance tuning, you can also enable the following settings for asynchronous deletion. These settings do not change the behavior of Redis.
 [redis news](http://antirez.com/news/93).
 
 ```ini


### PR DESCRIPTION
## Purpose of this pull request

As at the moment the installation of Redis is only sparely documented, I added some hint how to configure Redis for Magento.

This includes: Persistence, Cache Settings, and Performance.

## Affected DevDocs pages
https://devdocs.magento.com/guides/v2.4/config-guide/redis/config-redis.html
https://devdocs.magento.com/guides/v2.3/config-guide/redis/config-redis.html

## whatsnew
Adds a new section inside the [Redis installation guide](https://devdocs.magento.com/guides/v2.4/config-guide/redis/config-redis.html) about how to configure Redis to work with Magento.