### PR TITLE
Added requirement about minimum version of ece-tools for MQP

### DIFF
--- a/src/cloud/project/project-patch.md
+++ b/src/cloud/project/project-patch.md
@@ -29,7 +29,7 @@ When you update `{{ site.data.var.ct }}` or the {{ site.data.var.mcp-prod }} pac
 
 {% include cloud/note-upgrade.md %}
 
-The Magento Quality Patches package is a dependency for the {{ site.data.var.mcp-prod }} and {{site.data.var.ct}} packages. To apply the latest patches, you must have [the latest version of {{ site.data.var.ct }}]({{site.baseurl}}/cloud/project/ece-tools-update.html) installed.
+The Magento Quality Patches package is a dependency for the {{ site.data.var.mcp-prod }} and {{site.data.var.ct}} packages. To apply the latest patches, you must have [the latest version of {{ site.data.var.ct }}]({{site.baseurl}}/cloud/project/ece-tools-update.html) installed. The minimum required version of {{site.data.var.ct}} is 2002.1.2.
 
 ## View available patches and status
 


### PR DESCRIPTION
## Purpose of this pull request

Updates the [Magento Quality Patches](https://devdocs.magento.com/cloud/project/project-patch.html) topic in the _Software Update Guide_  to add requirement about the minimum version of ece-tools for MQP

## Affected DevDocs pages

 - https://devdocs.magento.com/cloud/project/project-patch.html
