### PR TITLE
Fix a typo of bin/magento command line setup:config:set argument/option

### DIFF
--- a/src/guides/v2.3/config-guide/redis/redis-session.md
+++ b/src/guides/v2.3/config-guide/redis/redis-session.md
@@ -50,7 +50,7 @@ where
 |session-save-redis-sentinel-master|sentinel_master|Redis Sentinel master name|empty|
 |session-save-redis-sentinel-servers|sentinel_servers|List of Redis Sentinel servers, comma separated|empty|
 |session-save-redis-sentinel-verify-master|sentinel_verify_master|Verify Redis Sentinel master status flag|0 (false)|
-|session-save-redis-sentinel-connect-retires|sentinel_connect_retries|Connection retries for sentinels|5|
+|session-save-redis-sentinel-connect-retries|sentinel_connect_retries|Connection retries for sentinels|5|
 
 ### Example command
 


### PR DESCRIPTION
Fix a typo of bin/magento command line setup:config:set argument/option.

## Purpose of this pull request

This pull request (PR) will fix typo in command line parameter.

## Affected DevDocs pages

<!-- REQUIRED List the affected pages on devdocs.magento.com (URLs). Not needed for large numbers of files. -->

- https://devdocs.magento.com/guides/v2.4/config-guide/redis/redis-session.html

## Links to Magento source code

<!--  OPTIONAL - REMOVE THIS SECTION IF NOT USED. If this pull request references a file in a Magento codebase repository, add it here. -->

- https://github.com/magento/magento2/blob/32ed03cad4f2b2abc6ca6e5dc14885cd822c4508/setup/src/Magento/Setup/Model/ConfigOptionsList/Session.php#L43

<!--
If you are fixing a GitHub issue, note it using GitHub keyword format (https://help.github.com/en/articles/closing-issues-using-keywords#closing-an-issue-in-a-different-repository) to close the issue when this pull request is merged. Example: `Fixes #1234`

`master` is the default branch. Merged pull requests to `master` go live on the site automatically. Any requested changes to content on the `master` branch must be related to the released codebase. Any content related to future releases goes in the `develop` branch.

See Contribution guidelines (https://github.com/magento/devdocs/blob/master/.github/CONTRIBUTING.md) for more information.
-->
