### PR TITLE
Fixing mispelled 'Braintree' word.

### DIFF
--- a/src/guides/v2.3/payments-integrations/payment-gateway/command-pool.md
+++ b/src/guides/v2.3/payments-integrations/payment-gateway/command-pool.md
@@ -26,7 +26,7 @@ Following is an example of the command pool configuring for the Braintree paymen
 
 ```xml
 ...
-<!-- BrainreeCommandPool - a command pool for the Braintree payments provider -->
+<!-- BraintreeCommandPool - a command pool for the Braintree payments provider -->
 <virtualType name="BraintreeCommandPool" type="Magento\Payment\Gateway\Command\CommandPool">
     <arguments>
         <argument name="commands" xsi:type="array">
@@ -38,7 +38,7 @@ Following is an example of the command pool configuring for the Braintree paymen
     </arguments>
 </virtualType>
 ...
-<!-- Adding BrainreeCommandPool to the Braintree payment method configuration:-->
+<!-- Adding BraintreeCommandPool to the Braintree payment method configuration:-->
 <virtualType name="BraintreeFacade" type="Magento\Payment\Model\Method\Adapter">
     <arguments>
         ...


### PR DESCRIPTION
## Purpose of this pull request

This pull request (PR) will fix a mispelling of the 'Braintree' word.

## Affected DevDocs pages

- https://devdocs.magento.com/guides/v2.3/payments-integrations/payment-gateway/command-pool.html
- https://devdocs.magento.com/guides/v2.4/payments-integrations/payment-gateway/command-pool.html
