### PR TITLE
MQE-2354: [MFTF SVC] Change "<test> ref change" from MAJOR  to a MINOR

### DIFF
--- a/src/guides/v2.4/extension-dev-guide/versioning/mftf-tests-codebase-changes.md
+++ b/src/guides/v2.4/extension-dev-guide/versioning/mftf-tests-codebase-changes.md
@@ -111,13 +111,13 @@ It MAY include minor and patch level changes. Patch and minor version MUST be re
 | |`<test>` `<action>` changed|PATCH
 | |`<test>` `<action>` sequence changed|MAJOR
 | |`<test>` `<action>` type (`click`, `fillField`, etc) changed|PATCH
-| |`<test>` `<actionGroup>` `ref` changed|MAJOR
+| |`<test>` `<actionGroup>` `ref` changed|MINOR
 | |`<test>` `<before/after>` `<action>` added|MINOR
 | |`<test>` `<before/after>` `<action>` removed|MAJOR
 | |`<test>` `<before/after>` `<action>` changed|PATCH
 | |`<test>` `<before/after>` `<action>` sequence changed|MAJOR
 | |`<test>` `<before/after>` `<action>` type (`click`, `fillField`, etc) changed|PATCH
-| |`<test>` `<before/after>` `<actionGroup>` `ref` changed|MAJOR
+| |`<test>` `<before/after>` `<actionGroup>` `ref` changed|MINOR
 | |`<test>` `<annotations>` `<annotation>` added|PATCH
 | |`<test>` `<annotations>` `<annotation>` changed|PATCH
 | |`<test>` `<annotations>` `<annotation>` GROUP removed|MAJOR
@@ -134,7 +134,7 @@ It MAY include minor and patch level changes. Patch and minor version MUST be re
 | |`<suite>` `<before/after>` `<action>` changed|PATCH
 | |`<suite>` `<before/after>` `<action>` sequence changed|MAJOR
 | |`<suite>` `<before/after>` `<action>` type (`click`, `fillField`, etc) changed|PATCH
-| |`<suite>` `<before/after>` `<actionGroup>` `ref` changed|MAJOR
+| |`<suite>` `<before/after>` `<actionGroup>` `ref` changed|MINOR
 
 ---------------------------
 


### PR DESCRIPTION
## Purpose of this pull request

[MQE-2354](https://jira.corp.magento.com/browse/MQE-2354): [MFTF SVC] Change "<test> ref change" from MAJOR  to a MINOR
Doc updates

## Affected DevDocs pages

https://devdocs.magento.com/guides/v2.4/extension-dev-guide/versioning/mftf-tests-codebase-changes.html