### PR TITLE
Moved the else logic before if condition

### DIFF
--- a/src/guides/v2.4/extension-dev-guide/searching-with-repositories.md
+++ b/src/guides/v2.4/extension-dev-guide/searching-with-repositories.md
@@ -227,12 +227,11 @@ class ProductCategoryFilter implements CustomFilterInterface
     {
         $value = $filter->getValue();
         $conditionType = $filter->getConditionType() ?: 'in';
+        $filterValue = [$value];
         if (($conditionType === 'in' || $conditionType === 'nin') && is_string($value)) {
-            $value = explode(',', $value);
-        } else {
-            $value = [$value];
+            $filterValue = explode(',', $value);
         }
-        $categoryFilter = [$conditionType => $value];
+        $categoryFilter = [$conditionType => $filterValue];
 
         /** @var Collection $collection */
         $collection->addCategoriesFilter($categoryFilter);


### PR DESCRIPTION
Moved the else logic before if condition.

## Purpose of this pull request

This pull request (PR) will move the else logic before if condition.

## Affected DevDocs pages

<!-- REQUIRED List the affected pages on devdocs.magento.com (URLs). Not needed for large numbers of files. -->

- https://devdocs.magento.com/guides/v2.4/extension-dev-guide/searching-with-repositories.html

## Links to Magento source code

<!--  OPTIONAL - REMOVE THIS SECTION IF NOT USED. If this pull request references a file in a Magento codebase repository, add it here. -->

- https://github.com/magento/magento2/blob/c0f3dfbc1d2a1d34dc612fbcb4622db2aa3d3df8/app/code/Magento/Catalog/Model/Api/SearchCriteria/CollectionProcessor/FilterProcessor/ProductCategoryFilter.php#L22

<!--
If you are fixing a GitHub issue, note it using GitHub keyword format (https://help.github.com/en/articles/closing-issues-using-keywords#closing-an-issue-in-a-different-repository) to close the issue when this pull request is merged. Example: `Fixes #1234`

`master` is the default branch. Merged pull requests to `master` go live on the site automatically. Any requested changes to content on the `master` branch must be related to the released codebase. Any content related to future releases goes in the `develop` branch.

See Contribution guidelines (https://github.com/magento/devdocs/blob/master/.github/CONTRIBUTING.md) for more information.
-->
