### PR TITLE
Removed Magento 1 reference from Create an Extension page; made Packaging an Extension a link to packaging guide

### DIFF
--- a/src/marketplace/sellers/extension-create.md
+++ b/src/marketplace/sellers/extension-create.md
@@ -25,7 +25,7 @@ Magento Marketplace does not support encrypted extensions at this time.
 
    Testing your extension in advance reduces the time it takes to pass Technical Review. For a list of code sniffer rules, see [Magento Extension Quality Program Coding Standard][2].
 
-1. Prepare, validate, and zip your extension as described in [Packaging a Component]({{ site.baseurl }}/guides/v2.3/extension-dev-guide/package/package_module.html).
+1. Prepare, validate, and zip your extension as described in [Packaging a Component]({{ site.baseurl }}/guides/v2.4 /extension-dev-guide/package/package_module.html).
 
 1. Prepare the following preliminary documentation:
 

--- a/src/marketplace/sellers/extension-create.md
+++ b/src/marketplace/sellers/extension-create.md
@@ -25,7 +25,7 @@ Magento Marketplace does not support encrypted extensions at this time.
 
    Testing your extension in advance reduces the time it takes to pass Technical Review. For a list of code sniffer rules, see [Magento Extension Quality Program Coding Standard][2].
 
-1. Prepare, validate, and zip your extension as described in [Packaging a Component]({{ site.baseurl }}/guides/v2.4 /extension-dev-guide/package/package_module.html).
+1. Prepare, validate, and zip your extension as described in [Packaging a Component]({{site.baseurl}}/guides/v2.4/extension-dev-guide/package/package_module.html).
 
 1. Prepare the following preliminary documentation:
 

--- a/src/marketplace/sellers/extension-create.md
+++ b/src/marketplace/sellers/extension-create.md
@@ -25,7 +25,7 @@ Magento Marketplace does not support encrypted extensions at this time.
 
    Testing your extension in advance reduces the time it takes to pass Technical Review. For a list of code sniffer rules, see [Magento Extension Quality Program Coding Standard][2].
 
-1. Prepare, validate, and zip your extension as described in Packaging a Component for Magento version [2.x]({{ site.baseurl }}/guides/v2.3/extension-dev-guide/package/package_module.html) or [1.x]({{ site.baseurl }}/marketplace/sellers/packaging-v1x-extensions.html).
+1. Prepare, validate, and zip your extension as described in [Packaging a Component]({{ site.baseurl }}/guides/v2.3/extension-dev-guide/package/package_module.html).
 
 1. Prepare the following preliminary documentation:
 


### PR DESCRIPTION
## Purpose of this pull request

This PR removes Magento 1 reference from Create an Extension page of the Marketplace dev docs, and makes "Packaging an Extension" a link to the Magento 2 packaging guide.

## Affected DevDocs pages

<!-- REQUIRED List the affected pages on devdocs.magento.com (URLs). Not needed for large numbers of files. -->

-  https://devdocs.magento.com/marketplace/sellers/extension-create.html


<!--
If you are fixing a GitHub issue, note it using GitHub keyword format (https://help.github.com/en/articles/closing-issues-using-keywords#closing-an-issue-in-a-different-repository) to close the issue when this pull request is merged. Example: `Fixes #1234`

`master` is the default branch. Merged pull requests to `master` go live on the site automatically. Any requested changes to content on the `master` branch must be related to the released codebase. Any content related to future releases goes in the `develop` branch.

See Contribution guidelines (https://github.com/magento/devdocs/blob/master/.github/CONTRIBUTING.md) for more information.
-->
