### PR TITLE
Updates for Cloud Docker 1.2.0 release

### DIFF
--- a/src/_data/toc/cloud-guide.yml
+++ b/src/_data/toc/cloud-guide.yml
@@ -215,13 +215,14 @@ pages:
               versionless: true
 
         - label: Launch Docker
-          children: 
-            - label: Developer mode
-              url: /cloud/docker/docker-mode-developer.html
-              versionless: true
 
+          children: 
             - label: Production mode
               url: /cloud/docker/docker-mode-production.html
+              versionless: true
+ 
+            - label: Developer mode
+              url: /cloud/docker/docker-mode-developer.html
               versionless: true
 
         - label: Functional Testing

--- a/src/_data/var.yml
+++ b/src/_data/var.yml
@@ -21,7 +21,7 @@ mbi: Magento Business Intelligence
 # Cloud product name variables
 
 ece: Magento Commerce Cloud
-ece-release-date: August 5, 2020
+ece-release-date: November 9, 2020
 csuite: Magento Commerce Cloud Suite
 ct: ece-tools
 ct-repo: magento/ece-tools
@@ -31,7 +31,7 @@ mcp-package: magento/magento-cloud-patches
 mcp-release: 1.0.8
 mcd-package: magento/magento-cloud-docker
 mcd-prod: Magento Cloud Docker
-mcd-release: 1.1.2
+mcd-release: 1.2.0
 mcc-prod: Magento Cloud Components
 mcc-package: magento/magento-cloud-components
 mcc-release: 1.0.7

--- a/src/_includes/cloud/cloud-docker-config-generator-cmds.md
+++ b/src/_includes/cloud/cloud-docker-config-generator-cmds.md
@@ -2,10 +2,11 @@ You use the following commands to generate the Docker configuration files and bu
 
 Action | Command
 :----- | :------
-Builds the Docker environment in [production mode][mode] by default and verifies configured service versions. | `ece-docker build:compose`
-Builds the docker environment in [developer mode][mode]. | `ece-docker build:compose --mode="developer"`
-Builds the docker environment in [production mode][mode]. |`ece-docker build:compose --mode="production"`
-Convert PHP configuration files to Docker ENV files. | `ece-docker image:generate:php`
+Builds the Docker environment in [production mode][mode] by default and verifies configured service versions. | `./vendor/bin/ece-docker build:compose`
+Builds the docker environment in [developer mode][mode]. | `./vendor/bin/ece-docker build:compose --mode="developer"`
+Builds the docker environment in [production mode][mode]. |`.vendor/bin/ece-docker build:compose --mode="production"`
+Convert PHP configuration files to Docker ENV files. | `.vendor/bin/ece-docker image:generate:php`
+Builds a custom `docker-compose.yaml` file | `./vendor/bin/ece-docker build:custom:compose`
 
 For example, the following command starts the Docker configuration generator in developer mode and specifies PHP version 7.2:
 

--- a/src/cloud/docker/docker-config.md
+++ b/src/cloud/docker/docker-config.md
@@ -142,7 +142,7 @@ By default, MailHog listens on port 1025 for SMTP and port 8025 for the frontend
 
 After updating the configuration and restarting the Docker environment, you can connect to the MailHog service from `http://magento2.docker:8026`, and use port 1026 for SMTP communication.
 
-If you do not need the [MailHog] service, use the `--no-mailhog` option to generate the Docker compose configuration: 
+If you do not need the [MailHog] service, use the `--no-mailhog` option to generate the Docker compose configuration:
 
 ```bash
 ./vendor/bin/ece-docker build:compose --no-mailhog

--- a/src/cloud/docker/docker-containers-service.md
+++ b/src/cloud/docker/docker-containers-service.md
@@ -86,8 +86,8 @@ You can change the list of plugins to install by updating the configuration for 
 services:
     elasticsearch:
         environment:
-          - 'ES_PLUGINS=analysis-stempel analysis-nori'   
-``` 
+          - 'ES_PLUGINS=analysis-stempel analysis-nori'
+```
 
 ### Troubleshooting
 

--- a/src/cloud/docker/docker-containers.md
+++ b/src/cloud/docker/docker-containers.md
@@ -54,7 +54,7 @@ The following table shows the options to customize service container configurati
 | [varnish][varnish-container] | Varnish | `--no-varnish` | 4, 6.2 | Varnish is provisioned by default. Use the `--no-varnish` option to skip Varnish service installation
 | [web][web-container] | NGINX | `--nginx` | 1.9, latest |
 
-Use the following command to view the available options for the `ece-docker build:compose` command:
+Use the following command to view all available options for the `ece-docker build:compose` command:
 
 ```bash
 ./vendor/bin/ece-docker build:compose --help

--- a/src/cloud/docker/docker-development-debug.md
+++ b/src/cloud/docker/docker-development-debug.md
@@ -25,9 +25,9 @@ If you use Microsoft Windows, take the following steps before continuing:
    ```bash
    vendor/bin/ece-docker build:compose --mode="developer" --sync-engine="mutagen" --with-xdebug
    ```
-   
+
    For Linux systems, you must use the `--set-docker-host` option to add the `host.docker.internal` entry to the `/etc/hosts` file for the `fpm_xdebug` container.
-   
+
       ```bash
       vendor/bin/ece-docker build:compose --mode="developer" --with-xdebug --set-docker-host
       ```

--- a/src/cloud/docker/docker-mode-developer.md
+++ b/src/cloud/docker/docker-mode-developer.md
@@ -26,13 +26,15 @@ To launch the Docker environment in developer mode:
 1. Install the template dependencies, and add the default hostname to your `/etc/hosts` file.
 
    ```bash
-   curl https://raw.githubusercontent.com/magento/magento-cloud-docker/1.1.0/bin/init-docker.sh | bash
+   curl https://raw.githubusercontent.com/magento/magento-cloud-docker/<magento-cloud-docker-package-version>/bin/init-docker.sh | bash
    ```
 
-   If required, you can add options to the `init-docker.sh` initialization script to customize your Docker environment. Run the following command to see the available options:
+   For `<package-version>`, use the [latest release of the {{site.data.var.mcd-package}}].
+
+   You can customize the options for the `init-docker.sh` initialization script your Docker environment. For example, you can specify the PHP version (default is 7.2) and the [Docker image version] (default 1.1). We recommend using the latest version of the Magento Cloud Docker images. Run the following command to see the available options:
 
    ```bash
-   curl https://raw.githubusercontent.com/magento/magento-cloud-docker/1.1.0/bin/init-docker.sh | bash -s -- --help
+   curl https://raw.githubusercontent.com/magento/magento-cloud-docker/<magento-cloud-package-version>/bin/init-docker.sh | bash -s -- --help
    ```
 
 1. On macOS or Windows hosts, install the selected file synchronization tool:
@@ -129,11 +131,15 @@ To launch the Docker environment in developer mode:
 
    -  `https://magento2.docker`
 
-[Synchronizing data in Docker]: {{site.baseurl}}/cloud/docker/docker-syncing-data.html
+<!--Link definitioons-->
+
 [cloud-repo]: https://github.com/magento/magento-cloud
-[magento-creds]: {{site.baseurl}}/guides/v2.3/install-gde/prereq/connect-auth.html
-[services]: {{site.baseurl}}/cloud/docker/docker-containers.html#service-containers
-[xdebug]: {{site.baseurl}}/cloud/docker/docker-development-debug.html#configure-xdebug]
-[service keys]: {{site.baseurl}}/cloud/docker/docker-containers.html#service-configuration-options
+[Docker image version]: https://hub.docker.com/r/magento/magento-cloud-docker-php/tags
 [dsync-install]: https://docker-sync.readthedocs.io/en/latest/getting-started/installation.html
+[latest release of the {{site.data.var.mcd-package}}]: https://github.com/magento/magento-cloud-docker/releases
+[magento-creds]: {{site.baseurl}}/guides/v2.3/install-gde/prereq/connect-auth.html
 [mutagen-install]: https://mutagen.io/documentation/introduction/installation/
+[services]: {{site.baseurl}}/cloud/docker/docker-containers.html#service-containers
+[service keys]: {{site.baseurl}}/cloud/docker/docker-containers.html#service-configuration-options
+[Synchronizing data in Docker]: {{site.baseurl}}/cloud/docker/docker-syncing-data.html
+[xdebug]: {{site.baseurl}}/cloud/docker/docker-development-debug.html#configure-xdebug]

--- a/src/cloud/docker/docker-mode-production.md
+++ b/src/cloud/docker/docker-mode-production.md
@@ -21,10 +21,12 @@ To launch the Docker environment in production mode:
 1. Install the template dependencies and add the default hostname to your `/etc/hosts` file, use the following command to run the Docker initialization script:
 
    ```bash
-   curl https://raw.githubusercontent.com/magento/magento-cloud-docker/1.1.0/bin/init-docker.sh | bash
+   curl https://raw.githubusercontent.com/magento/magento-cloud-docker/<package-version>/bin/init-docker.sh | bash
    ```
 
-   If required, you can add options to the `init-docker.sh` initialization script to customize your Docker environment. Run the following command to see the available options:
+   For `<package-version>`, use the [latest release of the {{site.data.var.mcd-package}}].
+
+   You can customize the options for the `init-docker.sh` initialization script your Docker environment. For example, you can specify the PHP version (default is 7.2) and the [Docker image version] (default 1.1). We recommend using the latest version of the Magento Cloud Docker images. Run the following command to see the available options:
 
    ```bash
    curl https://raw.githubusercontent.com/magento/magento-cloud-docker/1.1.0/bin/init-docker.sh | bash -s -- --help
@@ -97,6 +99,7 @@ To launch the Docker environment in production mode:
    -  [`https://magento2.docker`](https://magento2.docker)
 
 [cloud-repo]: https://github.com/magento/magento-cloud
+[Docker image version]: https://hub.docker.com/r/magento/magento-cloud-docker-php/tags
 [magento-creds]: {{site.baseurl}}/guides/v2.3/install-gde/prereq/connect-auth.html
 [services]: {{site.baseurl}}/cloud/docker/docker-containers.html#service-containers
 [configure Xdebug]: {{site.baseurl}}/cloud/docker/docker-development-debug.html#configure-xdebug

--- a/src/cloud/docker/docker-quick-reference.md
+++ b/src/cloud/docker/docker-quick-reference.md
@@ -111,6 +111,204 @@ Options:
 {:.bs-callout-info}
 See [Service versions] for additional information about the service configuration options for the `ece-docker build:compose` command.
 
+### Build a custom Docker Compose configuration
+
+Instead of building the `docker-compose.yaml` file using the {{site.data.var.ece }} project configuration. You can use the `build:custom:compose` command to build a custom `docker-compose.yaml` file with the configuration you supply. You provide the configuration as a JSON array as shown in [Example 1](#example-1).
+
+For {{site.data.var.mcd-prod}} 1.2 and later, you have an additional option to specify custom images and image versions using the `ece-docker build:custom:compose` command as shown in [Example 2](#example-2).
+
+#### Example 1
+
+> Generate a custom `docker-compose.yaml` file
+
+```bash
+./vendor/bin/ece-docker build:custom:compose '{"name":"magento","system":{"mode":"production","host":"magento2.test","port":"8080","db":{"increment_increment":3,"increment_offset":2},"mailhog":{"smtp_port":"1026","http_port":"8026"}},"services":{"php":{"version":"7.4","enabled":true,"extensions":{"enabled":["xsl"]}},"mysql":{"version":"10.2","image":"mariadb","enabled":true}, "mailhog": {"enabled":true}}}'
+```
+
+This command generates the following `docker-compose.yaml` file:
+
+```terminal
+version: '2.1'
+services:
+  db:
+    hostname: db.magento2.test
+    image: 'mariadb:10.2'
+    environment:
+      - MYSQL_ROOT_PASSWORD=magento2
+      - MYSQL_DATABASE=magento2
+      - MYSQL_USER=magento2
+      - MYSQL_PASSWORD=magento2
+    ports:
+      - '3306'
+    volumes:
+      - '.docker/mnt:/mnt:rw,delegated'
+      - 'magento-magento-db:/var/lib/mysql'
+    healthcheck:
+      test: 'mysqladmin ping -h localhost -pmagento2'
+      interval: 30s
+      timeout: 30s
+      retries: 3
+    command: '--auto_increment_increment=3 --auto_increment_offset=2'
+    networks:
+      magento:
+        aliases:
+          - db.magento2.test
+  fpm:
+    hostname: fpm.magento2.test
+    image: 'magento/magento-cloud-docker-php:7.3-fpm-1.2.0'
+    extends: generic
+    volumes:
+      - '.:/app:ro,delegated'
+      - 'magento-vendor:/app/vendor:ro,delegated'
+      - 'magento-generated:/app/generated:ro,delegated'
+      - '.docker/mnt:/mnt:rw,delegated'
+    networks:
+      magento:
+        aliases:
+          - fpm.magento2.test
+    depends_on:
+      db:
+        condition: service_healthy
+  web:
+    hostname: web.magento2.test
+    image: 'magento/magento-cloud-docker-nginx:1.19-1.2.0'
+    extends: generic
+    volumes:
+      - '.:/app:ro,delegated'
+      - 'magento-vendor:/app/vendor:ro,delegated'
+      - 'magento-generated:/app/generated:ro,delegated'
+      - '.docker/mnt:/mnt:rw,delegated'
+    environment:
+      - WITH_XDEBUG=0
+    networks:
+      magento:
+        aliases:
+          - web.magento2.test
+    depends_on:
+      fpm:
+        condition: service_started
+  varnish:
+    hostname: varnish.magento2.test
+    image: 'magento/magento-cloud-docker-varnish:6.2-1.2.0'
+    networks:
+      magento:
+        aliases:
+          - varnish.magento2.test
+    depends_on:
+      web:
+        condition: service_started
+  tls:
+    hostname: tls.magento2.test
+    image: 'magento/magento-cloud-docker-nginx:1.19-1.2.0'
+    extends: generic
+    networks:
+      magento:
+        aliases:
+          - magento2.test
+    environment:
+      UPSTREAM_HOST: varnish
+    ports:
+      - '8080:80'
+      - '443:443'
+    depends_on:
+      varnish:
+        condition: service_started
+  generic:
+    hostname: generic.magento2.test
+    image: 'magento/magento-cloud-docker-php:7.3-cli-1.2.0'
+    env_file: ./.docker/config.env
+    environment:
+      - 'PHP_EXTENSIONS=bcmath bz2 calendar exif gd gettext intl mysqli pcntl pdo_mysql soap sockets sysvmsg sysvsem sysvshm opcache zip xsl'
+  build:
+    hostname: build.magento2.test
+    image: 'magento/magento-cloud-docker-php:7.3-cli-1.2.0'
+    extends: generic
+    volumes:
+      - '.:/app:rw,delegated'
+      - 'magento-vendor:/app/vendor:rw,delegated'
+      - 'magento-generated:/app/generated:rw,delegated'
+      - '~/.composer/cache:/root/.composer/cache:rw,delegated'
+    networks:
+      magento-build:
+        aliases:
+          - build.magento2.test
+    depends_on:
+      db:
+        condition: service_healthy
+  deploy:
+    hostname: deploy.magento2.test
+    image: 'magento/magento-cloud-docker-php:7.3-cli-1.2.0'
+    extends: generic
+    volumes:
+      - '.:/app:ro,delegated'
+      - 'magento-vendor:/app/vendor:ro,delegated'
+      - 'magento-generated:/app/generated:ro,delegated'
+      - '.docker/mnt:/mnt:rw,delegated'
+    networks:
+      magento:
+        aliases:
+          - deploy.magento2.test
+    depends_on:
+      db:
+        condition: service_healthy
+  mailhog:
+    hostname: mailhog.magento2.test
+    image: 'mailhog/mailhog:latest'
+    ports:
+      - '1026:1025'
+      - '8026:8025'
+    networks:
+      magento:
+        aliases:
+          - mailhog.magento2.test
+volumes:
+  magento-vendor: {  }
+  magento-generated: {  }
+  magento-magento-db: {  }
+networks:
+  magento:
+    driver: bridge
+  magento-build:
+    driver: bridge
+
+```
+
+For {{site.data.var.mcd-prod}} 1.2 and later, you have an additional option to specify custom images and image versions using the `ece-docker build:custom:compose` command.
+
+#### Example 2
+
+> Generate a custom `docker-compose.yaml` file with custom images and image versions
+
+```bash
+./vendor/bin/ece-docker build:custom:compose '{"name":"magento","system":{"mode":"production","host":"magento2.test","port":"8080","db":{"increment_increment":3,"increment_offset":2},"mailhog":{"smtp_port":"1026","http_port":"8026"}},"services":{"php":{"image":"php-v1","version":"7.4","enabled":true},"php-cli":{"image-pattern":"%s:%s-cli"},"php-fpm":{"image-pattern":"%s:%s-fpm"},"mysql":{"image":"mariadb-v1","version":"10.3","image-pattern":"%s:%s","enabled":true},"redis":{"image":"redis-v1","enabled":"true","version":"5"},"elasticsearch":{"image":"elasticsearch-v1","image-pattern":"%s:%s","enabled":true,"version":"7.6"},"varnish":{"image":"varnish-v1","image-pattern":"%s:%s","enabled":true,"version":"6.2"},"nginx":{"image":"nginx-v1","version":"1.19","image-pattern":"%s:%s","enabled":"true"},"test":{"enabled":true}},"mounts":{"var":{"path":"var"},"app-etc":{"path":"app\/etc"},"pub-media":{"path":"pub\/media"},"pub-static":{"path":"pub\/static"}}}'
+```
+
+This command generates the following images in the Docker environment:
+
+```conf
+services:
+  db:
+    image: 'mariadb-v1:10.3'
+  redis:
+    image: 'redis-v1:5'
+  fpm:
+    image: 'php-v1:7.4-fpm'
+  web:
+    image: 'nginx-v1:1.19'
+  varnish:
+    image: 'varnish-v1:6.2'
+  tls:
+    image: 'nginx-v1:1.19'
+  test:
+    image: 'php-v1:7.4-cli'
+  generic:
+    image: 'php-v1:7.4-cli'
+  build:
+    image: 'php-v1:7.4-cli'
+  deploy:
+    image: 'php-v1:7.4-cli'
+```
+
 ## Magento Cloud Docker CLI
 
 The `bin/magento-docker` commands simplify running docker-compose tasks. For example, instead of running a separate docker-compose command for the build, deploy, and post-deploy steps, you can _redeploy_ Magento in a Docker environment using the following command:

--- a/src/cloud/docker/docker-quick-reference.md
+++ b/src/cloud/docker/docker-quick-reference.md
@@ -10,6 +10,8 @@ functional_areas:
 
 ## Docker Compose
 
+Docker Compose is a tool for defining and running multi-container Docker applications. The following table lists the Docker Compose commands for building, deploying, and operating {{site.data.var.mcd-prod}}. You can also use [Magento Cloud Docker CLI](#magento-cloud-docker-cli) commands to complete Docker Compose tasks.
+
 Action | Command
 :----- | :------
 Build and start Docker environment | `docker-compose up -d`
@@ -46,15 +48,68 @@ docker-compose -f docker-compose.yml -f docker-compose-custom.yml [-f more-custo
 
 ### Additional build options
 
-| Option       | Key              | Available values
-| ------------ | ---------------- | ------------------
-| [Mode][]         | `--mode`, `-m`   | production, developer
-| [File synchronization engine][] | `--sync-engine` | native (default), docker-sync, mutagen
-| Specify a custom URL for Magento | `--host`<br>`--port`
-| Specify custom HTTP and SMTP ports for MailHog | `--mailhog-http-port`<br>`--mailhog-smtp-port`
+View the available options for the `ece-docker build:compose` command:
+
+```bash
+php ./vendor/bin/ece-docker build:compose -h
+```
+
+```terminal
+Description:
+  Build docker configuration
+
+Usage:
+  build:compose [options]
+
+Options:
+      --php=PHP                                        PHP version
+      --nginx=NGINX                                    Nginx version
+      --db=DB                                          DB version
+      --db-image=DB-IMAGE                              DB image
+      --expose-db-port=EXPOSE-DB-PORT                  Expose DB port
+      --expose-db-quote-port=EXPOSE-DB-QUOTE-PORT      Expose port for DB sales
+      --expose-db-sales-port=EXPOSE-DB-SALES-PORT      Expose port for DB quote
+      --with-entrypoint                                Add DB entrypoint volume
+      --with-mariadb-conf                              Add MariaDb config volume
+      --redis=REDIS                                    Redis version
+      --es=ES                                          Elasticsearch version
+      --rmq=RMQ                                        RabbitMQ version
+      --node=NODE                                      Node.js version
+      --selenium-version=SELENIUM-VERSION              Selenium version
+      --selenium-image=SELENIUM-IMAGE                  Selenium image
+      --no-es                                          Disable Elasticsearch
+      --no-mailhog                                     Disable MailHog
+      --mailhog-http-port                              Custom HTTP port for MailHog
+      --mailhog-smtp-port                              Custom SMTP port for MailHog
+      --set-docker-host                                Sets host.docker.internal for fpm_xdebug container to
+                                                       resolve debug issue for LINUX system
+  -m, --mode=MODE                                      Mode of environment (developer, production)
+      --sync-engine=SYNC-ENGINE                        File sync engine. Works only with developer mode. Available: (docker-sync, mutagen, native)
+      --with-cron                                      Add cron container
+      --no-varnish                                     Remove Varnish container
+      --with-selenium                                  Add Selenium latest version
+      --with-test                                      Add container for running tests
+      --no-tmp-mounts                                  Remove /tmp mounted volume
+      --with-xdebug                                    Enables XDebug
+      --env-vars[=ENV-VARS]                            Cloud environment variables
+      --installation-type[=INSTALLATION-TYPE]          Sets magento installation type [default: "composer"]
+      --host[=HOST]                                    Host name
+      --port[=PORT]                                    Port
+      --tls-port                                       TLS port
+      --es-env-var=ES-ENV-VAR                          Environment variable for elasticsearch service (multiple values allowed)
+      --db-increment-increment=DB-INCREMENT-INCREMENT  "auto_increment_increment" database variable
+      --db-increment-offset=DB-INCREMENT-OFFSET        "auto_increment_offset" database variable
+  -h, --help                                           Display this help message
+  -q, --quiet                                          Do not output any message
+  -V, --version                                        Display this application version
+      --ansi                                           Force ANSI output
+      --no-ansi                                        Disable ANSI output
+  -n, --no-interaction                                 Do not ask any interactive question
+  -v|vv|vvv, --verbose                                 Increase the verbosity of messages: 1 for normal output, 2 for more verbose output and 3 for debug
+  ```
 
 {:.bs-callout-info}
-See [Service versions] for a list of service configuration options you can add to the `ece-docker build:compose` command to customize the Cloud Docker environment configuration.
+See [Service versions] for additional information about the service configuration options for the `ece-docker build:compose` command.
 
 ## Magento Cloud Docker CLI
 
@@ -92,6 +147,16 @@ Start containers | `./bin/magento-docker start`
 Restart containers | `./bin/magento-docker restart`
 Destroy containers | `./bin/magento-docker down`
 Destroy, re-create, and start containers | `./bin/magento-docker up`
+Clears Redis cache | `./bin/magento-docker flush-redis`
+Clears Varnish cache | `./bin/magento-docker flush-varnish`
+Access database | `./bin/magento-docker ece-db`
+Run a command in a PHP container<br>Supports the following values for the PHP version: 7.1, 7.2, 7.3, 7.4| `./bin/magento-docker php <version>`]
+
+Use the following command to view the magento-docker CLI command help:
+
+```bash
+./bin/magento-docker -h
+```
 
 <!--Link definitions-->
 

--- a/src/cloud/release-notes/mcd-release-notes.md
+++ b/src/cloud/release-notes/mcd-release-notes.md
@@ -16,6 +16,59 @@ The release notes include:
 -  {:.new}New features
 -  {:.fix}Fixes and improvements
 
+## v1.2.0
+*Release date: November 9, 2020*<br/>
+
+-  **Container updates–**
+
+   -  **PHP-FPM container**
+
+      -  {:.new}Added support for the gnupg PHP extension.<!--MCLOUD-5981-->
+
+   -  **Database container**
+
+      -  {:.fix}Fixed the database container health check by adding the required database password to the health check command.<!--MCLOUD-7122-->
+
+   -  **Elasticsearch container**
+
+      -  {:.new}Added support for Elasticsearch 7.9 for compatibility with upcoming Magento releases.<!--MCLOUD-7190-->
+
+      -  {:.new}Added support to use the Elasticsearch plugin configuration information from the `services.yaml` file to generate the `docker-compose.yaml` file for a {{ site.data.var.mcd-prod }} environment. See [Elasticsearch plugins]({{ site.baseurl}}/cloud/docker/docker-containers-service.html#elasticsearch-plugins).<!--MCLOUD-2789-->
+
+      -  {:new}Added support for the following Elasticsearch plugins: `analysis-icu`, `analysis-phonetic`, `analysis-stempel`, and `analysis-nori`.  The `analysis-icu` and `analysis-phonetic` plugins are installed by default. You can add or remove the `analysis-stempel` and `analysis-nori` plugins as needed.<!--MCLOUD-2789-->
+
+   -  **CLI container**
+
+      -  {:.new}Added the OpenSSH-client to PHP CLI containers so you can use ssh-agent forwarding for Composer if the `composer.json` file contains private git repositories that require an ssh client for various Composer commands.<!--MCLOUD-6008-->
+
+      -  {:new}Added a Magento Cloud Docker CLI command to run a script or command from the Docker PHP container, for example `./bin/magento-docker php 7.3 bin/magento list`. See [Magento Cloud Docker CLI]({{ site.baseurl }}/cloud/docker/docker-quick-reference.html#magento-cloud-docker-cli).<!--MCLOUD-5982-->
+
+-  **Test container**
+
+   -  {:.new}Added a test container for Magento application testing and added the `--with-test` option to the Docker `build:compose` command to create the container when testing Magento. See [Magento application testing](https://devdocs.magento.com/cloud/docker/docker-test-app-mftf.html).<!--MCLOUD-6394-->
+
+-  **FPM-XDEBUG container**
+
+   -  {:.fix}Fixed the Xdebug variable configuration for the Docker ENTRYPOINT to resolve `uninitialized "with_xdebug" variable` errors in the logs. *[Fix submitted by Florent Olivaud](https://github.com/magento/magento-cloud-docker/pull/218)*<!--MCLOUD-6043-->
+
+   -  {:.fix}Added the `--set-docker-host` option to the `ece-docker build:compose` command to configure the host.docker.internal value in the Xdebug container. This option is required to use Xdebug on Linux systems. See [Configure Xdebug for Docker]({{ site.baseurl }}/cloud/docker/docker-development-debug.html).<!--MCLOUD-6430-->
+
+-  {:.new}**Email configuration updates**–Added MailHog configuration options to the ece-docker `build:compose` command to customize the HTTP and SMTP ports and to disable MailHog. See [Set up email]({{ site.baseurl }}/cloud/docker/docker-config.html#set-up-email).<!--MCLOUD-6898, MCLOUD-6660-->
+
+-  **Docker configuration changes**
+
+   -  {:.new}For {{site.data.var.mcd-prod}} 1.2.0 and later, Magento now provides Docker images for each patch version, and the Docker configuration generator creates the Docker configuration with a specified patch version instead of using the latest version. Previously, the Docker configuration generator always used the latest patch version which could break {{ site.data.var.mcd-prod}} environments built an earlier patch version.<!--MCLOUD-7093-->
+
+   -  {:.new}Updated the `build:custom:compose` command with options to specify custom images and versions when generating the Docker compose configuration file, `docker-compose.yaml`. See [Build a custom Docker Compose configuration]({{ site.baseurl }}/cloud/docker/docker-quick-reference.html). <!--MCLOUD-7089-->
+
+   -  {:.fix}Updated the Docker host configuration to expose port 443 to enable access to Magento (https://magento2.docker) from all CLI containers.<!--MCLOUD-6806-->
+
+   -  {:.fix}Updated the build configuration to replace named volumes with regular volumes to prevent issues when deploying {{ site.data.var.mcd-prod }} on Linux or Windows Subsystem for Linux (WSL2).<!--MCLOUD-6732-->
+
+   -  {:.fix}Updated the {{site.data.var.mcd-prod}} functional tests to support Composer 2.0.<!--MCLOUD-7183-->
+
+-  {:.fix}Fixed an issue that caused the {{site.data.var.mcd-prod}} build to fail if the `app/etc/env.php` file exists.<!--MCLOUD-6732-->
+
 ## v1.1.2
 *Release date: September 9, 2020*<br/>
 


### PR DESCRIPTION
## Purpose of this pull request

- Updates for Magento Cloud Docker 1.2.0 release notes (MCLOUD-6649)
- Improves instructions for using the init-docker.sh installation script in the Launch production and launch developer mode
-  Added instructions for building custom docker-compose.yaml file (MCLOUD-7809)

## Affected DevDocs pages

-  https://devdocs.magento.com/cloud/docker/docker-config.html
-  https://devdocs.magento.com/cloud/docker/docker-containers-service.html
-  https://devdocs.magento.com/cloud/docker/docker-containers.html
-  https://devdocs.magento.com/cloud/docker/docker-development-debug.html
-  https://devdocs.magento.com/cloud/release-notes/mcd-release-notes.html

whatsnew
Added instructions for [building a custom `docker-compose.yaml` file](https://devdocs.magento.com/cloud/docker/docker-quick-reference.html#build-a-custom-docker-compose-configuration).