### PR TITLE
Specify supported version of Composer (latest 1.x)

### DIFF
--- a/src/guides/v2.3/install-gde/system-requirements-tech.md
+++ b/src/guides/v2.3/install-gde/system-requirements-tech.md
@@ -23,7 +23,7 @@ Upgrading the Magento applications and extensions you obtain from Magento Market
 
 [Composer][] is required for developers who wish to contribute to the Magento 2 codebase or anyone who wishes to develop Magento extensions.
 
-Magento supports the latest 1.x version of Composer.
+Magento does not support Composer 2.x.
 
 ## Web servers
 

--- a/src/guides/v2.3/install-gde/system-requirements-tech.md
+++ b/src/guides/v2.3/install-gde/system-requirements-tech.md
@@ -19,9 +19,11 @@ Magento is not supported on Microsoft Windows and macOS.
 
 Upgrading the Magento applications and extensions you obtain from Magento Marketplaces and other sources can require up to 2GB of RAM. If you are using a system with less than 2GB of RAM, we recommend you create a [swap file](https://support.magento.com/hc/en-us/articles/360032980432); otherwise, your upgrade might fail.
 
-## Composer (latest stable version)
+## Composer
 
 [Composer][] is required for developers who wish to contribute to the Magento 2 codebase or anyone who wishes to develop Magento extensions.
+
+Magento supports Composer 1.x.
 
 ## Web servers
 

--- a/src/guides/v2.3/install-gde/system-requirements-tech.md
+++ b/src/guides/v2.3/install-gde/system-requirements-tech.md
@@ -23,7 +23,7 @@ Upgrading the Magento applications and extensions you obtain from Magento Market
 
 [Composer][] is required for developers who wish to contribute to the Magento 2 codebase or anyone who wishes to develop Magento extensions.
 
-Magento supports Composer 1.x.
+Magento supports the latest 1.x version of Composer.
 
 ## Web servers
 

--- a/src/guides/v2.4/install-gde/system-requirements-tech.md
+++ b/src/guides/v2.4/install-gde/system-requirements-tech.md
@@ -23,7 +23,7 @@ Upgrading the Magento applications and extensions you obtain from Magento Market
 
 [Composer][] is required for developers who wish to contribute to the Magento 2 codebase or anyone who wishes to develop Magento extensions.
 
-Magento supports the latest 1.x version of Composer.
+Magento does not support Composer 2.x.
 
 ## Web servers
 

--- a/src/guides/v2.4/install-gde/system-requirements-tech.md
+++ b/src/guides/v2.4/install-gde/system-requirements-tech.md
@@ -19,9 +19,11 @@ Magento is not supported on Microsoft Windows and macOS.
 
 Upgrading the Magento applications and extensions you obtain from Magento Marketplaces and other sources can require up to 2GB of RAM. If you are using a system with less than 2GB of RAM, we recommend you create a [swap file](https://support.magento.com/hc/en-us/articles/360032980432); otherwise, your upgrade might fail.
 
-## Composer (latest stable version)
+## Composer
 
 [Composer][] is required for developers who wish to contribute to the Magento 2 codebase or anyone who wishes to develop Magento extensions.
+
+Magento supports Composer 1.x.
 
 ## Web servers
 

--- a/src/guides/v2.4/install-gde/system-requirements-tech.md
+++ b/src/guides/v2.4/install-gde/system-requirements-tech.md
@@ -23,7 +23,7 @@ Upgrading the Magento applications and extensions you obtain from Magento Market
 
 [Composer][] is required for developers who wish to contribute to the Magento 2 codebase or anyone who wishes to develop Magento extensions.
 
-Magento supports Composer 1.x.
+Magento supports the latest 1.x version of Composer.
 
 ## Web servers
 


### PR DESCRIPTION
## Purpose of this pull request

This pull request (PR) specifies that Magento supports the latest 1.x version of Composer. Composer recently released a 2.x version, which does not yet work with Magento.

## Affected DevDocs pages

- https://devdocs.magento.com/guides/v2.4/install-gde/system-requirements-tech.html
- https://devdocs.magento.com/guides/v2.3/install-gde/system-requirements-tech.html

whatsnew
Specified that Magento supports the latest 1.x version of Composer in the [system requirements](https://devdocs.magento.com/guides/v2.4/install-gde/system-requirements-tech.html). 