### PR TITLE
Added missing docblock in example

### DIFF
--- a/src/guides/v2.3/extension-dev-guide/attributes.md
+++ b/src/guides/v2.3/extension-dev-guide/attributes.md
@@ -58,13 +58,25 @@ use Magento\Framework\Setup\ModuleDataSetupInterface;
 use Magento\Framework\Setup\Patch\DataPatchInterface;
 use Magento\Framework\Setup\Patch\PatchVersionInterface;
 
+/**
+ * Class add customer example attribute to customer
+ */
 class AddCustomerExampleAttribute implements DataPatchInterface
 {
-
+    /**
+     * @var ModuleDataSetupInterface
+     */
     private $moduleDataSetup;
 
+    /**
+     * @var CustomerSetupFactory
+     */
     private $customerSetupFactory;
 
+    /**
+     * @param ModuleDataSetupInterface $moduleDataSetup
+     * @param CustomerSetupFactory $customerSetupFactory
+     */
     public function __construct(
         ModuleDataSetupInterface $moduleDataSetup,
         CustomerSetupFactory $customerSetupFactory
@@ -73,6 +85,9 @@ class AddCustomerExampleAttribute implements DataPatchInterface
         $this->customerSetupFactory = $customerSetupFactory;
     }
 
+    /**
+     * @inheritdoc
+     */
     public function apply()
     {
         $customerSetup = $this->customerSetupFactory->create(['setup' => $this->moduleDataSetup]);
@@ -82,7 +97,7 @@ class AddCustomerExampleAttribute implements DataPatchInterface
     }
 
     /**
-     * {@inheritdoc}
+     * @inheritdoc
      */
     public static function getDependencies()
     {
@@ -91,6 +106,9 @@ class AddCustomerExampleAttribute implements DataPatchInterface
         ];
     }
 
+    /**
+     * @inheritdoc
+     */
     public function getAliases()
     {
         return [];


### PR DESCRIPTION
Added missing docblock in example.

## Purpose of this pull request

This pull request (PR) will add/update docblock in example.

## Affected DevDocs pages

<!-- REQUIRED List the affected pages on devdocs.magento.com (URLs). Not needed for large numbers of files. -->

- https://devdocs.magento.com/guides/v2.4/extension-dev-guide/attributes.html
- https://devdocs.magento.com/guides/v2.3/extension-dev-guide/attributes.html

## Links to Magento source code

<!--  OPTIONAL - REMOVE THIS SECTION IF NOT USED. If this pull request references a file in a Magento codebase repository, add it here. -->

- https://github.com/magento/magento2/blob/c0f3dfbc1d2a1d34dc612fbcb4622db2aa3d3df8/app/code/Magento/Customer/Setup/Patch/Data/AddCustomerUpdatedAtAttribute.php#L19

<!--
If you are fixing a GitHub issue, note it using GitHub keyword format (https://help.github.com/en/articles/closing-issues-using-keywords#closing-an-issue-in-a-different-repository) to close the issue when this pull request is merged. Example: `Fixes #1234`

`master` is the default branch. Merged pull requests to `master` go live on the site automatically. Any requested changes to content on the `master` branch must be related to the released codebase. Any content related to future releases goes in the `develop` branch.

See Contribution guidelines (https://github.com/magento/devdocs/blob/master/.github/CONTRIBUTING.md) for more information.
-->
