### PR TITLE
[CLOUD] Removed extra trailing comma from composer.json snippet

### DIFF
--- a/src/cloud/project/project-upgrade.md
+++ b/src/cloud/project/project-upgrade.md
@@ -121,7 +121,7 @@ To check the `auto-load:psr-4` configuration:
           "Magento\\Framework\\": "lib/internal/Magento/Framework/",
           "Magento\\Setup\\": "setup/src/Magento/Setup/",
           "Magento\\": "app/code/Magento/",
-          "Zend\\Mvc\\Controller\\": "setup/src/Zend/Mvc/Controller/",
+          "Zend\\Mvc\\Controller\\": "setup/src/Zend/Mvc/Controller/"
        },
    ```
    {:.no-copy}


### PR DESCRIPTION
## Purpose of this pull request

This pull request (PR) removes extra trailing comma from composer.json snippet on "Upgrade Magento version" page

## Affected DevDocs pages

<!-- REQUIRED List the affected pages on devdocs.magento.com (URLs). Not needed for large numbers of files. -->

-  https://devdocs.magento.com/cloud/project/project-upgrade.html

<!--
If you are fixing a GitHub issue, note it using GitHub keyword format (https://help.github.com/en/articles/closing-issues-using-keywords#closing-an-issue-in-a-different-repository) to close the issue when this pull request is merged. Example: `Fixes #1234`

`master` is the default branch. Merged pull requests to `master` go live on the site automatically. Any requested changes to content on the `master` branch must be related to the released codebase. Any content related to future releases goes in the `develop` branch.

See Contribution guidelines (https://github.com/magento/devdocs/blob/master/.github/CONTRIBUTING.md) for more information.
-->
