### PR TITLE
Correct spelling on What's new page

### DIFF
--- a/src/_data/whats-new.yml
+++ b/src/_data/whats-new.yml
@@ -526,7 +526,7 @@ entries:
   contributor: jeff-matthews
   profile: https://github.com/jeff-matthews
 - description: Standardized [release terminology](https://devdocs.magento.com/release/policy/)
-    related to patch releases, hotfixes, invdividual fixes, and custom patches.
+    related to patch releases, hotfixes, individual fixes, and custom patches.
   versions: 2.4.0
   type: Major Update
   date: July 27, 2020


### PR DESCRIPTION
Change invdividual to individual

## Purpose of this pull request

This pull request (PR) fixes a small typo (invdividual -> individual)

## Affected DevDocs pages

<!-- REQUIRED List the affected pages on devdocs.magento.com (URLs). Not needed for large numbers of files. -->

-  https://devdocs.magento.com/whats-new.html
