### PR TITLE
Installation Guide reorganization

### DIFF
--- a/src/_data/main-nav.yml
+++ b/src/_data/main-nav.yml
@@ -59,7 +59,7 @@
   children:
 
     - label: Installation Guide
-      url: /install-gde/bk-install-guide.html
+      url: /install-gde/install-flow-diagram.html
 
     - label: Magento Extensions Guide
       url: /extensions/

--- a/src/_data/toc/installation-guide.yml
+++ b/src/_data/toc/installation-guide.yml
@@ -3,13 +3,7 @@ pages:
 
     - label: Installation flow diagram
       url: /install-gde/install-flow-diagram.html
-
-    - label: Quick start (recommended installation)
-      url: /install-gde/composer.html
-
-    - label: Install options
-      url: /install-gde/bk-install-guide.html
-
+    
     - label: Magento system requirements
       url: /install-gde/system-requirements.html
 
@@ -73,6 +67,12 @@ pages:
 
             - label: Update installation dependencies
               url: /install-gde/install/prepare-install.html
+
+    - label: Quick start (recommended installation)
+      url: /install-gde/composer.html
+
+    - label: Install options
+      url: /install-gde/bk-install-guide.html
 
     - label: Setup Wizard Install
       include_versions: ["2.3"]

--- a/src/_data/toc/installation-guide.yml
+++ b/src/_data/toc/installation-guide.yml
@@ -17,11 +17,11 @@ pages:
         - label: nginx
           url: /install-gde/prereq/nginx.html
 
-        - label: PHP
-          url: /install-gde/prereq/php-settings.html
-
         - label: MySQL
           url: /install-gde/prereq/mysql.html
+
+        - label: PHP
+          url: /install-gde/prereq/php-settings.html
 
         - label: Elasticsearch
           url: /install-gde/prereq/elasticsearch.html
@@ -163,37 +163,16 @@ pages:
 
             - label: Install by cloning repositories
               url: /install-gde/install/sample-data-after-clone.html
-        
-        - label: Uninstall or reinstall Magento
-          url: /install-gde/install/cli/install-cli-uninstall.html
 
-        - label: Display or change the Admin URI
-          url: /install-gde/install/cli/install-cli-adminurl.html
+    - label: Tutorials
+      children:
 
-        - label: Remove sample data modules or update sample data
-          url: /install-gde/install/cli/install-cli-sample-data-other.html
-
-        - label: Enable or disable modules
-          url: /install-gde/install/cli/install-cli-subcommands-enable.html
-
-        - label: Uninstall modules
-          url: /install-gde/install/cli/install-cli-uninstall-mods.html
-
-        - label: Create or update the deployment configuration
-          url: /install-gde/install/cli/install-cli-subcommands-deployment.html
-
-        - label: Enable or disable maintenance mode
-          url: /install-gde/install/cli/install-cli-subcommands-maint.html
+        - label: Back up and roll back the file system, media, and database
+          url: /install-gde/install/cli/install-cli-backup.html
 
         - label: Configure consumer behavior
           url: /install-gde/install/cli/install-cli-subcommands-consumers.html
-
-        - label: Create the Magento database schema
-          url: /install-gde/install/cli/install-cli-subcommands-db.html
-
-        - label: Update the Magento database schema and data
-          url: /install-gde/install/cli/install-cli-subcommands-db-upgr.html
-
+        
         - label: Configure the lock provider
           url: /install-gde/install/cli/install-cli-subcommands-lock.html
           
@@ -203,19 +182,41 @@ pages:
         - label: Create, edit, or unlock a Magento administrator account
           url: /install-gde/install/cli/install-cli-subcommands-admin.html
 
-        - label: Back up and roll back the file system, media, and database
-          url: /install-gde/install/cli/install-cli-backup.html
+        - label: Create or update the deployment configuration
+          url: /install-gde/install/cli/install-cli-subcommands-deployment.html
 
-        - label: Uninstall themes Composer packages
-          url: /install-gde/install/cli/install-cli-theme-uninstall.html
+        - label: Create the Magento database schema
+          url: /install-gde/install/cli/install-cli-subcommands-db.html
+
+        - label: Display or change the Admin URI
+          url: /install-gde/install/cli/install-cli-adminurl.html
+
+        - label: Enable or disable maintenance mode
+          url: /install-gde/install/cli/install-cli-subcommands-maint.html
+
+        - label: Enable or disable modules
+          url: /install-gde/install/cli/install-cli-subcommands-enable.html
+
+        - label: Modify docroot to improve security
+          url: /install-gde/tutorials/change-docroot-to-pub.html
+
+        - label: Remove sample data modules or update sample data
+          url: /install-gde/install/cli/install-cli-sample-data-other.html
 
         - label: Uninstall language packages
           url: /install-gde/install/cli/install-cli-uninstall-langpk.html
 
-    - label: Tutorials
-      children:
-        - label: Modify docroot to improve security
-          url: /install-gde/tutorials/change-docroot-to-pub.html
+        - label: Uninstall modules
+          url: /install-gde/install/cli/install-cli-uninstall-mods.html
+
+        - label: Uninstall or reinstall Magento
+          url: /install-gde/install/cli/install-cli-uninstall.html
+
+        - label: Update the Magento database schema and data
+          url: /install-gde/install/cli/install-cli-subcommands-db-upgr.html
+        
+        - label: Uninstall themes Composer packages
+          url: /install-gde/install/cli/install-cli-theme-uninstall.html
     
     - label: Troubleshooting
       children:

--- a/src/_data/toc/installation-guide.yml
+++ b/src/_data/toc/installation-guide.yml
@@ -1,109 +1,71 @@
 label: Installation Guide
 pages:
-    - label: How to get the Magento software
-      url: /install-gde/bk-install-guide.html
 
     - label: Installation flow diagram
       url: /install-gde/install-flow-diagram.html
 
+    - label: Quick start (recommended installation)
+      url: /install-gde/composer.html
+
+    - label: Install options
+      url: /install-gde/bk-install-guide.html
+
     - label: Magento system requirements
       url: /install-gde/system-requirements.html
 
-    - label: Just the basics
+    - label: Prerequisites
+      url: /install-gde/prereq/prereq-overview.html
       children:
 
-        - label: Is the Magento software installed already?
-          url: /install-gde/basics/basics_magento-installed.html
+        - label: Apache
+          url: /install-gde/prereq/apache.html
 
-        - label: What operating system is my server running?
-          url: /install-gde/basics/basics_os-version.html
+        - label: nginx
+          url: /install-gde/prereq/nginx.html
 
-        - label: How do I log in to my Magento server using a terminal, command prompt, or SSH?
-          url: /install-gde/basics/basics_login.html
+        - label: PHP
+          url: /install-gde/prereq/php-settings.html
 
-        - label: What's the difference between a module and a component?
-          url: /install-gde/basics/basics_module.html
+        - label: MySQL
+          url: /install-gde/prereq/mysql.html
 
-        - label: What is the software that the Magento server needs to run?
-          url: /install-gde/basics/basics_software.html
-
-        - label: What is a docroot?
-          url: /install-gde/basics/basics_docroot.html
-
-    - label: Getting Started
-      children:
-        - label: Helpful resources
-          url: /install-gde/install-resources-parent.html
+        - label: Elasticsearch
+          url: /install-gde/prereq/elasticsearch.html
+          exclude_versions: ["2.3"]
           children:
 
-            - label: Installation quick reference (tutorial)
-              url: /install-gde/install-quick-ref.html
+            - label: Configure nginx and Elasticsearch
+              url: /install-gde/prereq/es-config-nginx.html
 
-            - label: Installation flow diagram
-              url: /install-gde/install-resource-diagram.html
+            - label: Configure Apache and Elasticsearch
+              url: /install-gde/prereq/es-config-apache.html      
 
-            - label: Installation roadmap (reference)
-              url: /install-gde/install-roadmap_part1.html
+        - label: Get your authentication keys
+          url: /install-gde/prereq/connect-auth.html
 
-        - label: Prerequisites
-          url: /install-gde/prereq/prereq-overview.html
+        - label: Magento file system ownership and permissions
           children:
 
-            - label: Apache
-              url: /install-gde/prereq/apache.html
+            - label: Overview of ownership and permissions
+              url: /install-gde/prereq/file-sys-perms-over.html
 
-            - label: nginx
-              url: /install-gde/prereq/nginx.html
+            - label: Set pre-installation ownership and permissions
+              url: /install-gde/prereq/file-system-perms.html
 
-            - label: PHP
-              url: /install-gde/prereq/php-settings.html
+        - label: RabbitMQ
+          url: /install-gde/prereq/install-rabbitmq.html
+          
+        - label: Set up a remote MySQL database connection
+          url: /install-gde/prereq/mysql_remote.html
 
-            - label: MySQL
-              url: /install-gde/prereq/mysql.html
+        - label: SELinux and iptables
+          url: /install-gde/prereq/security.html
 
-            - label: Elasticsearch
-              url: /install-gde/prereq/elasticsearch.html
-              exclude_versions: ["2.3"]
-              children:
-
-                - label: Configure nginx and Elasticsearch
-                  url: /install-gde/prereq/es-config-nginx.html
-
-                - label: Configure Apache and Elasticsearch
-                  url: /install-gde/prereq/es-config-apache.html      
-
-            - label: Get your authentication keys
-              url: /install-gde/prereq/connect-auth.html
-
-            - label: Magento file system ownership and permissions
-              children:
-
-                - label: Overview of ownership and permissions
-                  url: /install-gde/prereq/file-sys-perms-over.html
-
-                - label: Set pre-installation ownership and permissions
-                  url: /install-gde/prereq/file-system-perms.html
-
-            - label: RabbitMQ
-              url: /install-gde/prereq/install-rabbitmq.html
-              
-            - label: Set up a remote MySQL database connection
-              url: /install-gde/prereq/mysql_remote.html
-
-            - label: SELinux and iptables
-              url: /install-gde/prereq/security.html
-
-            - label: Optional software
-              url: /install-gde/prereq/optional.html
+        - label: Optional software
+          url: /install-gde/prereq/optional.html
 
         - label: Get the Magento software
-          url: /install-gde/install/get-software.html
-
-        - label: Install Magento using Composer
-          url: /install-gde/composer.html
-
-        - label: (Easy) Install the Magento archive on your server
-          url: /install-gde/prereq/zip_install.html
+          url: /install-gde/bk-install-guide.html
 
         - label: (Contributor) Clone the Magento repository
           url: /install-gde/prereq/dev_install.html
@@ -111,12 +73,6 @@ pages:
 
             - label: Update installation dependencies
               url: /install-gde/install/prepare-install.html
-
-        - label: Get help with your installation
-          url: /install-gde/install/get-help.html
-
-        - label: Install options
-          url: /install-gde/continue-to-install.html
 
     - label: Setup Wizard Install
       include_versions: ["2.3"]
@@ -161,78 +117,14 @@ pages:
           include_versions: ["2.3"]
 
     - label: Command Line Installation
+      url: /install-gde/install/cli/install-cli.html
       children:
 
-        - label: Installation roadmap (reference)
-          url: /install-gde/install-roadmap_cli.html
+        - label: Get started with the command-line installation
+          url: /install-gde/install/cli/install-cli-subcommands.html
 
-        - label: Install the Magento software using the command line
-          url: /install-gde/install/cli/install-cli.html
-          children:
-
-            - label: Get started with the command-line installation
-              url: /install-gde/install/cli/install-cli-subcommands.html
-
-            - label: Install the Magento software
-              url: /install-gde/install/cli/install-cli-install.html
-
-            - label: Uninstall or reinstall Magento
-              url: /install-gde/install/cli/install-cli-uninstall.html
-
-            - label: Display or change the Admin URI
-              url: /install-gde/install/cli/install-cli-adminurl.html
-
-            - label: Remove sample data modules or update sample data
-              url: /install-gde/install/cli/install-cli-sample-data-other.html
-
-            - label: Enable or disable modules
-              url: /install-gde/install/cli/install-cli-subcommands-enable.html
-
-            - label: Uninstall modules
-              url: /install-gde/install/cli/install-cli-uninstall-mods.html
-
-            - label: Create or update the deployment configuration
-              url: /install-gde/install/cli/install-cli-subcommands-deployment.html
-
-            - label: Enable or disable maintenance mode
-              url: /install-gde/install/cli/install-cli-subcommands-maint.html
-
-            - label: Configure consumer behavior
-              url: /install-gde/install/cli/install-cli-subcommands-consumers.html
-
-            - label: Create the Magento database schema
-              url: /install-gde/install/cli/install-cli-subcommands-db.html
-
-            - label: Update the Magento database schema and data
-              url: /install-gde/install/cli/install-cli-subcommands-db-upgr.html
-
-            - label: Configure the lock provider
-              url: /install-gde/install/cli/install-cli-subcommands-lock.html
-              
-            - label: Configure the store
-              url: /install-gde/install/cli/install-cli-subcommands-store.html
-
-            - label: Create, edit, or unlock a Magento administrator account
-              url: /install-gde/install/cli/install-cli-subcommands-admin.html
-
-            - label: Back up and roll back the file system, media, and database
-              url: /install-gde/install/cli/install-cli-backup.html
-
-            - label: Uninstall themes Composer packages
-              url: /install-gde/install/cli/install-cli-theme-uninstall.html
-
-            - label: Uninstall language packages
-              url: /install-gde/install/cli/install-cli-uninstall-langpk.html
-
-        - label: Install optional sample data modules
-          url: /install-gde/install/cli/install-cli-sample-data.html
-          children:
-
-            - label: Install using Composer
-              url: /install-gde/install/cli/install-cli-sample-data-composer.html
-
-            - label: Install by cloning repositories
-              url: /install-gde/install/cli/install-cli-sample-data-clone.html
+        - label: Install the Magento software
+          url: /install-gde/install/cli/install-cli-install.html
 
         - label: Contributing developers—update, reinstall Magento
           url: /install-gde/install/cli/dev_options.html
@@ -250,10 +142,8 @@ pages:
             - label: Reinstall the Magento software
               url: /install-gde/install/cli/dev_reinstall.html
 
-        - label: Post-installation
-          url: /install-gde/continue-to-verify_cli.html
-
     - label: Post Installation
+      url: /install-gde/continue-to-verify_cli.html
       children:
         - label: Verify the installation
           url: /install-gde/install/verify.html
@@ -264,10 +154,7 @@ pages:
         - label: Optionally set a umask
           url: /install-gde/install/post-install-umask.html
 
-        - label: Appendix—Magento file system ownership and appendix (legacy)
-          url: /install-gde/install/legacy-file-system-perms.html
-
-        - label: Install sample data after Magento
+        - label: Install optional sample data
           url: /install-gde/install/sample-data-after-magento.html
           children:
 
@@ -276,7 +163,60 @@ pages:
 
             - label: Install by cloning repositories
               url: /install-gde/install/sample-data-after-clone.html
+        
+        - label: Uninstall or reinstall Magento
+          url: /install-gde/install/cli/install-cli-uninstall.html
 
+        - label: Display or change the Admin URI
+          url: /install-gde/install/cli/install-cli-adminurl.html
+
+        - label: Remove sample data modules or update sample data
+          url: /install-gde/install/cli/install-cli-sample-data-other.html
+
+        - label: Enable or disable modules
+          url: /install-gde/install/cli/install-cli-subcommands-enable.html
+
+        - label: Uninstall modules
+          url: /install-gde/install/cli/install-cli-uninstall-mods.html
+
+        - label: Create or update the deployment configuration
+          url: /install-gde/install/cli/install-cli-subcommands-deployment.html
+
+        - label: Enable or disable maintenance mode
+          url: /install-gde/install/cli/install-cli-subcommands-maint.html
+
+        - label: Configure consumer behavior
+          url: /install-gde/install/cli/install-cli-subcommands-consumers.html
+
+        - label: Create the Magento database schema
+          url: /install-gde/install/cli/install-cli-subcommands-db.html
+
+        - label: Update the Magento database schema and data
+          url: /install-gde/install/cli/install-cli-subcommands-db-upgr.html
+
+        - label: Configure the lock provider
+          url: /install-gde/install/cli/install-cli-subcommands-lock.html
+          
+        - label: Configure the store
+          url: /install-gde/install/cli/install-cli-subcommands-store.html
+
+        - label: Create, edit, or unlock a Magento administrator account
+          url: /install-gde/install/cli/install-cli-subcommands-admin.html
+
+        - label: Back up and roll back the file system, media, and database
+          url: /install-gde/install/cli/install-cli-backup.html
+
+        - label: Uninstall themes Composer packages
+          url: /install-gde/install/cli/install-cli-theme-uninstall.html
+
+        - label: Uninstall language packages
+          url: /install-gde/install/cli/install-cli-uninstall-langpk.html
+
+    - label: Tutorials
+      children:
+        - label: Modify docroot to improve security
+          url: /install-gde/tutorials/change-docroot-to-pub.html
+    
     - label: Troubleshooting
       children:
 
@@ -292,9 +232,3 @@ pages:
             - label: Installation dependencies not met
               url: /install-gde/trouble/tshoot_install_depend.html
               include_versions: ["2.3"]
-
-
-    - label: How Tos
-      children:
-        - label: Modify docroot to improve security
-          url: /install-gde/tutorials/change-docroot-to-pub.html

--- a/src/index.html
+++ b/src/index.html
@@ -11,7 +11,7 @@ guide_version: '2.4'
       <h2 class="title">Setup</h2>
       <ul>
         <li><a href="{{ page.baseurl }}/install-gde/system-requirements.html">System Requirements</a></li>
-        <li><a href="{{ page.baseurl }}/install-gde/bk-install-guide.html">Installation Guide</a></li>
+        <li><a href="{{ page.baseurl }}/install-gde/install-flow-diagram.html">Installation Guide</a></li>
         <li><a href="{{ page.baseurl }}/config-guide/bk-config-guide.html">Configuration Guide</a></li>
         <li><a href="{{ site.baseurl }}/cloud/bk-cloud.html">{{site.data.var.ece}}</a></li>
       </ul>


### PR DESCRIPTION
## Purpose of this pull request

This pull request (PR) is the first attempt at reorganizing the table of contents (TOC) for the _Installation Guide_. The goal is to remove unnecessary content and move the recommended content so that it is easier to find.

## Affected DevDocs pages

- Several pages in the Installation Guide

## Additional info

I didn't change topic titles to match revised TOC labels because I expect some churn as we deliberate internally. After we decide on titles, I can make updates. For example:

<img width="1470" alt="Screen Shot 2020-11-06 at 10 20 08 AM" src="https://user-images.githubusercontent.com/13662379/98389495-bfdaf080-2019-11eb-8458-51ffb4d47390.png">

See internal wiki for link to internal staging build.

## To do

- [ ] Rename topic titles to match TOC label changes (where applicable)
- [ ] Delete files for entries that were removed from the TOC; set up redirects if necessary