### PR TITLE
fix missing link

### DIFF
--- a/src/guides/v2.3/config-guide/deployment/pipeline/technical-details.md
+++ b/src/guides/v2.3/config-guide/deployment/pipeline/technical-details.md
@@ -309,4 +309,4 @@ Next steps
 *  [Set up your development systems]({{ page.baseurl }}/config-guide/deployment/pipeline/development-system.html)
 *  [Set up your build system]({{ page.baseurl }}/config-guide/deployment/pipeline/build-system.html)
 *  [Set up your production system]({{ page.baseurl }}/config-guide/deployment/pipeline/production-system.html)
-*  [config-cli-config-set]: {{ page.baseurl }}/config-guide/cli/config-cli-subcommands-config-mgmt-set.html#config-cli-config-set
+*  [config-cli-config-set]({{ page.baseurl }}/config-guide/cli/config-cli-subcommands-config-mgmt-set.html#config-cli-config-set)

--- a/src/guides/v2.3/config-guide/deployment/pipeline/technical-details.md
+++ b/src/guides/v2.3/config-guide/deployment/pipeline/technical-details.md
@@ -309,4 +309,4 @@ Next steps
 *  [Set up your development systems]({{ page.baseurl }}/config-guide/deployment/pipeline/development-system.html)
 *  [Set up your build system]({{ page.baseurl }}/config-guide/deployment/pipeline/build-system.html)
 *  [Set up your production system]({{ page.baseurl }}/config-guide/deployment/pipeline/production-system.html)
-*  [config-cli-config-set]({{ page.baseurl }}/config-guide/cli/config-cli-subcommands-config-mgmt-set.html#config-cli-config-set)
+*  [Set configuration values]({{ page.baseurl }}/config-guide/cli/config-cli-subcommands-config-mgmt-set.html#config-cli-config-set)


### PR DESCRIPTION
## Purpose of this pull request

on https://devdocs.magento.com/guides/v2.4/config-guide/deployment/pipeline/technical-details.html there should be four links, but only three are actually rendered

![image](https://user-images.githubusercontent.com/1112507/96311795-94f91000-100a-11eb-91fd-0ca8ad617f26.png)

This PR corrects the markdown here.

## Affected DevDocs pages

https://devdocs.magento.com/guides/v2.4/config-guide/deployment/pipeline/technical-details.html
https://devdocs.magento.com/guides/v2.3/config-guide/deployment/pipeline/technical-details.html
