### PR TITLE
Add Page Builder modules to the Module Reference Guide

### DIFF
--- a/src/_data/codebase/v2_3/mrg/b2b/BundleNegotiableQuote.yml
+++ b/src/_data/codebase/v2_3/mrg/b2b/BundleNegotiableQuote.yml
@@ -20,4 +20,4 @@ content: "## Overview\n\nThe Magento_BundleNegotiableQuote module enables bundle
   \n[The Magento dependency injection mechanism](http://devdocs.magento.com/guides/v2.2/extension-dev-guide/depend-inj.html)
   enables you to override the functionality of the Magento_BundleNegotiableQuote module.\n\n##
   Additional information\n \nYou can track [backward incompatible changes made in
-  a Magento B2b mainline after the Magento 2.2 release](http://devdocs.magento.com/guides/v2.2/release-notes/changes/b2b_changes.html).\n"
+  a Magento B2b mainline after the Magento 2.2 release](http://devdocs.magento.com/guides/v2.2/release-notes/changes/b2b_changes.html)."

--- a/src/_data/codebase/v2_3/mrg/b2b/BundleRequisitionList.yml
+++ b/src/_data/codebase/v2_3/mrg/b2b/BundleRequisitionList.yml
@@ -17,4 +17,4 @@ content: "## Overview\n\nThe Magento_BundleRequisitionList module enables bundle
   \n### Layouts\n \nYou can extend and override layouts in the `Magento\\BundleRequisitionList\\view\\frontend\\layout`
   directories.\n\nFor more information about layouts, see the [Layout documentation](http://devdocs.magento.com/guides/v2.2/frontend-dev-guide/layouts/layout-overview.html).\n\n##
   Additional information\n \nYou can track [backward incompatible changes made in
-  a Magento B2b mainline after the Magento 2.2 release](http://devdocs.magento.com/guides/v2.2/release-notes/changes/b2b_changes.html).\n"
+  a Magento B2b mainline after the Magento 2.2 release](http://devdocs.magento.com/guides/v2.2/release-notes/changes/b2b_changes.html)."

--- a/src/_data/codebase/v2_3/mrg/b2b/CheckoutAddressSearchNegotiableQuote.yml
+++ b/src/_data/codebase/v2_3/mrg/b2b/CheckoutAddressSearchNegotiableQuote.yml
@@ -4,7 +4,7 @@ source_repo: magento2b2b
 release: 1.1.6
 github_path: app/code/Magento/CheckoutAddressSearchNegotiableQuote/README.md
 last_modified_at: '2019-04-10 17:47:51 -0500'
-content: |
+content: |-
   ## CheckoutAddressSearchNegotiableQuote module Overview
 
   CheckoutAddressSearchNegotiableQuote module extends Magento_CheckoutAddressSearch if it is enabled in configuration and it modifies NegotiableQuote shipping address on checkout.

--- a/src/_data/codebase/v2_3/mrg/b2b/CheckoutAgreementsNegotiableQuote.yml
+++ b/src/_data/codebase/v2_3/mrg/b2b/CheckoutAgreementsNegotiableQuote.yml
@@ -4,7 +4,7 @@ source_repo: magento2b2b
 release: 1.1.6
 github_path: app/code/Magento/CheckoutAgreementsNegotiableQuote/README.md
 last_modified_at: '2019-08-16 15:20:08 -0500'
-content: |
+content: |-
   ## CheckoutAgreementsNegotiableQuote module Overview
 
   CheckoutAgreementsNegotiableQuote module extends CheckoutAgreements if it is enabled in configuration and it adds agreements to payment data on checkout with negotiable quote.

--- a/src/_data/codebase/v2_3/mrg/b2b/ConfigurableNegotiableQuote.yml
+++ b/src/_data/codebase/v2_3/mrg/b2b/ConfigurableNegotiableQuote.yml
@@ -20,4 +20,4 @@ content: "## Overview\n\nThe Magento_ConfigurableNegotiableQuote module enables 
   \n[The Magento dependency injection mechanism](http://devdocs.magento.com/guides/v2.2/extension-dev-guide/depend-inj.html)
   enables you to override the functionality of the Magento_ConfigurableNegotiableQuote
   module.\n\n## Additional information\n \nYou can track [backward incompatible changes
-  made in a Magento B2b mainline after the Magento 2.2 release](http://devdocs.magento.com/guides/v2.2/release-notes/changes/b2b_changes.html).\n"
+  made in a Magento B2b mainline after the Magento 2.2 release](http://devdocs.magento.com/guides/v2.2/release-notes/changes/b2b_changes.html)."

--- a/src/_data/codebase/v2_3/mrg/b2b/ConfigurableRequisitionList.yml
+++ b/src/_data/codebase/v2_3/mrg/b2b/ConfigurableRequisitionList.yml
@@ -17,4 +17,4 @@ content: "## Overview\n\nThe Magento_ConfigurableRequisitionList module enables 
   Layouts\n \nYou can extend and override layouts in the `Magento\\ConfigurableRequisitionList\\view\\frontend\\layout`
   directories.\n\nFor more information about layouts, see the [Layout documentation](http://devdocs.magento.com/guides/v2.2/frontend-dev-guide/layouts/layout-overview.html).\n\n##
   Additional information\n \nYou can track [backward incompatible changes made in
-  a Magento B2b mainline after the Magento 2.2 release](http://devdocs.magento.com/guides/v2.2/release-notes/changes/b2b_changes.html).\n"
+  a Magento B2b mainline after the Magento 2.2 release](http://devdocs.magento.com/guides/v2.2/release-notes/changes/b2b_changes.html)."

--- a/src/_data/codebase/v2_3/mrg/b2b/GiftCardNegotiableQuote.yml
+++ b/src/_data/codebase/v2_3/mrg/b2b/GiftCardNegotiableQuote.yml
@@ -4,7 +4,7 @@ source_repo: magento2b2b
 release: 1.1.6
 github_path: app/code/Magento/GiftCardNegotiableQuote/README.md
 last_modified_at: '2017-04-10 10:33:01 +0300'
-content: |
+content: |-
   ## Overview
 
   The Magento_GiftCardNegotiableQuote module enables gift cards to be displayed in a negotiable quote in an B2B environment. This module extends Magento_NegotiableQuote and Magento_GiftCard modules.

--- a/src/_data/codebase/v2_3/mrg/b2b/GiftCardRequisitionList.yml
+++ b/src/_data/codebase/v2_3/mrg/b2b/GiftCardRequisitionList.yml
@@ -15,4 +15,4 @@ content: "## Overview\n\nThe Magento_GiftCardRequisitionList module enables gift
   at any time.\n\n## Structure\n\n[Learn about a typical file structure for a Magento
   2 module](http://devdocs.magento.com/guides/v2.2/extension-dev-guide/build/module-file-structure.html).\n\n##
   Additional information\n\nYou can track [backward incompatible changes made in a
-  Magento B2b mainline after the Magento 2.2 release](http://devdocs.magento.com/guides/v2.2/release-notes/changes/b2b_changes.html).\n"
+  Magento B2b mainline after the Magento 2.2 release](http://devdocs.magento.com/guides/v2.2/release-notes/changes/b2b_changes.html)."

--- a/src/_data/codebase/v2_3/mrg/b2b/GiftCardSharedCatalog.yml
+++ b/src/_data/codebase/v2_3/mrg/b2b/GiftCardSharedCatalog.yml
@@ -27,4 +27,4 @@ content: "## Overview\n\nThe Magento_GiftCardSharedCatalog module enables gift c
   `Magento\\GiftCardSharedCatalog\\view\\adminhtml\\ui_component` - renderer for pricing
   and structure listings\n\nFor more information, see [UI Listing/Grid Component](http://devdocs.magento.com/guides/v2.2/ui-components/ui-listing-grid.html).\n\n##
   Additional information\n\nYou can track [backward incompatible changes made in a
-  Magento B2b mainline after the Magento 2.2 release](http://devdocs.magento.com/guides/v2.2/release-notes/changes/b2b_changes.html).\n"
+  Magento B2b mainline after the Magento 2.2 release](http://devdocs.magento.com/guides/v2.2/release-notes/changes/b2b_changes.html)."

--- a/src/_data/codebase/v2_3/mrg/b2b/GroupedRequisitionList.yml
+++ b/src/_data/codebase/v2_3/mrg/b2b/GroupedRequisitionList.yml
@@ -23,4 +23,4 @@ content: "## Overview\n\nThe Magento_GroupedRequisitionList module enables group
   module.\n\n### Layouts\n \nYou can extend and override layouts in the `Magento\\GroupedRequistionList\\view\\frontend\\layout`
   directories.\n\nFor more information about layouts, see the [Layout documentation](http://devdocs.magento.com/guides/v2.2/frontend-dev-guide/layouts/layout-overview.html).\n\n##
   Additional information\n \nYou can track [backward incompatible changes made in
-  a Magento B2b mainline after the Magento 2.2 release](http://devdocs.magento.com/guides/v2.2/release-notes/changes/b2b_changes.html).\n"
+  a Magento B2b mainline after the Magento 2.2 release](http://devdocs.magento.com/guides/v2.2/release-notes/changes/b2b_changes.html)."

--- a/src/_data/codebase/v2_3/mrg/b2b/SharedCatalog.yml
+++ b/src/_data/codebase/v2_3/mrg/b2b/SharedCatalog.yml
@@ -42,4 +42,4 @@ content: "## Overview\n\nThe Magento_SharedCatalog modules defines the visibilit
   more information, see [UI Listing/Grid Component](http://devdocs.magento.com/guides/v2.2/ui-components/ui-listing-grid.html)
   and [UI Form Component](http://devdocs.magento.com/guides/v2.2/ui_comp_guide/components/ui-form.html).\n\n##
   Additional information\n \nYou can track [backward incompatible changes made in
-  a Magento B2b mainline after the Magento 2.2 release](http://devdocs.magento.com/guides/v2.2/release-notes/changes/b2b_changes.html).\n"
+  a Magento B2b mainline after the Magento 2.2 release](http://devdocs.magento.com/guides/v2.2/release-notes/changes/b2b_changes.html)."

--- a/src/_data/codebase/v2_3/mrg/ce/AdminNotification.yml
+++ b/src/_data/codebase/v2_3/mrg/ce/AdminNotification.yml
@@ -4,7 +4,7 @@ source_repo: magento2ce
 release: 2.3.6
 github_path: app/code/Magento/AdminNotification/README.md
 last_modified_at: '2019-08-19 00:16:18 +0100'
-content: |
+content: |-
   The Magento_AdminNotification module provides the ability to alert administrators via system messages and provides a message inbox for surveys and notifications.
 
   ## Installation details

--- a/src/_data/codebase/v2_3/mrg/ce/AmqpStore.yml
+++ b/src/_data/codebase/v2_3/mrg/ce/AmqpStore.yml
@@ -4,7 +4,7 @@ source_repo: magento2ce
 release: 2.3.6
 github_path: app/code/Magento/AmqpStore/README.md
 last_modified_at: '2019-08-27 01:59:34 +0100'
-content: |
+content: |-
   The Magento_AmqpStore module provides the ability to specify a store before publishing messages with the Advanced Message Queuing Protocol (AMQP).
 
   ## Extensibility

--- a/src/_data/codebase/v2_3/mrg/ce/Analytics.yml
+++ b/src/_data/codebase/v2_3/mrg/ce/Analytics.yml
@@ -4,7 +4,7 @@ source_repo: magento2ce
 release: 2.3.6
 github_path: app/code/Magento/Analytics/README.md
 last_modified_at: '2019-09-15 22:49:37 +0100'
-content: |
+content: |-
   The Magento_Analytics module integrates your Magento instance with the [Magento Business Intelligence (MBI)](https://magento.com/products/business-intelligence) to use [Advanced Reporting](https://devdocs.magento.com/guides/v2.3/advanced-reporting/modules.html) functionality.
 
   The module implements the following functionality:

--- a/src/_data/codebase/v2_3/mrg/ce/AsynchronousOperations.yml
+++ b/src/_data/codebase/v2_3/mrg/ce/AsynchronousOperations.yml
@@ -25,4 +25,4 @@ content: "This component is designed to provide a response for a client that lau
   `bulk_details_form`\n- `bulk_details_form_modal`\n- `bulk_listing`\n- `failed_operation_listing`\n-
   `failed_operation_modal_listing`\n- `notification_area`\n- `retriable_operation_listing`\n-
   `retriable_operation_modal_listing`\n\nFor information about UI components in Magento
-  2, see [Overview of UI components](https://devdocs.magento.com/guides/v2.3/ui_comp_guide/bk-ui_comps.html).\n"
+  2, see [Overview of UI components](https://devdocs.magento.com/guides/v2.3/ui_comp_guide/bk-ui_comps.html)."

--- a/src/_data/codebase/v2_3/mrg/ce/Authorization.yml
+++ b/src/_data/codebase/v2_3/mrg/ce/Authorization.yml
@@ -4,7 +4,7 @@ source_repo: magento2ce
 release: 2.3.6
 github_path: app/code/Magento/Authorization/README.md
 last_modified_at: '2019-08-25 07:43:56 +0100'
-content: |
+content: |-
   The Magento_Authorization module enables management of access control list roles and rules in the application.
 
   ## Installation details

--- a/src/_data/codebase/v2_3/mrg/ce/Authorizenet.yml
+++ b/src/_data/codebase/v2_3/mrg/ce/Authorizenet.yml
@@ -26,4 +26,4 @@ content: "The Magento_Authorizenet module implements the integration with the Au
   module introduces the following layouts and layout handles in the `view/frontend/layout`
   directory:\n\n- `authorizenet_directpost_payment_backendresponse`\n- `authorizenet_directpost_payment_redirect`\n-
   `authorizenet_directpost_payment_response`\n\nFor more information about layouts
-  in Magento 2, see the [Layout documentation](https://devdocs.magento.com/guides/v2.3/frontend-dev-guide/layouts/layout-overview.html).\n"
+  in Magento 2, see the [Layout documentation](https://devdocs.magento.com/guides/v2.3/frontend-dev-guide/layouts/layout-overview.html)."

--- a/src/_data/codebase/v2_3/mrg/ce/AuthorizenetAcceptjs.yml
+++ b/src/_data/codebase/v2_3/mrg/ce/AuthorizenetAcceptjs.yml
@@ -4,7 +4,7 @@ source_repo: magento2ce
 release: 2.3.6
 github_path: app/code/Magento/AuthorizenetAcceptjs/README.md
 last_modified_at: '2019-08-28 00:26:17 +0100'
-content: |
+content: |-
   The Magento_AuthorizenetAcceptjs module implements the integration with the Authorize.Net payment gateway and makes the latter available as a payment method in Magento.
 
   ## Installation details

--- a/src/_data/codebase/v2_3/mrg/ce/AuthorizenetCardinal.yml
+++ b/src/_data/codebase/v2_3/mrg/ce/AuthorizenetCardinal.yml
@@ -16,4 +16,4 @@ content: "Use the Magento_AuthorizenetCardinal module to enable 3D Secure 2.0 su
   enables you to override the functionality of the Magento_AuthorizenetCardinal module.\n\n###
   Events\n   \nThis module observes the following events:\n\n- `payment_method_assign_data_authorizenet_acceptjs`
   event in the `Magento\\AuthorizenetCardinal\\Observer\\DataAssignObserver` file.\n\nFor
-  information about an event in Magento 2, see [Events and observers](https://devdocs.magento.com/guides/v2.3/extension-dev-guide/events-and-observers.html#events).\n"
+  information about an event in Magento 2, see [Events and observers](https://devdocs.magento.com/guides/v2.3/extension-dev-guide/events-and-observers.html#events)."

--- a/src/_data/codebase/v2_3/mrg/ce/AuthorizenetGraphQl.yml
+++ b/src/_data/codebase/v2_3/mrg/ce/AuthorizenetGraphQl.yml
@@ -4,7 +4,7 @@ source_repo: magento2ce
 release: 2.3.6
 github_path: app/code/Magento/AuthorizenetGraphQl/README.md
 last_modified_at: '2019-08-28 00:38:47 +0100'
-content: |
+content: |-
   The Magento_AuthorizenetGraphQl module defines the data types needed to pass payment information data from the client to Magento.
 
   ## Extensibility

--- a/src/_data/codebase/v2_3/mrg/ce/Backend.yml
+++ b/src/_data/codebase/v2_3/mrg/ce/Backend.yml
@@ -4,7 +4,7 @@ source_repo: magento2ce
 release: 2.3.6
 github_path: app/code/Magento/Backend/README.md
 last_modified_at: '2019-09-15 23:59:05 +0100'
-content: |
+content: |-
   The Magento_Backend module contains common infrastructure and assets for other modules to be defined and used in their
   administration user interface (UI).
 

--- a/src/_data/codebase/v2_3/mrg/ce/Backup.yml
+++ b/src/_data/codebase/v2_3/mrg/ce/Backup.yml
@@ -16,4 +16,4 @@ content: "The Magento_Backup module allows administrators to perform backups and
   directory:   \n\n`backup_index_block`\n`backup_index_disabled`\n`backup_index_grid`\n`backup_index_index`\n\nFor
   more information about layouts in Magento 2, see the [Layout documentation](https://devdocs.magento.com/guides/v2.3/frontend-dev-guide/layouts/layout-overview.html).\n\n##
   Additional information\n\nFor information about significant changes in patch releases,
-  see [2.3.x Release information](https://devdocs.magento.com/guides/v2.3/release-notes/bk-release-notes.html).\n"
+  see [2.3.x Release information](https://devdocs.magento.com/guides/v2.3/release-notes/bk-release-notes.html)."

--- a/src/_data/codebase/v2_3/mrg/ce/Braintree.yml
+++ b/src/_data/codebase/v2_3/mrg/ce/Braintree.yml
@@ -4,7 +4,7 @@ source_repo: magento2ce
 release: 2.3.6
 github_path: app/code/Magento/Braintree/README.md
 last_modified_at: '2019-09-23 14:26:40 -0500'
-content: |
+content: |-
   The Magento_Braintree module implements integration with the Braintree payment system.
 
   ## Extensibility

--- a/src/_data/codebase/v2_3/mrg/ce/BraintreeGraphQl.yml
+++ b/src/_data/codebase/v2_3/mrg/ce/BraintreeGraphQl.yml
@@ -4,7 +4,7 @@ source_repo: magento2ce
 release: 2.3.6
 github_path: app/code/Magento/BraintreeGraphQl/README.md
 last_modified_at: '2019-09-30 15:26:35 +0100'
-content: |
+content: |-
   The Magento_BraintreeGraphQl module provides type and resolver information for the GraphQL module to pass payment information data from the client to Magento.
 
   ## Extensibility

--- a/src/_data/codebase/v2_3/mrg/ce/Bundle.yml
+++ b/src/_data/codebase/v2_3/mrg/ce/Bundle.yml
@@ -4,6 +4,6 @@ source_repo: magento2ce
 release: 2.3.6
 github_path: app/code/Magento/Bundle/README.md
 last_modified_at: '2014-12-12 12:14:06 -0800'
-content: |
+content: |-
   Magento_Bundle module introduces new product type in the Magento application named Bundle Product.
   This module is designed to extend existing functionality of Magento_Catalog module by adding new product type.

--- a/src/_data/codebase/v2_3/mrg/ce/BundleGraphQl.yml
+++ b/src/_data/codebase/v2_3/mrg/ce/BundleGraphQl.yml
@@ -4,6 +4,6 @@ source_repo: magento2ce
 release: 2.3.6
 github_path: app/code/Magento/BundleGraphQl/README.md
 last_modified_at: '2018-01-24 11:57:46 -0600'
-content: |
+content: |-
   **BundleGraphQl** provides type and resolver information for the GraphQl module
   to generate bundle product information.

--- a/src/_data/codebase/v2_3/mrg/ce/BundleImportExport.yml
+++ b/src/_data/codebase/v2_3/mrg/ce/BundleImportExport.yml
@@ -4,6 +4,6 @@ source_repo: magento2ce
 release: 2.3.6
 github_path: app/code/Magento/BundleImportExport/README.md
 last_modified_at: '2015-05-28 02:24:13 +0300'
-content: |
+content: |-
   Magento_BundleImportExport module implements Bundle products import/export functionality.
   This module is designed to extend existing functionality of Magento_CatalogImportExport module by adding new product type.

--- a/src/_data/codebase/v2_3/mrg/ce/Catalog.yml
+++ b/src/_data/codebase/v2_3/mrg/ce/Catalog.yml
@@ -4,7 +4,7 @@ source_repo: magento2ce
 release: 2.3.6
 github_path: app/code/Magento/Catalog/README.md
 last_modified_at: '2014-12-12 12:14:06 -0800'
-content: |
+content: |-
   Magento_Catalog module functionality is represented by the following sub-systems:
    - Products Management. It includes CRUD operation of product, product media, product attributes, etc...
    - Category Management. It includes CRUD operation of category, category attributes

--- a/src/_data/codebase/v2_3/mrg/ce/CatalogAnalytics.yml
+++ b/src/_data/codebase/v2_3/mrg/ce/CatalogAnalytics.yml
@@ -4,7 +4,5 @@ source_repo: magento2ce
 release: 2.3.6
 github_path: app/code/Magento/CatalogAnalytics/README.md
 last_modified_at: '2019-08-06 14:40:28 -0500'
-content: 'The Magento_CatalogAnalytics module configures data definitions for a data
+content: The Magento_CatalogAnalytics module configures data definitions for a data
   collection related to the Catalog module entities to be used in [Advanced Reporting](https://devdocs.magento.com/guides/v2.3/advanced-reporting/modules.html).
-
-'

--- a/src/_data/codebase/v2_3/mrg/ce/CatalogGraphQl.yml
+++ b/src/_data/codebase/v2_3/mrg/ce/CatalogGraphQl.yml
@@ -4,6 +4,6 @@ source_repo: magento2ce
 release: 2.3.6
 github_path: app/code/Magento/CatalogGraphQl/README.md
 last_modified_at: '2018-01-16 13:17:37 -0600'
-content: |
+content: |-
   **CatalogGraphQl** provides type and resolver information for the GraphQl module
   to generate catalog and product information endpoints.

--- a/src/_data/codebase/v2_3/mrg/ce/CatalogInventory.yml
+++ b/src/_data/codebase/v2_3/mrg/ce/CatalogInventory.yml
@@ -4,7 +4,5 @@ source_repo: magento2ce
 release: 2.3.6
 github_path: app/code/Magento/CatalogInventory/README.md
 last_modified_at: '2014-12-12 12:14:06 -0800'
-content: 'Magento_CatalogInventory module allows retrieve and update stock attributes,
+content: Magento_CatalogInventory module allows retrieve and update stock attributes,
   such as status and quantity.
-
-'

--- a/src/_data/codebase/v2_3/mrg/ce/CatalogInventoryGraphQl.yml
+++ b/src/_data/codebase/v2_3/mrg/ce/CatalogInventoryGraphQl.yml
@@ -4,6 +4,6 @@ source_repo: magento2ce
 release: 2.3.6
 github_path: app/code/Magento/CatalogInventoryGraphQl/README.md
 last_modified_at: '2018-07-18 16:40:53 +0200'
-content: |
+content: |-
   **CatalogInventoryGraphQl** provides type information for the GraphQl module
   to generate inventory stock fields for product information endpoints.

--- a/src/_data/codebase/v2_3/mrg/ce/CatalogRule.yml
+++ b/src/_data/codebase/v2_3/mrg/ce/CatalogRule.yml
@@ -4,8 +4,5 @@ source_repo: magento2ce
 release: 2.3.6
 github_path: app/code/Magento/CatalogRule/README.md
 last_modified_at: '2014-12-12 12:14:06 -0800'
-content: 'Magento_CatalogRule module is responsible for one of the types of price
-  rules in Magento. Catalog Rules are applied to products before they are added to
-  the cart.
-
-'
+content: Magento_CatalogRule module is responsible for one of the types of price rules
+  in Magento. Catalog Rules are applied to products before they are added to the cart.

--- a/src/_data/codebase/v2_3/mrg/ce/CatalogRuleConfigurable.yml
+++ b/src/_data/codebase/v2_3/mrg/ce/CatalogRuleConfigurable.yml
@@ -4,8 +4,6 @@ source_repo: magento2ce
 release: 2.3.6
 github_path: app/code/Magento/CatalogRuleConfigurable/README.md
 last_modified_at: '2015-09-07 17:18:34 +0300'
-content: 'Magento_CatalogRuleConfigurable module is an extension of Magento_CatalogRule
+content: Magento_CatalogRuleConfigurable module is an extension of Magento_CatalogRule
   and Magento_ConfigurableProduct modules that handle catalog rule indexer for configurable
   product
-
-'

--- a/src/_data/codebase/v2_3/mrg/ce/CatalogRuleGraphQl.yml
+++ b/src/_data/codebase/v2_3/mrg/ce/CatalogRuleGraphQl.yml
@@ -4,7 +4,5 @@ source_repo: magento2ce
 release: 2.3.6
 github_path: app/code/Magento/CatalogRuleGraphQl/README.md
 last_modified_at: '2020-07-10 18:30:28 +0300'
-content: 'The *Magento_CatalogRuleGraphQl* module applies catalog rules to products
+content: The *Magento_CatalogRuleGraphQl* module applies catalog rules to products
   for GraphQL requests.
-
-'

--- a/src/_data/codebase/v2_3/mrg/ce/CatalogSearch.yml
+++ b/src/_data/codebase/v2_3/mrg/ce/CatalogSearch.yml
@@ -4,6 +4,6 @@ source_repo: magento2ce
 release: 2.3.6
 github_path: app/code/Magento/CatalogSearch/README.md
 last_modified_at: '2014-12-12 12:14:06 -0800'
-content: |
+content: |-
   Magento_CatalogSearch module is an extension of Magento_Catalog module that allows to use search engine for product searching capabilities.
   The module implements Magento_Search library interfaces.

--- a/src/_data/codebase/v2_3/mrg/ce/CatalogUrlRewriteGraphQl.yml
+++ b/src/_data/codebase/v2_3/mrg/ce/CatalogUrlRewriteGraphQl.yml
@@ -4,6 +4,6 @@ source_repo: magento2ce
 release: 2.3.6
 github_path: app/code/Magento/CatalogUrlRewriteGraphQl/README.md
 last_modified_at: '2018-01-16 16:07:17 -0600'
-content: |
+content: |-
   **CatalogUrlRewriteGraphQl** provides type information for the GraphQl module
   to generate url rewrite fields for catalog and product information endpoints.

--- a/src/_data/codebase/v2_3/mrg/ce/CatalogWidget.yml
+++ b/src/_data/codebase/v2_3/mrg/ce/CatalogWidget.yml
@@ -4,6 +4,6 @@ source_repo: magento2ce
 release: 2.3.6
 github_path: app/code/Magento/CatalogWidget/README.md
 last_modified_at: '2014-12-12 12:14:06 -0800'
-content: |
+content: |-
   **CatalogWidget** contains various widgets that extend Catalog module functionality:
   - Product List widget provides widget that contains product list created using rule based filter.

--- a/src/_data/codebase/v2_3/mrg/ce/CheckoutAgreementsGraphQl.yml
+++ b/src/_data/codebase/v2_3/mrg/ce/CheckoutAgreementsGraphQl.yml
@@ -4,6 +4,6 @@ source_repo: magento2ce
 release: 2.3.6
 github_path: app/code/Magento/CheckoutAgreementsGraphQl/README.md
 last_modified_at: '2019-03-20 17:00:47 +0200'
-content: |
+content: |-
   **CheckoutAgreementsGraphQl** provides type information for the GraphQl module
   to generate Checkout Agreements fields for Checkout Agreements information endpoints.

--- a/src/_data/codebase/v2_3/mrg/ce/CmsGraphQl.yml
+++ b/src/_data/codebase/v2_3/mrg/ce/CmsGraphQl.yml
@@ -4,6 +4,6 @@ source_repo: magento2ce
 release: 2.3.6
 github_path: app/code/Magento/CmsGraphQl/README.md
 last_modified_at: '2018-06-30 14:36:35 +0300'
-content: |
+content: |-
   **CmsGraphQl** provides type information for the GraphQl module
   to generate CMS fields for cms information endpoints.

--- a/src/_data/codebase/v2_3/mrg/ce/CmsUrlRewrite.yml
+++ b/src/_data/codebase/v2_3/mrg/ce/CmsUrlRewrite.yml
@@ -7,4 +7,4 @@ last_modified_at: '2017-03-07 16:04:38 -0600'
 content: "## Overview\n \nThe Magento_CmsUrlRewrite module adds support for URL rewrite
   rules for CMS pages. See also Magento_UrlRewrite module. \n\nThe module adds and
   removes URL rewrite rules as CMS pages are added or removed by a user.\nThe rules
-  can be edited by an admin user as any other URL rewrite rule. \n"
+  can be edited by an admin user as any other URL rewrite rule."

--- a/src/_data/codebase/v2_3/mrg/ce/CmsUrlRewriteGraphQl.yml
+++ b/src/_data/codebase/v2_3/mrg/ce/CmsUrlRewriteGraphQl.yml
@@ -4,6 +4,6 @@ source_repo: magento2ce
 release: 2.3.6
 github_path: app/code/Magento/CmsUrlRewriteGraphQl/README.md
 last_modified_at: '2018-01-17 16:25:54 -0600'
-content: |
+content: |-
   **CmsUrlRewriteGraphQl** provides type information for the GraphQl module
   to generate url rewrite fields for cms information endpoints.

--- a/src/_data/codebase/v2_3/mrg/ce/Config.yml
+++ b/src/_data/codebase/v2_3/mrg/ce/Config.yml
@@ -4,7 +4,7 @@ source_repo: magento2ce
 release: 2.3.6
 github_path: app/code/Magento/Config/README.md
 last_modified_at: '2019-09-03 18:23:54 +0300'
-content: |
+content: |-
   The Config module is designed to implement system configuration functionality.
   It provides mechanisms to add, edit, store and retrieve the configuration data for each scope (there can be a default scope as well as scopes for each website and store).
 

--- a/src/_data/codebase/v2_3/mrg/ce/ConfigurableProduct.yml
+++ b/src/_data/codebase/v2_3/mrg/ce/ConfigurableProduct.yml
@@ -4,7 +4,7 @@ source_repo: magento2ce
 release: 2.3.6
 github_path: app/code/Magento/ConfigurableProduct/README.md
 last_modified_at: '2014-12-12 12:14:06 -0800'
-content: |
+content: |-
   Magento_ConfigurableProduct module introduces new product type in the Magento application called Configurable Product.
   This module is designed to extend existing functionality of Magento_Catalog module by adding new product type.
 

--- a/src/_data/codebase/v2_3/mrg/ce/ConfigurableProductGraphQl.yml
+++ b/src/_data/codebase/v2_3/mrg/ce/ConfigurableProductGraphQl.yml
@@ -4,6 +4,6 @@ source_repo: magento2ce
 release: 2.3.6
 github_path: app/code/Magento/ConfigurableProductGraphQl/README.md
 last_modified_at: '2018-01-16 13:17:37 -0600'
-content: |
+content: |-
   **ConfigurableProductGraphQl** provides type and resolver information for the GraphQl module
   to generate configurable product information.

--- a/src/_data/codebase/v2_3/mrg/ce/ConfigurableProductSales.yml
+++ b/src/_data/codebase/v2_3/mrg/ce/ConfigurableProductSales.yml
@@ -4,6 +4,6 @@ source_repo: magento2ce
 release: 2.3.6
 github_path: app/code/Magento/ConfigurableProductSales/README.md
 last_modified_at: '2017-07-14 16:51:00 +0300'
-content: "The Magento_ConfigurableProductSales module checks that the selected options
-  of order item are still presented in\nCatalog. Returns true if the previously ordered
-  item configuration is still available. "
+content: |-
+  The Magento_ConfigurableProductSales module checks that the selected options of order item are still presented in
+  Catalog. Returns true if the previously ordered item configuration is still available.

--- a/src/_data/codebase/v2_3/mrg/ce/Contact.yml
+++ b/src/_data/codebase/v2_3/mrg/ce/Contact.yml
@@ -4,8 +4,6 @@ source_repo: magento2ce
 release: 2.3.6
 github_path: app/code/Magento/Contact/README.md
 last_modified_at: '2014-12-12 12:14:06 -0800'
-content: 'Magento_Contact module provides an implementation of "Contact Us" feature
+content: Magento_Contact module provides an implementation of "Contact Us" feature
   based on sending email message, allows to configure email recipients, email template,
   etc...
-
-'

--- a/src/_data/codebase/v2_3/mrg/ce/Cookie.yml
+++ b/src/_data/codebase/v2_3/mrg/ce/Cookie.yml
@@ -4,7 +4,5 @@ source_repo: magento2ce
 release: 2.3.6
 github_path: app/code/Magento/Cookie/README.md
 last_modified_at: '2015-01-28 16:50:13 -0600'
-content: 'Magento_Cookie module allows enabling and configuring HTTP cookie related
+content: Magento_Cookie module allows enabling and configuring HTTP cookie related
   settings for the store. These settings are available in the store administration.
-
-'

--- a/src/_data/codebase/v2_3/mrg/ce/Csp.yml
+++ b/src/_data/codebase/v2_3/mrg/ce/Csp.yml
@@ -4,6 +4,6 @@ source_repo: magento2ce
 release: 2.3.6
 github_path: app/code/Magento/Csp/README.md
 last_modified_at: '2019-11-14 16:21:59 -0600'
-content: |
+content: |-
   Magento_Csp implements Content Security Policies for Magento. Allows CSP configuration for Merchants,
   provides a way for extension and theme developers to configure CSP headers for their extensions.

--- a/src/_data/codebase/v2_3/mrg/ce/CurrencySymbol.yml
+++ b/src/_data/codebase/v2_3/mrg/ce/CurrencySymbol.yml
@@ -4,7 +4,7 @@ source_repo: magento2ce
 release: 2.3.6
 github_path: app/code/Magento/CurrencySymbol/README.md
 last_modified_at: '2014-12-12 12:14:06 -0800'
-content: |+
+content: |-
   **CurrencySymbol** enables the creation of custom currencies and management of currency conversion rates.
 
   ## Controllers
@@ -17,4 +17,3 @@ content: |+
   ### Currency Symbol Controllers
   ***CurrencySymbol\Controller\Adminhtml\System\Currencysymbol\Reset.php*** resets all custom currency symbols.
   ***CurrencySymbol\Controller\Adminhtml\System\Currencysymbol\Save.php*** creates custom currency symbols.
-

--- a/src/_data/codebase/v2_3/mrg/ce/Customer.yml
+++ b/src/_data/codebase/v2_3/mrg/ce/Customer.yml
@@ -6,4 +6,4 @@ github_path: app/code/Magento/Customer/README.md
 last_modified_at: '2015-08-27 15:34:05 -0500'
 content: "The Magento_Customer module serves to handle the customer data (Customer,
   Customer Address and Customer Group entities) both in the admin panel and the storefront.
-  \nFor customer passwords, the module implements upgrading hashes. \n"
+  \nFor customer passwords, the module implements upgrading hashes."

--- a/src/_data/codebase/v2_3/mrg/ce/CustomerAnalytics.yml
+++ b/src/_data/codebase/v2_3/mrg/ce/CustomerAnalytics.yml
@@ -4,7 +4,5 @@ source_repo: magento2ce
 release: 2.3.6
 github_path: app/code/Magento/CustomerAnalytics/README.md
 last_modified_at: '2019-08-06 14:40:28 -0500'
-content: 'The Magento_CustomerAnalytics module configures data definitions for a data
+content: The Magento_CustomerAnalytics module configures data definitions for a data
   collection related to the Customer module entities to be used in [Advanced Reporting](https://devdocs.magento.com/guides/v2.3/advanced-reporting/modules.html).
-
-'

--- a/src/_data/codebase/v2_3/mrg/ce/CustomerDownloadableGraphQl.yml
+++ b/src/_data/codebase/v2_3/mrg/ce/CustomerDownloadableGraphQl.yml
@@ -4,6 +4,6 @@ source_repo: magento2ce
 release: 2.3.6
 github_path: app/code/Magento/CustomerDownloadableGraphQl/README.md
 last_modified_at: '2019-06-25 22:45:10 +0200'
-content: |
+content: |-
   **CustomerDownloadableGraphQl** provides type and resolver information for the GraphQl module
   to generate downloadable product information.

--- a/src/_data/codebase/v2_3/mrg/ce/CustomerGraphQl.yml
+++ b/src/_data/codebase/v2_3/mrg/ce/CustomerGraphQl.yml
@@ -4,6 +4,6 @@ source_repo: magento2ce
 release: 2.3.6
 github_path: app/code/Magento/CustomerGraphQl/README.md
 last_modified_at: '2018-01-16 13:17:37 -0600'
-content: |
+content: |-
   **CustomerGraphQl** provides type and resolver information for the GraphQl module
   to generate customer information endpoints.

--- a/src/_data/codebase/v2_3/mrg/ce/CustomerImportExport.yml
+++ b/src/_data/codebase/v2_3/mrg/ce/CustomerImportExport.yml
@@ -4,7 +4,5 @@ source_repo: magento2ce
 release: 2.3.6
 github_path: app/code/Magento/CustomerImportExport/README.md
 last_modified_at: '2014-10-31 09:04:08 -0700'
-content: 'The Magento_CustomerImportExport module handles the import and export of
+content: The Magento_CustomerImportExport module handles the import and export of
   the customers data and related addresses.
-
-'

--- a/src/_data/codebase/v2_3/mrg/ce/Deploy.yml
+++ b/src/_data/codebase/v2_3/mrg/ce/Deploy.yml
@@ -14,4 +14,4 @@ content: "## Purpose of module\n\nDeploy is a module that holds collection of se
   to production mode, you can pass optional parameter skip-compilation to do not compile
   static files, CSS \nand do not run the compilation process.\n\n# Deployment\n##
   System requirements\n\n## Install\nThe Magento_Deploy module is installed automatically
-  (using the native Magento install mechanism) without any additional actions.\n"
+  (using the native Magento install mechanism) without any additional actions."

--- a/src/_data/codebase/v2_3/mrg/ce/Developer.yml
+++ b/src/_data/codebase/v2_3/mrg/ce/Developer.yml
@@ -4,7 +4,5 @@ source_repo: magento2ce
 release: 2.3.6
 github_path: app/code/Magento/Developer/README.md
 last_modified_at: '2015-01-15 14:33:14 -0600'
-content: 'The Magento_Developer module provides functionality to make it easier to
+content: The Magento_Developer module provides functionality to make it easier to
   develop in Magento 2.
-
-'

--- a/src/_data/codebase/v2_3/mrg/ce/Dhl.yml
+++ b/src/_data/codebase/v2_3/mrg/ce/Dhl.yml
@@ -4,6 +4,6 @@ source_repo: magento2ce
 release: 2.3.6
 github_path: app/code/Magento/Dhl/README.md
 last_modified_at: '2014-10-31 09:04:08 -0700'
-content: |
+content: |-
   The Magento_Dhl module implements the integration with the DHL shipping carrier.
   DHL is available for international shipments only.

--- a/src/_data/codebase/v2_3/mrg/ce/Directory.yml
+++ b/src/_data/codebase/v2_3/mrg/ce/Directory.yml
@@ -4,6 +4,6 @@ source_repo: magento2ce
 release: 2.3.6
 github_path: app/code/Magento/Directory/README.md
 last_modified_at: '2014-12-12 12:14:06 -0800'
-content: |
+content: |-
   **Directory** enables the management of countries and regions recognized by the store and associated data
   like the country code and currency rates. Also, enables conversion of prices to a specified currency format.

--- a/src/_data/codebase/v2_3/mrg/ce/DirectoryGraphQl.yml
+++ b/src/_data/codebase/v2_3/mrg/ce/DirectoryGraphQl.yml
@@ -4,6 +4,6 @@ source_repo: magento2ce
 release: 2.3.6
 github_path: app/code/Magento/DirectoryGraphQl/README.md
 last_modified_at: '2019-01-31 09:12:38 -0500'
-content: |
+content: |-
   **DirectoryGraphQl** provides type and resolver information for the GraphQl module
   to generate directory information endpoints.

--- a/src/_data/codebase/v2_3/mrg/ce/Downloadable.yml
+++ b/src/_data/codebase/v2_3/mrg/ce/Downloadable.yml
@@ -4,6 +4,6 @@ source_repo: magento2ce
 release: 2.3.6
 github_path: app/code/Magento/Downloadable/README.md
 last_modified_at: '2014-12-12 12:14:06 -0800'
-content: |
+content: |-
   Magento_Downloadable module introduces new product type in the Magento application called Downloadable Product.
   This module is designed to extend existing functionality of Magento_Catalog module by adding new product type.

--- a/src/_data/codebase/v2_3/mrg/ce/DownloadableGraphQl.yml
+++ b/src/_data/codebase/v2_3/mrg/ce/DownloadableGraphQl.yml
@@ -4,6 +4,6 @@ source_repo: magento2ce
 release: 2.3.6
 github_path: app/code/Magento/DownloadableGraphQl/README.md
 last_modified_at: '2018-01-24 15:58:51 -0600'
-content: |
+content: |-
   **DownloadableGraphQl** provides type and resolver information for the GraphQl module
   to generate downloadable product information.

--- a/src/_data/codebase/v2_3/mrg/ce/DownloadableImportExport.yml
+++ b/src/_data/codebase/v2_3/mrg/ce/DownloadableImportExport.yml
@@ -4,7 +4,5 @@ source_repo: magento2ce
 release: 2.3.6
 github_path: app/code/Magento/DownloadableImportExport/README.md
 last_modified_at: '2015-08-10 11:16:49 +0300'
-content: 'The Magento_DownloadableImportExport module handles the import and export
+content: The Magento_DownloadableImportExport module handles the import and export
   of the downloadable products.
-
-'

--- a/src/_data/codebase/v2_3/mrg/ce/EavGraphQl.yml
+++ b/src/_data/codebase/v2_3/mrg/ce/EavGraphQl.yml
@@ -5,4 +5,4 @@ release: 2.3.6
 github_path: app/code/Magento/EavGraphQl/README.md
 last_modified_at: '2018-01-16 13:17:37 -0600'
 content: "**EavGraphQl** primarily provides the GraphQl module information to generate
-  metadata for Eav attributes.\n"
+  metadata for Eav attributes."

--- a/src/_data/codebase/v2_3/mrg/ce/Elasticsearch6.yml
+++ b/src/_data/codebase/v2_3/mrg/ce/Elasticsearch6.yml
@@ -4,6 +4,6 @@ source_repo: magento2ce
 release: 2.3.6
 github_path: app/code/Magento/Elasticsearch6/README.md
 last_modified_at: '2019-02-27 13:06:48 +0100'
-content: |
+content: |-
   Magento\Elasticsearch module allows to use Elastic search engine (v6) for product searching capabilities.
   The module implements Magento\Search library interfaces.

--- a/src/_data/codebase/v2_3/mrg/ce/Elasticsearch7.yml
+++ b/src/_data/codebase/v2_3/mrg/ce/Elasticsearch7.yml
@@ -4,6 +4,6 @@ source_repo: magento2ce
 release: 2.3.6
 github_path: app/code/Magento/Elasticsearch7/README.md
 last_modified_at: '2020-01-31 16:12:43 -0600'
-content: |
+content: |-
   Magento\Elasticsearch7 module allows to use Elastic search engine (v7) for product searching capabilities.
   The module implements Magento\Search library interfaces.

--- a/src/_data/codebase/v2_3/mrg/ce/Email.yml
+++ b/src/_data/codebase/v2_3/mrg/ce/Email.yml
@@ -4,6 +4,6 @@ source_repo: magento2ce
 release: 2.3.6
 github_path: app/code/Magento/Email/README.md
 last_modified_at: '2014-12-12 12:14:06 -0800'
-content: |
+content: |-
   **Email** enables you to manage email templates, which are used when you send email through the
   *\Magento\Framework\Mail\TransportInterface* implementations.

--- a/src/_data/codebase/v2_3/mrg/ce/EncryptionKey.yml
+++ b/src/_data/codebase/v2_3/mrg/ce/EncryptionKey.yml
@@ -4,7 +4,5 @@ source_repo: magento2ce
 release: 2.3.6
 github_path: app/code/Magento/EncryptionKey/README.md
 last_modified_at: '2015-08-27 15:34:05 -0500'
-content: 'The Magento_EncryptionKey module provides an advanced encryption model to
+content: The Magento_EncryptionKey module provides an advanced encryption model to
   protect passwords and other sensitive data.
-
-'

--- a/src/_data/codebase/v2_3/mrg/ce/Fedex.yml
+++ b/src/_data/codebase/v2_3/mrg/ce/Fedex.yml
@@ -4,6 +4,4 @@ source_repo: magento2ce
 release: 2.3.6
 github_path: app/code/Magento/Fedex/README.md
 last_modified_at: '2014-10-31 09:04:08 -0700'
-content: 'The Magento_Fedex implements the integration with the FedEx shipping carrier.
-
-'
+content: The Magento_Fedex implements the integration with the FedEx shipping carrier.

--- a/src/_data/codebase/v2_3/mrg/ce/GoogleAdwords.yml
+++ b/src/_data/codebase/v2_3/mrg/ce/GoogleAdwords.yml
@@ -4,6 +4,4 @@ source_repo: magento2ce
 release: 2.3.6
 github_path: app/code/Magento/GoogleAdwords/README.md
 last_modified_at: '2014-12-12 12:14:06 -0800'
-content: 'GoogleAdwords is a module designed for integration of Google Adwords service.
-
-'
+content: GoogleAdwords is a module designed for integration of Google Adwords service.

--- a/src/_data/codebase/v2_3/mrg/ce/GoogleAnalytics.yml
+++ b/src/_data/codebase/v2_3/mrg/ce/GoogleAnalytics.yml
@@ -4,7 +4,5 @@ source_repo: magento2ce
 release: 2.3.6
 github_path: app/code/Magento/GoogleAnalytics/README.md
 last_modified_at: '2014-12-12 12:14:06 -0800'
-content: 'Magento_GoogleAnalytics is a module for integration with Google Analytics
+content: Magento_GoogleAnalytics is a module for integration with Google Analytics
   service.
-
-'

--- a/src/_data/codebase/v2_3/mrg/ce/GoogleOptimizer.yml
+++ b/src/_data/codebase/v2_3/mrg/ce/GoogleOptimizer.yml
@@ -13,4 +13,4 @@ content: "Magento_GoogleOptimizer module implements functionality of Google Expe
   categories on different store views.\nThis functionality can be switched on and
   off on the configuration page (Stores -> Configuration -> General -> Google Api
   -> Google Analytics).\nAlso this functionality depends on Google Analytics module
-  and configuration options.\n"
+  and configuration options."

--- a/src/_data/codebase/v2_3/mrg/ce/GraphQl.yml
+++ b/src/_data/codebase/v2_3/mrg/ce/GraphQl.yml
@@ -7,4 +7,4 @@ last_modified_at: '2017-10-25 11:14:11 -0500'
 content: "**GraphQl** provides the framework for the application to expose GraphQL
   compliant web services. It exposes an area for\nGraphQL services and resolves request
   data based on the generated schema. It also maps this response to a JSON object
-  \nfor the client to read.\n"
+  \nfor the client to read."

--- a/src/_data/codebase/v2_3/mrg/ce/GraphQlCache.yml
+++ b/src/_data/codebase/v2_3/mrg/ce/GraphQlCache.yml
@@ -4,6 +4,6 @@ source_repo: magento2ce
 release: 2.3.6
 github_path: app/code/Magento/GraphQlCache/README.md
 last_modified_at: '2019-04-08 11:49:04 -0500'
-content: "**GraphQL Cache** provides the ability to cache GraphQL queries.\nThis module
-  allows Magento's built-in cache or Varnish as the application for serving the Full
-  Page Cache to the front end. \n"
+content: |-
+  **GraphQL Cache** provides the ability to cache GraphQL queries.
+  This module allows Magento's built-in cache or Varnish as the application for serving the Full Page Cache to the front end.

--- a/src/_data/codebase/v2_3/mrg/ce/GroupedCatalogInventory.yml
+++ b/src/_data/codebase/v2_3/mrg/ce/GroupedCatalogInventory.yml
@@ -4,7 +4,5 @@ source_repo: magento2ce
 release: 2.3.6
 github_path: app/code/Magento/GroupedCatalogInventory/README.md
 last_modified_at: '2018-11-27 16:04:57 -0600'
-content: 'Magento_GroupedCatalogInventory contains behavior related to the inventory
+content: Magento_GroupedCatalogInventory contains behavior related to the inventory
   status of items within grouped products.
-
-'

--- a/src/_data/codebase/v2_3/mrg/ce/GroupedProduct.yml
+++ b/src/_data/codebase/v2_3/mrg/ce/GroupedProduct.yml
@@ -4,7 +4,7 @@ source_repo: magento2ce
 release: 2.3.6
 github_path: app/code/Magento/GroupedProduct/README.md
 last_modified_at: '2014-12-12 12:14:06 -0800'
-content: |
+content: |-
   Magento_GroupedProduct module provides ability to offer several standalone products for sale as a group on the same Product Detail page.
   It can offer variations of a product, or group them by season or theme to create a coordinated set.
   Products can be purchased separately or as a set.

--- a/src/_data/codebase/v2_3/mrg/ce/GroupedProductGraphQl.yml
+++ b/src/_data/codebase/v2_3/mrg/ce/GroupedProductGraphQl.yml
@@ -4,6 +4,6 @@ source_repo: magento2ce
 release: 2.3.6
 github_path: app/code/Magento/GroupedProductGraphQl/README.md
 last_modified_at: '2018-01-29 15:12:49 -0600'
-content: |
+content: |-
   **GroupedProductGraphQl** provides type and resolver information for the GraphQl module
   to generate grouped product information.

--- a/src/_data/codebase/v2_3/mrg/ce/ImportExport.yml
+++ b/src/_data/codebase/v2_3/mrg/ce/ImportExport.yml
@@ -4,6 +4,6 @@ source_repo: magento2ce
 release: 2.3.6
 github_path: app/code/Magento/ImportExport/README.md
 last_modified_at: '2014-12-12 12:14:06 -0800'
-content: |
+content: |-
   Magento_ImportExport module provides a framework and basic functionality for importing/exporting various entities in Magento.
   It can be disabled and in such case all dependent import/export functionality (products, customers, orders etc.) will be disabled in Magento.

--- a/src/_data/codebase/v2_3/mrg/ce/InstantPurchase.yml
+++ b/src/_data/codebase/v2_3/mrg/ce/InstantPurchase.yml
@@ -4,7 +4,7 @@ source_repo: magento2ce
 release: 2.3.6
 github_path: app/code/Magento/InstantPurchase/README.md
 last_modified_at: '2019-08-06 14:40:28 -0500'
-content: |
+content: |-
   ## Overview
 
   Instant Purchase feature allows the Customer to place the order in seconds without going through full checkout. Once clicked, system places the order using default shipping and billing addresses and stored payment method. Order is placed and customer gets confirmation message in notification area.

--- a/src/_data/codebase/v2_3/mrg/ce/Integration.yml
+++ b/src/_data/codebase/v2_3/mrg/ce/Integration.yml
@@ -4,7 +4,7 @@ source_repo: magento2ce
 release: 2.3.6
 github_path: app/code/Magento/Integration/README.md
 last_modified_at: '2014-12-12 12:14:06 -0800'
-content: |
+content: |-
   **Integration** enables third-party services to call the Web API by using access tokens.
   It provides an admin UI that enables manual creation of integrations. Extensions can also provide a configuration
   file so that an integration can be automatically pre-configured. The module also contains the data

--- a/src/_data/codebase/v2_3/mrg/ce/LayeredNavigation.yml
+++ b/src/_data/codebase/v2_3/mrg/ce/LayeredNavigation.yml
@@ -4,6 +4,6 @@ source_repo: magento2ce
 release: 2.3.6
 github_path: app/code/Magento/LayeredNavigation/README.md
 last_modified_at: '2014-12-12 12:14:06 -0800'
-content: |
+content: |-
   Magento_LayeredNavigation module introduces Layered Navigation UI for Catalog (faceted search).
   This module can be removed from Magento installation without impact on the application.

--- a/src/_data/codebase/v2_3/mrg/ce/MediaGallery.yml
+++ b/src/_data/codebase/v2_3/mrg/ce/MediaGallery.yml
@@ -4,7 +4,7 @@ source_repo: magento2ce
 release: 2.3.6
 github_path: app/code/Magento/MediaGallery/README.md
 last_modified_at: '2019-11-04 11:34:55 +0000'
-content: |
+content: |-
   The Magento_MediaGallery module is responsible for storing and managing media gallery assets attributes.
 
   ## Installation details

--- a/src/_data/codebase/v2_3/mrg/ce/MediaGalleryApi.yml
+++ b/src/_data/codebase/v2_3/mrg/ce/MediaGalleryApi.yml
@@ -4,7 +4,7 @@ source_repo: magento2ce
 release: 2.3.6
 github_path: app/code/Magento/MediaGalleryApi/README.md
 last_modified_at: '2019-11-04 11:34:55 +0000'
-content: |
+content: |-
   The Magento_MediaGalleryApi module serves as application program interface (API) responsible for storing and managing media gallery asset attributes.
 
   ## Extensibility

--- a/src/_data/codebase/v2_3/mrg/ce/MediaStorage.yml
+++ b/src/_data/codebase/v2_3/mrg/ce/MediaStorage.yml
@@ -4,7 +4,5 @@ source_repo: magento2ce
 release: 2.3.6
 github_path: app/code/Magento/MediaStorage/README.md
 last_modified_at: '2015-02-26 14:04:15 +0200'
-content: 'The Magento_MediaStorage module implements functionality related with upload
+content: The Magento_MediaStorage module implements functionality related with upload
   media files and synchronize it by database.
-
-'

--- a/src/_data/codebase/v2_3/mrg/ce/MessageQueue.yml
+++ b/src/_data/codebase/v2_3/mrg/ce/MessageQueue.yml
@@ -4,4 +4,4 @@ source_repo: magento2ce
 release: 2.3.6
 github_path: app/code/Magento/MessageQueue/README.md
 last_modified_at: '2018-02-21 14:27:13 +0200'
-content: "**MessageQueue** provides support of Advanced Message Queuing Protocol\n"
+content: "**MessageQueue** provides support of Advanced Message Queuing Protocol"

--- a/src/_data/codebase/v2_3/mrg/ce/MysqlMq.yml
+++ b/src/_data/codebase/v2_3/mrg/ce/MysqlMq.yml
@@ -4,4 +4,4 @@ source_repo: magento2ce
 release: 2.3.6
 github_path: app/code/Magento/MysqlMq/README.md
 last_modified_at: '2018-02-21 14:27:42 +0200'
-content: "**MysqlMq** provides message queue implementation based on MySQL.\n"
+content: "**MysqlMq** provides message queue implementation based on MySQL."

--- a/src/_data/codebase/v2_3/mrg/ce/NewRelicReporting.yml
+++ b/src/_data/codebase/v2_3/mrg/ce/NewRelicReporting.yml
@@ -6,4 +6,4 @@ github_path: app/code/Magento/NewRelicReporting/README.md
 last_modified_at: '2015-10-01 16:15:45 +0300'
 content: "Module Magento\\NewRelicReporting implements integration New Relic APM and
   New Relic Insights with Magento, giving \nreal-time visibility into business and
-  performance metrics for data-driven decision making. "
+  performance metrics for data-driven decision making."

--- a/src/_data/codebase/v2_3/mrg/ce/Newsletter.yml
+++ b/src/_data/codebase/v2_3/mrg/ce/Newsletter.yml
@@ -4,8 +4,6 @@ source_repo: magento2ce
 release: 2.3.6
 github_path: app/code/Magento/Newsletter/README.md
 last_modified_at: '2014-12-12 12:14:06 -0800'
-content: 'Magento_Newsletter module allows clients to subscribe for information about
+content: Magento_Newsletter module allows clients to subscribe for information about
   new promotions and discounts and allows store administrators to send newsletters
   to clients subscribed for them.
-
-'

--- a/src/_data/codebase/v2_3/mrg/ce/OfflinePayments.yml
+++ b/src/_data/codebase/v2_3/mrg/ce/OfflinePayments.yml
@@ -4,7 +4,7 @@ source_repo: magento2ce
 release: 2.3.6
 github_path: app/code/Magento/OfflinePayments/README.md
 last_modified_at: '2014-10-31 09:04:08 -0700'
-content: |
+content: |-
   The Magento_OfflinePayments module implements the payment methods which do not require interaction with a payment gateway (so called offline methods). These methods are the following:
   *Bank transfer
   *Cash on delivery

--- a/src/_data/codebase/v2_3/mrg/ce/OfflineShipping.yml
+++ b/src/_data/codebase/v2_3/mrg/ce/OfflineShipping.yml
@@ -4,10 +4,9 @@ source_repo: magento2ce
 release: 2.3.6
 github_path: app/code/Magento/OfflineShipping/README.md
 last_modified_at: '2014-10-31 09:04:08 -0700'
-content: |+
+content: |-
   The Magento_OfflineShipping module implements the shipping methods which do not involve a direct interaction with shipping carriers, so called offline shipping methods. Namely, the following:
   *Free Shipping
   *Flat Rate
   *Table Rates
   *Store Pickup
-

--- a/src/_data/codebase/v2_3/mrg/ce/Payment.yml
+++ b/src/_data/codebase/v2_3/mrg/ce/Payment.yml
@@ -4,6 +4,6 @@ source_repo: magento2ce
 release: 2.3.6
 github_path: app/code/Magento/Payment/README.md
 last_modified_at: '2014-10-31 09:04:08 -0700'
-content: |
+content: |-
   The Magento_Payment module provides the abstraction level for all payment methods, and all logic that should be used when adding a new payment method. This logic includes configuration models, separate models for payment data verification and so on.
   For example, Magento\Payment\Model\Method\AbstractMethod is an abstract model which should be extended by particular payment methods.

--- a/src/_data/codebase/v2_3/mrg/ce/Paypal.yml
+++ b/src/_data/codebase/v2_3/mrg/ce/Paypal.yml
@@ -4,7 +4,7 @@ source_repo: magento2ce
 release: 2.3.6
 github_path: app/code/Magento/Paypal/README.md
 last_modified_at: '2019-03-31 18:42:40 +0300'
-content: |
+content: |-
   Module Magento\PayPal implements integration with the PayPal payment system. Namely, it enables the following payment methods:
   * PayPal Express Checkout
   * PayPal Payments Standard

--- a/src/_data/codebase/v2_3/mrg/ce/PaypalGraphQl.yml
+++ b/src/_data/codebase/v2_3/mrg/ce/PaypalGraphQl.yml
@@ -5,4 +5,4 @@ release: 2.3.6
 github_path: app/code/Magento/PaypalGraphQl/README.md
 last_modified_at: '2019-05-23 10:50:05 -0500'
 content: "**PaypalGraphQl** provides resolver information for using Paypal payment
-  methods via GraphQl.\n"
+  methods via GraphQl."

--- a/src/_data/codebase/v2_3/mrg/ce/Persistent.yml
+++ b/src/_data/codebase/v2_3/mrg/ce/Persistent.yml
@@ -4,7 +4,7 @@ source_repo: magento2ce
 release: 2.3.6
 github_path: app/code/Magento/Persistent/README.md
 last_modified_at: '2014-10-24 14:51:44 -0700'
-content: |
+content: |-
   Magento\Persistent module enables set customer a long-term cookie containing internal id (random hash - to exclude brute
   force) of persistent session. Persistent session data is kept in DB - so it's not deleted in some days and is kept for
   as much time as we need. DB session keeps customerId + some data from real customer session that we want to sync (e.g.

--- a/src/_data/codebase/v2_3/mrg/ce/ProductAlert.yml
+++ b/src/_data/codebase/v2_3/mrg/ce/ProductAlert.yml
@@ -4,7 +4,5 @@ source_repo: magento2ce
 release: 2.3.6
 github_path: app/code/Magento/ProductAlert/README.md
 last_modified_at: '2014-10-31 09:04:08 -0700'
-content: 'The Magento_ProductAlert module enables product alerts, which allow customers
+content: The Magento_ProductAlert module enables product alerts, which allow customers
   to sign up for emails about product price or stock status change.
-
-'

--- a/src/_data/codebase/v2_3/mrg/ce/ProductVideo.yml
+++ b/src/_data/codebase/v2_3/mrg/ce/ProductVideo.yml
@@ -4,7 +4,5 @@ source_repo: magento2ce
 release: 2.3.6
 github_path: app/code/Magento/ProductVideo/README.md
 last_modified_at: '2015-09-11 16:19:20 +0300'
-content: 'The Magento_ProductVideo module implements functionality related with linking
+content: The Magento_ProductVideo module implements functionality related with linking
   video files from external resources to product.
-
-'

--- a/src/_data/codebase/v2_3/mrg/ce/Quote.yml
+++ b/src/_data/codebase/v2_3/mrg/ce/Quote.yml
@@ -4,7 +4,7 @@ source_repo: magento2ce
 release: 2.3.6
 github_path: app/code/Magento/Quote/README.md
 last_modified_at: '2015-01-06 12:45:10 +0200'
-content: |
+content: |-
   ## Purpose of module
 
 

--- a/src/_data/codebase/v2_3/mrg/ce/QuoteAnalytics.yml
+++ b/src/_data/codebase/v2_3/mrg/ce/QuoteAnalytics.yml
@@ -4,7 +4,5 @@ source_repo: magento2ce
 release: 2.3.6
 github_path: app/code/Magento/QuoteAnalytics/README.md
 last_modified_at: '2019-08-06 14:40:28 -0500'
-content: 'The Magento_QuoteAnalytics module configures data definitions for a data
+content: The Magento_QuoteAnalytics module configures data definitions for a data
   collection related to the Quote module entities to be used in [Advanced Reporting](https://devdocs.magento.com/guides/v2.3/advanced-reporting/modules.html).
-
-'

--- a/src/_data/codebase/v2_3/mrg/ce/QuoteGraphQl.yml
+++ b/src/_data/codebase/v2_3/mrg/ce/QuoteGraphQl.yml
@@ -4,6 +4,6 @@ source_repo: magento2ce
 release: 2.3.6
 github_path: app/code/Magento/QuoteGraphQl/README.md
 last_modified_at: '2018-07-31 14:11:47 +0200'
-content: |
+content: |-
   **QuoteGraphQl** provides type and resolver information for the GraphQl module
   to generate quote (cart) information endpoints. Also provides endpoints for modifying a quote.

--- a/src/_data/codebase/v2_3/mrg/ce/ReleaseNotification.yml
+++ b/src/_data/codebase/v2_3/mrg/ce/ReleaseNotification.yml
@@ -45,4 +45,4 @@ content: "The **Release Notification Module** serves to provide a notification d
   will cause a clickable link to be created. The text between the brackets [text]
   will be the text that the clickable link shows.\n\n### Link Format Example:\n\nThe
   text: `https://devdocs.magento.com/ [Magento DevDocs].` will appear as [Magento
-  DevDocs](https://devdocs.magento.com/).\n"
+  DevDocs](https://devdocs.magento.com/)."

--- a/src/_data/codebase/v2_3/mrg/ce/Reports.yml
+++ b/src/_data/codebase/v2_3/mrg/ce/Reports.yml
@@ -4,7 +4,7 @@ source_repo: magento2ce
 release: 2.3.6
 github_path: app/code/Magento/Reports/README.md
 last_modified_at: '2014-12-12 12:14:06 -0800'
-content: |
+content: |-
   Magento_Reports module provides ability to collect various reports such as:
    - products reports (bestsellers, low stock, most viewed, products ordered),
    - sales reports (orders, tax, invoiced, shipping, refunds, coupons, and PayPal settlement reports),

--- a/src/_data/codebase/v2_3/mrg/ce/RequireJs.yml
+++ b/src/_data/codebase/v2_3/mrg/ce/RequireJs.yml
@@ -4,7 +4,7 @@ source_repo: magento2ce
 release: 2.3.6
 github_path: app/code/Magento/RequireJs/README.md
 last_modified_at: '2014-11-28 11:40:11 -0800'
-content: |
+content: |-
   ## Purpose of module
 
   The Magento\RequireJs module introduces support for RequireJs JavaScript library and provides infrastructure for other modules to have them declared related configuration for RequireJs library.

--- a/src/_data/codebase/v2_3/mrg/ce/Review.yml
+++ b/src/_data/codebase/v2_3/mrg/ce/Review.yml
@@ -4,6 +4,4 @@ source_repo: magento2ce
 release: 2.3.6
 github_path: app/code/Magento/Review/README.md
 last_modified_at: '2014-12-12 12:14:06 -0800'
-content: 'Magento_Review module functionality allows to write reviews for products.
-
-'
+content: Magento_Review module functionality allows to write reviews for products.

--- a/src/_data/codebase/v2_3/mrg/ce/ReviewAnalytics.yml
+++ b/src/_data/codebase/v2_3/mrg/ce/ReviewAnalytics.yml
@@ -4,7 +4,5 @@ source_repo: magento2ce
 release: 2.3.6
 github_path: app/code/Magento/ReviewAnalytics/README.md
 last_modified_at: '2019-08-06 14:40:28 -0500'
-content: 'The Magento_ReviewAnalytics module configures data definitions for a data
+content: The Magento_ReviewAnalytics module configures data definitions for a data
   collection related to the Review module entities to be used in [Advanced Reporting](https://devdocs.magento.com/guides/v2.3/advanced-reporting/modules.html).
-
-'

--- a/src/_data/codebase/v2_3/mrg/ce/Robots.yml
+++ b/src/_data/codebase/v2_3/mrg/ce/Robots.yml
@@ -7,4 +7,4 @@ last_modified_at: '2017-06-15 17:15:28 +0300'
 content: "The Robots module provides the following functionalities: \n* contains a
   router to match application action class for requests to the `robots.txt` file;\n*
   allows obtaining the content of the `robots.txt` file depending on the settings
-  of the current website.\n"
+  of the current website."

--- a/src/_data/codebase/v2_3/mrg/ce/Rss.yml
+++ b/src/_data/codebase/v2_3/mrg/ce/Rss.yml
@@ -4,7 +4,5 @@ source_repo: magento2ce
 release: 2.3.6
 github_path: app/code/Magento/Rss/README.md
 last_modified_at: '2014-12-12 12:14:06 -0800'
-content: 'Magento_Rss module is responsible for processing all RSS feeds of the application
+content: Magento_Rss module is responsible for processing all RSS feeds of the application
   and allows to turn on/off RSS centrally.
-
-'

--- a/src/_data/codebase/v2_3/mrg/ce/Rule.yml
+++ b/src/_data/codebase/v2_3/mrg/ce/Rule.yml
@@ -6,6 +6,4 @@ github_path: app/code/Magento/Rule/README.md
 last_modified_at: '2014-12-12 12:14:06 -0800'
 content: 'Magento_Rule module provides abstract implementation of rules and rule conditions
   that are extended by other modules, in particular by: Magento_SalesRule, Magento_CatalogRule,
-  etc...
-
-'
+  etc...'

--- a/src/_data/codebase/v2_3/mrg/ce/Sales.yml
+++ b/src/_data/codebase/v2_3/mrg/ce/Sales.yml
@@ -4,7 +4,7 @@ source_repo: magento2ce
 release: 2.3.6
 github_path: app/code/Magento/Sales/README.md
 last_modified_at: '2014-10-24 14:51:44 -0700'
-content: |
+content: |-
   ## Purpose of module
 
   Magento\Sales module is responsible for order processing and appearance in system,

--- a/src/_data/codebase/v2_3/mrg/ce/SalesAnalytics.yml
+++ b/src/_data/codebase/v2_3/mrg/ce/SalesAnalytics.yml
@@ -4,7 +4,5 @@ source_repo: magento2ce
 release: 2.3.6
 github_path: app/code/Magento/SalesAnalytics/README.md
 last_modified_at: '2019-08-06 14:40:28 -0500'
-content: 'The Magento_SalesAnalytics module configures data definitions for a data
+content: The Magento_SalesAnalytics module configures data definitions for a data
   collection related to the Sales module entities to be used in [Advanced Reporting](https://devdocs.magento.com/guides/v2.3/advanced-reporting/modules.html).
-
-'

--- a/src/_data/codebase/v2_3/mrg/ce/SalesGraphQl.yml
+++ b/src/_data/codebase/v2_3/mrg/ce/SalesGraphQl.yml
@@ -4,6 +4,6 @@ source_repo: magento2ce
 release: 2.3.6
 github_path: app/code/Magento/SalesGraphQl/README.md
 last_modified_at: '2018-10-15 19:46:32 +0300'
-content: |
+content: |-
   **SalesGraphQl** provides type and resolver information for the GraphQl module
   to generate sales orders information.

--- a/src/_data/codebase/v2_3/mrg/ce/SalesInventory.yml
+++ b/src/_data/codebase/v2_3/mrg/ce/SalesInventory.yml
@@ -4,7 +4,5 @@ source_repo: magento2ce
 release: 2.3.6
 github_path: app/code/Magento/SalesInventory/README.md
 last_modified_at: '2016-09-21 16:39:44 +0300'
-content: 'Magento_SalesInventory module allows retrieve and update stock attributes
+content: Magento_SalesInventory module allows retrieve and update stock attributes
   related to Magento_Sales, such as status and quantity.
-
-'

--- a/src/_data/codebase/v2_3/mrg/ce/SalesRule.yml
+++ b/src/_data/codebase/v2_3/mrg/ce/SalesRule.yml
@@ -4,5 +4,5 @@ source_repo: magento2ce
 release: 2.3.6
 github_path: app/code/Magento/SalesRule/README.md
 last_modified_at: '2014-10-24 14:51:44 -0700'
-content: "SalesRule module is responsible for managing and processing Promotion Shopping
-  Cart Rules.\n\n"
+content: SalesRule module is responsible for managing and processing Promotion Shopping
+  Cart Rules.

--- a/src/_data/codebase/v2_3/mrg/ce/SalesSequence.yml
+++ b/src/_data/codebase/v2_3/mrg/ce/SalesSequence.yml
@@ -4,7 +4,7 @@ source_repo: magento2ce
 release: 2.3.6
 github_path: app/code/Magento/SalesSequence/README.md
 last_modified_at: '2015-03-20 16:50:43 +0200'
-content: |
+content: |-
   ## Purpose of module
 
   Magento\SalesSequence module is responsible for sequences processing in Sales module,

--- a/src/_data/codebase/v2_3/mrg/ce/SampleData.yml
+++ b/src/_data/codebase/v2_3/mrg/ce/SampleData.yml
@@ -4,7 +4,7 @@ source_repo: magento2ce
 release: 2.3.6
 github_path: app/code/Magento/SampleData/README.md
 last_modified_at: '2019-08-06 14:40:28 -0500'
-content: |
+content: |-
   Magento sample data includes a sample store, complete with more than 250 products (about 200 of them are configurable products), categories, promotional price rules, CMS pages, banners, and so on. Sample data uses the Luma theme on the storefront.
 
   Installing sample data is optional.

--- a/src/_data/codebase/v2_3/mrg/ce/Search.yml
+++ b/src/_data/codebase/v2_3/mrg/ce/Search.yml
@@ -4,7 +4,5 @@ source_repo: magento2ce
 release: 2.3.6
 github_path: app/code/Magento/Search/README.md
 last_modified_at: '2014-12-12 12:14:06 -0800'
-content: 'Magento_Search module introduces basic search functionality and provides
+content: Magento_Search module introduces basic search functionality and provides
   interfaces that allow to implement search for specific module.
-
-'

--- a/src/_data/codebase/v2_3/mrg/ce/Security.yml
+++ b/src/_data/codebase/v2_3/mrg/ce/Security.yml
@@ -4,7 +4,7 @@ source_repo: magento2ce
 release: 2.3.6
 github_path: app/code/Magento/Security/README.md
 last_modified_at: '2016-01-11 17:45:47 +0300'
-content: |
+content: |-
   **Security** management module
   _Main features:_
   1. Added support for simultaneous admin user logins with ability to enable/disable the feature, review and disconnect the list of current logged in sessions

--- a/src/_data/codebase/v2_3/mrg/ce/SendFriend.yml
+++ b/src/_data/codebase/v2_3/mrg/ce/SendFriend.yml
@@ -4,8 +4,6 @@ source_repo: magento2ce
 release: 2.3.6
 github_path: app/code/Magento/SendFriend/README.md
 last_modified_at: '2015-06-02 12:45:34 +0300'
-content: 'The Magento_SendFriend implements the functionality behind the "Email to
+content: The Magento_SendFriend implements the functionality behind the "Email to
   a Friend" link on a product page, which allows to share favorite products with others
   by clicking the link.
-
-'

--- a/src/_data/codebase/v2_3/mrg/ce/SendFriendGraphQl.yml
+++ b/src/_data/codebase/v2_3/mrg/ce/SendFriendGraphQl.yml
@@ -4,4 +4,4 @@ source_repo: magento2ce
 release: 2.3.6
 github_path: app/code/Magento/SendFriendGraphQl/README.md
 last_modified_at: '2018-11-19 20:18:31 +0200'
-content: "**SendFriendGraphQl** provides support of GraphQL for SendFriend functionality.\n"
+content: "**SendFriendGraphQl** provides support of GraphQL for SendFriend functionality."

--- a/src/_data/codebase/v2_3/mrg/ce/Shipping.yml
+++ b/src/_data/codebase/v2_3/mrg/ce/Shipping.yml
@@ -4,6 +4,6 @@ source_repo: magento2ce
 release: 2.3.6
 github_path: app/code/Magento/Shipping/README.md
 last_modified_at: '2014-10-31 09:04:08 -0700'
-content: |
+content: |-
   The Magento_Shipping module provides the abstract models and interfaces for a shipping carrier integration, including the web interface for the Shipment entity.
   You need to extend these abstractions if you are adding new shipping carrier integration.

--- a/src/_data/codebase/v2_3/mrg/ce/Signifyd.yml
+++ b/src/_data/codebase/v2_3/mrg/ce/Signifyd.yml
@@ -4,7 +4,7 @@ source_repo: magento2ce
 release: 2.3.6
 github_path: app/code/Magento/Signifyd/README.md
 last_modified_at: '2019-08-06 14:40:28 -0500'
-content: |
+content: |-
   ## Overview
 
   The Magento_Signifyd module provides integration with the [Signifyd](https://www.signifyd.com/) fraud protection system. The integration is based on the Signifyd API; see the [Signifyd API docs](https://www.signifyd.com/docs/api/#/introduction/) for technical details.

--- a/src/_data/codebase/v2_3/mrg/ce/StoreGraphQl.yml
+++ b/src/_data/codebase/v2_3/mrg/ce/StoreGraphQl.yml
@@ -4,6 +4,6 @@ source_repo: magento2ce
 release: 2.3.6
 github_path: app/code/Magento/StoreGraphQl/README.md
 last_modified_at: '2018-04-09 17:36:37 -0500'
-content: |
+content: |-
   **StoreGraphQl** provides type information for the GraphQl module
   to generate store fields information endpoints.

--- a/src/_data/codebase/v2_3/mrg/ce/Swagger.yml
+++ b/src/_data/codebase/v2_3/mrg/ce/Swagger.yml
@@ -4,7 +4,7 @@ source_repo: magento2ce
 release: 2.3.6
 github_path: app/code/Magento/Swagger/README.md
 last_modified_at: '2015-08-14 15:14:44 -0500'
-content: |
+content: |-
   The Magento_Swagger module provides access to a page generated using the swagger-ui package. The swagger-ui can be viewed
   [on Github](https://github.com/swagger-api/swagger-ui). It accesses the JSON Schema describing Magento's REST APIs,
   and displays it in a user-friendly, navigable format.

--- a/src/_data/codebase/v2_3/mrg/ce/SwatchesGraphQl.yml
+++ b/src/_data/codebase/v2_3/mrg/ce/SwatchesGraphQl.yml
@@ -4,6 +4,6 @@ source_repo: magento2ce
 release: 2.3.6
 github_path: app/code/Magento/SwatchesGraphQl/README.md
 last_modified_at: '2018-01-16 16:07:17 -0600'
-content: |
+content: |-
   **SwatchesGraphQl** provides type information for the GraphQl module
   to generate swatches fields for catalog and product information endpoints.

--- a/src/_data/codebase/v2_3/mrg/ce/SwatchesLayeredNavigation.yml
+++ b/src/_data/codebase/v2_3/mrg/ce/SwatchesLayeredNavigation.yml
@@ -4,7 +4,7 @@ source_repo: magento2ce
 release: 2.3.6
 github_path: app/code/Magento/SwatchesLayeredNavigation/README.md
 last_modified_at: '2016-03-10 13:38:33 +0200'
-content: |
+content: |-
   ## Overview
 
   The **Magento_SwatchesLayeredNavigation** module enables LayeredNavigation functionality for Swatch attributes

--- a/src/_data/codebase/v2_3/mrg/ce/TaxGraphQl.yml
+++ b/src/_data/codebase/v2_3/mrg/ce/TaxGraphQl.yml
@@ -4,6 +4,6 @@ source_repo: magento2ce
 release: 2.3.6
 github_path: app/code/Magento/TaxGraphQl/README.md
 last_modified_at: '2018-01-16 16:07:17 -0600'
-content: |
+content: |-
   **TaxGraphQl** provides type information for the GraphQl module
   to generate tax fields for catalog and product information endpoints.

--- a/src/_data/codebase/v2_3/mrg/ce/ThemeGraphQl.yml
+++ b/src/_data/codebase/v2_3/mrg/ce/ThemeGraphQl.yml
@@ -4,6 +4,6 @@ source_repo: magento2ce
 release: 2.3.6
 github_path: app/code/Magento/ThemeGraphQl/README.md
 last_modified_at: '2018-12-06 10:59:37 -0500'
-content: |
+content: |-
   **ThemeGraphQl** provides type information for the GraphQl module
   to generate theme fields information endpoints.

--- a/src/_data/codebase/v2_3/mrg/ce/Translation.yml
+++ b/src/_data/codebase/v2_3/mrg/ce/Translation.yml
@@ -4,6 +4,6 @@ source_repo: magento2ce
 release: 2.3.6
 github_path: app/code/Magento/Translation/README.md
 last_modified_at: '2014-12-12 12:14:06 -0800'
-content: |
+content: |-
   **Translation** enables localization of a store for multiple regions and markets.
   Also provides the inline translation tool.

--- a/src/_data/codebase/v2_3/mrg/ce/Ui.yml
+++ b/src/_data/codebase/v2_3/mrg/ce/Ui.yml
@@ -4,7 +4,7 @@ source_repo: magento2ce
 release: 2.3.6
 github_path: app/code/Magento/Ui/README.md
 last_modified_at: '2016-08-05 21:54:51 +1200'
-content: |
+content: |-
   ## Purpose of module
 
   The Magento\Ui module introduces a set of common UI components, which could be used and configured via layout XML files.

--- a/src/_data/codebase/v2_3/mrg/ce/Ups.yml
+++ b/src/_data/codebase/v2_3/mrg/ce/Ups.yml
@@ -4,7 +4,5 @@ source_repo: magento2ce
 release: 2.3.6
 github_path: app/code/Magento/Ups/README.md
 last_modified_at: '2014-10-31 09:04:08 -0700'
-content: 'The Magento_Ups module implements integration with the United Parcel Service
+content: The Magento_Ups module implements integration with the United Parcel Service
   shipping carrier.
-
-'

--- a/src/_data/codebase/v2_3/mrg/ce/UrlRewrite.yml
+++ b/src/_data/codebase/v2_3/mrg/ce/UrlRewrite.yml
@@ -4,7 +4,5 @@ source_repo: magento2ce
 release: 2.3.6
 github_path: app/code/Magento/UrlRewrite/README.md
 last_modified_at: '2014-12-12 12:14:06 -0800'
-content: 'Magento_UrlRewrite module provides ability to customize website URLs by
-  creating custom URL rewrite rules.
-
-'
+content: Magento_UrlRewrite module provides ability to customize website URLs by creating
+  custom URL rewrite rules.

--- a/src/_data/codebase/v2_3/mrg/ce/UrlRewriteGraphQl.yml
+++ b/src/_data/codebase/v2_3/mrg/ce/UrlRewriteGraphQl.yml
@@ -4,7 +4,7 @@ source_repo: magento2ce
 release: 2.3.6
 github_path: app/code/Magento/UrlRewriteGraphQl/README.md
 last_modified_at: '2018-01-17 11:18:15 -0600'
-content: |
+content: |-
   **UrlRewriteGraphQl** provides type information for the GraphQl module
   to generate url rewrites from entities that implement such rewrites,
   like categories, products or cms and other 3rd party modules.

--- a/src/_data/codebase/v2_3/mrg/ce/User.yml
+++ b/src/_data/codebase/v2_3/mrg/ce/User.yml
@@ -4,7 +4,7 @@ source_repo: magento2ce
 release: 2.3.6
 github_path: app/code/Magento/User/README.md
 last_modified_at: '2015-08-27 15:34:05 -0500'
-content: |
+content: |-
   **User** enables admin users to manage and assign roles to administrators and other non-customer users,
   reset user passwords, and invalidate access tokens.
   Different roles can be assigned to different users to define their permissions.

--- a/src/_data/codebase/v2_3/mrg/ce/Usps.yml
+++ b/src/_data/codebase/v2_3/mrg/ce/Usps.yml
@@ -4,7 +4,5 @@ source_repo: magento2ce
 release: 2.3.6
 github_path: app/code/Magento/Usps/README.md
 last_modified_at: '2014-10-31 09:04:08 -0700'
-content: 'The Magento_Usps module provides integration with the United States Postal
+content: The Magento_Usps module provides integration with the United States Postal
   Service shipping carrier.
-
-'

--- a/src/_data/codebase/v2_3/mrg/ce/Variable.yml
+++ b/src/_data/codebase/v2_3/mrg/ce/Variable.yml
@@ -4,7 +4,5 @@ source_repo: magento2ce
 release: 2.3.6
 github_path: app/code/Magento/Variable/README.md
 last_modified_at: '2015-02-10 10:11:24 -0600'
-content: 'Magento\Variable Allows to create custom variables and then use them in
-  email templates or in WYSIWYG editor for editing description of system entities.
-
-'
+content: Magento\Variable Allows to create custom variables and then use them in email
+  templates or in WYSIWYG editor for editing description of system entities.

--- a/src/_data/codebase/v2_3/mrg/ce/Vault.yml
+++ b/src/_data/codebase/v2_3/mrg/ce/Vault.yml
@@ -4,7 +4,5 @@ source_repo: magento2ce
 release: 2.3.6
 github_path: app/code/Magento/Vault/README.md
 last_modified_at: '2015-12-02 14:06:21 +0200'
-content: 'The Magento_Vault module implements the integration with the Vault payment
+content: The Magento_Vault module implements the integration with the Vault payment
   gateway and makes the latter available as a payment method in Magento.
-
-'

--- a/src/_data/codebase/v2_3/mrg/ce/VaultGraphQl.yml
+++ b/src/_data/codebase/v2_3/mrg/ce/VaultGraphQl.yml
@@ -4,7 +4,7 @@ source_repo: magento2ce
 release: 2.3.6
 github_path: app/code/Magento/VaultGraphQl/README.md
 last_modified_at: '2019-01-22 15:13:27 -0500'
-content: |
+content: |-
   **VaultGraphQl** provides type and resolver information for the GraphQl module
   to generate Vault (stored payment information) information endpoints. This module also
   provides mutations for modifying a payment token.

--- a/src/_data/codebase/v2_3/mrg/ce/Version.yml
+++ b/src/_data/codebase/v2_3/mrg/ce/Version.yml
@@ -4,6 +4,4 @@ source_repo: magento2ce
 release: 2.3.6
 github_path: app/code/Magento/Version/README.md
 last_modified_at: '2015-01-29 16:15:56 -0600'
-content: 'Magento\Version Allows to get Magento version and edition by HTTP GET request
-
-'
+content: Magento\Version Allows to get Magento version and edition by HTTP GET request

--- a/src/_data/codebase/v2_3/mrg/ce/Webapi.yml
+++ b/src/_data/codebase/v2_3/mrg/ce/Webapi.yml
@@ -4,7 +4,7 @@ source_repo: magento2ce
 release: 2.3.6
 github_path: app/code/Magento/Webapi/README.md
 last_modified_at: '2014-10-24 14:51:44 -0700'
-content: "**Webapi** provides the framework for the application to expose REST and
-  SOAP web services. It exposes an area for REST\nand another area for SOAP services
-  and routes requests based on the Webapi configuration. It also handles\ndeserialization
-  of requests and serialization of responses. \n"
+content: |-
+  **Webapi** provides the framework for the application to expose REST and SOAP web services. It exposes an area for REST
+  and another area for SOAP services and routes requests based on the Webapi configuration. It also handles
+  deserialization of requests and serialization of responses.

--- a/src/_data/codebase/v2_3/mrg/ce/WebapiAsync.yml
+++ b/src/_data/codebase/v2_3/mrg/ce/WebapiAsync.yml
@@ -6,4 +6,4 @@ github_path: app/code/Magento/WebapiAsync/README.md
 last_modified_at: '2018-03-20 12:57:53 +0200'
 content: "**WebapiAsync** Extends Webapi extension and provide functional to process
   asynchronous requests. It handle asynchronous requests, schedule, publish and consum
-  bulk operations from queue.\n"
+  bulk operations from queue."

--- a/src/_data/codebase/v2_3/mrg/ce/WebapiSecurity.yml
+++ b/src/_data/codebase/v2_3/mrg/ce/WebapiSecurity.yml
@@ -4,7 +4,7 @@ source_repo: magento2ce
 release: 2.3.6
 github_path: app/code/Magento/WebapiSecurity/README.md
 last_modified_at: '2016-03-22 15:38:49 -0500'
-content: |
+content: |-
   **WebapiSecurity** enables access management of some Web API resources.
   If checkbox is enabled in backend through: Stores -> Configuration -> Services -> Magento Web API -> Web Api Security
   then the security of all of the services outlined in app/code/Magento/WebapiSecurity/etc/di.xml would be loosened. You may modify this list to customize which services should follow this behavior.

--- a/src/_data/codebase/v2_3/mrg/ce/Weee.yml
+++ b/src/_data/codebase/v2_3/mrg/ce/Weee.yml
@@ -4,7 +4,7 @@ source_repo: magento2ce
 release: 2.3.6
 github_path: app/code/Magento/Weee/README.md
 last_modified_at: '2017-04-10 16:29:08 -0500'
-content: |
+content: |-
   The Magento_Weee module enables the application of fees/fixed product taxes (FPT) on certain types of products, usually related to electronic devices and recycling.
   Fixed product taxes can be used to setup a WEEE tax that is a fixed amount, rather than a percentage of the product price. FPT can be configured to be displayed at various places in Magento. Rules, amounts, and display options can be configured in the backend. This module extends the existing functionality of Magento_Tax.
 

--- a/src/_data/codebase/v2_3/mrg/ce/WeeeGraphQl.yml
+++ b/src/_data/codebase/v2_3/mrg/ce/WeeeGraphQl.yml
@@ -4,6 +4,6 @@ source_repo: magento2ce
 release: 2.3.6
 github_path: app/code/Magento/WeeeGraphQl/README.md
 last_modified_at: '2018-01-17 17:11:48 -0600'
-content: |
+content: |-
   **WeeeGraphQl** provides type information for the GraphQl module
   to generate wee tax fields for catalog and product information endpoints.

--- a/src/_data/codebase/v2_3/mrg/ce/Wishlist.yml
+++ b/src/_data/codebase/v2_3/mrg/ce/Wishlist.yml
@@ -4,6 +4,6 @@ source_repo: magento2ce
 release: 2.3.6
 github_path: app/code/Magento/Wishlist/README.md
 last_modified_at: '2014-10-31 09:04:08 -0700'
-content: |
+content: |-
   The Magento_Wishlist implements the Wishlist functionality.
   This allows customers to create a list of products that they can add to their shopping cart to be purchased at a later date, or share with friends.

--- a/src/_data/codebase/v2_3/mrg/ce/WishlistAnalytics.yml
+++ b/src/_data/codebase/v2_3/mrg/ce/WishlistAnalytics.yml
@@ -4,7 +4,5 @@ source_repo: magento2ce
 release: 2.3.6
 github_path: app/code/Magento/WishlistAnalytics/README.md
 last_modified_at: '2019-08-06 14:40:28 -0500'
-content: 'The Magento_WishlistAnalytics module configures data definitions for a data
+content: The Magento_WishlistAnalytics module configures data definitions for a data
   collection related to the Wishlist module entities to be used in [Advanced Reporting](https://devdocs.magento.com/guides/v2.3/advanced-reporting/modules.html).
-
-'

--- a/src/_data/codebase/v2_3/mrg/ce/WishlistGraphQl.yml
+++ b/src/_data/codebase/v2_3/mrg/ce/WishlistGraphQl.yml
@@ -4,6 +4,6 @@ source_repo: magento2ce
 release: 2.3.6
 github_path: app/code/Magento/WishlistGraphQl/README.md
 last_modified_at: '2018-10-26 12:42:07 +0200'
-content: |
+content: |-
   **WishlistGraphQl** provides type information for the GraphQl module
   to generate wishlist fields.

--- a/src/_data/codebase/v2_3/mrg/ee/AdminGws.yml
+++ b/src/_data/codebase/v2_3/mrg/ee/AdminGws.yml
@@ -6,4 +6,4 @@ github_path: app/code/Magento/AdminGws/README.md
 last_modified_at: '2014-12-17 18:31:49 +0000'
 content: "**AdminGws** provides configuration management within the Global, Website,
   and Store data scopes. Restrictions can be \nimposed on various system elements
-  through configurations that are applied at the desired level.\n"
+  through configurations that are applied at the desired level."

--- a/src/_data/codebase/v2_3/mrg/ee/AdminGwsConfigurableProduct.yml
+++ b/src/_data/codebase/v2_3/mrg/ee/AdminGwsConfigurableProduct.yml
@@ -4,7 +4,7 @@ source_repo: magento2ee
 release: 2.3.6
 github_path: app/code/Magento/AdminGwsConfigurableProduct/README.md
 last_modified_at: '2020-06-02 14:53:14 +0300'
-content: |
+content: |-
   <h2>Magento_AdminGwsConfigurableProduct module</h2>
 
   ## Overview

--- a/src/_data/codebase/v2_3/mrg/ee/AdminGwsStaging.yml
+++ b/src/_data/codebase/v2_3/mrg/ee/AdminGwsStaging.yml
@@ -4,7 +4,7 @@ source_repo: magento2ee
 release: 2.3.6
 github_path: app/code/Magento/AdminGwsStaging/README.md
 last_modified_at: '2020-03-19 10:46:04 -0500'
-content: |
+content: |-
   <h2>Magento_AdminGwsStaging module</h2>
 
   ## Overview

--- a/src/_data/codebase/v2_3/mrg/ee/AdvancedCatalog.yml
+++ b/src/_data/codebase/v2_3/mrg/ee/AdvancedCatalog.yml
@@ -4,7 +4,7 @@ source_repo: magento2ee
 release: 2.3.6
 github_path: app/code/Magento/AdvancedCatalog/README.md
 last_modified_at: '2015-06-22 19:38:00 +0300'
-content: |
+content: |-
   Magento\AdvancedCatalog module introduces list of optimizations to allow higher concurrency on product management
   operations with immediate update of product data on frontend and plays as an extension to indexation logic of
   Magento\Catalog module.

--- a/src/_data/codebase/v2_3/mrg/ee/AdvancedRule.yml
+++ b/src/_data/codebase/v2_3/mrg/ee/AdvancedRule.yml
@@ -4,4 +4,4 @@ source_repo: magento2ee
 release: 2.3.6
 github_path: app/code/Magento/AdvancedRule/README.md
 last_modified_at: '2015-11-20 12:14:51 -0600'
-content: "AdvancedRule module enhances the performance of rule processing.\n\n"
+content: AdvancedRule module enhances the performance of rule processing.

--- a/src/_data/codebase/v2_3/mrg/ee/AdvancedSalesRule.yml
+++ b/src/_data/codebase/v2_3/mrg/ee/AdvancedSalesRule.yml
@@ -4,4 +4,4 @@ source_repo: magento2ee
 release: 2.3.6
 github_path: app/code/Magento/AdvancedSalesRule/README.md
 last_modified_at: '2015-11-20 12:14:51 -0600'
-content: "AdvancedSalesRule module enhances the performance of sale rule processing.\n\n"
+content: AdvancedSalesRule module enhances the performance of sale rule processing.

--- a/src/_data/codebase/v2_3/mrg/ee/CatalogEvent.yml
+++ b/src/_data/codebase/v2_3/mrg/ee/CatalogEvent.yml
@@ -4,6 +4,6 @@ source_repo: magento2ee
 release: 2.3.6
 github_path: app/code/Magento/CatalogEvent/README.md
 last_modified_at: '2014-12-17 18:31:49 +0000'
-content: |
+content: |-
   Magento_CatalogEvent module is designed for creating campaigns that encourage customers to buy products with lower prices.
   There are three types of the catalog events: upcoming, open, closed.

--- a/src/_data/codebase/v2_3/mrg/ee/CatalogImportExportStaging.yml
+++ b/src/_data/codebase/v2_3/mrg/ee/CatalogImportExportStaging.yml
@@ -4,7 +4,7 @@ source_repo: magento2ee
 release: 2.3.6
 github_path: app/code/Magento/CatalogImportExportStaging/README.md
 last_modified_at: '2016-04-07 09:45:21 -0500'
-content: |
+content: |-
   <h2>Magento_CatalogImportExportStaging module</h2>
 
   ## Overview

--- a/src/_data/codebase/v2_3/mrg/ee/CatalogPermissions.yml
+++ b/src/_data/codebase/v2_3/mrg/ee/CatalogPermissions.yml
@@ -4,7 +4,7 @@ source_repo: magento2ee
 release: 2.3.6
 github_path: app/code/Magento/CatalogPermissions/README.md
 last_modified_at: '2015-05-14 15:09:36 +0300'
-content: |
+content: |-
   Magento_CatalogPermissions feature allows to restrict the following permissions:
   - Browse categories
   - Display product prices

--- a/src/_data/codebase/v2_3/mrg/ee/CatalogStagingGraphQl.yml
+++ b/src/_data/codebase/v2_3/mrg/ee/CatalogStagingGraphQl.yml
@@ -4,6 +4,6 @@ source_repo: magento2ee
 release: 2.3.6
 github_path: app/code/Magento/CatalogStagingGraphQl/README.md
 last_modified_at: '2019-11-22 09:44:16 -0600'
-content: |
+content: |-
   **CatalogStagingGraphQl** supports Staging functionality for Catalog in the scope of GraphQl.
   This includes preview capabilities for catalog entities.

--- a/src/_data/codebase/v2_3/mrg/ee/CheckoutAddressSearch.yml
+++ b/src/_data/codebase/v2_3/mrg/ee/CheckoutAddressSearch.yml
@@ -4,7 +4,7 @@ source_repo: magento2ee
 release: 2.3.6
 github_path: app/code/Magento/CheckoutAddressSearch/README.md
 last_modified_at: '2019-04-10 17:47:51 -0500'
-content: |
+content: |-
   ## CheckoutAddressSearch module Overview
 
   CheckoutAddressSearch module extends Magento_Checkout and adds functionality to search customer shipping and billing addresses with ui-select component.

--- a/src/_data/codebase/v2_3/mrg/ee/CheckoutAddressSearchGiftRegistry.yml
+++ b/src/_data/codebase/v2_3/mrg/ee/CheckoutAddressSearchGiftRegistry.yml
@@ -4,7 +4,7 @@ source_repo: magento2ee
 release: 2.3.6
 github_path: app/code/Magento/CheckoutAddressSearchGiftRegistry/README.md
 last_modified_at: '2019-04-05 18:54:17 -0500'
-content: |
+content: |-
   ## CheckoutAddressSearchGiftRegistry module Overview
 
   CheckoutAddressSearchGiftRegistry module extends Magento_GiftRegistry and adds search customer shipping and billing addresses functionality on checkout to gift registry only if customer address search is enabled in configuration.

--- a/src/_data/codebase/v2_3/mrg/ee/CheckoutStaging.yml
+++ b/src/_data/codebase/v2_3/mrg/ee/CheckoutStaging.yml
@@ -4,7 +4,7 @@ source_repo: magento2ee
 release: 2.3.6
 github_path: app/code/Magento/CheckoutStaging/README.md
 last_modified_at: '2016-07-04 12:55:14 +0000'
-content: |
+content: |-
   ## Magento_CheckoutStaging module
 
   ## Overview

--- a/src/_data/codebase/v2_3/mrg/ee/ConfigurableProductStaging.yml
+++ b/src/_data/codebase/v2_3/mrg/ee/ConfigurableProductStaging.yml
@@ -4,7 +4,7 @@ source_repo: magento2ee
 release: 2.3.6
 github_path: app/code/Magento/ConfigurableProductStaging/README.md
 last_modified_at: '2017-02-06 15:24:41 +0200'
-content: |
+content: |-
   ## Magento_ConfigurableProductStaging module
 
   ## Overview

--- a/src/_data/codebase/v2_3/mrg/ee/CustomAttributeManagement.yml
+++ b/src/_data/codebase/v2_3/mrg/ee/CustomAttributeManagement.yml
@@ -4,7 +4,7 @@ source_repo: magento2ee
 release: 2.3.6
 github_path: app/code/Magento/CustomAttributeManagement/README.md
 last_modified_at: '2014-12-17 18:31:49 +0000'
-content: |
+content: |-
   Magento_CustomAttributeManagement implements user-defined attributes management which provides ability to manage attributes of customers and their address.
   Admin user can manage attributes on UI level without assistance of programmer.
   Admin user can create new, modify, and remove attributes, control attributes properties and visibility on frontend.

--- a/src/_data/codebase/v2_3/mrg/ee/CustomerBalance.yml
+++ b/src/_data/codebase/v2_3/mrg/ee/CustomerBalance.yml
@@ -4,6 +4,6 @@ source_repo: magento2ee
 release: 2.3.6
 github_path: app/code/Magento/CustomerBalance/README.md
 last_modified_at: '2014-12-17 18:31:49 +0000'
-content: |
+content: |-
   The Magento_CustomerBalance module enables customers to have a non-monetary balance in store credits associated to their accounts.
   Store credit can be used by customers for shopping in the store and by the store administrator for making refunds.

--- a/src/_data/codebase/v2_3/mrg/ee/CustomerBalanceGraphQl.yml
+++ b/src/_data/codebase/v2_3/mrg/ee/CustomerBalanceGraphQl.yml
@@ -4,6 +4,6 @@ source_repo: magento2ee
 release: 2.3.6
 github_path: app/code/Magento/CustomerBalanceGraphQl/README.md
 last_modified_at: '2019-07-16 10:30:00 -0500'
-content: |
+content: |-
   The **CustomerBalanceGraphQl** provides type and resolver information for enabling customers to have a non-monetary balance in store credits associated to their accounts.
   Store credit can be used by customers for shopping in the store and by the store administrator for making refunds.

--- a/src/_data/codebase/v2_3/mrg/ee/CustomerCustomAttributes.yml
+++ b/src/_data/codebase/v2_3/mrg/ee/CustomerCustomAttributes.yml
@@ -4,6 +4,6 @@ source_repo: magento2ee
 release: 2.3.6
 github_path: app/code/Magento/CustomerCustomAttributes/README.md
 last_modified_at: '2014-12-17 18:31:49 +0000'
-content: |
+content: |-
   The Magento_CustomerCustomAttributes module handles user-defined customer and customer address attributes.
   User-defined attributes are the ones, which are created by a store administrator additionally to the default ones.

--- a/src/_data/codebase/v2_3/mrg/ee/CustomerFinance.yml
+++ b/src/_data/codebase/v2_3/mrg/ee/CustomerFinance.yml
@@ -4,6 +4,6 @@ source_repo: magento2ee
 release: 2.3.6
 github_path: app/code/Magento/CustomerFinance/README.md
 last_modified_at: '2014-12-17 18:31:49 +0000'
-content: |
+content: |-
   The Magento\CustomerFinance module handles the import and export of the store credit and reward customer data.
   It extends Magento_CustomerImportExport and joins the basic customer data with reward and customer balance information to enable to import/export of customer data with reward and store credit data.

--- a/src/_data/codebase/v2_3/mrg/ee/CustomerSegment.yml
+++ b/src/_data/codebase/v2_3/mrg/ee/CustomerSegment.yml
@@ -4,6 +4,6 @@ source_repo: magento2ee
 release: 2.3.6
 github_path: app/code/Magento/CustomerSegment/README.md
 last_modified_at: '2014-12-17 18:31:49 +0000'
-content: |
+content: |-
   The Magento_CustomerSegment module enables customer segmentation, allowing the creation of customer groups based on characteristics like shopping cart content, orders history, address, and so on.
   This allows dynamically targeting different content and promotions for those groups. Various components of a website, such as promotions and banners, can be personalized depending on the customer segment of a customer browsing the store at the moment.

--- a/src/_data/codebase/v2_3/mrg/ee/Cybersource.yml
+++ b/src/_data/codebase/v2_3/mrg/ee/Cybersource.yml
@@ -4,7 +4,5 @@ source_repo: magento2ee
 release: 2.3.6
 github_path: app/code/Magento/Cybersource/README.md
 last_modified_at: '2015-06-19 14:49:00 +0300'
-content: 'The Magento_Cybersource module implements the integration with the Cybersource
+content: The Magento_Cybersource module implements the integration with the Cybersource
   payment gateway and makes the latter available as a payment method in Magento.
-
-'

--- a/src/_data/codebase/v2_3/mrg/ee/Eway.yml
+++ b/src/_data/codebase/v2_3/mrg/ee/Eway.yml
@@ -4,7 +4,5 @@ source_repo: magento2ee
 release: 2.3.6
 github_path: app/code/Magento/Eway/README.md
 last_modified_at: '2015-07-29 19:08:38 +0300'
-content: 'The Magento_Eway module implements the integration with the Eway payment
+content: The Magento_Eway module implements the integration with the Eway payment
   gateway and makes the latter available as a payment method in Magento.
-
-'

--- a/src/_data/codebase/v2_3/mrg/ee/GiftCard.yml
+++ b/src/_data/codebase/v2_3/mrg/ee/GiftCard.yml
@@ -10,4 +10,4 @@ content: "Magento_GiftCard module introduces new product type in the Magento app
   offers gift cards in Virtual, Physical, or Combination format. \nWhen a gift card
   is ordered, a unique code is generated that is emailed to a customer for virtual
   gift cards, or exported for printing to physical gift cards. \nThis unique number
-  can only be redeemed by one customer.\n"
+  can only be redeemed by one customer."

--- a/src/_data/codebase/v2_3/mrg/ee/GiftCardAccount.yml
+++ b/src/_data/codebase/v2_3/mrg/ee/GiftCardAccount.yml
@@ -4,8 +4,6 @@ source_repo: magento2ee
 release: 2.3.6
 github_path: app/code/Magento/GiftCardAccount/README.md
 last_modified_at: '2014-12-17 18:31:49 +0000'
-content: 'The Magento_GiftCardAccount module is responsible for gift card balances,
+content: The Magento_GiftCardAccount module is responsible for gift card balances,
   for both gift cards created by a store administrator and gift cards sold as gift
   card products.
-
-'

--- a/src/_data/codebase/v2_3/mrg/ee/GiftCardAccountGraphQl.yml
+++ b/src/_data/codebase/v2_3/mrg/ee/GiftCardAccountGraphQl.yml
@@ -4,6 +4,6 @@ source_repo: magento2ee
 release: 2.3.6
 github_path: app/code/Magento/GiftCardAccountGraphQl/README.md
 last_modified_at: '2019-05-30 10:55:23 -0500'
-content: |
+content: |-
   **GiftCardAccountGraphQl** provides type and resolver information for the GraphQl module
   to generate giftcard acccount information.

--- a/src/_data/codebase/v2_3/mrg/ee/GiftCardGraphQl.yml
+++ b/src/_data/codebase/v2_3/mrg/ee/GiftCardGraphQl.yml
@@ -4,6 +4,6 @@ source_repo: magento2ee
 release: 2.3.6
 github_path: app/code/Magento/GiftCardGraphQl/README.md
 last_modified_at: '2018-01-30 15:41:07 -0600'
-content: |
+content: |-
   **GiftCardGraphQl** provides type and resolver information for the GraphQl module
   to generate giftcard product information.

--- a/src/_data/codebase/v2_3/mrg/ee/GiftCardImportExport.yml
+++ b/src/_data/codebase/v2_3/mrg/ee/GiftCardImportExport.yml
@@ -4,6 +4,6 @@ source_repo: magento2ee
 release: 2.3.6
 github_path: app/code/Magento/GiftCardImportExport/README.md
 last_modified_at: '2015-08-18 15:10:06 +0300'
-content: |
+content: |-
   Magento_GiftCardImportExport module introduces import and export form GiftCard Product.
   This module extends existing functionality of Magento_CatalogImportExport module by adding new product type.

--- a/src/_data/codebase/v2_3/mrg/ee/GiftCardStaging.yml
+++ b/src/_data/codebase/v2_3/mrg/ee/GiftCardStaging.yml
@@ -4,7 +4,7 @@ source_repo: magento2ee
 release: 2.3.6
 github_path: app/code/Magento/GiftCardStaging/README.md
 last_modified_at: '2016-07-13 17:35:04 -0500'
-content: |
+content: |-
   ## Magento_GiftCardStaging module
 
   ## Overview

--- a/src/_data/codebase/v2_3/mrg/ee/GoogleTagManager.yml
+++ b/src/_data/codebase/v2_3/mrg/ee/GoogleTagManager.yml
@@ -4,7 +4,5 @@ source_repo: magento2ee
 release: 2.3.6
 github_path: app/code/Magento/GoogleTagManager/README.md
 last_modified_at: '2015-06-22 19:55:26 +0300'
-content: 'Magento_GoogleTagManager is a module for integration with Google Tag Manager
+content: Magento_GoogleTagManager is a module for integration with Google Tag Manager
   service.
-
-'

--- a/src/_data/codebase/v2_3/mrg/ee/Invitation.yml
+++ b/src/_data/codebase/v2_3/mrg/ee/Invitation.yml
@@ -4,7 +4,5 @@ source_repo: magento2ee
 release: 2.3.6
 github_path: app/code/Magento/Invitation/README.md
 last_modified_at: '2014-12-17 18:31:49 +0000'
-content: 'The Magento_Invitation module enables invitation sending, referral tracking
+content: The Magento_Invitation module enables invitation sending, referral tracking
   and generating invitation reports.
-
-'

--- a/src/_data/codebase/v2_3/mrg/ee/LayeredNavigationStaging.yml
+++ b/src/_data/codebase/v2_3/mrg/ee/LayeredNavigationStaging.yml
@@ -4,7 +4,7 @@ source_repo: magento2ee
 release: 2.3.6
 github_path: app/code/Magento/LayeredNavigationStaging/README.md
 last_modified_at: '2016-07-04 12:55:14 +0000'
-content: |
+content: |-
   ## Magento_LayeredNavigationStaging module
 
   ## Overview

--- a/src/_data/codebase/v2_3/mrg/ee/MultipleWishlist.yml
+++ b/src/_data/codebase/v2_3/mrg/ee/MultipleWishlist.yml
@@ -4,6 +4,6 @@ source_repo: magento2ee
 release: 2.3.6
 github_path: app/code/Magento/MultipleWishlist/README.md
 last_modified_at: '2014-12-17 18:31:49 +0000'
-content: |
+content: |-
   The Magento_MultipleWishlist module implements the multiple wishlists functionality.
   These are lists of products from a store a customer would like to buy. Customers can save products to multiple wish lists and copy or move items from list to list.

--- a/src/_data/codebase/v2_3/mrg/ee/PaymentStaging.yml
+++ b/src/_data/codebase/v2_3/mrg/ee/PaymentStaging.yml
@@ -4,7 +4,7 @@ source_repo: magento2ee
 release: 2.3.6
 github_path: app/code/Magento/PaymentStaging/README.md
 last_modified_at: '2016-07-04 12:55:14 +0000'
-content: |
+content: |-
   ## Magento Magento_PaymentStaging Module
 
   ## Overview

--- a/src/_data/codebase/v2_3/mrg/ee/PricePermissions.yml
+++ b/src/_data/codebase/v2_3/mrg/ee/PricePermissions.yml
@@ -4,7 +4,5 @@ source_repo: magento2ee
 release: 2.3.6
 github_path: app/code/Magento/PricePermissions/README.md
 last_modified_at: '2014-12-17 18:31:49 +0000'
-content: 'Magento_PricePermissions module allows to restrict such admin rights as
-  changing or reading product price, changing product status.
-
-'
+content: Magento_PricePermissions module allows to restrict such admin rights as changing
+  or reading product price, changing product status.

--- a/src/_data/codebase/v2_3/mrg/ee/Reminder.yml
+++ b/src/_data/codebase/v2_3/mrg/ee/Reminder.yml
@@ -4,7 +4,5 @@ source_repo: magento2ee
 release: 2.3.6
 github_path: app/code/Magento/Reminder/README.md
 last_modified_at: '2014-12-17 18:31:49 +0000'
-content: 'Magento_Reminder module provides functionality for sending reminder emails
+content: Magento_Reminder module provides functionality for sending reminder emails
   to customers according to pre-configured rules.
-
-'

--- a/src/_data/codebase/v2_3/mrg/ee/ResourceConnections.yml
+++ b/src/_data/codebase/v2_3/mrg/ee/ResourceConnections.yml
@@ -25,4 +25,4 @@ content: "Magento\\ResourceConnections module adds a mechanism to segregate data
   \   //.......\n```\nTo add slave connection for resources other than 'default' repeat
   the step and add to db/slave_connection \nnew element with same name and slave configuration
   for specified resource. \nConfig structure retains backward compatibility if module
-  is turned off.\n\nWARNING: 'indexer' connection is not designed to have slave configuration.\n"
+  is turned off.\n\nWARNING: 'indexer' connection is not designed to have slave configuration."

--- a/src/_data/codebase/v2_3/mrg/ee/RewardGraphQl.yml
+++ b/src/_data/codebase/v2_3/mrg/ee/RewardGraphQl.yml
@@ -4,6 +4,6 @@ source_repo: magento2ee
 release: 2.3.6
 github_path: app/code/Magento/RewardGraphQl/README.md
 last_modified_at: '2018-01-16 16:07:42 -0600'
-content: |
+content: |-
   **RewardGraphQl** provides type information for the GraphQl module
   to generate reward fields for customer information endpoints.

--- a/src/_data/codebase/v2_3/mrg/ee/RmaGraphQl.yml
+++ b/src/_data/codebase/v2_3/mrg/ee/RmaGraphQl.yml
@@ -4,6 +4,6 @@ source_repo: magento2ee
 release: 2.3.6
 github_path: app/code/Magento/RmaGraphQl/README.md
 last_modified_at: '2018-01-16 16:07:42 -0600'
-content: |
+content: |-
   **RmaGraphQl** provides type information for the GraphQl module
   to generate rma fields for catalog and product information endpoints.

--- a/src/_data/codebase/v2_3/mrg/ee/SalesRuleStaging.yml
+++ b/src/_data/codebase/v2_3/mrg/ee/SalesRuleStaging.yml
@@ -29,4 +29,4 @@ content: "<h2>Magento_SalesRuleStaging module</h2>\n\n## Overview\n\nThe Magento
   Additional information\n\nFor more Magento 2 developer documentation, see [Magento
   2 Developer Documentation](http://devdocs.magento.com). Also, you can track there
   [backward incompatible changes made in a Magento EE mainline after the Magento 2.0
-  release](http://devdocs.magento.com/guides/v2.0/release-notes/changes/ee_changes.html).\n"
+  release](http://devdocs.magento.com/guides/v2.0/release-notes/changes/ee_changes.html)."

--- a/src/_data/codebase/v2_3/mrg/ee/ScalableInventory.yml
+++ b/src/_data/codebase/v2_3/mrg/ee/ScalableInventory.yml
@@ -4,7 +4,7 @@ source_repo: magento2ee
 release: 2.3.6
 github_path: app/code/Magento/ScalableInventory/README.md
 last_modified_at: '2015-09-01 17:12:45 +0300'
-content: |
+content: |-
   Magento\ScalableInventory module provides ability for system extension (CatalogInventory can be configured to work with separate quantity storage).
   Extraction of quantity updates to separate storage will guarantee better scalability for Magento,
   and will allow main server to be optimised for read operations which will reduce latency.

--- a/src/_data/codebase/v2_3/mrg/ee/ScheduledImportExport.yml
+++ b/src/_data/codebase/v2_3/mrg/ee/ScheduledImportExport.yml
@@ -4,6 +4,6 @@ source_repo: magento2ee
 release: 2.3.6
 github_path: app/code/Magento/ScheduledImportExport/README.md
 last_modified_at: '2014-12-17 18:31:49 +0000'
-content: |
+content: |-
   Magento_ScheduledImportExport functionality allows to simplify routine of importing and/or exporting data in the store by automating this process.
   Admin user can create a rule for importing or exporting new data (which could be Products, Customers and Customer Addresses) and specify date and time of the operation.

--- a/src/_data/codebase/v2_3/mrg/ee/SearchStaging.yml
+++ b/src/_data/codebase/v2_3/mrg/ee/SearchStaging.yml
@@ -4,7 +4,7 @@ source_repo: magento2ee
 release: 2.3.6
 github_path: app/code/Magento/SearchStaging/README.md
 last_modified_at: '2016-07-04 12:55:14 +0000'
-content: |
+content: |-
   ## Magento_SearchStaging module
 
   ## Overview

--- a/src/_data/codebase/v2_3/mrg/ee/Staging.yml
+++ b/src/_data/codebase/v2_3/mrg/ee/Staging.yml
@@ -4,7 +4,7 @@ source_repo: magento2ee
 release: 2.3.6
 github_path: app/code/Magento/Staging/README.md
 last_modified_at: '2016-10-19 18:10:05 +0300'
-content: |
+content: |-
   ## Overview
   Magento_Staging module is used for setting up, previewing and managing future store updates.
 

--- a/src/_data/codebase/v2_3/mrg/ee/StagingGraphQl.yml
+++ b/src/_data/codebase/v2_3/mrg/ee/StagingGraphQl.yml
@@ -4,6 +4,6 @@ source_repo: magento2ee
 release: 2.3.6
 github_path: app/code/Magento/StagingGraphQl/README.md
 last_modified_at: '2019-11-20 16:45:00 -0600'
-content: |
+content: |-
   **StagingGraphQl** provides type information for the GraphQl module
   to stage and preview entities.

--- a/src/_data/codebase/v2_3/mrg/ee/Support.yml
+++ b/src/_data/codebase/v2_3/mrg/ee/Support.yml
@@ -4,7 +4,5 @@ source_repo: magento2ee
 release: 2.3.6
 github_path: app/code/Magento/Support/README.md
 last_modified_at: '2015-07-31 14:51:10 +0300'
-content: 'Magento_Support module is used for generation of system reports, which provide
+content: Magento_Support module is used for generation of system reports, which provide
   detailed information about the system environment and Magento instance configuration.
-
-'

--- a/src/_data/codebase/v2_3/mrg/ee/TargetRule.yml
+++ b/src/_data/codebase/v2_3/mrg/ee/TargetRule.yml
@@ -4,7 +4,5 @@ source_repo: magento2ee
 release: 2.3.6
 github_path: app/code/Magento/TargetRule/README.md
 last_modified_at: '2014-12-17 18:31:49 +0000'
-content: 'Magento_TargetRule module allows to configure the rules for showing related
+content: Magento_TargetRule module allows to configure the rules for showing related
   products.
-
-'

--- a/src/_data/codebase/v2_3/mrg/ee/VersionsCms.yml
+++ b/src/_data/codebase/v2_3/mrg/ee/VersionsCms.yml
@@ -4,7 +4,7 @@ source_repo: magento2ee
 release: 2.3.6
 github_path: app/code/Magento/VersionsCms/README.md
 last_modified_at: '2017-04-14 11:20:03 -0500'
-content: |
+content: |-
   The Versions CMS module adds a hierarchy feature for CMS pages.
 
   The hierarchy feature organizes CMS pages as a hierarchy tree that allows parent/child relationships between pages.

--- a/src/_data/codebase/v2_3/mrg/ee/VersionsCmsUrlRewrite.yml
+++ b/src/_data/codebase/v2_3/mrg/ee/VersionsCmsUrlRewrite.yml
@@ -7,4 +7,4 @@ last_modified_at: '2020-01-20 12:07:09 +0200'
 content: "The Versions CMS Url Rewrite Module ties up the Store Switcher program with
   implementation of the Hierarchy structure. See also Magento_UrlRewrite and Magento_VersionsCms
   modules. \n\nExtends the Store Switcher program and makes it take into account nodes
-  from the Hierarchy structure.\n"
+  from the Hierarchy structure."

--- a/src/_data/codebase/v2_3/mrg/ee/WebsiteRestriction.yml
+++ b/src/_data/codebase/v2_3/mrg/ee/WebsiteRestriction.yml
@@ -4,7 +4,7 @@ source_repo: magento2ee
 release: 2.3.6
 github_path: app/code/Magento/WebsiteRestriction/README.md
 last_modified_at: '2014-12-17 18:31:49 +0000'
-content: |
+content: |-
   **Website Restriction** enables administrators to restrict all access to the site or restrict site access
   to only logged in customers. You might want to restrict all access when the site is closed for maintenance.
   You might want to restrict site access to only logged in customers if the site is a B2B site or if there is

--- a/src/_data/codebase/v2_3/mrg/ee/Worldpay.yml
+++ b/src/_data/codebase/v2_3/mrg/ee/Worldpay.yml
@@ -4,7 +4,5 @@ source_repo: magento2ee
 release: 2.3.6
 github_path: app/code/Magento/Worldpay/README.md
 last_modified_at: '2015-07-07 12:08:21 +0300'
-content: 'The Magento_Worldpay module implements the integration with the Worldpay
+content: The Magento_Worldpay module implements the integration with the Worldpay
   payment gateway and makes the latter available as a payment method in Magento.
-
-'

--- a/src/_data/codebase/v2_3/mrg/msi/Inventory.yml
+++ b/src/_data/codebase/v2_3/mrg/msi/Inventory.yml
@@ -17,4 +17,4 @@ content: "The `Inventory` module is part of the new inventory infrastructure,\nw
   does not recommend using or referring to classes and other entities in the `Inventory`
   module. All public \ninterfaces and extension points related to this module are
   located in the `InventoryApi` module. \nUse the interfaces and extension points
-  defined in `InventoryApi` to extend this module.\n"
+  defined in `InventoryApi` to extend this module."

--- a/src/_data/codebase/v2_3/mrg/msi/InventoryAdminUi.yml
+++ b/src/_data/codebase/v2_3/mrg/msi/InventoryAdminUi.yml
@@ -4,7 +4,7 @@ source_repo: inventory
 release: 1.1.6
 github_path: InventoryAdminUi/README.md
 last_modified_at: '2018-11-09 00:12:40 +0200'
-content: |
+content: |-
   The `InventoryAdminUi` module extends the Magento Admin UI to add Inventory Management functionality.
 
   This module is part of the new inventory infrastructure. The

--- a/src/_data/codebase/v2_3/mrg/msi/InventoryApi.yml
+++ b/src/_data/codebase/v2_3/mrg/msi/InventoryApi.yml
@@ -13,4 +13,4 @@ content: "The `InventoryApi` module provides Inventory Management service contra
   3rd-party developers\ncan use to provide custom inventory functionality.\n\n###
   Public APIs\n\nPublic APIs are defined in the `Api` and `Api/Data` directories.\n\n###
   REST endpoints\n\nThe `etc/webapi.xml` file defines endpoints for managing sources,
-  stocks, stock source links, and source items.\n"
+  stocks, stock source links, and source items."

--- a/src/_data/codebase/v2_3/mrg/msi/InventoryBundleProduct.yml
+++ b/src/_data/codebase/v2_3/mrg/msi/InventoryBundleProduct.yml
@@ -4,7 +4,7 @@ source_repo: inventory
 release: 1.1.6
 github_path: InventoryBundleProduct/README.md
 last_modified_at: '2018-11-09 00:12:40 +0200'
-content: |
+content: |-
   The `InventoryBundleProduct` module integrates inventory management business logic into Magento's bundle product logic.
 
   This module is part of the new inventory infrastructure. The

--- a/src/_data/codebase/v2_3/mrg/msi/InventoryBundleProductAdminUi.yml
+++ b/src/_data/codebase/v2_3/mrg/msi/InventoryBundleProductAdminUi.yml
@@ -10,4 +10,4 @@ content: "The `InventoryBundleProductAdminUi`extends the Magento Admin UI to add
   the MSI (Multi-Source Inventory) project in more detail.\n\n## Installation details\n\nThis
   module is installed as part of Magento Open Source. It may be disabled if the Inventory
   Management UI\nis provided by a 3rd-party system or if you run a headless version
-  of Magento.\n \n## Extensibility\n\nThere are no extension points or for this module.\n"
+  of Magento.\n \n## Extensibility\n\nThere are no extension points or for this module."

--- a/src/_data/codebase/v2_3/mrg/msi/InventoryCache.yml
+++ b/src/_data/codebase/v2_3/mrg/msi/InventoryCache.yml
@@ -4,7 +4,7 @@ source_repo: inventory
 release: 1.1.6
 github_path: InventoryCache/README.md
 last_modified_at: '2018-11-09 00:12:40 +0200'
-content: |
+content: |-
   The `InventoryCache` module integrates inventory management business logic into Magento's cache logic.
 
   This module is part of the new inventory infrastructure. The

--- a/src/_data/codebase/v2_3/mrg/msi/InventoryCatalog.yml
+++ b/src/_data/codebase/v2_3/mrg/msi/InventoryCatalog.yml
@@ -12,4 +12,4 @@ content: "The `InventoryCatalog` module integrates inventory management business
   for `InventoryCatalogApi`\nis provided by a 3rd-party module, the module cannot
   be deleted or disabled.\n\n## Extension points and service contracts\n\nAll public
   interfaces related to this module are located in the `InventoryCatalogApi` module.
-  \nUse the interfaces defined in `InventoryCatalogApi` to extend this module.\n"
+  \nUse the interfaces defined in `InventoryCatalogApi` to extend this module."

--- a/src/_data/codebase/v2_3/mrg/msi/InventoryCatalogAdminUi.yml
+++ b/src/_data/codebase/v2_3/mrg/msi/InventoryCatalogAdminUi.yml
@@ -4,7 +4,7 @@ source_repo: inventory
 release: 1.1.6
 github_path: InventoryCatalogAdminUi/README.md
 last_modified_at: '2018-11-09 00:12:40 +0200'
-content: |
+content: |-
   The `InventoryCatalogAdminUi` module extends the Magento Admin UI to add MSI functionality.
 
   This module is part of the new inventory infrastructure. The

--- a/src/_data/codebase/v2_3/mrg/msi/InventoryCatalogApi.yml
+++ b/src/_data/codebase/v2_3/mrg/msi/InventoryCatalogApi.yml
@@ -13,4 +13,4 @@ content: "The `InventoryCatalogApi` module provides service contracts for defaul
   APIs that 3rd-party developers\ncan use to provide custom inventory catalog functionality.\n\n###
   Public APIs\n\nPublic APIs are defined in the `Api` directory.\n\n### REST endpoints\n\nThe
   `etc/webapi.xml` file defines endpoints for assigning, unassigning, and transferring
-  sources in bulk.\n"
+  sources in bulk."

--- a/src/_data/codebase/v2_3/mrg/msi/InventoryCatalogSearch.yml
+++ b/src/_data/codebase/v2_3/mrg/msi/InventoryCatalogSearch.yml
@@ -4,7 +4,7 @@ source_repo: inventory
 release: 1.1.6
 github_path: InventoryCatalogSearch/README.md
 last_modified_at: '2018-11-09 00:12:40 +0200'
-content: |
+content: |-
   The `InventoryCatalogSearch` module integrates inventory management business logic into Magento's search logic.
 
   This module is part of the new inventory infrastructure. The

--- a/src/_data/codebase/v2_3/mrg/msi/InventoryConfigurableProduct.yml
+++ b/src/_data/codebase/v2_3/mrg/msi/InventoryConfigurableProduct.yml
@@ -4,7 +4,7 @@ source_repo: inventory
 release: 1.1.6
 github_path: InventoryConfigurableProduct/README.md
 last_modified_at: '2018-11-09 00:12:40 +0200'
-content: |
+content: |-
   ## InventoryConfigurableProduct module
 
   The `InventoryConfigurableProduct` module integrates inventory management business logic into Magento's configurable product logic.

--- a/src/_data/codebase/v2_3/mrg/msi/InventoryConfigurableProductAdminUi.yml
+++ b/src/_data/codebase/v2_3/mrg/msi/InventoryConfigurableProductAdminUi.yml
@@ -12,4 +12,4 @@ content: "The `InventoryConfigurableProductAdminUi`extends the Magento Admin UI 
   Management UI\nis provided by a 3rd-party system or if you run a headless version
   of Magento.\n \n## Extensibility\n\nThe `InventoryConfigurableProductAdminUi` module
   contains several extension points.\n\n### UI Components\n\nThe `view/adminhtml/ui_component`
-  directory contains extensible UI components.\n"
+  directory contains extensible UI components."

--- a/src/_data/codebase/v2_3/mrg/msi/InventoryConfigurableProductIndexer.yml
+++ b/src/_data/codebase/v2_3/mrg/msi/InventoryConfigurableProductIndexer.yml
@@ -4,7 +4,7 @@ source_repo: inventory
 release: 1.1.6
 github_path: InventoryConfigurableProductIndexer/README.md
 last_modified_at: '2018-11-09 00:12:40 +0200'
-content: |
+content: |-
   The `InventoryConfigurableProductIndexer` module integrates inventory management business logic into Magento's indexation logic for configurable products.
 
   This module is part of the new inventory infrastructure. The

--- a/src/_data/codebase/v2_3/mrg/msi/InventoryConfiguration.yml
+++ b/src/_data/codebase/v2_3/mrg/msi/InventoryConfiguration.yml
@@ -13,4 +13,4 @@ content: "The `InventoryConfiguration` module implements logic for inventory man
   be deleted or disabled.\n\n## Extension points and service contracts\n\nAll public
   interfaces related to this module are located in the `InventoryConfigurationApi`
   module. \nUse the interfaces defined in `InventoryConfigurationApi` to extend this
-  module.\n"
+  module."

--- a/src/_data/codebase/v2_3/mrg/msi/InventoryConfigurationApi.yml
+++ b/src/_data/codebase/v2_3/mrg/msi/InventoryConfigurationApi.yml
@@ -4,7 +4,7 @@ source_repo: inventory
 release: 1.1.6
 github_path: InventoryConfigurationApi/README.md
 last_modified_at: '2018-11-09 00:12:40 +0200'
-content: |
+content: |-
   The `InventoryConfigurationApi` module provides service contracts for inventory management configuration.
 
   This module is part of the new inventory infrastructure. The

--- a/src/_data/codebase/v2_3/mrg/msi/InventoryDistanceBasedSourceSelection.yml
+++ b/src/_data/codebase/v2_3/mrg/msi/InventoryDistanceBasedSourceSelection.yml
@@ -11,4 +11,4 @@ content: "The `InventoryDistanceBasedSourceSelection` module implements logic fo
   module is installed as part of Magento Open Source.\n\n## Extension points and service
   contracts\n\nAll public interfaces related to this module are located in the `InventoryDistanceBasedSourceSelectionApi`
   module. \nUse the interfaces defined in `InventoryDistanceBasedSourceSelectionApi`
-  to extend this module.\n"
+  to extend this module."

--- a/src/_data/codebase/v2_3/mrg/msi/InventoryDistanceBasedSourceSelectionAdminUi.yml
+++ b/src/_data/codebase/v2_3/mrg/msi/InventoryDistanceBasedSourceSelectionAdminUi.yml
@@ -4,7 +4,7 @@ source_repo: inventory
 release: 1.1.6
 github_path: InventoryDistanceBasedSourceSelectionAdminUi/README.md
 last_modified_at: '2018-12-28 10:54:19 +0100'
-content: |
+content: |-
   The `InventoryDistanceBasedSourceSelectionAdminUi` module extends Magento's admin UI with source selection based on distance functionality.
 
   This module is part of the new inventory infrastructure. The

--- a/src/_data/codebase/v2_3/mrg/msi/InventoryDistanceBasedSourceSelectionApi.yml
+++ b/src/_data/codebase/v2_3/mrg/msi/InventoryDistanceBasedSourceSelectionApi.yml
@@ -12,4 +12,4 @@ content: "The `InventoryDistanceBasedSourceSelectionApi` module provides service
   module contains extension points and APIs that 3rd-party developers\ncan use to
   provide custom distance based source selection algorithms.\n\n### Public APIs\n\nPublic
   APIs are defined in the `Api` and `Api/Data` directories.\n\n### REST endpoints\n\nThe
-  `etc/webapi.xml` file defines endpoints for managing distance based algorithms.\n"
+  `etc/webapi.xml` file defines endpoints for managing distance based algorithms."

--- a/src/_data/codebase/v2_3/mrg/msi/InventoryElasticsearch.yml
+++ b/src/_data/codebase/v2_3/mrg/msi/InventoryElasticsearch.yml
@@ -4,7 +4,7 @@ source_repo: inventory
 release: 1.1.6
 github_path: InventoryElasticsearch/README.md
 last_modified_at: '2018-12-21 16:08:11 +0200'
-content: |
+content: |-
   The `InventoryElasticsearch` module provides elastic search support for Inventory Management.
 
   This module is part of the new inventory infrastructure. The

--- a/src/_data/codebase/v2_3/mrg/msi/InventoryExportStock.yml
+++ b/src/_data/codebase/v2_3/mrg/msi/InventoryExportStock.yml
@@ -4,7 +4,7 @@ source_repo: inventory
 release: 1.1.6
 github_path: InventoryExportStock/README.md
 last_modified_at: '2019-04-23 22:46:43 +0300'
-content: |
+content: |-
   The `InventoryExportStock` module provides aggregated stock export functionality.
 
   This module is part of the new inventory infrastructure. The

--- a/src/_data/codebase/v2_3/mrg/msi/InventoryExportStockApi.yml
+++ b/src/_data/codebase/v2_3/mrg/msi/InventoryExportStockApi.yml
@@ -4,7 +4,7 @@ source_repo: inventory
 release: 1.1.6
 github_path: InventoryExportStockApi/README.md
 last_modified_at: '2019-04-23 22:46:43 +0300'
-content: |
+content: |-
   The `InventoryExportStockApi` module provides provides aggregated stock export functionality api.
 
   This module is part of the new inventory infrastructure. The

--- a/src/_data/codebase/v2_3/mrg/msi/InventoryGraphQl.yml
+++ b/src/_data/codebase/v2_3/mrg/msi/InventoryGraphQl.yml
@@ -4,7 +4,7 @@ source_repo: inventory
 release: 1.1.6
 github_path: InventoryGraphQl/README.md
 last_modified_at: '2019-03-30 16:15:21 +0100'
-content: |
+content: |-
   The `InventoryGraphQl` provides type information for the GraphQl module
                          to generate inventory stock fields for product information endpoints.
 

--- a/src/_data/codebase/v2_3/mrg/msi/InventoryGroupedProduct.yml
+++ b/src/_data/codebase/v2_3/mrg/msi/InventoryGroupedProduct.yml
@@ -10,4 +10,4 @@ content: "The `InventoryGroupedProduct` module integrates inventory management b
   the MSI (Multi-Source Inventory) project in more detail.\n\n## Installation details\n\nThis
   module is installed as part of Magento Open Source. It cannot be deleted or disabled.\n
   \n## Extension points and service contracts\n\nThere are no extension points or
-  service contracts for this module.\n"
+  service contracts for this module."

--- a/src/_data/codebase/v2_3/mrg/msi/InventoryGroupedProductAdminUi.yml
+++ b/src/_data/codebase/v2_3/mrg/msi/InventoryGroupedProductAdminUi.yml
@@ -4,7 +4,7 @@ source_repo: inventory
 release: 1.1.6
 github_path: InventoryGroupedProductAdminUi/README.md
 last_modified_at: '2018-11-09 00:12:40 +0200'
-content: |
+content: |-
   The `InventoryGroupedProductAdminUi` module extends Magento's admin UI with inventory management functionality.
 
   This module is part of the new inventory infrastructure. The

--- a/src/_data/codebase/v2_3/mrg/msi/InventoryGroupedProductIndexer.yml
+++ b/src/_data/codebase/v2_3/mrg/msi/InventoryGroupedProductIndexer.yml
@@ -4,7 +4,7 @@ source_repo: inventory
 release: 1.1.6
 github_path: InventoryGroupedProductIndexer/README.md
 last_modified_at: '2018-11-09 00:12:40 +0200'
-content: |
+content: |-
   The `InventoryGroupedProductIndexer` module integrates inventory management business logic into Magento's indexation logic for grouped products.
 
   This module is part of the new inventory infrastructure. The

--- a/src/_data/codebase/v2_3/mrg/msi/InventoryImportExport.yml
+++ b/src/_data/codebase/v2_3/mrg/msi/InventoryImportExport.yml
@@ -11,4 +11,4 @@ content: "The `InventoryImportExport` module provides compatibility between Mage
   module is installed as part of Magento Open Source. It cannot be deleted or disabled.\n\n##
   Extension points and service contracts\n\nThere are no extension points or service
   contracts for this module.\n\n## Additional information\n\nThe `files/sample/stock_sources.csv`
-  file is a template for importing inventory into the system.\n"
+  file is a template for importing inventory into the system."

--- a/src/_data/codebase/v2_3/mrg/msi/InventoryIndexer.yml
+++ b/src/_data/codebase/v2_3/mrg/msi/InventoryIndexer.yml
@@ -4,7 +4,7 @@ source_repo: inventory
 release: 1.1.6
 github_path: InventoryIndexer/README.md
 last_modified_at: '2018-11-09 00:12:40 +0200'
-content: |
+content: |-
   The `InventoryIndexer` module provides indexation logic for Inventory Management.
 
   This module is part of the new inventory infrastructure. The

--- a/src/_data/codebase/v2_3/mrg/msi/InventoryLowQuantityNotification.yml
+++ b/src/_data/codebase/v2_3/mrg/msi/InventoryLowQuantityNotification.yml
@@ -13,4 +13,4 @@ content: "The `InventoryLowQuantityNotification` module integrates Inventory Man
   module cannot be deleted or disabled.\n\n## Extension points and service contracts\n\nAll
   public interfaces related to this module are located in the `InventoryLowQuantityNotificationApi`
   module. \nUse the interfaces defined in `InventoryLowQuantityNotificationApi` to
-  extend this module.\n"
+  extend this module."

--- a/src/_data/codebase/v2_3/mrg/msi/InventoryLowQuantityNotificationAdminUi.yml
+++ b/src/_data/codebase/v2_3/mrg/msi/InventoryLowQuantityNotificationAdminUi.yml
@@ -4,7 +4,7 @@ source_repo: inventory
 release: 1.1.6
 github_path: InventoryLowQuantityNotificationAdminUi/README.md
 last_modified_at: '2018-11-09 00:12:40 +0200'
-content: |
+content: |-
   The `InventoryLowQuantityNotificationAdminUi` module extends Magento's admin UI with inventory management functionality.
 
   This module is part of the new inventory infrastructure. The

--- a/src/_data/codebase/v2_3/mrg/msi/InventoryLowQuantityNotificationApi.yml
+++ b/src/_data/codebase/v2_3/mrg/msi/InventoryLowQuantityNotificationApi.yml
@@ -13,4 +13,4 @@ content: "The `InventoryLowQuantityNotificationApi` module provides service cont
   points and APIs that 3rd-party developers\ncan use to provide custom low quantity
   notification functionality.\n\n### Public APIs\n\nPublic APIs are defined in the
   `Api` and `Api/Data` directories.\n\n### REST endpoints\n\nThe `etc/webapi.xml`
-  file defines endpoints for managing low quantity notifications.\n"
+  file defines endpoints for managing low quantity notifications."

--- a/src/_data/codebase/v2_3/mrg/msi/InventoryMultiDimensionalIndexerApi.yml
+++ b/src/_data/codebase/v2_3/mrg/msi/InventoryMultiDimensionalIndexerApi.yml
@@ -15,4 +15,4 @@ content: "The `InventoryMultiDimensionalIndexerApi` module  provides functionali
   for resolving \nindex names based on the provided scope. The multi-dimension indexes
   are introduced for the sake of data scalability\nand the ability to reindex data
   in the scope of particular dimension only.\n\nAn aliasing mechanism guarantees zero
-  downtime to make Front-End responsive while Full Reindex being processed.\n"
+  downtime to make Front-End responsive while Full Reindex being processed."

--- a/src/_data/codebase/v2_3/mrg/msi/InventoryProductAlert.yml
+++ b/src/_data/codebase/v2_3/mrg/msi/InventoryProductAlert.yml
@@ -4,7 +4,7 @@ source_repo: inventory
 release: 1.1.6
 github_path: InventoryProductAlert/README.md
 last_modified_at: '2018-11-09 00:12:40 +0200'
-content: |+
+content: |-
   The `InventoryProductAlert` module integrates Inventory Management business logic into Magento's product alert logic.
 
   This module is part of the new inventory infrastructure. The
@@ -18,4 +18,3 @@ content: |+
   ## Extension points and service contracts
 
   There are no extension points or service contracts for this module.
-

--- a/src/_data/codebase/v2_3/mrg/msi/InventoryReservationCli.yml
+++ b/src/_data/codebase/v2_3/mrg/msi/InventoryReservationCli.yml
@@ -4,7 +4,7 @@ source_repo: inventory
 release: 1.1.6
 github_path: InventoryReservationCli/README.md
 last_modified_at: '2019-04-10 12:11:17 +0200'
-content: |
+content: |-
   The `InventoryReservationCli` module provide a cli command which helps the developer to discover inconsistencies on reservation.
 
   This module is part of the new inventory infrastructure. The

--- a/src/_data/codebase/v2_3/mrg/msi/InventoryReservations.yml
+++ b/src/_data/codebase/v2_3/mrg/msi/InventoryReservations.yml
@@ -13,4 +13,4 @@ content: "The `InventoryReservations` module provides logic for handling product
   interfaces related to this module are located in the `InventoryReservationsApi`
   module. \nUse the interfaces defined in `InventoryReservationsApi` to extend this
   module.\n\n## Additional information\n\nThe `InventoryReservations` module creates
-  the `inventory_cleanup_reservations` cron job.\n"
+  the `inventory_cleanup_reservations` cron job."

--- a/src/_data/codebase/v2_3/mrg/msi/InventoryReservationsApi.yml
+++ b/src/_data/codebase/v2_3/mrg/msi/InventoryReservationsApi.yml
@@ -4,7 +4,7 @@ source_repo: inventory
 release: 1.1.6
 github_path: InventoryReservationsApi/README.md
 last_modified_at: '2018-11-09 00:12:40 +0200'
-content: |
+content: |-
   The `InventoryReservationsApi` module provides service contracts for Inventory Management reservations.
 
   This module is part of the new inventory infrastructure. The

--- a/src/_data/codebase/v2_3/mrg/msi/InventorySales.yml
+++ b/src/_data/codebase/v2_3/mrg/msi/InventorySales.yml
@@ -12,4 +12,4 @@ content: "The `InventorySales` module integrates Inventory Management business l
   for `InventorySalesApi`\nis provided by a 3rd-party module, the module cannot be
   deleted or disabled.\n\n## Extension points and service contracts\n\nAll public
   interfaces related to this module are located in the `InventorySalesApi` module.
-  \nUse the interfaces defined in `InventorySalesApi` to extend this module.\n"
+  \nUse the interfaces defined in `InventorySalesApi` to extend this module."

--- a/src/_data/codebase/v2_3/mrg/msi/InventorySalesAdminUi.yml
+++ b/src/_data/codebase/v2_3/mrg/msi/InventorySalesAdminUi.yml
@@ -13,4 +13,4 @@ content: "The `InventorySalesAdminUi` module extends Magento's Admin UI with Inv
   of Magento.\n\n## Extensibility\n\nThe `InventorySalesAdminUi` module contains several
   extension points.\n\n### Layouts\n\nYou can extend and override layouts defined
   in the `view/adminhtml/layout`  directory.\n\n### UI Components\n\nThe `view/adminhtml/ui_component`
-  directory contains extensible UI components.\n"
+  directory contains extensible UI components."

--- a/src/_data/codebase/v2_3/mrg/msi/InventorySalesApi.yml
+++ b/src/_data/codebase/v2_3/mrg/msi/InventorySalesApi.yml
@@ -13,4 +13,4 @@ content: "The `InventorySalesApi` module provides service contracts for inventor
   that 3rd-party developers\ncan use to provide custom inventory catalog functionality.\n\n###
   Public APIs\n\nPublic APIs are defined in the `Api` and `Api/Data` directories.\n\n###
   REST endpoints\n\nThe `etc/webapi.xml` file defines endpoints for determining whether
-  a salable amount of products are available for purchase.\n"
+  a salable amount of products are available for purchase."

--- a/src/_data/codebase/v2_3/mrg/msi/InventorySalesFrontendUi.yml
+++ b/src/_data/codebase/v2_3/mrg/msi/InventorySalesFrontendUi.yml
@@ -10,4 +10,4 @@ content: "The `InventorySalesFrontendUi` module extends Magento's frontend UI wi
   the MSI (Multi-Source Inventory) project in more detail.\n\n## Installation details\n\nThis
   module is installed as part of Magento Open Source. You can remove it if you run
   a headless version of Magento.\n\n## Extension points and service contracts\n\nThere
-  are no extension points or service contracts for this module.\n"
+  are no extension points or service contracts for this module."

--- a/src/_data/codebase/v2_3/mrg/msi/InventorySetupFixtureGenerator.yml
+++ b/src/_data/codebase/v2_3/mrg/msi/InventorySetupFixtureGenerator.yml
@@ -10,4 +10,4 @@ content: "The `InventorySetupFixtureGenerator` module customizes the process of 
   the MSI (Multi-Source Inventory) project in more detail.\n\n## Installation details\n\nThis
   module is installed as part of Magento Open Source. Unless a custom implementation
   \nfor Inventory Data generation is provided by a 3rd-party module, the module cannot
-  be deleted or disabled.\n"
+  be deleted or disabled."

--- a/src/_data/codebase/v2_3/mrg/msi/InventoryShippingAdminUi.yml
+++ b/src/_data/codebase/v2_3/mrg/msi/InventoryShippingAdminUi.yml
@@ -4,7 +4,7 @@ source_repo: inventory
 release: 1.1.6
 github_path: InventoryShippingAdminUi/README.md
 last_modified_at: '2018-11-09 00:12:40 +0200'
-content: |
+content: |-
   The `InventoryShippingAdminUi` module extends Magento's Admin UI with Inventory Management functionality.
 
   This module is part of the new inventory infrastructure. The

--- a/src/_data/codebase/v2_3/mrg/msi/InventorySourceDeductionApi.yml
+++ b/src/_data/codebase/v2_3/mrg/msi/InventorySourceDeductionApi.yml
@@ -8,4 +8,4 @@ content: "The `InventorySourceDeductionApi` module provides service contracts fo
   managing source deductuions when products are sold. \n\nThis module is part of the
   new inventory infrastructure. The\n[Inventory Management overview](https://devdocs.magento.com/guides/v2.3/inventory/index.html)\ndescribes
   the MSI (Multi-Source Inventory) project in more detail.\n\n## Installation details\n\nThis
-  module is installed as part of Magento Open Source. It cannot be deleted or disabled.\n"
+  module is installed as part of Magento Open Source. It cannot be deleted or disabled."

--- a/src/_data/codebase/v2_3/mrg/msi/InventorySourceSelection.yml
+++ b/src/_data/codebase/v2_3/mrg/msi/InventorySourceSelection.yml
@@ -13,4 +13,4 @@ content: "The `InventorySourceSelection` module provides source selection logic 
   cannot be deleted or disabled.\n\n## Extension points and service contracts\n\nAll
   public interfaces related to this module are located in the `InventorySourceSelectionApi`
   module. \nUse the interfaces defined in `InventorySourceSelectionApi` to extend
-  this module.\n"
+  this module."

--- a/src/_data/codebase/v2_3/mrg/msi/InventorySourceSelectionApi.yml
+++ b/src/_data/codebase/v2_3/mrg/msi/InventorySourceSelectionApi.yml
@@ -4,7 +4,7 @@ source_repo: inventory
 release: 1.1.6
 github_path: InventorySourceSelectionApi/README.md
 last_modified_at: '2018-11-09 00:12:40 +0200'
-content: |
+content: |-
   The `InventorySourceSelectionApi` module provides service contracts for source selection algorithms (SSA).
 
   This module is part of the new inventory infrastructure. The

--- a/src/_data/codebase/v2_3/mrg/page-builder/CatalogPageBuilderAnalytics.yml
+++ b/src/_data/codebase/v2_3/mrg/page-builder/CatalogPageBuilderAnalytics.yml
@@ -1,0 +1,9 @@
+---
+title: Magento_CatalogPageBuilderAnalytics
+source_repo: magento2-page-builder
+release: v1.3.3
+github_path: app/code/Magento/CatalogPageBuilderAnalytics/README.md
+last_modified_at: '2019-03-05 18:34:09 +0100'
+content: The Magento_CatalogPageBuilderAnalytics module configures data definitions
+  for a data collection related to the PageBuilder module entities to be used in [Advanced
+  Reporting](http://devdocs.magento.com/guides/v2.2/advanced-reporting/modules.html).

--- a/src/_data/codebase/v2_3/mrg/page-builder/CmsPageBuilderAnalytics.yml
+++ b/src/_data/codebase/v2_3/mrg/page-builder/CmsPageBuilderAnalytics.yml
@@ -1,0 +1,9 @@
+---
+title: Magento_CmsPageBuilderAnalytics
+source_repo: magento2-page-builder
+release: v1.3.3
+github_path: app/code/Magento/CmsPageBuilderAnalytics/README.md
+last_modified_at: '2019-03-05 18:34:09 +0100'
+content: The Magento_CmsPageBuilderAnalytics module configures data definitions for
+  a data collection related to the PageBuilder module entities to be used in [Advanced
+  Reporting](http://devdocs.magento.com/guides/v2.2/advanced-reporting/modules.html).

--- a/src/_data/codebase/v2_3/mrg/page-builder/PageBuilder.yml
+++ b/src/_data/codebase/v2_3/mrg/page-builder/PageBuilder.yml
@@ -1,0 +1,55 @@
+---
+title: Magento_PageBuilder
+source_repo: magento2-page-builder
+release: v1.3.3
+github_path: app/code/Magento/PageBuilder/README.md
+last_modified_at: '2018-02-20 21:19:48 -0600'
+content: |-
+  The Magento_PageBuilder module provides an enhancement for the default Magento WYSIWYG editor. It installs an alternative editor in the Admin area for building content.
+
+  The PageBuilder editor can be used on the following content pages:
+
+  * Category Pages
+  * CMS Pages
+  * CMS Blocks
+  * Dynamic Blocks
+
+  ## Enable the module
+
+  The PageBuilder module and the editor is enabled by default after installation.
+
+  The editor itself is enabled globally in the Admin area under *Stores > Configuration > Content Management > Advanced Content Tool > Enable Page Builder*.
+  This setting determines the `is_pagebuilder_enabled` configuration value.
+
+  ## Disable the module
+
+  You can disable the PageBuilder module for a specific field by adding the following entry to a field configuration in an XML configuration file:
+
+  ```
+  <item name="wysiwygConfigData" xsi:type="array">
+      <item name="is_pagebuilder_enabled" xsi:type="boolean">false</item>
+  </item>
+  ```
+
+  ### Example
+
+  The following example disables the PageBuilder editor for the content field.
+
+  ```
+  <form xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="urn:magento:module:Magento_Ui:etc/ui_configuration.xsd">
+      <fieldset name="content" sortOrder="10">
+          <field name="content" formElement="wysiwyg">
+              <argument name="data" xsi:type="array">
+                  <item name="config" xsi:type="array">
+                      <item name="source" xsi:type="string">page</item>
+                      <item name="wysiwygConfigData" xsi:type="array">
+                          <item name="is_pagebuilder_enabled" xsi:type="boolean">false</item>
+                      </item>
+                  </item>
+              </argument>
+          </field>
+      </fieldset>
+  </form>
+  ```
+
+  **Note:** Disabling the editor this way overrides the value of `is_pagebuilder_enabled` for the specified field.

--- a/src/_data/codebase/v2_3/mrg/page-builder/PageBuilderAnalytics.yml
+++ b/src/_data/codebase/v2_3/mrg/page-builder/PageBuilderAnalytics.yml
@@ -1,0 +1,9 @@
+---
+title: Magento_PageBuilderAnalytics
+source_repo: magento2-page-builder
+release: v1.3.3
+github_path: app/code/Magento/PageBuilderAnalytics/README.md
+last_modified_at: '2018-07-26 15:13:54 +0300'
+content: The Magento_PageBuilderAnalytics module configures data definitions for a
+  data collection related to the PageBuilder module entities to be used in [Advanced
+  Reporting](http://devdocs.magento.com/guides/v2.2/advanced-reporting/modules.html).

--- a/src/_data/codebase/v2_4/mrg/b2b/BundleNegotiableQuote.yml
+++ b/src/_data/codebase/v2_4/mrg/b2b/BundleNegotiableQuote.yml
@@ -20,4 +20,4 @@ content: "## Overview\n\nThe Magento_BundleNegotiableQuote module enables bundle
   \n[The Magento dependency injection mechanism](http://devdocs.magento.com/guides/v2.2/extension-dev-guide/depend-inj.html)
   enables you to override the functionality of the Magento_BundleNegotiableQuote module.\n\n##
   Additional information\n \nYou can track [backward incompatible changes made in
-  a Magento B2b mainline after the Magento 2.2 release](http://devdocs.magento.com/guides/v2.2/release-notes/changes/b2b_changes.html).\n"
+  a Magento B2b mainline after the Magento 2.2 release](http://devdocs.magento.com/guides/v2.2/release-notes/changes/b2b_changes.html)."

--- a/src/_data/codebase/v2_4/mrg/b2b/BundleRequisitionList.yml
+++ b/src/_data/codebase/v2_4/mrg/b2b/BundleRequisitionList.yml
@@ -17,4 +17,4 @@ content: "## Overview\n\nThe Magento_BundleRequisitionList module enables bundle
   \n### Layouts\n \nYou can extend and override layouts in the `Magento\\BundleRequisitionList\\view\\frontend\\layout`
   directories.\n\nFor more information about layouts, see the [Layout documentation](http://devdocs.magento.com/guides/v2.2/frontend-dev-guide/layouts/layout-overview.html).\n\n##
   Additional information\n \nYou can track [backward incompatible changes made in
-  a Magento B2b mainline after the Magento 2.2 release](http://devdocs.magento.com/guides/v2.2/release-notes/changes/b2b_changes.html).\n"
+  a Magento B2b mainline after the Magento 2.2 release](http://devdocs.magento.com/guides/v2.2/release-notes/changes/b2b_changes.html)."

--- a/src/_data/codebase/v2_4/mrg/b2b/CheckoutAddressSearchNegotiableQuote.yml
+++ b/src/_data/codebase/v2_4/mrg/b2b/CheckoutAddressSearchNegotiableQuote.yml
@@ -4,7 +4,7 @@ source_repo: magento2b2b
 release: 1.3.0
 github_path: app/code/Magento/CheckoutAddressSearchNegotiableQuote/README.md
 last_modified_at: '2019-04-10 17:47:51 -0500'
-content: |
+content: |-
   ## CheckoutAddressSearchNegotiableQuote module Overview
 
   CheckoutAddressSearchNegotiableQuote module extends Magento_CheckoutAddressSearch if it is enabled in configuration and it modifies NegotiableQuote shipping address on checkout.

--- a/src/_data/codebase/v2_4/mrg/b2b/CheckoutAgreementsNegotiableQuote.yml
+++ b/src/_data/codebase/v2_4/mrg/b2b/CheckoutAgreementsNegotiableQuote.yml
@@ -4,7 +4,7 @@ source_repo: magento2b2b
 release: 1.3.0
 github_path: app/code/Magento/CheckoutAgreementsNegotiableQuote/README.md
 last_modified_at: '2019-08-16 15:20:08 -0500'
-content: |
+content: |-
   ## CheckoutAgreementsNegotiableQuote module Overview
 
   CheckoutAgreementsNegotiableQuote module extends CheckoutAgreements if it is enabled in configuration and it adds agreements to payment data on checkout with negotiable quote.

--- a/src/_data/codebase/v2_4/mrg/b2b/CompanyCredit.yml
+++ b/src/_data/codebase/v2_4/mrg/b2b/CompanyCredit.yml
@@ -33,4 +33,4 @@ content: "## Overview\n\nThe Magento_CompanyCredit module adds the \"Payment on 
   - balance history listing\n\nFor more information, see [UI Listing/Grid Component](http://devdocs.magento.com/guides/v2.2/ui-components/ui-listing-grid.html)
   and [UI Form Component](http://devdocs.magento.com/guides/v2.2/ui_comp_guide/components/ui-form.html)\n\n##
   Additional information\n \nYou can track [backward incompatible changes made in
-  a Magento B2b mainline after the Magento 2.2 release](http://devdocs.magento.com/guides/v2.2/release-notes/changes/b2b_changes.html).\n"
+  a Magento B2b mainline after the Magento 2.2 release](http://devdocs.magento.com/guides/v2.2/release-notes/changes/b2b_changes.html)."

--- a/src/_data/codebase/v2_4/mrg/b2b/CompanyShipping.yml
+++ b/src/_data/codebase/v2_4/mrg/b2b/CompanyShipping.yml
@@ -25,4 +25,4 @@ content: "## Overview\n\nThe Magento_CompanyShipping module allows a merchant to
   or \"company shipping methods\"? -->\n\n* `Magento\\CompanyShipping\\view\\frontend\\ui_component`
   - company form\n\nFor more information, see [UI Form Component](http://devdocs.magento.com/guides/v2.4/ui_comp_guide/components/ui-form.html).\n\n##
   Additional information\n \nYou can track [backward incompatible changes made in
-  a Magento B2b mainline after the Magento 2.2 release](http://devdocs.magento.com/guides/v2.4/release-notes/changes/b2b_changes.html).\n"
+  a Magento B2b mainline after the Magento 2.2 release](http://devdocs.magento.com/guides/v2.4/release-notes/changes/b2b_changes.html)."

--- a/src/_data/codebase/v2_4/mrg/b2b/ConfigurableNegotiableQuote.yml
+++ b/src/_data/codebase/v2_4/mrg/b2b/ConfigurableNegotiableQuote.yml
@@ -20,4 +20,4 @@ content: "## Overview\n\nThe Magento_ConfigurableNegotiableQuote module enables 
   \n[The Magento dependency injection mechanism](http://devdocs.magento.com/guides/v2.2/extension-dev-guide/depend-inj.html)
   enables you to override the functionality of the Magento_ConfigurableNegotiableQuote
   module.\n\n## Additional information\n \nYou can track [backward incompatible changes
-  made in a Magento B2b mainline after the Magento 2.2 release](http://devdocs.magento.com/guides/v2.2/release-notes/changes/b2b_changes.html).\n"
+  made in a Magento B2b mainline after the Magento 2.2 release](http://devdocs.magento.com/guides/v2.2/release-notes/changes/b2b_changes.html)."

--- a/src/_data/codebase/v2_4/mrg/b2b/ConfigurableRequisitionList.yml
+++ b/src/_data/codebase/v2_4/mrg/b2b/ConfigurableRequisitionList.yml
@@ -17,4 +17,4 @@ content: "## Overview\n\nThe Magento_ConfigurableRequisitionList module enables 
   Layouts\n \nYou can extend and override layouts in the `Magento\\ConfigurableRequisitionList\\view\\frontend\\layout`
   directories.\n\nFor more information about layouts, see the [Layout documentation](http://devdocs.magento.com/guides/v2.2/frontend-dev-guide/layouts/layout-overview.html).\n\n##
   Additional information\n \nYou can track [backward incompatible changes made in
-  a Magento B2b mainline after the Magento 2.2 release](http://devdocs.magento.com/guides/v2.2/release-notes/changes/b2b_changes.html).\n"
+  a Magento B2b mainline after the Magento 2.2 release](http://devdocs.magento.com/guides/v2.2/release-notes/changes/b2b_changes.html)."

--- a/src/_data/codebase/v2_4/mrg/b2b/GiftCardNegotiableQuote.yml
+++ b/src/_data/codebase/v2_4/mrg/b2b/GiftCardNegotiableQuote.yml
@@ -4,7 +4,7 @@ source_repo: magento2b2b
 release: 1.3.0
 github_path: app/code/Magento/GiftCardNegotiableQuote/README.md
 last_modified_at: '2017-04-10 10:33:01 +0300'
-content: |
+content: |-
   ## Overview
 
   The Magento_GiftCardNegotiableQuote module enables gift cards to be displayed in a negotiable quote in an B2B environment. This module extends Magento_NegotiableQuote and Magento_GiftCard modules.

--- a/src/_data/codebase/v2_4/mrg/b2b/GiftCardRequisitionList.yml
+++ b/src/_data/codebase/v2_4/mrg/b2b/GiftCardRequisitionList.yml
@@ -15,4 +15,4 @@ content: "## Overview\n\nThe Magento_GiftCardRequisitionList module enables gift
   at any time.\n\n## Structure\n\n[Learn about a typical file structure for a Magento
   2 module](http://devdocs.magento.com/guides/v2.2/extension-dev-guide/build/module-file-structure.html).\n\n##
   Additional information\n\nYou can track [backward incompatible changes made in a
-  Magento B2b mainline after the Magento 2.2 release](http://devdocs.magento.com/guides/v2.2/release-notes/changes/b2b_changes.html).\n"
+  Magento B2b mainline after the Magento 2.2 release](http://devdocs.magento.com/guides/v2.2/release-notes/changes/b2b_changes.html)."

--- a/src/_data/codebase/v2_4/mrg/b2b/GiftCardSharedCatalog.yml
+++ b/src/_data/codebase/v2_4/mrg/b2b/GiftCardSharedCatalog.yml
@@ -27,4 +27,4 @@ content: "## Overview\n\nThe Magento_GiftCardSharedCatalog module enables gift c
   `Magento\\GiftCardSharedCatalog\\view\\adminhtml\\ui_component` - renderer for pricing
   and structure listings\n\nFor more information, see [UI Listing/Grid Component](http://devdocs.magento.com/guides/v2.2/ui-components/ui-listing-grid.html).\n\n##
   Additional information\n\nYou can track [backward incompatible changes made in a
-  Magento B2b mainline after the Magento 2.2 release](http://devdocs.magento.com/guides/v2.2/release-notes/changes/b2b_changes.html).\n"
+  Magento B2b mainline after the Magento 2.2 release](http://devdocs.magento.com/guides/v2.2/release-notes/changes/b2b_changes.html)."

--- a/src/_data/codebase/v2_4/mrg/b2b/GroupedRequisitionList.yml
+++ b/src/_data/codebase/v2_4/mrg/b2b/GroupedRequisitionList.yml
@@ -23,4 +23,4 @@ content: "## Overview\n\nThe Magento_GroupedRequisitionList module enables group
   module.\n\n### Layouts\n \nYou can extend and override layouts in the `Magento\\GroupedRequistionList\\view\\frontend\\layout`
   directories.\n\nFor more information about layouts, see the [Layout documentation](http://devdocs.magento.com/guides/v2.2/frontend-dev-guide/layouts/layout-overview.html).\n\n##
   Additional information\n \nYou can track [backward incompatible changes made in
-  a Magento B2b mainline after the Magento 2.2 release](http://devdocs.magento.com/guides/v2.2/release-notes/changes/b2b_changes.html).\n"
+  a Magento B2b mainline after the Magento 2.2 release](http://devdocs.magento.com/guides/v2.2/release-notes/changes/b2b_changes.html)."

--- a/src/_data/codebase/v2_4/mrg/b2b/NegotiableQuoteWeee.yml
+++ b/src/_data/codebase/v2_4/mrg/b2b/NegotiableQuoteWeee.yml
@@ -4,7 +4,7 @@ source_repo: magento2b2b
 release: 1.3.0
 github_path: app/code/Magento/NegotiableQuoteWeee/README.md
 last_modified_at: '2020-02-13 12:57:22 +0200'
-content: |
+content: |-
   ## NegotiableQuoteWeee module Overview
 
   NegotiableQuoteWeee module extends Weee if it is enabled in configuration and it adds fpt attributes to negotiable quote.

--- a/src/_data/codebase/v2_4/mrg/b2b/PurchaseOrder.yml
+++ b/src/_data/codebase/v2_4/mrg/b2b/PurchaseOrder.yml
@@ -4,18 +4,18 @@ source_repo: magento2b2b
 release: 1.3.0
 github_path: app/code/Magento/PurchaseOrder/README.md
 last_modified_at: '2020-05-13 11:51:49 -0500'
-content: "\n​\n## Overview\n​\nThe PurchaseOrder module contains functionality for
-  creating purchase orders in a B2B environment. When enabled, all orders created
-  within the company will be created as purchase orders.  This allows B2B users to
-  enforce purchasing rules and worflows within a Magento store.\n​\n## Installation
-  details\n​\nThe PurchaseOrder module has dependencies on the following modules:\n​\n-
-  \ Module_Authorization\n-  Module_Catalog\n-  Module_Checkout\n-  Module_Company\n-
-  \ Module_Customer\n-  Module_Directory\n-  Module_Msrp \n-  Module_Negotiable_Quote\n-
-  \ Module_Payment\n-  Module_Quote\n-  Module_Sales\n-  Module_Sales_Sequence\n-
-  \ Module_Store\n-  Module_Tax\n-  Module_Theme\n-  Module_Ui\n\n​\nwhich must be
-  installed and enabled first. This module does not create any backward incompatible
-  changes. It can be uninstalled or deactivated at any time.\n​\n## Structure\n​\n[Learn
-  about a typical file structure for a Magento 2 module](http://devdocs.magento.com/guides/v2.4/extension-dev-guide/build/module-file-structure.html).\n​\n##
+content: "​\n## Overview\n​\nThe PurchaseOrder module contains functionality for creating
+  purchase orders in a B2B environment. When enabled, all orders created within the
+  company will be created as purchase orders.  This allows B2B users to enforce purchasing
+  rules and worflows within a Magento store.\n​\n## Installation details\n​\nThe PurchaseOrder
+  module has dependencies on the following modules:\n​\n-  Module_Authorization\n-
+  \ Module_Catalog\n-  Module_Checkout\n-  Module_Company\n-  Module_Customer\n-  Module_Directory\n-
+  \ Module_Msrp \n-  Module_Negotiable_Quote\n-  Module_Payment\n-  Module_Quote\n-
+  \ Module_Sales\n-  Module_Sales_Sequence\n-  Module_Store\n-  Module_Tax\n-  Module_Theme\n-
+  \ Module_Ui\n\n​\nwhich must be installed and enabled first. This module does not
+  create any backward incompatible changes. It can be uninstalled or deactivated at
+  any time.\n​\n## Structure\n​\n[Learn about a typical file structure for a Magento
+  2 module](http://devdocs.magento.com/guides/v2.4/extension-dev-guide/build/module-file-structure.html).\n​\n##
   Extensibility\n​​Extension developers can interact with the Magento_PurchaseOrder
   module. For more information about the Magento extension mechanism, see [Magento
   plug-ins](https://devdocs.magento.com/guides/v2.4/extension-dev-guide/plugins.html).\n
@@ -27,4 +27,4 @@ content: "\n​\n## Overview\n​\nThe PurchaseOrder module contains functionali
   UI components\n​\nYou can extend the purchase order listings using the `company_purchaseorder_listing.xml`
   and `my_purchaseorder_listing.xml` configuration files.\n\n## Additional information\n​\nCheck
   the [B2B release notes](https://devdocs.magento.com/guides/v2.4/release-notes/b2b-release-notes.html)
-  for more information on new changes.\n"
+  for more information on new changes."

--- a/src/_data/codebase/v2_4/mrg/b2b/PurchaseOrderRule.yml
+++ b/src/_data/codebase/v2_4/mrg/b2b/PurchaseOrderRule.yml
@@ -28,4 +28,4 @@ content: "​\n## Overview\n​\nThe PurchaseOrderRule module contains functiona
   UI components\n​\nYou can extend the purchase order rule listings using the `purchase_order_rule_listing.xml`
   and `require_my_approval_purchaseorder_listing.xml` configuration files.\n \n##
   Additional information\n​\nCheck the [B2B release notes](https://devdocs.magento.com/guides/v2.4/release-notes/b2b-release-notes.html)
-  for more information on new changes.\n"
+  for more information on new changes."

--- a/src/_data/codebase/v2_4/mrg/b2b/RequisitionList.yml
+++ b/src/_data/codebase/v2_4/mrg/b2b/RequisitionList.yml
@@ -7,7 +7,7 @@ last_modified_at: '2017-02-15 17:02:23 +0300'
 content: "## Overview\n\nThe Magento_RequisitionList module allows a customer to create
   multiple lists of frequently-purchased items and use those lists for order placement.
   This feature is available for both logged-in users and guests.\n \nRequisitionList
-  functionality is similar to wish lists, but it has the following differences: \n\n*
+  functionality is similiar to wish lists, but it has the following differences: \n\n*
   A requisition list is not purged after sending items to the shopping cart. It can
   be used to place multiple orders.\n\n* The UI for requisition lists has been modified
   to a compact view in order to display large number of items. \n\nThe merchant can

--- a/src/_data/codebase/v2_4/mrg/b2b/SharedCatalog.yml
+++ b/src/_data/codebase/v2_4/mrg/b2b/SharedCatalog.yml
@@ -42,4 +42,4 @@ content: "## Overview\n\nThe Magento_SharedCatalog modules defines the visibilit
   more information, see [UI Listing/Grid Component](http://devdocs.magento.com/guides/v2.2/ui-components/ui-listing-grid.html)
   and [UI Form Component](http://devdocs.magento.com/guides/v2.2/ui_comp_guide/components/ui-form.html).\n\n##
   Additional information\n \nYou can track [backward incompatible changes made in
-  a Magento B2b mainline after the Magento 2.2 release](http://devdocs.magento.com/guides/v2.2/release-notes/changes/b2b_changes.html).\n"
+  a Magento B2b mainline after the Magento 2.2 release](http://devdocs.magento.com/guides/v2.2/release-notes/changes/b2b_changes.html)."

--- a/src/_data/codebase/v2_4/mrg/ce/AdminNotification.yml
+++ b/src/_data/codebase/v2_4/mrg/ce/AdminNotification.yml
@@ -4,7 +4,7 @@ source_repo: magento2ce
 release: 2.4.1
 github_path: app/code/Magento/AdminNotification/README.md
 last_modified_at: '2019-08-19 00:16:18 +0100'
-content: |
+content: |-
   The Magento_AdminNotification module provides the ability to alert administrators via system messages and provides a message inbox for surveys and notifications.
 
   ## Installation details

--- a/src/_data/codebase/v2_4/mrg/ce/AmqpStore.yml
+++ b/src/_data/codebase/v2_4/mrg/ce/AmqpStore.yml
@@ -4,7 +4,7 @@ source_repo: magento2ce
 release: 2.4.1
 github_path: app/code/Magento/AmqpStore/README.md
 last_modified_at: '2019-08-27 01:59:34 +0100'
-content: |
+content: |-
   The Magento_AmqpStore module provides the ability to specify a store before publishing messages with the Advanced Message Queuing Protocol (AMQP).
 
   ## Extensibility

--- a/src/_data/codebase/v2_4/mrg/ce/Analytics.yml
+++ b/src/_data/codebase/v2_4/mrg/ce/Analytics.yml
@@ -4,7 +4,7 @@ source_repo: magento2ce
 release: 2.4.1
 github_path: app/code/Magento/Analytics/README.md
 last_modified_at: '2019-09-15 22:49:37 +0100'
-content: |
+content: |-
   The Magento_Analytics module integrates your Magento instance with the [Magento Business Intelligence (MBI)](https://magento.com/products/business-intelligence) to use [Advanced Reporting](https://devdocs.magento.com/guides/v2.3/advanced-reporting/modules.html) functionality.
 
   The module implements the following functionality:

--- a/src/_data/codebase/v2_4/mrg/ce/AsynchronousOperations.yml
+++ b/src/_data/codebase/v2_4/mrg/ce/AsynchronousOperations.yml
@@ -25,4 +25,4 @@ content: "This component is designed to provide a response for a client that lau
   `bulk_details_form`\n- `bulk_details_form_modal`\n- `bulk_listing`\n- `failed_operation_listing`\n-
   `failed_operation_modal_listing`\n- `notification_area`\n- `retriable_operation_listing`\n-
   `retriable_operation_modal_listing`\n\nFor information about UI components in Magento
-  2, see [Overview of UI components](https://devdocs.magento.com/guides/v2.3/ui_comp_guide/bk-ui_comps.html).\n"
+  2, see [Overview of UI components](https://devdocs.magento.com/guides/v2.3/ui_comp_guide/bk-ui_comps.html)."

--- a/src/_data/codebase/v2_4/mrg/ce/Authorization.yml
+++ b/src/_data/codebase/v2_4/mrg/ce/Authorization.yml
@@ -4,7 +4,7 @@ source_repo: magento2ce
 release: 2.4.1
 github_path: app/code/Magento/Authorization/README.md
 last_modified_at: '2019-08-25 07:43:56 +0100'
-content: |
+content: |-
   The Magento_Authorization module enables management of access control list roles and rules in the application.
 
   ## Installation details

--- a/src/_data/codebase/v2_4/mrg/ce/Backend.yml
+++ b/src/_data/codebase/v2_4/mrg/ce/Backend.yml
@@ -4,7 +4,7 @@ source_repo: magento2ce
 release: 2.4.1
 github_path: app/code/Magento/Backend/README.md
 last_modified_at: '2020-03-26 15:07:34 +0200'
-content: |
+content: |-
   The Magento_Backend module contains common infrastructure and assets for other modules to be defined and used in their
   administration user interface (UI).
 

--- a/src/_data/codebase/v2_4/mrg/ce/Backup.yml
+++ b/src/_data/codebase/v2_4/mrg/ce/Backup.yml
@@ -16,4 +16,4 @@ content: "The Magento_Backup module allows administrators to perform backups and
   directory:   \n\n`backup_index_block`\n`backup_index_disabled`\n`backup_index_grid`\n`backup_index_index`\n\nFor
   more information about layouts in Magento 2, see the [Layout documentation](https://devdocs.magento.com/guides/v2.3/frontend-dev-guide/layouts/layout-overview.html).\n\n##
   Additional information\n\nFor information about significant changes in patch releases,
-  see [2.3.x Release information](https://devdocs.magento.com/guides/v2.3/release-notes/bk-release-notes.html).\n"
+  see [2.3.x Release information](https://devdocs.magento.com/guides/v2.3/release-notes/bk-release-notes.html)."

--- a/src/_data/codebase/v2_4/mrg/ce/Bundle.yml
+++ b/src/_data/codebase/v2_4/mrg/ce/Bundle.yml
@@ -4,6 +4,6 @@ source_repo: magento2ce
 release: 2.4.1
 github_path: app/code/Magento/Bundle/README.md
 last_modified_at: '2014-12-12 12:14:06 -0800'
-content: |
+content: |-
   Magento_Bundle module introduces new product type in the Magento application named Bundle Product.
   This module is designed to extend existing functionality of Magento_Catalog module by adding new product type.

--- a/src/_data/codebase/v2_4/mrg/ce/BundleGraphQl.yml
+++ b/src/_data/codebase/v2_4/mrg/ce/BundleGraphQl.yml
@@ -4,6 +4,6 @@ source_repo: magento2ce
 release: 2.4.1
 github_path: app/code/Magento/BundleGraphQl/README.md
 last_modified_at: '2018-01-24 11:57:46 -0600'
-content: |
+content: |-
   **BundleGraphQl** provides type and resolver information for the GraphQl module
   to generate bundle product information.

--- a/src/_data/codebase/v2_4/mrg/ce/BundleImportExport.yml
+++ b/src/_data/codebase/v2_4/mrg/ce/BundleImportExport.yml
@@ -4,6 +4,6 @@ source_repo: magento2ce
 release: 2.4.1
 github_path: app/code/Magento/BundleImportExport/README.md
 last_modified_at: '2015-05-28 02:24:13 +0300'
-content: |
+content: |-
   Magento_BundleImportExport module implements Bundle products import/export functionality.
   This module is designed to extend existing functionality of Magento_CatalogImportExport module by adding new product type.

--- a/src/_data/codebase/v2_4/mrg/ce/Catalog.yml
+++ b/src/_data/codebase/v2_4/mrg/ce/Catalog.yml
@@ -4,7 +4,7 @@ source_repo: magento2ce
 release: 2.4.1
 github_path: app/code/Magento/Catalog/README.md
 last_modified_at: '2014-12-12 12:14:06 -0800'
-content: |
+content: |-
   Magento_Catalog module functionality is represented by the following sub-systems:
    - Products Management. It includes CRUD operation of product, product media, product attributes, etc...
    - Category Management. It includes CRUD operation of category, category attributes

--- a/src/_data/codebase/v2_4/mrg/ce/CatalogAnalytics.yml
+++ b/src/_data/codebase/v2_4/mrg/ce/CatalogAnalytics.yml
@@ -4,7 +4,5 @@ source_repo: magento2ce
 release: 2.4.1
 github_path: app/code/Magento/CatalogAnalytics/README.md
 last_modified_at: '2019-08-06 14:40:28 -0500'
-content: 'The Magento_CatalogAnalytics module configures data definitions for a data
+content: The Magento_CatalogAnalytics module configures data definitions for a data
   collection related to the Catalog module entities to be used in [Advanced Reporting](https://devdocs.magento.com/guides/v2.3/advanced-reporting/modules.html).
-
-'

--- a/src/_data/codebase/v2_4/mrg/ce/CatalogGraphQl.yml
+++ b/src/_data/codebase/v2_4/mrg/ce/CatalogGraphQl.yml
@@ -4,6 +4,6 @@ source_repo: magento2ce
 release: 2.4.1
 github_path: app/code/Magento/CatalogGraphQl/README.md
 last_modified_at: '2018-01-16 13:17:37 -0600'
-content: |
+content: |-
   **CatalogGraphQl** provides type and resolver information for the GraphQl module
   to generate catalog and product information endpoints.

--- a/src/_data/codebase/v2_4/mrg/ce/CatalogInventory.yml
+++ b/src/_data/codebase/v2_4/mrg/ce/CatalogInventory.yml
@@ -4,7 +4,5 @@ source_repo: magento2ce
 release: 2.4.1
 github_path: app/code/Magento/CatalogInventory/README.md
 last_modified_at: '2014-12-12 12:14:06 -0800'
-content: 'Magento_CatalogInventory module allows retrieve and update stock attributes,
+content: Magento_CatalogInventory module allows retrieve and update stock attributes,
   such as status and quantity.
-
-'

--- a/src/_data/codebase/v2_4/mrg/ce/CatalogInventoryGraphQl.yml
+++ b/src/_data/codebase/v2_4/mrg/ce/CatalogInventoryGraphQl.yml
@@ -4,6 +4,6 @@ source_repo: magento2ce
 release: 2.4.1
 github_path: app/code/Magento/CatalogInventoryGraphQl/README.md
 last_modified_at: '2018-07-18 16:40:53 +0200'
-content: |
+content: |-
   **CatalogInventoryGraphQl** provides type information for the GraphQl module
   to generate inventory stock fields for product information endpoints.

--- a/src/_data/codebase/v2_4/mrg/ce/CatalogRule.yml
+++ b/src/_data/codebase/v2_4/mrg/ce/CatalogRule.yml
@@ -4,8 +4,5 @@ source_repo: magento2ce
 release: 2.4.1
 github_path: app/code/Magento/CatalogRule/README.md
 last_modified_at: '2014-12-12 12:14:06 -0800'
-content: 'Magento_CatalogRule module is responsible for one of the types of price
-  rules in Magento. Catalog Rules are applied to products before they are added to
-  the cart.
-
-'
+content: Magento_CatalogRule module is responsible for one of the types of price rules
+  in Magento. Catalog Rules are applied to products before they are added to the cart.

--- a/src/_data/codebase/v2_4/mrg/ce/CatalogRuleConfigurable.yml
+++ b/src/_data/codebase/v2_4/mrg/ce/CatalogRuleConfigurable.yml
@@ -4,8 +4,6 @@ source_repo: magento2ce
 release: 2.4.1
 github_path: app/code/Magento/CatalogRuleConfigurable/README.md
 last_modified_at: '2015-09-07 17:18:34 +0300'
-content: 'Magento_CatalogRuleConfigurable module is an extension of Magento_CatalogRule
+content: Magento_CatalogRuleConfigurable module is an extension of Magento_CatalogRule
   and Magento_ConfigurableProduct modules that handle catalog rule indexer for configurable
   product
-
-'

--- a/src/_data/codebase/v2_4/mrg/ce/CatalogSearch.yml
+++ b/src/_data/codebase/v2_4/mrg/ce/CatalogSearch.yml
@@ -4,6 +4,6 @@ source_repo: magento2ce
 release: 2.4.1
 github_path: app/code/Magento/CatalogSearch/README.md
 last_modified_at: '2014-12-12 12:14:06 -0800'
-content: |
+content: |-
   Magento_CatalogSearch module is an extension of Magento_Catalog module that allows to use search engine for product searching capabilities.
   The module implements Magento_Search library interfaces.

--- a/src/_data/codebase/v2_4/mrg/ce/CatalogUrlRewriteGraphQl.yml
+++ b/src/_data/codebase/v2_4/mrg/ce/CatalogUrlRewriteGraphQl.yml
@@ -4,6 +4,6 @@ source_repo: magento2ce
 release: 2.4.1
 github_path: app/code/Magento/CatalogUrlRewriteGraphQl/README.md
 last_modified_at: '2018-01-16 16:07:17 -0600'
-content: |
+content: |-
   **CatalogUrlRewriteGraphQl** provides type information for the GraphQl module
   to generate url rewrite fields for catalog and product information endpoints.

--- a/src/_data/codebase/v2_4/mrg/ce/CatalogWidget.yml
+++ b/src/_data/codebase/v2_4/mrg/ce/CatalogWidget.yml
@@ -4,6 +4,6 @@ source_repo: magento2ce
 release: 2.4.1
 github_path: app/code/Magento/CatalogWidget/README.md
 last_modified_at: '2014-12-12 12:14:06 -0800'
-content: |
+content: |-
   **CatalogWidget** contains various widgets that extend Catalog module functionality:
   - Product List widget provides widget that contains product list created using rule based filter.

--- a/src/_data/codebase/v2_4/mrg/ce/CheckoutAgreementsGraphQl.yml
+++ b/src/_data/codebase/v2_4/mrg/ce/CheckoutAgreementsGraphQl.yml
@@ -4,6 +4,6 @@ source_repo: magento2ce
 release: 2.4.1
 github_path: app/code/Magento/CheckoutAgreementsGraphQl/README.md
 last_modified_at: '2019-03-20 17:00:47 +0200'
-content: |
+content: |-
   **CheckoutAgreementsGraphQl** provides type information for the GraphQl module
   to generate Checkout Agreements fields for Checkout Agreements information endpoints.

--- a/src/_data/codebase/v2_4/mrg/ce/CmsGraphQl.yml
+++ b/src/_data/codebase/v2_4/mrg/ce/CmsGraphQl.yml
@@ -4,6 +4,6 @@ source_repo: magento2ce
 release: 2.4.1
 github_path: app/code/Magento/CmsGraphQl/README.md
 last_modified_at: '2018-06-30 14:36:35 +0300'
-content: |
+content: |-
   **CmsGraphQl** provides type information for the GraphQl module
   to generate CMS fields for cms information endpoints.

--- a/src/_data/codebase/v2_4/mrg/ce/CmsUrlRewrite.yml
+++ b/src/_data/codebase/v2_4/mrg/ce/CmsUrlRewrite.yml
@@ -7,4 +7,4 @@ last_modified_at: '2017-03-07 16:04:38 -0600'
 content: "## Overview\n \nThe Magento_CmsUrlRewrite module adds support for URL rewrite
   rules for CMS pages. See also Magento_UrlRewrite module. \n\nThe module adds and
   removes URL rewrite rules as CMS pages are added or removed by a user.\nThe rules
-  can be edited by an admin user as any other URL rewrite rule. \n"
+  can be edited by an admin user as any other URL rewrite rule."

--- a/src/_data/codebase/v2_4/mrg/ce/CmsUrlRewriteGraphQl.yml
+++ b/src/_data/codebase/v2_4/mrg/ce/CmsUrlRewriteGraphQl.yml
@@ -4,6 +4,6 @@ source_repo: magento2ce
 release: 2.4.1
 github_path: app/code/Magento/CmsUrlRewriteGraphQl/README.md
 last_modified_at: '2018-01-17 16:25:54 -0600'
-content: |
+content: |-
   **CmsUrlRewriteGraphQl** provides type information for the GraphQl module
   to generate url rewrite fields for cms information endpoints.

--- a/src/_data/codebase/v2_4/mrg/ce/Config.yml
+++ b/src/_data/codebase/v2_4/mrg/ce/Config.yml
@@ -4,7 +4,7 @@ source_repo: magento2ce
 release: 2.4.1
 github_path: app/code/Magento/Config/README.md
 last_modified_at: '2019-09-03 18:23:54 +0300'
-content: |
+content: |-
   The Config module is designed to implement system configuration functionality.
   It provides mechanisms to add, edit, store and retrieve the configuration data for each scope (there can be a default scope as well as scopes for each website and store).
 

--- a/src/_data/codebase/v2_4/mrg/ce/ConfigurableProduct.yml
+++ b/src/_data/codebase/v2_4/mrg/ce/ConfigurableProduct.yml
@@ -4,7 +4,7 @@ source_repo: magento2ce
 release: 2.4.1
 github_path: app/code/Magento/ConfigurableProduct/README.md
 last_modified_at: '2014-12-12 12:14:06 -0800'
-content: |
+content: |-
   Magento_ConfigurableProduct module introduces new product type in the Magento application called Configurable Product.
   This module is designed to extend existing functionality of Magento_Catalog module by adding new product type.
 

--- a/src/_data/codebase/v2_4/mrg/ce/ConfigurableProductGraphQl.yml
+++ b/src/_data/codebase/v2_4/mrg/ce/ConfigurableProductGraphQl.yml
@@ -4,6 +4,6 @@ source_repo: magento2ce
 release: 2.4.1
 github_path: app/code/Magento/ConfigurableProductGraphQl/README.md
 last_modified_at: '2018-01-16 13:17:37 -0600'
-content: |
+content: |-
   **ConfigurableProductGraphQl** provides type and resolver information for the GraphQl module
   to generate configurable product information.

--- a/src/_data/codebase/v2_4/mrg/ce/ConfigurableProductSales.yml
+++ b/src/_data/codebase/v2_4/mrg/ce/ConfigurableProductSales.yml
@@ -4,6 +4,6 @@ source_repo: magento2ce
 release: 2.4.1
 github_path: app/code/Magento/ConfigurableProductSales/README.md
 last_modified_at: '2017-07-14 16:51:00 +0300'
-content: "The Magento_ConfigurableProductSales module checks that the selected options
-  of order item are still presented in\nCatalog. Returns true if the previously ordered
-  item configuration is still available. "
+content: |-
+  The Magento_ConfigurableProductSales module checks that the selected options of order item are still presented in
+  Catalog. Returns true if the previously ordered item configuration is still available.

--- a/src/_data/codebase/v2_4/mrg/ce/Contact.yml
+++ b/src/_data/codebase/v2_4/mrg/ce/Contact.yml
@@ -4,8 +4,6 @@ source_repo: magento2ce
 release: 2.4.1
 github_path: app/code/Magento/Contact/README.md
 last_modified_at: '2014-12-12 12:14:06 -0800'
-content: 'Magento_Contact module provides an implementation of "Contact Us" feature
+content: Magento_Contact module provides an implementation of "Contact Us" feature
   based on sending email message, allows to configure email recipients, email template,
   etc...
-
-'

--- a/src/_data/codebase/v2_4/mrg/ce/Cookie.yml
+++ b/src/_data/codebase/v2_4/mrg/ce/Cookie.yml
@@ -4,7 +4,5 @@ source_repo: magento2ce
 release: 2.4.1
 github_path: app/code/Magento/Cookie/README.md
 last_modified_at: '2015-01-28 16:50:13 -0600'
-content: 'Magento_Cookie module allows enabling and configuring HTTP cookie related
+content: Magento_Cookie module allows enabling and configuring HTTP cookie related
   settings for the store. These settings are available in the store administration.
-
-'

--- a/src/_data/codebase/v2_4/mrg/ce/Csp.yml
+++ b/src/_data/codebase/v2_4/mrg/ce/Csp.yml
@@ -4,6 +4,6 @@ source_repo: magento2ce
 release: 2.4.1
 github_path: app/code/Magento/Csp/README.md
 last_modified_at: '2019-11-14 16:21:59 -0600'
-content: |
+content: |-
   Magento_Csp implements Content Security Policies for Magento. Allows CSP configuration for Merchants,
   provides a way for extension and theme developers to configure CSP headers for their extensions.

--- a/src/_data/codebase/v2_4/mrg/ce/CurrencySymbol.yml
+++ b/src/_data/codebase/v2_4/mrg/ce/CurrencySymbol.yml
@@ -4,7 +4,7 @@ source_repo: magento2ce
 release: 2.4.1
 github_path: app/code/Magento/CurrencySymbol/README.md
 last_modified_at: '2014-12-12 12:14:06 -0800'
-content: |+
+content: |-
   **CurrencySymbol** enables the creation of custom currencies and management of currency conversion rates.
 
   ## Controllers
@@ -17,4 +17,3 @@ content: |+
   ### Currency Symbol Controllers
   ***CurrencySymbol\Controller\Adminhtml\System\Currencysymbol\Reset.php*** resets all custom currency symbols.
   ***CurrencySymbol\Controller\Adminhtml\System\Currencysymbol\Save.php*** creates custom currency symbols.
-

--- a/src/_data/codebase/v2_4/mrg/ce/Customer.yml
+++ b/src/_data/codebase/v2_4/mrg/ce/Customer.yml
@@ -6,4 +6,4 @@ github_path: app/code/Magento/Customer/README.md
 last_modified_at: '2015-08-27 15:34:05 -0500'
 content: "The Magento_Customer module serves to handle the customer data (Customer,
   Customer Address and Customer Group entities) both in the admin panel and the storefront.
-  \nFor customer passwords, the module implements upgrading hashes. \n"
+  \nFor customer passwords, the module implements upgrading hashes."

--- a/src/_data/codebase/v2_4/mrg/ce/CustomerAnalytics.yml
+++ b/src/_data/codebase/v2_4/mrg/ce/CustomerAnalytics.yml
@@ -4,7 +4,5 @@ source_repo: magento2ce
 release: 2.4.1
 github_path: app/code/Magento/CustomerAnalytics/README.md
 last_modified_at: '2019-08-06 14:40:28 -0500'
-content: 'The Magento_CustomerAnalytics module configures data definitions for a data
+content: The Magento_CustomerAnalytics module configures data definitions for a data
   collection related to the Customer module entities to be used in [Advanced Reporting](https://devdocs.magento.com/guides/v2.3/advanced-reporting/modules.html).
-
-'

--- a/src/_data/codebase/v2_4/mrg/ce/CustomerDownloadableGraphQl.yml
+++ b/src/_data/codebase/v2_4/mrg/ce/CustomerDownloadableGraphQl.yml
@@ -4,6 +4,6 @@ source_repo: magento2ce
 release: 2.4.1
 github_path: app/code/Magento/CustomerDownloadableGraphQl/README.md
 last_modified_at: '2019-06-25 22:45:10 +0200'
-content: |
+content: |-
   **CustomerDownloadableGraphQl** provides type and resolver information for the GraphQl module
   to generate downloadable product information.

--- a/src/_data/codebase/v2_4/mrg/ce/CustomerGraphQl.yml
+++ b/src/_data/codebase/v2_4/mrg/ce/CustomerGraphQl.yml
@@ -4,6 +4,6 @@ source_repo: magento2ce
 release: 2.4.1
 github_path: app/code/Magento/CustomerGraphQl/README.md
 last_modified_at: '2018-01-16 13:17:37 -0600'
-content: |
+content: |-
   **CustomerGraphQl** provides type and resolver information for the GraphQl module
   to generate customer information endpoints.

--- a/src/_data/codebase/v2_4/mrg/ce/CustomerImportExport.yml
+++ b/src/_data/codebase/v2_4/mrg/ce/CustomerImportExport.yml
@@ -4,7 +4,5 @@ source_repo: magento2ce
 release: 2.4.1
 github_path: app/code/Magento/CustomerImportExport/README.md
 last_modified_at: '2014-10-31 09:04:08 -0700'
-content: 'The Magento_CustomerImportExport module handles the import and export of
+content: The Magento_CustomerImportExport module handles the import and export of
   the customers data and related addresses.
-
-'

--- a/src/_data/codebase/v2_4/mrg/ce/Deploy.yml
+++ b/src/_data/codebase/v2_4/mrg/ce/Deploy.yml
@@ -14,4 +14,4 @@ content: "## Purpose of module\n\nDeploy is a module that holds collection of se
   to production mode, you can pass optional parameter skip-compilation to do not compile
   static files, CSS \nand do not run the compilation process.\n\n# Deployment\n##
   System requirements\n\n## Install\nThe Magento_Deploy module is installed automatically
-  (using the native Magento install mechanism) without any additional actions.\n"
+  (using the native Magento install mechanism) without any additional actions."

--- a/src/_data/codebase/v2_4/mrg/ce/Developer.yml
+++ b/src/_data/codebase/v2_4/mrg/ce/Developer.yml
@@ -4,7 +4,5 @@ source_repo: magento2ce
 release: 2.4.1
 github_path: app/code/Magento/Developer/README.md
 last_modified_at: '2015-01-15 14:33:14 -0600'
-content: 'The Magento_Developer module provides functionality to make it easier to
+content: The Magento_Developer module provides functionality to make it easier to
   develop in Magento 2.
-
-'

--- a/src/_data/codebase/v2_4/mrg/ce/Dhl.yml
+++ b/src/_data/codebase/v2_4/mrg/ce/Dhl.yml
@@ -4,6 +4,6 @@ source_repo: magento2ce
 release: 2.4.1
 github_path: app/code/Magento/Dhl/README.md
 last_modified_at: '2014-10-31 09:04:08 -0700'
-content: |
+content: |-
   The Magento_Dhl module implements the integration with the DHL shipping carrier.
   DHL is available for international shipments only.

--- a/src/_data/codebase/v2_4/mrg/ce/Directory.yml
+++ b/src/_data/codebase/v2_4/mrg/ce/Directory.yml
@@ -4,6 +4,6 @@ source_repo: magento2ce
 release: 2.4.1
 github_path: app/code/Magento/Directory/README.md
 last_modified_at: '2014-12-12 12:14:06 -0800'
-content: |
+content: |-
   **Directory** enables the management of countries and regions recognized by the store and associated data
   like the country code and currency rates. Also, enables conversion of prices to a specified currency format.

--- a/src/_data/codebase/v2_4/mrg/ce/DirectoryGraphQl.yml
+++ b/src/_data/codebase/v2_4/mrg/ce/DirectoryGraphQl.yml
@@ -4,6 +4,6 @@ source_repo: magento2ce
 release: 2.4.1
 github_path: app/code/Magento/DirectoryGraphQl/README.md
 last_modified_at: '2019-01-31 09:12:38 -0500'
-content: |
+content: |-
   **DirectoryGraphQl** provides type and resolver information for the GraphQl module
   to generate directory information endpoints.

--- a/src/_data/codebase/v2_4/mrg/ce/Downloadable.yml
+++ b/src/_data/codebase/v2_4/mrg/ce/Downloadable.yml
@@ -4,6 +4,6 @@ source_repo: magento2ce
 release: 2.4.1
 github_path: app/code/Magento/Downloadable/README.md
 last_modified_at: '2014-12-12 12:14:06 -0800'
-content: |
+content: |-
   Magento_Downloadable module introduces new product type in the Magento application called Downloadable Product.
   This module is designed to extend existing functionality of Magento_Catalog module by adding new product type.

--- a/src/_data/codebase/v2_4/mrg/ce/DownloadableGraphQl.yml
+++ b/src/_data/codebase/v2_4/mrg/ce/DownloadableGraphQl.yml
@@ -4,6 +4,6 @@ source_repo: magento2ce
 release: 2.4.1
 github_path: app/code/Magento/DownloadableGraphQl/README.md
 last_modified_at: '2018-01-24 15:58:51 -0600'
-content: |
+content: |-
   **DownloadableGraphQl** provides type and resolver information for the GraphQl module
   to generate downloadable product information.

--- a/src/_data/codebase/v2_4/mrg/ce/DownloadableImportExport.yml
+++ b/src/_data/codebase/v2_4/mrg/ce/DownloadableImportExport.yml
@@ -4,7 +4,5 @@ source_repo: magento2ce
 release: 2.4.1
 github_path: app/code/Magento/DownloadableImportExport/README.md
 last_modified_at: '2015-08-10 11:16:49 +0300'
-content: 'The Magento_DownloadableImportExport module handles the import and export
+content: The Magento_DownloadableImportExport module handles the import and export
   of the downloadable products.
-
-'

--- a/src/_data/codebase/v2_4/mrg/ce/EavGraphQl.yml
+++ b/src/_data/codebase/v2_4/mrg/ce/EavGraphQl.yml
@@ -5,4 +5,4 @@ release: 2.4.1
 github_path: app/code/Magento/EavGraphQl/README.md
 last_modified_at: '2018-01-16 13:17:37 -0600'
 content: "**EavGraphQl** primarily provides the GraphQl module information to generate
-  metadata for Eav attributes.\n"
+  metadata for Eav attributes."

--- a/src/_data/codebase/v2_4/mrg/ce/Elasticsearch6.yml
+++ b/src/_data/codebase/v2_4/mrg/ce/Elasticsearch6.yml
@@ -4,6 +4,6 @@ source_repo: magento2ce
 release: 2.4.1
 github_path: app/code/Magento/Elasticsearch6/README.md
 last_modified_at: '2019-02-27 13:06:48 +0100'
-content: |
+content: |-
   Magento\Elasticsearch module allows to use Elastic search engine (v6) for product searching capabilities.
   The module implements Magento\Search library interfaces.

--- a/src/_data/codebase/v2_4/mrg/ce/Elasticsearch7.yml
+++ b/src/_data/codebase/v2_4/mrg/ce/Elasticsearch7.yml
@@ -4,6 +4,6 @@ source_repo: magento2ce
 release: 2.4.1
 github_path: app/code/Magento/Elasticsearch7/README.md
 last_modified_at: '2020-03-06 11:22:29 -0600'
-content: |
+content: |-
   Magento\Elasticsearch7 module allows to use Elastic search engine (v7) for product searching capabilities.
   The module implements Magento\Search library interfaces.

--- a/src/_data/codebase/v2_4/mrg/ce/Email.yml
+++ b/src/_data/codebase/v2_4/mrg/ce/Email.yml
@@ -4,6 +4,6 @@ source_repo: magento2ce
 release: 2.4.1
 github_path: app/code/Magento/Email/README.md
 last_modified_at: '2014-12-12 12:14:06 -0800'
-content: |
+content: |-
   **Email** enables you to manage email templates, which are used when you send email through the
   *\Magento\Framework\Mail\TransportInterface* implementations.

--- a/src/_data/codebase/v2_4/mrg/ce/EncryptionKey.yml
+++ b/src/_data/codebase/v2_4/mrg/ce/EncryptionKey.yml
@@ -4,7 +4,5 @@ source_repo: magento2ce
 release: 2.4.1
 github_path: app/code/Magento/EncryptionKey/README.md
 last_modified_at: '2015-08-27 15:34:05 -0500'
-content: 'The Magento_EncryptionKey module provides an advanced encryption model to
+content: The Magento_EncryptionKey module provides an advanced encryption model to
   protect passwords and other sensitive data.
-
-'

--- a/src/_data/codebase/v2_4/mrg/ce/Fedex.yml
+++ b/src/_data/codebase/v2_4/mrg/ce/Fedex.yml
@@ -4,6 +4,4 @@ source_repo: magento2ce
 release: 2.4.1
 github_path: app/code/Magento/Fedex/README.md
 last_modified_at: '2014-10-31 09:04:08 -0700'
-content: 'The Magento_Fedex implements the integration with the FedEx shipping carrier.
-
-'
+content: The Magento_Fedex implements the integration with the FedEx shipping carrier.

--- a/src/_data/codebase/v2_4/mrg/ce/GiftMessageGraphQl.yml
+++ b/src/_data/codebase/v2_4/mrg/ce/GiftMessageGraphQl.yml
@@ -5,4 +5,4 @@ release: 2.4.1
 github_path: app/code/Magento/GiftMessageGraphQl/README.md
 last_modified_at: '2020-06-08 17:14:15 +0300'
 content: "**GiftMessageGraphQl** provides information about gift messages for carts,
-  cart items, orders and order items.\n"
+  cart items, orders and order items."

--- a/src/_data/codebase/v2_4/mrg/ce/GoogleAdwords.yml
+++ b/src/_data/codebase/v2_4/mrg/ce/GoogleAdwords.yml
@@ -4,6 +4,4 @@ source_repo: magento2ce
 release: 2.4.1
 github_path: app/code/Magento/GoogleAdwords/README.md
 last_modified_at: '2014-12-12 12:14:06 -0800'
-content: 'GoogleAdwords is a module designed for integration of Google Adwords service.
-
-'
+content: GoogleAdwords is a module designed for integration of Google Adwords service.

--- a/src/_data/codebase/v2_4/mrg/ce/GoogleAnalytics.yml
+++ b/src/_data/codebase/v2_4/mrg/ce/GoogleAnalytics.yml
@@ -4,7 +4,5 @@ source_repo: magento2ce
 release: 2.4.1
 github_path: app/code/Magento/GoogleAnalytics/README.md
 last_modified_at: '2014-12-12 12:14:06 -0800'
-content: 'Magento_GoogleAnalytics is a module for integration with Google Analytics
+content: Magento_GoogleAnalytics is a module for integration with Google Analytics
   service.
-
-'

--- a/src/_data/codebase/v2_4/mrg/ce/GoogleOptimizer.yml
+++ b/src/_data/codebase/v2_4/mrg/ce/GoogleOptimizer.yml
@@ -13,4 +13,4 @@ content: "Magento_GoogleOptimizer module implements functionality of Google Expe
   categories on different store views.\nThis functionality can be switched on and
   off on the configuration page (Stores -> Configuration -> General -> Google Api
   -> Google Analytics).\nAlso this functionality depends on Google Analytics module
-  and configuration options.\n"
+  and configuration options."

--- a/src/_data/codebase/v2_4/mrg/ce/GraphQl.yml
+++ b/src/_data/codebase/v2_4/mrg/ce/GraphQl.yml
@@ -7,4 +7,4 @@ last_modified_at: '2017-10-25 11:14:11 -0500'
 content: "**GraphQl** provides the framework for the application to expose GraphQL
   compliant web services. It exposes an area for\nGraphQL services and resolves request
   data based on the generated schema. It also maps this response to a JSON object
-  \nfor the client to read.\n"
+  \nfor the client to read."

--- a/src/_data/codebase/v2_4/mrg/ce/GraphQlCache.yml
+++ b/src/_data/codebase/v2_4/mrg/ce/GraphQlCache.yml
@@ -4,6 +4,6 @@ source_repo: magento2ce
 release: 2.4.1
 github_path: app/code/Magento/GraphQlCache/README.md
 last_modified_at: '2019-04-08 11:49:04 -0500'
-content: "**GraphQL Cache** provides the ability to cache GraphQL queries.\nThis module
-  allows Magento's built-in cache or Varnish as the application for serving the Full
-  Page Cache to the front end. \n"
+content: |-
+  **GraphQL Cache** provides the ability to cache GraphQL queries.
+  This module allows Magento's built-in cache or Varnish as the application for serving the Full Page Cache to the front end.

--- a/src/_data/codebase/v2_4/mrg/ce/GroupedCatalogInventory.yml
+++ b/src/_data/codebase/v2_4/mrg/ce/GroupedCatalogInventory.yml
@@ -4,7 +4,5 @@ source_repo: magento2ce
 release: 2.4.1
 github_path: app/code/Magento/GroupedCatalogInventory/README.md
 last_modified_at: '2018-11-27 16:04:57 -0600'
-content: 'Magento_GroupedCatalogInventory contains behavior related to the inventory
+content: Magento_GroupedCatalogInventory contains behavior related to the inventory
   status of items within grouped products.
-
-'

--- a/src/_data/codebase/v2_4/mrg/ce/GroupedProduct.yml
+++ b/src/_data/codebase/v2_4/mrg/ce/GroupedProduct.yml
@@ -4,7 +4,7 @@ source_repo: magento2ce
 release: 2.4.1
 github_path: app/code/Magento/GroupedProduct/README.md
 last_modified_at: '2014-12-12 12:14:06 -0800'
-content: |
+content: |-
   Magento_GroupedProduct module provides ability to offer several standalone products for sale as a group on the same Product Detail page.
   It can offer variations of a product, or group them by season or theme to create a coordinated set.
   Products can be purchased separately or as a set.

--- a/src/_data/codebase/v2_4/mrg/ce/GroupedProductGraphQl.yml
+++ b/src/_data/codebase/v2_4/mrg/ce/GroupedProductGraphQl.yml
@@ -4,6 +4,6 @@ source_repo: magento2ce
 release: 2.4.1
 github_path: app/code/Magento/GroupedProductGraphQl/README.md
 last_modified_at: '2018-01-29 15:12:49 -0600'
-content: |
+content: |-
   **GroupedProductGraphQl** provides type and resolver information for the GraphQl module
   to generate grouped product information.

--- a/src/_data/codebase/v2_4/mrg/ce/ImportExport.yml
+++ b/src/_data/codebase/v2_4/mrg/ce/ImportExport.yml
@@ -4,6 +4,6 @@ source_repo: magento2ce
 release: 2.4.1
 github_path: app/code/Magento/ImportExport/README.md
 last_modified_at: '2014-12-12 12:14:06 -0800'
-content: |
+content: |-
   Magento_ImportExport module provides a framework and basic functionality for importing/exporting various entities in Magento.
   It can be disabled and in such case all dependent import/export functionality (products, customers, orders etc.) will be disabled in Magento.

--- a/src/_data/codebase/v2_4/mrg/ce/InstantPurchase.yml
+++ b/src/_data/codebase/v2_4/mrg/ce/InstantPurchase.yml
@@ -4,7 +4,7 @@ source_repo: magento2ce
 release: 2.4.1
 github_path: app/code/Magento/InstantPurchase/README.md
 last_modified_at: '2019-08-06 14:40:28 -0500'
-content: |
+content: |-
   ## Overview
 
   Instant Purchase feature allows the Customer to place the order in seconds without going through full checkout. Once clicked, system places the order using default shipping and billing addresses and stored payment method. Order is placed and customer gets confirmation message in notification area.

--- a/src/_data/codebase/v2_4/mrg/ce/Integration.yml
+++ b/src/_data/codebase/v2_4/mrg/ce/Integration.yml
@@ -4,7 +4,7 @@ source_repo: magento2ce
 release: 2.4.1
 github_path: app/code/Magento/Integration/README.md
 last_modified_at: '2014-12-12 12:14:06 -0800'
-content: |
+content: |-
   **Integration** enables third-party services to call the Web API by using access tokens.
   It provides an admin UI that enables manual creation of integrations. Extensions can also provide a configuration
   file so that an integration can be automatically pre-configured. The module also contains the data

--- a/src/_data/codebase/v2_4/mrg/ce/LayeredNavigation.yml
+++ b/src/_data/codebase/v2_4/mrg/ce/LayeredNavigation.yml
@@ -4,6 +4,6 @@ source_repo: magento2ce
 release: 2.4.1
 github_path: app/code/Magento/LayeredNavigation/README.md
 last_modified_at: '2014-12-12 12:14:06 -0800'
-content: |
+content: |-
   Magento_LayeredNavigation module introduces Layered Navigation UI for Catalog (faceted search).
   This module can be removed from Magento installation without impact on the application.

--- a/src/_data/codebase/v2_4/mrg/ce/LoginAsCustomer.yml
+++ b/src/_data/codebase/v2_4/mrg/ce/LoginAsCustomer.yml
@@ -4,7 +4,5 @@ source_repo: magento2ce
 release: 2.4.1
 github_path: app/code/Magento/LoginAsCustomer/README.md
 last_modified_at: '2020-04-15 04:18:57 -0500'
-content: 'The Magento_LoginAsCustomer module is responsible for ability to login into
+content: The Magento_LoginAsCustomer module is responsible for ability to login into
   customer account using the admin panel.
-
-'

--- a/src/_data/codebase/v2_4/mrg/ce/LoginAsCustomerAdminUi.yml
+++ b/src/_data/codebase/v2_4/mrg/ce/LoginAsCustomerAdminUi.yml
@@ -4,6 +4,4 @@ source_repo: magento2ce
 release: 2.4.1
 github_path: app/code/Magento/LoginAsCustomerAdminUi/README.md
 last_modified_at: '2020-05-21 22:39:24 -0500'
-content: 'The Magento_LoginAsCustomerAdminUi module provides UI for Admin Panel
-
-'
+content: The Magento_LoginAsCustomerAdminUi module provides UI for Admin Panel

--- a/src/_data/codebase/v2_4/mrg/ce/LoginAsCustomerApi.yml
+++ b/src/_data/codebase/v2_4/mrg/ce/LoginAsCustomerApi.yml
@@ -4,7 +4,5 @@ source_repo: magento2ce
 release: 2.4.1
 github_path: app/code/Magento/LoginAsCustomerApi/README.md
 last_modified_at: '2020-04-27 20:39:08 -0500'
-content: 'The Magento_LoginAsCustomerApi module provides API for ability to login
-  into customer account for an admin user.
-
-'
+content: The Magento_LoginAsCustomerApi module provides API for ability to login into
+  customer account for an admin user.

--- a/src/_data/codebase/v2_4/mrg/ce/LoginAsCustomerAssistance.yml
+++ b/src/_data/codebase/v2_4/mrg/ce/LoginAsCustomerAssistance.yml
@@ -4,7 +4,5 @@ source_repo: magento2ce
 release: 2.4.1
 github_path: app/code/Magento/LoginAsCustomerAssistance/README.md
 last_modified_at: '2020-08-05 17:47:02 +0300'
-content: 'The Magento_LoginAsCustomerAssistance module provides possibility to enable/disable
+content: The Magento_LoginAsCustomerAssistance module provides possibility to enable/disable
   LoginAsCustomer functionality per Customer.
-
-'

--- a/src/_data/codebase/v2_4/mrg/ce/LoginAsCustomerFrontendUi.yml
+++ b/src/_data/codebase/v2_4/mrg/ce/LoginAsCustomerFrontendUi.yml
@@ -4,6 +4,4 @@ source_repo: magento2ce
 release: 2.4.1
 github_path: app/code/Magento/LoginAsCustomerFrontendUi/README.md
 last_modified_at: '2020-05-21 22:39:24 -0500'
-content: 'The Magento_LoginAsCustomerFrontendUi module provides UI for Storefront
-
-'
+content: The Magento_LoginAsCustomerFrontendUi module provides UI for Storefront

--- a/src/_data/codebase/v2_4/mrg/ce/LoginAsCustomerLog.yml
+++ b/src/_data/codebase/v2_4/mrg/ce/LoginAsCustomerLog.yml
@@ -4,7 +4,5 @@ source_repo: magento2ce
 release: 2.4.1
 github_path: app/code/Magento/LoginAsCustomerLog/README.md
 last_modified_at: '2020-05-04 17:44:22 +0300'
-content: 'The Magento_LoginAsCustomerLog module provides log for Login as Customer
+content: The Magento_LoginAsCustomerLog module provides log for Login as Customer
   functionality
-
-'

--- a/src/_data/codebase/v2_4/mrg/ce/LoginAsCustomerPageCache.yml
+++ b/src/_data/codebase/v2_4/mrg/ce/LoginAsCustomerPageCache.yml
@@ -4,7 +4,5 @@ source_repo: magento2ce
 release: 2.4.1
 github_path: app/code/Magento/LoginAsCustomerPageCache/README.md
 last_modified_at: '2020-04-27 21:52:37 -0500'
-content: 'The Magento_LoginAsCustomerPageCache module provides adaptation to PageCache
+content: The Magento_LoginAsCustomerPageCache module provides adaptation to PageCache
   functionality
-
-'

--- a/src/_data/codebase/v2_4/mrg/ce/LoginAsCustomerQuote.yml
+++ b/src/_data/codebase/v2_4/mrg/ce/LoginAsCustomerQuote.yml
@@ -4,7 +4,5 @@ source_repo: magento2ce
 release: 2.4.1
 github_path: app/code/Magento/LoginAsCustomerQuote/README.md
 last_modified_at: '2020-05-21 22:39:24 -0500'
-content: 'The Magento_LoginAsCustomerQuote module is responsible for communication
+content: The Magento_LoginAsCustomerQuote module is responsible for communication
   between Magento_LoginAsCustomer and shopping cart state.
-
-'

--- a/src/_data/codebase/v2_4/mrg/ce/LoginAsCustomerSales.yml
+++ b/src/_data/codebase/v2_4/mrg/ce/LoginAsCustomerSales.yml
@@ -4,7 +4,5 @@ source_repo: magento2ce
 release: 2.4.1
 github_path: app/code/Magento/LoginAsCustomerSales/README.md
 last_modified_at: '2020-05-21 22:39:24 -0500'
-content: 'The Magento_LoginAsCustomerSales module is responsible for communication
+content: The Magento_LoginAsCustomerSales module is responsible for communication
   between Magento_LoginAsCustomer and order placement.
-
-'

--- a/src/_data/codebase/v2_4/mrg/ce/MediaContent.yml
+++ b/src/_data/codebase/v2_4/mrg/ce/MediaContent.yml
@@ -4,7 +4,7 @@ source_repo: magento2ce
 release: 2.4.1
 github_path: app/code/Magento/MediaContent/README.md
 last_modified_at: '2020-04-01 17:18:20 +0100'
-content: |
+content: |-
   The Magento_MediaContent module provides implementations for managing relations between content and media files used in that content.
 
   ## Extensibility

--- a/src/_data/codebase/v2_4/mrg/ce/MediaContentApi.yml
+++ b/src/_data/codebase/v2_4/mrg/ce/MediaContentApi.yml
@@ -4,7 +4,7 @@ source_repo: magento2ce
 release: 2.4.1
 github_path: app/code/Magento/MediaContentApi/README.md
 last_modified_at: '2020-04-01 17:18:20 +0100'
-content: |
+content: |-
   The Magento_MediaContentApi module provides interfaces for managing relations between content and media files used in that content.
 
   ## Extensibility

--- a/src/_data/codebase/v2_4/mrg/ce/MediaContentCatalog.yml
+++ b/src/_data/codebase/v2_4/mrg/ce/MediaContentCatalog.yml
@@ -4,7 +4,7 @@ source_repo: magento2ce
 release: 2.4.1
 github_path: app/code/Magento/MediaContentCatalog/README.md
 last_modified_at: '2020-04-01 21:43:19 +0100'
-content: |
+content: |-
   The Magento_MediaContentCatalog provides the implementation of MediaContent functionality for Magento_Catalog module
 
   ## Extensibility

--- a/src/_data/codebase/v2_4/mrg/ce/MediaContentCms.yml
+++ b/src/_data/codebase/v2_4/mrg/ce/MediaContentCms.yml
@@ -4,7 +4,7 @@ source_repo: magento2ce
 release: 2.4.1
 github_path: app/code/Magento/MediaContentCms/README.md
 last_modified_at: '2020-04-01 21:43:19 +0100'
-content: |
+content: |-
   The Magento_MediaContentCms provides the implementation of MediaContent functionality for Magento_Cms module
 
   ## Extensibility

--- a/src/_data/codebase/v2_4/mrg/ce/MediaContentSynchronization.yml
+++ b/src/_data/codebase/v2_4/mrg/ce/MediaContentSynchronization.yml
@@ -4,7 +4,7 @@ source_repo: magento2ce
 release: 2.4.1
 github_path: app/code/Magento/MediaContentSynchronization/README.md
 last_modified_at: '2020-08-03 11:01:09 +0100'
-content: |
+content: |-
   The Magento_MediaContentSynchronization module represents implementation of synchronization between data and objects contains
   media asset information.
 

--- a/src/_data/codebase/v2_4/mrg/ce/MediaContentSynchronizationApi.yml
+++ b/src/_data/codebase/v2_4/mrg/ce/MediaContentSynchronizationApi.yml
@@ -4,7 +4,7 @@ source_repo: magento2ce
 release: 2.4.1
 github_path: app/code/Magento/MediaContentSynchronizationApi/README.md
 last_modified_at: '2020-08-03 11:01:09 +0100'
-content: |
+content: |-
   The Magento_MediaContentSynchronizationApi module is responsible for the media gallery data synchronization implementation API.
 
   ## Extensibility

--- a/src/_data/codebase/v2_4/mrg/ce/MediaContentSynchronizationCatalog.yml
+++ b/src/_data/codebase/v2_4/mrg/ce/MediaContentSynchronizationCatalog.yml
@@ -4,7 +4,7 @@ source_repo: magento2ce
 release: 2.4.1
 github_path: app/code/Magento/MediaContentSynchronizationCatalog/README.md
 last_modified_at: '2020-08-03 11:01:09 +0100'
-content: |
+content: |-
   The Magento_MediaContentCatalog provides the implementation of MediaContentSyncronization functionality for Magento_Catalog module
 
   ## Extensibility

--- a/src/_data/codebase/v2_4/mrg/ce/MediaContentSynchronizationCms.yml
+++ b/src/_data/codebase/v2_4/mrg/ce/MediaContentSynchronizationCms.yml
@@ -4,7 +4,7 @@ source_repo: magento2ce
 release: 2.4.1
 github_path: app/code/Magento/MediaContentSynchronizationCms/README.md
 last_modified_at: '2020-08-03 11:01:09 +0100'
-content: |
+content: |-
   The Magento_MediaContentCms provides the implementation of MediaContentSyncronization functionality for Magento_Cms module
 
   ## Extensibility

--- a/src/_data/codebase/v2_4/mrg/ce/MediaGallery.yml
+++ b/src/_data/codebase/v2_4/mrg/ce/MediaGallery.yml
@@ -4,7 +4,7 @@ source_repo: magento2ce
 release: 2.4.1
 github_path: app/code/Magento/MediaGallery/README.md
 last_modified_at: '2019-11-04 11:34:55 +0000'
-content: |
+content: |-
   The Magento_MediaGallery module is responsible for storing and managing media gallery assets attributes.
 
   ## Installation details

--- a/src/_data/codebase/v2_4/mrg/ce/MediaGalleryApi.yml
+++ b/src/_data/codebase/v2_4/mrg/ce/MediaGalleryApi.yml
@@ -4,7 +4,7 @@ source_repo: magento2ce
 release: 2.4.1
 github_path: app/code/Magento/MediaGalleryApi/README.md
 last_modified_at: '2019-11-04 11:34:55 +0000'
-content: |
+content: |-
   The Magento_MediaGalleryApi module serves as application program interface (API) responsible for storing and managing media gallery asset attributes.
 
   ## Extensibility

--- a/src/_data/codebase/v2_4/mrg/ce/MediaGalleryCatalog.yml
+++ b/src/_data/codebase/v2_4/mrg/ce/MediaGalleryCatalog.yml
@@ -4,7 +4,7 @@ source_repo: magento2ce
 release: 2.4.1
 github_path: app/code/Magento/MediaGalleryCatalog/README.md
 last_modified_at: '2020-04-09 11:17:22 +0100'
-content: |
+content: |-
   The Magento_MediaGalleryCatalog module is responsible for for catalog gallery processor delete operation handling
 
   ## Installation details

--- a/src/_data/codebase/v2_4/mrg/ce/MediaGalleryCatalogIntegration.yml
+++ b/src/_data/codebase/v2_4/mrg/ce/MediaGalleryCatalogIntegration.yml
@@ -4,6 +4,4 @@ source_repo: magento2ce
 release: 2.4.1
 github_path: app/code/Magento/MediaGalleryCatalogIntegration/README.md
 last_modified_at: '2020-08-03 11:01:09 +0100'
-content: 'The purpose of this module is for extending catalog image uploader functionality.
-
-'
+content: The purpose of this module is for extending catalog image uploader functionality.

--- a/src/_data/codebase/v2_4/mrg/ce/MediaGalleryCatalogUi.yml
+++ b/src/_data/codebase/v2_4/mrg/ce/MediaGalleryCatalogUi.yml
@@ -4,7 +4,7 @@ source_repo: magento2ce
 release: 2.4.1
 github_path: app/code/Magento/MediaGalleryCatalogUi/README.md
 last_modified_at: '2020-08-03 11:01:09 +0100'
-content: |
+content: |-
   The Magento_MediaGalleryCatalogUi module that implement category grid for media gallery.
 
   ## Extensibility

--- a/src/_data/codebase/v2_4/mrg/ce/MediaGalleryCmsUi.yml
+++ b/src/_data/codebase/v2_4/mrg/ce/MediaGalleryCmsUi.yml
@@ -4,7 +4,7 @@ source_repo: magento2ce
 release: 2.4.1
 github_path: app/code/Magento/MediaGalleryCmsUi/README.md
 last_modified_at: '2020-08-03 11:01:09 +0100'
-content: |
+content: |-
   The Magento_MediaGalleryCmsUi module provides Magento_Cms related UI elements to the media gallery user interface
 
   ## Extensibility

--- a/src/_data/codebase/v2_4/mrg/ce/MediaGalleryIntegration.yml
+++ b/src/_data/codebase/v2_4/mrg/ce/MediaGalleryIntegration.yml
@@ -4,7 +4,5 @@ source_repo: magento2ce
 release: 2.4.1
 github_path: app/code/Magento/MediaGalleryIntegration/README.md
 last_modified_at: '2020-08-03 11:01:09 +0100'
-content: 'The purpose of this module is to keep the integration of enhanced media
-  gallery to Magento separated from implementation.
-
-'
+content: The purpose of this module is to keep the integration of enhanced media gallery
+  to Magento separated from implementation.

--- a/src/_data/codebase/v2_4/mrg/ce/MediaGalleryMetadata.yml
+++ b/src/_data/codebase/v2_4/mrg/ce/MediaGalleryMetadata.yml
@@ -4,8 +4,6 @@ source_repo: magento2ce
 release: 2.4.1
 github_path: app/code/Magento/MediaGalleryMetadata/README.md
 last_modified_at: '2020-08-03 11:01:09 +0100'
-content: 'The purpose of this module is to provide an ability to extract the metadata
+content: The purpose of this module is to provide an ability to extract the metadata
   from file and populating Media Asset entity fields when an image is uploaded to
   Magento and also provide an ability to update the metadata stored in an image file.
-
-'

--- a/src/_data/codebase/v2_4/mrg/ce/MediaGalleryMetadataApi.yml
+++ b/src/_data/codebase/v2_4/mrg/ce/MediaGalleryMetadataApi.yml
@@ -4,7 +4,5 @@ source_repo: magento2ce
 release: 2.4.1
 github_path: app/code/Magento/MediaGalleryMetadataApi/README.md
 last_modified_at: '2020-08-03 11:01:09 +0100'
-content: 'The Magento_MediaGalleryMetadataApi module is responsible for the media
-  gallery metadata implementation API.
-
-'
+content: The Magento_MediaGalleryMetadataApi module is responsible for the media gallery
+  metadata implementation API.

--- a/src/_data/codebase/v2_4/mrg/ce/MediaGallerySynchronization.yml
+++ b/src/_data/codebase/v2_4/mrg/ce/MediaGallerySynchronization.yml
@@ -4,7 +4,7 @@ source_repo: magento2ce
 release: 2.4.1
 github_path: app/code/Magento/MediaGallerySynchronization/README.md
 last_modified_at: '2020-08-03 11:29:40 +0100'
-content: |
+content: |-
   The Magento_MediaGallerySynchronization module represents implementation of synchronization between data and objects contains
   media asset information.
 

--- a/src/_data/codebase/v2_4/mrg/ce/MediaGallerySynchronizationApi.yml
+++ b/src/_data/codebase/v2_4/mrg/ce/MediaGallerySynchronizationApi.yml
@@ -4,7 +4,7 @@ source_repo: magento2ce
 release: 2.4.1
 github_path: app/code/Magento/MediaGallerySynchronizationApi/README.md
 last_modified_at: '2020-08-03 11:29:40 +0100'
-content: |
+content: |-
   The Magento_MediaGallerySynchronizationApi module is responsible for the media gallery data synchronization implementation API.
 
   ## Extensibility

--- a/src/_data/codebase/v2_4/mrg/ce/MediaGallerySynchronizationMetadata.yml
+++ b/src/_data/codebase/v2_4/mrg/ce/MediaGallerySynchronizationMetadata.yml
@@ -4,7 +4,5 @@ source_repo: magento2ce
 release: 2.4.1
 github_path: app/code/Magento/MediaGallerySynchronizationMetadata/README.md
 last_modified_at: '2020-08-29 16:38:18 +0100'
-content: 'The purpose of this module is to include assets metadata to media gallery
+content: The purpose of this module is to include assets metadata to media gallery
   synchronization process
-
-'

--- a/src/_data/codebase/v2_4/mrg/ce/MediaGalleryUi.yml
+++ b/src/_data/codebase/v2_4/mrg/ce/MediaGalleryUi.yml
@@ -4,7 +4,7 @@ source_repo: magento2ce
 release: 2.4.1
 github_path: app/code/Magento/MediaGalleryUi/README.md
 last_modified_at: '2020-08-03 11:01:09 +0100'
-content: |
+content: |-
   The Magento_MediaGalleryUi module is responsible for the media gallery user interface (UI) implementation.
 
   ## Extensibility

--- a/src/_data/codebase/v2_4/mrg/ce/MediaGalleryUiApi.yml
+++ b/src/_data/codebase/v2_4/mrg/ce/MediaGalleryUiApi.yml
@@ -4,7 +4,7 @@ source_repo: magento2ce
 release: 2.4.1
 github_path: app/code/Magento/MediaGalleryUiApi/README.md
 last_modified_at: '2020-08-03 11:01:09 +0100'
-content: |
+content: |-
   The Magento_MediaGalleryUiApi module is responsible for the media gallery user interface (UI) implementation API.
 
   ## Extensibility

--- a/src/_data/codebase/v2_4/mrg/ce/MediaStorage.yml
+++ b/src/_data/codebase/v2_4/mrg/ce/MediaStorage.yml
@@ -4,7 +4,5 @@ source_repo: magento2ce
 release: 2.4.1
 github_path: app/code/Magento/MediaStorage/README.md
 last_modified_at: '2015-02-26 14:04:15 +0200'
-content: 'The Magento_MediaStorage module implements functionality related with upload
+content: The Magento_MediaStorage module implements functionality related with upload
   media files and synchronize it by database.
-
-'

--- a/src/_data/codebase/v2_4/mrg/ce/MessageQueue.yml
+++ b/src/_data/codebase/v2_4/mrg/ce/MessageQueue.yml
@@ -4,4 +4,4 @@ source_repo: magento2ce
 release: 2.4.1
 github_path: app/code/Magento/MessageQueue/README.md
 last_modified_at: '2018-02-21 14:27:13 +0200'
-content: "**MessageQueue** provides support of Advanced Message Queuing Protocol\n"
+content: "**MessageQueue** provides support of Advanced Message Queuing Protocol"

--- a/src/_data/codebase/v2_4/mrg/ce/MysqlMq.yml
+++ b/src/_data/codebase/v2_4/mrg/ce/MysqlMq.yml
@@ -4,4 +4,4 @@ source_repo: magento2ce
 release: 2.4.1
 github_path: app/code/Magento/MysqlMq/README.md
 last_modified_at: '2018-02-21 14:27:42 +0200'
-content: "**MysqlMq** provides message queue implementation based on MySQL.\n"
+content: "**MysqlMq** provides message queue implementation based on MySQL."

--- a/src/_data/codebase/v2_4/mrg/ce/NewRelicReporting.yml
+++ b/src/_data/codebase/v2_4/mrg/ce/NewRelicReporting.yml
@@ -6,4 +6,4 @@ github_path: app/code/Magento/NewRelicReporting/README.md
 last_modified_at: '2015-10-01 16:15:45 +0300'
 content: "Module Magento\\NewRelicReporting implements integration New Relic APM and
   New Relic Insights with Magento, giving \nreal-time visibility into business and
-  performance metrics for data-driven decision making. "
+  performance metrics for data-driven decision making."

--- a/src/_data/codebase/v2_4/mrg/ce/Newsletter.yml
+++ b/src/_data/codebase/v2_4/mrg/ce/Newsletter.yml
@@ -4,8 +4,6 @@ source_repo: magento2ce
 release: 2.4.1
 github_path: app/code/Magento/Newsletter/README.md
 last_modified_at: '2014-12-12 12:14:06 -0800'
-content: 'Magento_Newsletter module allows clients to subscribe for information about
+content: Magento_Newsletter module allows clients to subscribe for information about
   new promotions and discounts and allows store administrators to send newsletters
   to clients subscribed for them.
-
-'

--- a/src/_data/codebase/v2_4/mrg/ce/NewsletterGraphQl.yml
+++ b/src/_data/codebase/v2_4/mrg/ce/NewsletterGraphQl.yml
@@ -4,7 +4,5 @@ source_repo: magento2ce
 release: 2.4.1
 github_path: app/code/Magento/NewsletterGraphQl/README.md
 last_modified_at: '2020-05-07 00:32:47 +0300'
-content: 'The Magento_NewsletterGraphQl module allows a shopper to subscribe to a
-  newsletter using GraphQL.
-
-'
+content: The Magento_NewsletterGraphQl module allows a shopper to subscribe to a newsletter
+  using GraphQL.

--- a/src/_data/codebase/v2_4/mrg/ce/OfflinePayments.yml
+++ b/src/_data/codebase/v2_4/mrg/ce/OfflinePayments.yml
@@ -4,7 +4,7 @@ source_repo: magento2ce
 release: 2.4.1
 github_path: app/code/Magento/OfflinePayments/README.md
 last_modified_at: '2014-10-31 09:04:08 -0700'
-content: |
+content: |-
   The Magento_OfflinePayments module implements the payment methods which do not require interaction with a payment gateway (so called offline methods). These methods are the following:
   *Bank transfer
   *Cash on delivery

--- a/src/_data/codebase/v2_4/mrg/ce/OfflineShipping.yml
+++ b/src/_data/codebase/v2_4/mrg/ce/OfflineShipping.yml
@@ -4,10 +4,9 @@ source_repo: magento2ce
 release: 2.4.1
 github_path: app/code/Magento/OfflineShipping/README.md
 last_modified_at: '2014-10-31 09:04:08 -0700'
-content: |+
+content: |-
   The Magento_OfflineShipping module implements the shipping methods which do not involve a direct interaction with shipping carriers, so called offline shipping methods. Namely, the following:
   *Free Shipping
   *Flat Rate
   *Table Rates
   *Store Pickup
-

--- a/src/_data/codebase/v2_4/mrg/ce/Payment.yml
+++ b/src/_data/codebase/v2_4/mrg/ce/Payment.yml
@@ -4,6 +4,6 @@ source_repo: magento2ce
 release: 2.4.1
 github_path: app/code/Magento/Payment/README.md
 last_modified_at: '2014-10-31 09:04:08 -0700'
-content: |
+content: |-
   The Magento_Payment module provides the abstraction level for all payment methods, and all logic that should be used when adding a new payment method. This logic includes configuration models, separate models for payment data verification and so on.
   For example, Magento\Payment\Model\Method\AbstractMethod is an abstract model which should be extended by particular payment methods.

--- a/src/_data/codebase/v2_4/mrg/ce/Paypal.yml
+++ b/src/_data/codebase/v2_4/mrg/ce/Paypal.yml
@@ -4,7 +4,7 @@ source_repo: magento2ce
 release: 2.4.1
 github_path: app/code/Magento/Paypal/README.md
 last_modified_at: '2019-03-31 18:42:40 +0300'
-content: |
+content: |-
   Module Magento\PayPal implements integration with the PayPal payment system. Namely, it enables the following payment methods:
   * PayPal Express Checkout
   * PayPal Payments Standard

--- a/src/_data/codebase/v2_4/mrg/ce/PaypalGraphQl.yml
+++ b/src/_data/codebase/v2_4/mrg/ce/PaypalGraphQl.yml
@@ -5,4 +5,4 @@ release: 2.4.1
 github_path: app/code/Magento/PaypalGraphQl/README.md
 last_modified_at: '2019-05-23 10:50:05 -0500'
 content: "**PaypalGraphQl** provides resolver information for using Paypal payment
-  methods via GraphQl.\n"
+  methods via GraphQl."

--- a/src/_data/codebase/v2_4/mrg/ce/Persistent.yml
+++ b/src/_data/codebase/v2_4/mrg/ce/Persistent.yml
@@ -4,7 +4,7 @@ source_repo: magento2ce
 release: 2.4.1
 github_path: app/code/Magento/Persistent/README.md
 last_modified_at: '2014-10-24 14:51:44 -0700'
-content: |
+content: |-
   Magento\Persistent module enables set customer a long-term cookie containing internal id (random hash - to exclude brute
   force) of persistent session. Persistent session data is kept in DB - so it's not deleted in some days and is kept for
   as much time as we need. DB session keeps customerId + some data from real customer session that we want to sync (e.g.

--- a/src/_data/codebase/v2_4/mrg/ce/ProductAlert.yml
+++ b/src/_data/codebase/v2_4/mrg/ce/ProductAlert.yml
@@ -4,7 +4,5 @@ source_repo: magento2ce
 release: 2.4.1
 github_path: app/code/Magento/ProductAlert/README.md
 last_modified_at: '2014-10-31 09:04:08 -0700'
-content: 'The Magento_ProductAlert module enables product alerts, which allow customers
+content: The Magento_ProductAlert module enables product alerts, which allow customers
   to sign up for emails about product price or stock status change.
-
-'

--- a/src/_data/codebase/v2_4/mrg/ce/ProductVideo.yml
+++ b/src/_data/codebase/v2_4/mrg/ce/ProductVideo.yml
@@ -4,7 +4,5 @@ source_repo: magento2ce
 release: 2.4.1
 github_path: app/code/Magento/ProductVideo/README.md
 last_modified_at: '2015-09-11 16:19:20 +0300'
-content: 'The Magento_ProductVideo module implements functionality related with linking
+content: The Magento_ProductVideo module implements functionality related with linking
   video files from external resources to product.
-
-'

--- a/src/_data/codebase/v2_4/mrg/ce/Quote.yml
+++ b/src/_data/codebase/v2_4/mrg/ce/Quote.yml
@@ -4,7 +4,7 @@ source_repo: magento2ce
 release: 2.4.1
 github_path: app/code/Magento/Quote/README.md
 last_modified_at: '2015-01-06 12:45:10 +0200'
-content: |
+content: |-
   ## Purpose of module
 
 

--- a/src/_data/codebase/v2_4/mrg/ce/QuoteAnalytics.yml
+++ b/src/_data/codebase/v2_4/mrg/ce/QuoteAnalytics.yml
@@ -4,7 +4,5 @@ source_repo: magento2ce
 release: 2.4.1
 github_path: app/code/Magento/QuoteAnalytics/README.md
 last_modified_at: '2019-08-06 14:40:28 -0500'
-content: 'The Magento_QuoteAnalytics module configures data definitions for a data
+content: The Magento_QuoteAnalytics module configures data definitions for a data
   collection related to the Quote module entities to be used in [Advanced Reporting](https://devdocs.magento.com/guides/v2.3/advanced-reporting/modules.html).
-
-'

--- a/src/_data/codebase/v2_4/mrg/ce/QuoteBundleOptions.yml
+++ b/src/_data/codebase/v2_4/mrg/ce/QuoteBundleOptions.yml
@@ -5,4 +5,4 @@ release: 2.4.1
 github_path: app/code/Magento/QuoteBundleOptions/README.md
 last_modified_at: '2020-05-07 17:17:41 +0200'
 content: "**QuoteBundleOptions** provides data provider for creating buy request for
-  bundle products.\n"
+  bundle products."

--- a/src/_data/codebase/v2_4/mrg/ce/QuoteConfigurableOptions.yml
+++ b/src/_data/codebase/v2_4/mrg/ce/QuoteConfigurableOptions.yml
@@ -5,4 +5,4 @@ release: 2.4.1
 github_path: app/code/Magento/QuoteConfigurableOptions/README.md
 last_modified_at: '2020-05-07 17:17:41 +0200'
 content: "**QuoteConfigurableOptions** provides data provider for creating buy request
-  for configurable products.\n"
+  for configurable products."

--- a/src/_data/codebase/v2_4/mrg/ce/QuoteDownloadableLinks.yml
+++ b/src/_data/codebase/v2_4/mrg/ce/QuoteDownloadableLinks.yml
@@ -5,4 +5,4 @@ release: 2.4.1
 github_path: app/code/Magento/QuoteDownloadableLinks/README.md
 last_modified_at: '2020-05-07 17:17:41 +0200'
 content: "**QuoteDownloadableLinks** provides data provider for creating buy request
-  for links of downloadable products.\n"
+  for links of downloadable products."

--- a/src/_data/codebase/v2_4/mrg/ce/QuoteGraphQl.yml
+++ b/src/_data/codebase/v2_4/mrg/ce/QuoteGraphQl.yml
@@ -4,6 +4,6 @@ source_repo: magento2ce
 release: 2.4.1
 github_path: app/code/Magento/QuoteGraphQl/README.md
 last_modified_at: '2018-07-31 14:11:47 +0200'
-content: |
+content: |-
   **QuoteGraphQl** provides type and resolver information for the GraphQl module
   to generate quote (cart) information endpoints. Also provides endpoints for modifying a quote.

--- a/src/_data/codebase/v2_4/mrg/ce/ReleaseNotification.yml
+++ b/src/_data/codebase/v2_4/mrg/ce/ReleaseNotification.yml
@@ -45,4 +45,4 @@ content: "The **Release Notification Module** serves to provide a notification d
   will cause a clickable link to be created. The text between the brackets [text]
   will be the text that the clickable link shows.\n\n### Link Format Example:\n\nThe
   text: `https://devdocs.magento.com/ [Magento DevDocs].` will appear as [Magento
-  DevDocs](https://devdocs.magento.com/).\n"
+  DevDocs](https://devdocs.magento.com/)."

--- a/src/_data/codebase/v2_4/mrg/ce/Reports.yml
+++ b/src/_data/codebase/v2_4/mrg/ce/Reports.yml
@@ -4,7 +4,7 @@ source_repo: magento2ce
 release: 2.4.1
 github_path: app/code/Magento/Reports/README.md
 last_modified_at: '2014-12-12 12:14:06 -0800'
-content: |
+content: |-
   Magento_Reports module provides ability to collect various reports such as:
    - products reports (bestsellers, low stock, most viewed, products ordered),
    - sales reports (orders, tax, invoiced, shipping, refunds, coupons, and PayPal settlement reports),

--- a/src/_data/codebase/v2_4/mrg/ce/RequireJs.yml
+++ b/src/_data/codebase/v2_4/mrg/ce/RequireJs.yml
@@ -4,7 +4,7 @@ source_repo: magento2ce
 release: 2.4.1
 github_path: app/code/Magento/RequireJs/README.md
 last_modified_at: '2014-11-28 11:40:11 -0800'
-content: |
+content: |-
   ## Purpose of module
 
   The Magento\RequireJs module introduces support for RequireJs JavaScript library and provides infrastructure for other modules to have them declared related configuration for RequireJs library.

--- a/src/_data/codebase/v2_4/mrg/ce/Review.yml
+++ b/src/_data/codebase/v2_4/mrg/ce/Review.yml
@@ -4,6 +4,4 @@ source_repo: magento2ce
 release: 2.4.1
 github_path: app/code/Magento/Review/README.md
 last_modified_at: '2014-12-12 12:14:06 -0800'
-content: 'Magento_Review module functionality allows to write reviews for products.
-
-'
+content: Magento_Review module functionality allows to write reviews for products.

--- a/src/_data/codebase/v2_4/mrg/ce/ReviewAnalytics.yml
+++ b/src/_data/codebase/v2_4/mrg/ce/ReviewAnalytics.yml
@@ -4,7 +4,5 @@ source_repo: magento2ce
 release: 2.4.1
 github_path: app/code/Magento/ReviewAnalytics/README.md
 last_modified_at: '2019-08-06 14:40:28 -0500'
-content: 'The Magento_ReviewAnalytics module configures data definitions for a data
+content: The Magento_ReviewAnalytics module configures data definitions for a data
   collection related to the Review module entities to be used in [Advanced Reporting](https://devdocs.magento.com/guides/v2.3/advanced-reporting/modules.html).
-
-'

--- a/src/_data/codebase/v2_4/mrg/ce/ReviewGraphQl.yml
+++ b/src/_data/codebase/v2_4/mrg/ce/ReviewGraphQl.yml
@@ -5,4 +5,4 @@ release: 2.4.1
 github_path: app/code/Magento/ReviewGraphQl/README.md
 last_modified_at: '2020-05-06 14:36:44 +0300'
 content: "**ReviewGraphQl** provides endpoints for getting and creating the Product
-  reviews by guest and logged in customers.\n"
+  reviews by guest and logged in customers."

--- a/src/_data/codebase/v2_4/mrg/ce/Robots.yml
+++ b/src/_data/codebase/v2_4/mrg/ce/Robots.yml
@@ -7,4 +7,4 @@ last_modified_at: '2017-06-15 17:15:28 +0300'
 content: "The Robots module provides the following functionalities: \n* contains a
   router to match application action class for requests to the `robots.txt` file;\n*
   allows obtaining the content of the `robots.txt` file depending on the settings
-  of the current website.\n"
+  of the current website."

--- a/src/_data/codebase/v2_4/mrg/ce/Rss.yml
+++ b/src/_data/codebase/v2_4/mrg/ce/Rss.yml
@@ -4,7 +4,5 @@ source_repo: magento2ce
 release: 2.4.1
 github_path: app/code/Magento/Rss/README.md
 last_modified_at: '2014-12-12 12:14:06 -0800'
-content: 'Magento_Rss module is responsible for processing all RSS feeds of the application
+content: Magento_Rss module is responsible for processing all RSS feeds of the application
   and allows to turn on/off RSS centrally.
-
-'

--- a/src/_data/codebase/v2_4/mrg/ce/Rule.yml
+++ b/src/_data/codebase/v2_4/mrg/ce/Rule.yml
@@ -6,6 +6,4 @@ github_path: app/code/Magento/Rule/README.md
 last_modified_at: '2014-12-12 12:14:06 -0800'
 content: 'Magento_Rule module provides abstract implementation of rules and rule conditions
   that are extended by other modules, in particular by: Magento_SalesRule, Magento_CatalogRule,
-  etc...
-
-'
+  etc...'

--- a/src/_data/codebase/v2_4/mrg/ce/Sales.yml
+++ b/src/_data/codebase/v2_4/mrg/ce/Sales.yml
@@ -4,7 +4,7 @@ source_repo: magento2ce
 release: 2.4.1
 github_path: app/code/Magento/Sales/README.md
 last_modified_at: '2014-10-24 14:51:44 -0700'
-content: |
+content: |-
   ## Purpose of module
 
   Magento\Sales module is responsible for order processing and appearance in system,

--- a/src/_data/codebase/v2_4/mrg/ce/SalesAnalytics.yml
+++ b/src/_data/codebase/v2_4/mrg/ce/SalesAnalytics.yml
@@ -4,7 +4,5 @@ source_repo: magento2ce
 release: 2.4.1
 github_path: app/code/Magento/SalesAnalytics/README.md
 last_modified_at: '2019-08-06 14:40:28 -0500'
-content: 'The Magento_SalesAnalytics module configures data definitions for a data
+content: The Magento_SalesAnalytics module configures data definitions for a data
   collection related to the Sales module entities to be used in [Advanced Reporting](https://devdocs.magento.com/guides/v2.3/advanced-reporting/modules.html).
-
-'

--- a/src/_data/codebase/v2_4/mrg/ce/SalesGraphQl.yml
+++ b/src/_data/codebase/v2_4/mrg/ce/SalesGraphQl.yml
@@ -4,6 +4,6 @@ source_repo: magento2ce
 release: 2.4.1
 github_path: app/code/Magento/SalesGraphQl/README.md
 last_modified_at: '2018-10-15 19:46:32 +0300'
-content: |
+content: |-
   **SalesGraphQl** provides type and resolver information for the GraphQl module
   to generate sales orders information.

--- a/src/_data/codebase/v2_4/mrg/ce/SalesInventory.yml
+++ b/src/_data/codebase/v2_4/mrg/ce/SalesInventory.yml
@@ -4,7 +4,5 @@ source_repo: magento2ce
 release: 2.4.1
 github_path: app/code/Magento/SalesInventory/README.md
 last_modified_at: '2016-09-21 16:39:44 +0300'
-content: 'Magento_SalesInventory module allows retrieve and update stock attributes
+content: Magento_SalesInventory module allows retrieve and update stock attributes
   related to Magento_Sales, such as status and quantity.
-
-'

--- a/src/_data/codebase/v2_4/mrg/ce/SalesRule.yml
+++ b/src/_data/codebase/v2_4/mrg/ce/SalesRule.yml
@@ -4,5 +4,5 @@ source_repo: magento2ce
 release: 2.4.1
 github_path: app/code/Magento/SalesRule/README.md
 last_modified_at: '2014-10-24 14:51:44 -0700'
-content: "SalesRule module is responsible for managing and processing Promotion Shopping
-  Cart Rules.\n\n"
+content: SalesRule module is responsible for managing and processing Promotion Shopping
+  Cart Rules.

--- a/src/_data/codebase/v2_4/mrg/ce/SalesSequence.yml
+++ b/src/_data/codebase/v2_4/mrg/ce/SalesSequence.yml
@@ -4,7 +4,7 @@ source_repo: magento2ce
 release: 2.4.1
 github_path: app/code/Magento/SalesSequence/README.md
 last_modified_at: '2015-03-20 16:50:43 +0200'
-content: |
+content: |-
   ## Purpose of module
 
   Magento\SalesSequence module is responsible for sequences processing in Sales module,

--- a/src/_data/codebase/v2_4/mrg/ce/SampleData.yml
+++ b/src/_data/codebase/v2_4/mrg/ce/SampleData.yml
@@ -4,7 +4,7 @@ source_repo: magento2ce
 release: 2.4.1
 github_path: app/code/Magento/SampleData/README.md
 last_modified_at: '2020-06-16 18:27:26 +0100'
-content: |
+content: |-
   Magento sample data includes a sample store, complete with more than 250 products (about 200 of them are configurable products), categories, promotional price rules, CMS pages, banners, and so on. Sample data uses the Luma theme on the storefront.
 
   Installing sample data is optional.

--- a/src/_data/codebase/v2_4/mrg/ce/Search.yml
+++ b/src/_data/codebase/v2_4/mrg/ce/Search.yml
@@ -4,7 +4,5 @@ source_repo: magento2ce
 release: 2.4.1
 github_path: app/code/Magento/Search/README.md
 last_modified_at: '2014-12-12 12:14:06 -0800'
-content: 'Magento_Search module introduces basic search functionality and provides
+content: Magento_Search module introduces basic search functionality and provides
   interfaces that allow to implement search for specific module.
-
-'

--- a/src/_data/codebase/v2_4/mrg/ce/Security.yml
+++ b/src/_data/codebase/v2_4/mrg/ce/Security.yml
@@ -4,7 +4,7 @@ source_repo: magento2ce
 release: 2.4.1
 github_path: app/code/Magento/Security/README.md
 last_modified_at: '2016-01-11 17:45:47 +0300'
-content: |
+content: |-
   **Security** management module
   _Main features:_
   1. Added support for simultaneous admin user logins with ability to enable/disable the feature, review and disconnect the list of current logged in sessions

--- a/src/_data/codebase/v2_4/mrg/ce/SendFriend.yml
+++ b/src/_data/codebase/v2_4/mrg/ce/SendFriend.yml
@@ -4,8 +4,6 @@ source_repo: magento2ce
 release: 2.4.1
 github_path: app/code/Magento/SendFriend/README.md
 last_modified_at: '2015-06-02 12:45:34 +0300'
-content: 'The Magento_SendFriend implements the functionality behind the "Email to
+content: The Magento_SendFriend implements the functionality behind the "Email to
   a Friend" link on a product page, which allows to share favorite products with others
   by clicking the link.
-
-'

--- a/src/_data/codebase/v2_4/mrg/ce/SendFriendGraphQl.yml
+++ b/src/_data/codebase/v2_4/mrg/ce/SendFriendGraphQl.yml
@@ -4,4 +4,4 @@ source_repo: magento2ce
 release: 2.4.1
 github_path: app/code/Magento/SendFriendGraphQl/README.md
 last_modified_at: '2018-11-19 20:18:31 +0200'
-content: "**SendFriendGraphQl** provides support of GraphQL for SendFriend functionality.\n"
+content: "**SendFriendGraphQl** provides support of GraphQL for SendFriend functionality."

--- a/src/_data/codebase/v2_4/mrg/ce/Shipping.yml
+++ b/src/_data/codebase/v2_4/mrg/ce/Shipping.yml
@@ -4,6 +4,6 @@ source_repo: magento2ce
 release: 2.4.1
 github_path: app/code/Magento/Shipping/README.md
 last_modified_at: '2014-10-31 09:04:08 -0700'
-content: |
+content: |-
   The Magento_Shipping module provides the abstract models and interfaces for a shipping carrier integration, including the web interface for the Shipment entity.
   You need to extend these abstractions if you are adding new shipping carrier integration.

--- a/src/_data/codebase/v2_4/mrg/ce/StoreGraphQl.yml
+++ b/src/_data/codebase/v2_4/mrg/ce/StoreGraphQl.yml
@@ -4,6 +4,6 @@ source_repo: magento2ce
 release: 2.4.1
 github_path: app/code/Magento/StoreGraphQl/README.md
 last_modified_at: '2018-04-09 17:36:37 -0500'
-content: |
+content: |-
   **StoreGraphQl** provides type information for the GraphQl module
   to generate store fields information endpoints.

--- a/src/_data/codebase/v2_4/mrg/ce/Swagger.yml
+++ b/src/_data/codebase/v2_4/mrg/ce/Swagger.yml
@@ -4,7 +4,7 @@ source_repo: magento2ce
 release: 2.4.1
 github_path: app/code/Magento/Swagger/README.md
 last_modified_at: '2015-08-14 15:14:44 -0500'
-content: |
+content: |-
   The Magento_Swagger module provides access to a page generated using the swagger-ui package. The swagger-ui can be viewed
   [on Github](https://github.com/swagger-api/swagger-ui). It accesses the JSON Schema describing Magento's REST APIs,
   and displays it in a user-friendly, navigable format.

--- a/src/_data/codebase/v2_4/mrg/ce/SwatchesGraphQl.yml
+++ b/src/_data/codebase/v2_4/mrg/ce/SwatchesGraphQl.yml
@@ -4,6 +4,6 @@ source_repo: magento2ce
 release: 2.4.1
 github_path: app/code/Magento/SwatchesGraphQl/README.md
 last_modified_at: '2018-01-16 16:07:17 -0600'
-content: |
+content: |-
   **SwatchesGraphQl** provides type information for the GraphQl module
   to generate swatches fields for catalog and product information endpoints.

--- a/src/_data/codebase/v2_4/mrg/ce/SwatchesLayeredNavigation.yml
+++ b/src/_data/codebase/v2_4/mrg/ce/SwatchesLayeredNavigation.yml
@@ -4,7 +4,7 @@ source_repo: magento2ce
 release: 2.4.1
 github_path: app/code/Magento/SwatchesLayeredNavigation/README.md
 last_modified_at: '2016-03-10 13:38:33 +0200'
-content: |
+content: |-
   ## Overview
 
   The **Magento_SwatchesLayeredNavigation** module enables LayeredNavigation functionality for Swatch attributes

--- a/src/_data/codebase/v2_4/mrg/ce/TaxGraphQl.yml
+++ b/src/_data/codebase/v2_4/mrg/ce/TaxGraphQl.yml
@@ -4,6 +4,6 @@ source_repo: magento2ce
 release: 2.4.1
 github_path: app/code/Magento/TaxGraphQl/README.md
 last_modified_at: '2018-01-16 16:07:17 -0600'
-content: |
+content: |-
   **TaxGraphQl** provides type information for the GraphQl module
   to generate tax fields for catalog and product information endpoints.

--- a/src/_data/codebase/v2_4/mrg/ce/ThemeGraphQl.yml
+++ b/src/_data/codebase/v2_4/mrg/ce/ThemeGraphQl.yml
@@ -4,6 +4,6 @@ source_repo: magento2ce
 release: 2.4.1
 github_path: app/code/Magento/ThemeGraphQl/README.md
 last_modified_at: '2018-12-06 10:59:37 -0500'
-content: |
+content: |-
   **ThemeGraphQl** provides type information for the GraphQl module
   to generate theme fields information endpoints.

--- a/src/_data/codebase/v2_4/mrg/ce/Translation.yml
+++ b/src/_data/codebase/v2_4/mrg/ce/Translation.yml
@@ -4,6 +4,6 @@ source_repo: magento2ce
 release: 2.4.1
 github_path: app/code/Magento/Translation/README.md
 last_modified_at: '2014-12-12 12:14:06 -0800'
-content: |
+content: |-
   **Translation** enables localization of a store for multiple regions and markets.
   Also provides the inline translation tool.

--- a/src/_data/codebase/v2_4/mrg/ce/Ui.yml
+++ b/src/_data/codebase/v2_4/mrg/ce/Ui.yml
@@ -4,7 +4,7 @@ source_repo: magento2ce
 release: 2.4.1
 github_path: app/code/Magento/Ui/README.md
 last_modified_at: '2016-08-05 21:54:51 +1200'
-content: |
+content: |-
   ## Purpose of module
 
   The Magento\Ui module introduces a set of common UI components, which could be used and configured via layout XML files.

--- a/src/_data/codebase/v2_4/mrg/ce/Ups.yml
+++ b/src/_data/codebase/v2_4/mrg/ce/Ups.yml
@@ -4,7 +4,5 @@ source_repo: magento2ce
 release: 2.4.1
 github_path: app/code/Magento/Ups/README.md
 last_modified_at: '2014-10-31 09:04:08 -0700'
-content: 'The Magento_Ups module implements integration with the United Parcel Service
+content: The Magento_Ups module implements integration with the United Parcel Service
   shipping carrier.
-
-'

--- a/src/_data/codebase/v2_4/mrg/ce/UrlRewrite.yml
+++ b/src/_data/codebase/v2_4/mrg/ce/UrlRewrite.yml
@@ -4,7 +4,5 @@ source_repo: magento2ce
 release: 2.4.1
 github_path: app/code/Magento/UrlRewrite/README.md
 last_modified_at: '2014-12-12 12:14:06 -0800'
-content: 'Magento_UrlRewrite module provides ability to customize website URLs by
-  creating custom URL rewrite rules.
-
-'
+content: Magento_UrlRewrite module provides ability to customize website URLs by creating
+  custom URL rewrite rules.

--- a/src/_data/codebase/v2_4/mrg/ce/UrlRewriteGraphQl.yml
+++ b/src/_data/codebase/v2_4/mrg/ce/UrlRewriteGraphQl.yml
@@ -4,7 +4,7 @@ source_repo: magento2ce
 release: 2.4.1
 github_path: app/code/Magento/UrlRewriteGraphQl/README.md
 last_modified_at: '2018-01-17 11:18:15 -0600'
-content: |
+content: |-
   **UrlRewriteGraphQl** provides type information for the GraphQl module
   to generate url rewrites from entities that implement such rewrites,
   like categories, products or cms and other 3rd party modules.

--- a/src/_data/codebase/v2_4/mrg/ce/User.yml
+++ b/src/_data/codebase/v2_4/mrg/ce/User.yml
@@ -4,7 +4,7 @@ source_repo: magento2ce
 release: 2.4.1
 github_path: app/code/Magento/User/README.md
 last_modified_at: '2015-08-27 15:34:05 -0500'
-content: |
+content: |-
   **User** enables admin users to manage and assign roles to administrators and other non-customer users,
   reset user passwords, and invalidate access tokens.
   Different roles can be assigned to different users to define their permissions.

--- a/src/_data/codebase/v2_4/mrg/ce/Usps.yml
+++ b/src/_data/codebase/v2_4/mrg/ce/Usps.yml
@@ -4,7 +4,5 @@ source_repo: magento2ce
 release: 2.4.1
 github_path: app/code/Magento/Usps/README.md
 last_modified_at: '2014-10-31 09:04:08 -0700'
-content: 'The Magento_Usps module provides integration with the United States Postal
+content: The Magento_Usps module provides integration with the United States Postal
   Service shipping carrier.
-
-'

--- a/src/_data/codebase/v2_4/mrg/ce/Variable.yml
+++ b/src/_data/codebase/v2_4/mrg/ce/Variable.yml
@@ -4,7 +4,5 @@ source_repo: magento2ce
 release: 2.4.1
 github_path: app/code/Magento/Variable/README.md
 last_modified_at: '2015-02-10 10:11:24 -0600'
-content: 'Magento\Variable Allows to create custom variables and then use them in
-  email templates or in WYSIWYG editor for editing description of system entities.
-
-'
+content: Magento\Variable Allows to create custom variables and then use them in email
+  templates or in WYSIWYG editor for editing description of system entities.

--- a/src/_data/codebase/v2_4/mrg/ce/Vault.yml
+++ b/src/_data/codebase/v2_4/mrg/ce/Vault.yml
@@ -4,7 +4,5 @@ source_repo: magento2ce
 release: 2.4.1
 github_path: app/code/Magento/Vault/README.md
 last_modified_at: '2015-12-02 14:06:21 +0200'
-content: 'The Magento_Vault module implements the integration with the Vault payment
+content: The Magento_Vault module implements the integration with the Vault payment
   gateway and makes the latter available as a payment method in Magento.
-
-'

--- a/src/_data/codebase/v2_4/mrg/ce/VaultGraphQl.yml
+++ b/src/_data/codebase/v2_4/mrg/ce/VaultGraphQl.yml
@@ -4,7 +4,7 @@ source_repo: magento2ce
 release: 2.4.1
 github_path: app/code/Magento/VaultGraphQl/README.md
 last_modified_at: '2019-01-22 15:13:27 -0500'
-content: |
+content: |-
   **VaultGraphQl** provides type and resolver information for the GraphQl module
   to generate Vault (stored payment information) information endpoints. This module also
   provides mutations for modifying a payment token.

--- a/src/_data/codebase/v2_4/mrg/ce/Version.yml
+++ b/src/_data/codebase/v2_4/mrg/ce/Version.yml
@@ -4,6 +4,4 @@ source_repo: magento2ce
 release: 2.4.1
 github_path: app/code/Magento/Version/README.md
 last_modified_at: '2015-01-29 16:15:56 -0600'
-content: 'Magento\Version Allows to get Magento version and edition by HTTP GET request
-
-'
+content: Magento\Version Allows to get Magento version and edition by HTTP GET request

--- a/src/_data/codebase/v2_4/mrg/ce/Webapi.yml
+++ b/src/_data/codebase/v2_4/mrg/ce/Webapi.yml
@@ -4,7 +4,7 @@ source_repo: magento2ce
 release: 2.4.1
 github_path: app/code/Magento/Webapi/README.md
 last_modified_at: '2014-10-24 14:51:44 -0700'
-content: "**Webapi** provides the framework for the application to expose REST and
-  SOAP web services. It exposes an area for REST\nand another area for SOAP services
-  and routes requests based on the Webapi configuration. It also handles\ndeserialization
-  of requests and serialization of responses. \n"
+content: |-
+  **Webapi** provides the framework for the application to expose REST and SOAP web services. It exposes an area for REST
+  and another area for SOAP services and routes requests based on the Webapi configuration. It also handles
+  deserialization of requests and serialization of responses.

--- a/src/_data/codebase/v2_4/mrg/ce/WebapiAsync.yml
+++ b/src/_data/codebase/v2_4/mrg/ce/WebapiAsync.yml
@@ -6,4 +6,4 @@ github_path: app/code/Magento/WebapiAsync/README.md
 last_modified_at: '2018-03-20 12:57:53 +0200'
 content: "**WebapiAsync** Extends Webapi extension and provide functional to process
   asynchronous requests. It handle asynchronous requests, schedule, publish and consum
-  bulk operations from queue.\n"
+  bulk operations from queue."

--- a/src/_data/codebase/v2_4/mrg/ce/WebapiSecurity.yml
+++ b/src/_data/codebase/v2_4/mrg/ce/WebapiSecurity.yml
@@ -4,7 +4,7 @@ source_repo: magento2ce
 release: 2.4.1
 github_path: app/code/Magento/WebapiSecurity/README.md
 last_modified_at: '2016-03-22 15:38:49 -0500'
-content: |
+content: |-
   **WebapiSecurity** enables access management of some Web API resources.
   If checkbox is enabled in backend through: Stores -> Configuration -> Services -> Magento Web API -> Web Api Security
   then the security of all of the services outlined in app/code/Magento/WebapiSecurity/etc/di.xml would be loosened. You may modify this list to customize which services should follow this behavior.

--- a/src/_data/codebase/v2_4/mrg/ce/Weee.yml
+++ b/src/_data/codebase/v2_4/mrg/ce/Weee.yml
@@ -4,7 +4,7 @@ source_repo: magento2ce
 release: 2.4.1
 github_path: app/code/Magento/Weee/README.md
 last_modified_at: '2019-12-11 15:16:04 +0000'
-content: |
+content: |-
   The Magento_Weee module enables the application of fees/fixed product taxes (FPT) on certain types of products, usually related to electronic devices and recycling.
   Fixed product taxes can be used to setup a WEEE tax that is a fixed amount, rather than a percentage of the product price. FPT can be configured to be displayed at various places in Magento. Rules, amounts, and display options can be configured in the backend. This module extends the existing functionality of Magento_Tax.
 

--- a/src/_data/codebase/v2_4/mrg/ce/WeeeGraphQl.yml
+++ b/src/_data/codebase/v2_4/mrg/ce/WeeeGraphQl.yml
@@ -4,6 +4,6 @@ source_repo: magento2ce
 release: 2.4.1
 github_path: app/code/Magento/WeeeGraphQl/README.md
 last_modified_at: '2018-01-17 17:11:48 -0600'
-content: |
+content: |-
   **WeeeGraphQl** provides type information for the GraphQl module
   to generate wee tax fields for catalog and product information endpoints.

--- a/src/_data/codebase/v2_4/mrg/ce/Wishlist.yml
+++ b/src/_data/codebase/v2_4/mrg/ce/Wishlist.yml
@@ -4,6 +4,6 @@ source_repo: magento2ce
 release: 2.4.1
 github_path: app/code/Magento/Wishlist/README.md
 last_modified_at: '2014-10-31 09:04:08 -0700'
-content: |
+content: |-
   The Magento_Wishlist implements the Wishlist functionality.
   This allows customers to create a list of products that they can add to their shopping cart to be purchased at a later date, or share with friends.

--- a/src/_data/codebase/v2_4/mrg/ce/WishlistAnalytics.yml
+++ b/src/_data/codebase/v2_4/mrg/ce/WishlistAnalytics.yml
@@ -4,7 +4,5 @@ source_repo: magento2ce
 release: 2.4.1
 github_path: app/code/Magento/WishlistAnalytics/README.md
 last_modified_at: '2019-08-06 14:40:28 -0500'
-content: 'The Magento_WishlistAnalytics module configures data definitions for a data
+content: The Magento_WishlistAnalytics module configures data definitions for a data
   collection related to the Wishlist module entities to be used in [Advanced Reporting](https://devdocs.magento.com/guides/v2.3/advanced-reporting/modules.html).
-
-'

--- a/src/_data/codebase/v2_4/mrg/ce/WishlistGraphQl.yml
+++ b/src/_data/codebase/v2_4/mrg/ce/WishlistGraphQl.yml
@@ -4,6 +4,6 @@ source_repo: magento2ce
 release: 2.4.1
 github_path: app/code/Magento/WishlistGraphQl/README.md
 last_modified_at: '2018-10-26 12:42:07 +0200'
-content: |
+content: |-
   **WishlistGraphQl** provides type information for the GraphQl module
   to generate wishlist fields.

--- a/src/_data/codebase/v2_4/mrg/ee/AdminGws.yml
+++ b/src/_data/codebase/v2_4/mrg/ee/AdminGws.yml
@@ -6,4 +6,4 @@ github_path: app/code/Magento/AdminGws/README.md
 last_modified_at: '2014-12-17 18:31:49 +0000'
 content: "**AdminGws** provides configuration management within the Global, Website,
   and Store data scopes. Restrictions can be \nimposed on various system elements
-  through configurations that are applied at the desired level.\n"
+  through configurations that are applied at the desired level."

--- a/src/_data/codebase/v2_4/mrg/ee/AdminGwsConfigurableProduct.yml
+++ b/src/_data/codebase/v2_4/mrg/ee/AdminGwsConfigurableProduct.yml
@@ -4,7 +4,7 @@ source_repo: magento2ee
 release: 2.4.1
 github_path: app/code/Magento/AdminGwsConfigurableProduct/README.md
 last_modified_at: '2020-06-03 18:39:45 +0300'
-content: |
+content: |-
   <h2>Magento_AdminGwsConfigurableProduct module</h2>
 
   ## Overview

--- a/src/_data/codebase/v2_4/mrg/ee/AdminGwsStaging.yml
+++ b/src/_data/codebase/v2_4/mrg/ee/AdminGwsStaging.yml
@@ -4,7 +4,7 @@ source_repo: magento2ee
 release: 2.4.1
 github_path: app/code/Magento/AdminGwsStaging/README.md
 last_modified_at: '2020-03-23 14:32:03 +0200'
-content: |
+content: |-
   <h2>Magento_AdminGwsStaging module</h2>
 
   ## Overview

--- a/src/_data/codebase/v2_4/mrg/ee/AdvancedCatalog.yml
+++ b/src/_data/codebase/v2_4/mrg/ee/AdvancedCatalog.yml
@@ -4,7 +4,7 @@ source_repo: magento2ee
 release: 2.4.1
 github_path: app/code/Magento/AdvancedCatalog/README.md
 last_modified_at: '2015-06-22 19:38:00 +0300'
-content: |
+content: |-
   Magento\AdvancedCatalog module introduces list of optimizations to allow higher concurrency on product management
   operations with immediate update of product data on frontend and plays as an extension to indexation logic of
   Magento\Catalog module.

--- a/src/_data/codebase/v2_4/mrg/ee/AdvancedRule.yml
+++ b/src/_data/codebase/v2_4/mrg/ee/AdvancedRule.yml
@@ -4,4 +4,4 @@ source_repo: magento2ee
 release: 2.4.1
 github_path: app/code/Magento/AdvancedRule/README.md
 last_modified_at: '2015-11-20 12:14:51 -0600'
-content: "AdvancedRule module enhances the performance of rule processing.\n\n"
+content: AdvancedRule module enhances the performance of rule processing.

--- a/src/_data/codebase/v2_4/mrg/ee/AdvancedSalesRule.yml
+++ b/src/_data/codebase/v2_4/mrg/ee/AdvancedSalesRule.yml
@@ -4,4 +4,4 @@ source_repo: magento2ee
 release: 2.4.1
 github_path: app/code/Magento/AdvancedSalesRule/README.md
 last_modified_at: '2015-11-20 12:14:51 -0600'
-content: "AdvancedSalesRule module enhances the performance of sale rule processing.\n\n"
+content: AdvancedSalesRule module enhances the performance of sale rule processing.

--- a/src/_data/codebase/v2_4/mrg/ee/CatalogEvent.yml
+++ b/src/_data/codebase/v2_4/mrg/ee/CatalogEvent.yml
@@ -4,6 +4,6 @@ source_repo: magento2ee
 release: 2.4.1
 github_path: app/code/Magento/CatalogEvent/README.md
 last_modified_at: '2014-12-17 18:31:49 +0000'
-content: |
+content: |-
   Magento_CatalogEvent module is designed for creating campaigns that encourage customers to buy products with lower prices.
   There are three types of the catalog events: upcoming, open, closed.

--- a/src/_data/codebase/v2_4/mrg/ee/CatalogImportExportStaging.yml
+++ b/src/_data/codebase/v2_4/mrg/ee/CatalogImportExportStaging.yml
@@ -4,7 +4,7 @@ source_repo: magento2ee
 release: 2.4.1
 github_path: app/code/Magento/CatalogImportExportStaging/README.md
 last_modified_at: '2016-04-07 09:45:21 -0500'
-content: |
+content: |-
   <h2>Magento_CatalogImportExportStaging module</h2>
 
   ## Overview

--- a/src/_data/codebase/v2_4/mrg/ee/CatalogPermissions.yml
+++ b/src/_data/codebase/v2_4/mrg/ee/CatalogPermissions.yml
@@ -4,7 +4,7 @@ source_repo: magento2ee
 release: 2.4.1
 github_path: app/code/Magento/CatalogPermissions/README.md
 last_modified_at: '2015-05-14 15:09:36 +0300'
-content: |
+content: |-
   Magento_CatalogPermissions feature allows to restrict the following permissions:
   - Browse categories
   - Display product prices

--- a/src/_data/codebase/v2_4/mrg/ee/CatalogPermissionsGraphQl.yml
+++ b/src/_data/codebase/v2_4/mrg/ee/CatalogPermissionsGraphQl.yml
@@ -4,7 +4,5 @@ source_repo: magento2ee
 release: 2.4.1
 github_path: app/code/Magento/CatalogPermissionsGraphQl/README.md
 last_modified_at: '2020-06-21 10:09:05 +0200'
-content: 'Magento_CatalogPermissionsGraphQL feature allows to apply Magento_CatalogPermissions
+content: Magento_CatalogPermissionsGraphQL feature allows to apply Magento_CatalogPermissions
   features to product queries in GraphQl area
-
-'

--- a/src/_data/codebase/v2_4/mrg/ee/CatalogStagingGraphQl.yml
+++ b/src/_data/codebase/v2_4/mrg/ee/CatalogStagingGraphQl.yml
@@ -4,6 +4,6 @@ source_repo: magento2ee
 release: 2.4.1
 github_path: app/code/Magento/CatalogStagingGraphQl/README.md
 last_modified_at: '2020-01-14 14:07:38 -0600'
-content: |
+content: |-
   **CatalogStagingGraphQl** supports Staging functionality for Catalog in the scope of GraphQl.
   This includes preview capabilities for catalog entities.

--- a/src/_data/codebase/v2_4/mrg/ee/CheckoutAddressSearch.yml
+++ b/src/_data/codebase/v2_4/mrg/ee/CheckoutAddressSearch.yml
@@ -4,7 +4,7 @@ source_repo: magento2ee
 release: 2.4.1
 github_path: app/code/Magento/CheckoutAddressSearch/README.md
 last_modified_at: '2019-04-10 17:47:51 -0500'
-content: |
+content: |-
   ## CheckoutAddressSearch module Overview
 
   CheckoutAddressSearch module extends Magento_Checkout and adds functionality to search customer shipping and billing addresses with ui-select component.

--- a/src/_data/codebase/v2_4/mrg/ee/CheckoutAddressSearchGiftRegistry.yml
+++ b/src/_data/codebase/v2_4/mrg/ee/CheckoutAddressSearchGiftRegistry.yml
@@ -4,7 +4,7 @@ source_repo: magento2ee
 release: 2.4.1
 github_path: app/code/Magento/CheckoutAddressSearchGiftRegistry/README.md
 last_modified_at: '2019-04-05 18:54:17 -0500'
-content: |
+content: |-
   ## CheckoutAddressSearchGiftRegistry module Overview
 
   CheckoutAddressSearchGiftRegistry module extends Magento_GiftRegistry and adds search customer shipping and billing addresses functionality on checkout to gift registry only if customer address search is enabled in configuration.

--- a/src/_data/codebase/v2_4/mrg/ee/CheckoutStaging.yml
+++ b/src/_data/codebase/v2_4/mrg/ee/CheckoutStaging.yml
@@ -4,7 +4,7 @@ source_repo: magento2ee
 release: 2.4.1
 github_path: app/code/Magento/CheckoutStaging/README.md
 last_modified_at: '2016-07-04 12:55:14 +0000'
-content: |
+content: |-
   ## Magento_CheckoutStaging module
 
   ## Overview

--- a/src/_data/codebase/v2_4/mrg/ee/ConfigurableProductStaging.yml
+++ b/src/_data/codebase/v2_4/mrg/ee/ConfigurableProductStaging.yml
@@ -4,7 +4,7 @@ source_repo: magento2ee
 release: 2.4.1
 github_path: app/code/Magento/ConfigurableProductStaging/README.md
 last_modified_at: '2017-02-06 15:24:41 +0200'
-content: |
+content: |-
   ## Magento_ConfigurableProductStaging module
 
   ## Overview

--- a/src/_data/codebase/v2_4/mrg/ee/CustomAttributeManagement.yml
+++ b/src/_data/codebase/v2_4/mrg/ee/CustomAttributeManagement.yml
@@ -4,7 +4,7 @@ source_repo: magento2ee
 release: 2.4.1
 github_path: app/code/Magento/CustomAttributeManagement/README.md
 last_modified_at: '2014-12-17 18:31:49 +0000'
-content: |
+content: |-
   Magento_CustomAttributeManagement implements user-defined attributes management which provides ability to manage attributes of customers and their address.
   Admin user can manage attributes on UI level without assistance of programmer.
   Admin user can create new, modify, and remove attributes, control attributes properties and visibility on frontend.

--- a/src/_data/codebase/v2_4/mrg/ee/CustomerBalance.yml
+++ b/src/_data/codebase/v2_4/mrg/ee/CustomerBalance.yml
@@ -4,6 +4,6 @@ source_repo: magento2ee
 release: 2.4.1
 github_path: app/code/Magento/CustomerBalance/README.md
 last_modified_at: '2014-12-17 18:31:49 +0000'
-content: |
+content: |-
   The Magento_CustomerBalance module enables customers to have a non-monetary balance in store credits associated to their accounts.
   Store credit can be used by customers for shopping in the store and by the store administrator for making refunds.

--- a/src/_data/codebase/v2_4/mrg/ee/CustomerBalanceGraphQl.yml
+++ b/src/_data/codebase/v2_4/mrg/ee/CustomerBalanceGraphQl.yml
@@ -4,6 +4,6 @@ source_repo: magento2ee
 release: 2.4.1
 github_path: app/code/Magento/CustomerBalanceGraphQl/README.md
 last_modified_at: '2019-07-16 10:30:00 -0500'
-content: |
+content: |-
   The **CustomerBalanceGraphQl** provides type and resolver information for enabling customers to have a non-monetary balance in store credits associated to their accounts.
   Store credit can be used by customers for shopping in the store and by the store administrator for making refunds.

--- a/src/_data/codebase/v2_4/mrg/ee/CustomerCustomAttributes.yml
+++ b/src/_data/codebase/v2_4/mrg/ee/CustomerCustomAttributes.yml
@@ -4,6 +4,6 @@ source_repo: magento2ee
 release: 2.4.1
 github_path: app/code/Magento/CustomerCustomAttributes/README.md
 last_modified_at: '2014-12-17 18:31:49 +0000'
-content: |
+content: |-
   The Magento_CustomerCustomAttributes module handles user-defined customer and customer address attributes.
   User-defined attributes are the ones, which are created by a store administrator additionally to the default ones.

--- a/src/_data/codebase/v2_4/mrg/ee/CustomerFinance.yml
+++ b/src/_data/codebase/v2_4/mrg/ee/CustomerFinance.yml
@@ -4,6 +4,6 @@ source_repo: magento2ee
 release: 2.4.1
 github_path: app/code/Magento/CustomerFinance/README.md
 last_modified_at: '2014-12-17 18:31:49 +0000'
-content: |
+content: |-
   The Magento\CustomerFinance module handles the import and export of the store credit and reward customer data.
   It extends Magento_CustomerImportExport and joins the basic customer data with reward and customer balance information to enable to import/export of customer data with reward and store credit data.

--- a/src/_data/codebase/v2_4/mrg/ee/CustomerSegment.yml
+++ b/src/_data/codebase/v2_4/mrg/ee/CustomerSegment.yml
@@ -4,6 +4,6 @@ source_repo: magento2ee
 release: 2.4.1
 github_path: app/code/Magento/CustomerSegment/README.md
 last_modified_at: '2014-12-17 18:31:49 +0000'
-content: |
+content: |-
   The Magento_CustomerSegment module enables customer segmentation, allowing the creation of customer groups based on characteristics like shopping cart content, orders history, address, and so on.
   This allows dynamically targeting different content and promotions for those groups. Various components of a website, such as promotions and banners, can be personalized depending on the customer segment of a customer browsing the store at the moment.

--- a/src/_data/codebase/v2_4/mrg/ee/GiftCard.yml
+++ b/src/_data/codebase/v2_4/mrg/ee/GiftCard.yml
@@ -10,4 +10,4 @@ content: "Magento_GiftCard module introduces new product type in the Magento app
   offers gift cards in Virtual, Physical, or Combination format. \nWhen a gift card
   is ordered, a unique code is generated that is emailed to a customer for virtual
   gift cards, or exported for printing to physical gift cards. \nThis unique number
-  can only be redeemed by one customer.\n"
+  can only be redeemed by one customer."

--- a/src/_data/codebase/v2_4/mrg/ee/GiftCardAccount.yml
+++ b/src/_data/codebase/v2_4/mrg/ee/GiftCardAccount.yml
@@ -4,8 +4,6 @@ source_repo: magento2ee
 release: 2.4.1
 github_path: app/code/Magento/GiftCardAccount/README.md
 last_modified_at: '2014-12-17 18:31:49 +0000'
-content: 'The Magento_GiftCardAccount module is responsible for gift card balances,
+content: The Magento_GiftCardAccount module is responsible for gift card balances,
   for both gift cards created by a store administrator and gift cards sold as gift
   card products.
-
-'

--- a/src/_data/codebase/v2_4/mrg/ee/GiftCardAccountGraphQl.yml
+++ b/src/_data/codebase/v2_4/mrg/ee/GiftCardAccountGraphQl.yml
@@ -4,6 +4,6 @@ source_repo: magento2ee
 release: 2.4.1
 github_path: app/code/Magento/GiftCardAccountGraphQl/README.md
 last_modified_at: '2019-05-30 10:55:23 -0500'
-content: |
+content: |-
   **GiftCardAccountGraphQl** provides type and resolver information for the GraphQl module
   to generate giftcard acccount information.

--- a/src/_data/codebase/v2_4/mrg/ee/GiftCardGraphQl.yml
+++ b/src/_data/codebase/v2_4/mrg/ee/GiftCardGraphQl.yml
@@ -4,6 +4,6 @@ source_repo: magento2ee
 release: 2.4.1
 github_path: app/code/Magento/GiftCardGraphQl/README.md
 last_modified_at: '2018-01-30 15:41:07 -0600'
-content: |
+content: |-
   **GiftCardGraphQl** provides type and resolver information for the GraphQl module
   to generate giftcard product information.

--- a/src/_data/codebase/v2_4/mrg/ee/GiftCardImportExport.yml
+++ b/src/_data/codebase/v2_4/mrg/ee/GiftCardImportExport.yml
@@ -4,6 +4,6 @@ source_repo: magento2ee
 release: 2.4.1
 github_path: app/code/Magento/GiftCardImportExport/README.md
 last_modified_at: '2015-08-18 15:10:06 +0300'
-content: |
+content: |-
   Magento_GiftCardImportExport module introduces import and export form GiftCard Product.
   This module extends existing functionality of Magento_CatalogImportExport module by adding new product type.

--- a/src/_data/codebase/v2_4/mrg/ee/GiftCardStaging.yml
+++ b/src/_data/codebase/v2_4/mrg/ee/GiftCardStaging.yml
@@ -4,7 +4,7 @@ source_repo: magento2ee
 release: 2.4.1
 github_path: app/code/Magento/GiftCardStaging/README.md
 last_modified_at: '2016-07-13 17:35:04 -0500'
-content: |
+content: |-
   ## Magento_GiftCardStaging module
 
   ## Overview

--- a/src/_data/codebase/v2_4/mrg/ee/GiftWrappingGraphQl.yml
+++ b/src/_data/codebase/v2_4/mrg/ee/GiftWrappingGraphQl.yml
@@ -4,6 +4,6 @@ source_repo: magento2ee
 release: 2.4.1
 github_path: app/code/Magento/GiftWrappingGraphQl/README.md
 last_modified_at: '2020-05-12 17:54:53 +0300'
-content: |
+content: |-
   **Magento_GiftWrappingGraphQl** provides type and resolver information for the GraphQl module
   to generate GiftWrapping information for order and cart.

--- a/src/_data/codebase/v2_4/mrg/ee/GoogleTagManager.yml
+++ b/src/_data/codebase/v2_4/mrg/ee/GoogleTagManager.yml
@@ -4,7 +4,5 @@ source_repo: magento2ee
 release: 2.4.1
 github_path: app/code/Magento/GoogleTagManager/README.md
 last_modified_at: '2015-06-22 19:55:26 +0300'
-content: 'Magento_GoogleTagManager is a module for integration with Google Tag Manager
+content: Magento_GoogleTagManager is a module for integration with Google Tag Manager
   service.
-
-'

--- a/src/_data/codebase/v2_4/mrg/ee/Invitation.yml
+++ b/src/_data/codebase/v2_4/mrg/ee/Invitation.yml
@@ -4,7 +4,5 @@ source_repo: magento2ee
 release: 2.4.1
 github_path: app/code/Magento/Invitation/README.md
 last_modified_at: '2014-12-17 18:31:49 +0000'
-content: 'The Magento_Invitation module enables invitation sending, referral tracking
+content: The Magento_Invitation module enables invitation sending, referral tracking
   and generating invitation reports.
-
-'

--- a/src/_data/codebase/v2_4/mrg/ee/LayeredNavigationStaging.yml
+++ b/src/_data/codebase/v2_4/mrg/ee/LayeredNavigationStaging.yml
@@ -4,7 +4,7 @@ source_repo: magento2ee
 release: 2.4.1
 github_path: app/code/Magento/LayeredNavigationStaging/README.md
 last_modified_at: '2016-07-04 12:55:14 +0000'
-content: |
+content: |-
   ## Magento_LayeredNavigationStaging module
 
   ## Overview

--- a/src/_data/codebase/v2_4/mrg/ee/MediaContentCatalogStaging.yml
+++ b/src/_data/codebase/v2_4/mrg/ee/MediaContentCatalogStaging.yml
@@ -4,7 +4,7 @@ source_repo: magento2ee
 release: 2.4.1
 github_path: app/code/Magento/MediaContentCatalogStaging/README.md
 last_modified_at: '2020-04-29 00:24:11 -0500'
-content: |
+content: |-
   The Magento_MediaContentCatalogStaging provides the implementation of MediaContent functionality for Magento_Catalog module
 
   ## Extensibility

--- a/src/_data/codebase/v2_4/mrg/ee/MultipleWishlist.yml
+++ b/src/_data/codebase/v2_4/mrg/ee/MultipleWishlist.yml
@@ -4,6 +4,6 @@ source_repo: magento2ee
 release: 2.4.1
 github_path: app/code/Magento/MultipleWishlist/README.md
 last_modified_at: '2014-12-17 18:31:49 +0000'
-content: |
+content: |-
   The Magento_MultipleWishlist module implements the multiple wishlists functionality.
   These are lists of products from a store a customer would like to buy. Customers can save products to multiple wish lists and copy or move items from list to list.

--- a/src/_data/codebase/v2_4/mrg/ee/PaymentStaging.yml
+++ b/src/_data/codebase/v2_4/mrg/ee/PaymentStaging.yml
@@ -4,7 +4,7 @@ source_repo: magento2ee
 release: 2.4.1
 github_path: app/code/Magento/PaymentStaging/README.md
 last_modified_at: '2016-07-04 12:55:14 +0000'
-content: |
+content: |-
   ## Magento Magento_PaymentStaging Module
 
   ## Overview

--- a/src/_data/codebase/v2_4/mrg/ee/PricePermissions.yml
+++ b/src/_data/codebase/v2_4/mrg/ee/PricePermissions.yml
@@ -4,7 +4,5 @@ source_repo: magento2ee
 release: 2.4.1
 github_path: app/code/Magento/PricePermissions/README.md
 last_modified_at: '2014-12-17 18:31:49 +0000'
-content: 'Magento_PricePermissions module allows to restrict such admin rights as
-  changing or reading product price, changing product status.
-
-'
+content: Magento_PricePermissions module allows to restrict such admin rights as changing
+  or reading product price, changing product status.

--- a/src/_data/codebase/v2_4/mrg/ee/QuoteGiftCardOptions.yml
+++ b/src/_data/codebase/v2_4/mrg/ee/QuoteGiftCardOptions.yml
@@ -5,4 +5,4 @@ release: 2.4.1
 github_path: app/code/Magento/QuoteGiftCardOptions/README.md
 last_modified_at: '2020-08-10 17:53:55 +0300'
 content: "**QuoteGiftCardOptions** defines the data provider that creates buy requests
-  for gift card products.\n"
+  for gift card products."

--- a/src/_data/codebase/v2_4/mrg/ee/Reminder.yml
+++ b/src/_data/codebase/v2_4/mrg/ee/Reminder.yml
@@ -4,7 +4,5 @@ source_repo: magento2ee
 release: 2.4.1
 github_path: app/code/Magento/Reminder/README.md
 last_modified_at: '2014-12-17 18:31:49 +0000'
-content: 'Magento_Reminder module provides functionality for sending reminder emails
+content: Magento_Reminder module provides functionality for sending reminder emails
   to customers according to pre-configured rules.
-
-'

--- a/src/_data/codebase/v2_4/mrg/ee/ResourceConnections.yml
+++ b/src/_data/codebase/v2_4/mrg/ee/ResourceConnections.yml
@@ -25,4 +25,4 @@ content: "Magento\\ResourceConnections module adds a mechanism to segregate data
   \   //.......\n```\nTo add slave connection for resources other than 'default' repeat
   the step and add to db/slave_connection \nnew element with same name and slave configuration
   for specified resource. \nConfig structure retains backward compatibility if module
-  is turned off.\n\nWARNING: 'indexer' connection is not designed to have slave configuration.\n"
+  is turned off.\n\nWARNING: 'indexer' connection is not designed to have slave configuration."

--- a/src/_data/codebase/v2_4/mrg/ee/RewardGraphQl.yml
+++ b/src/_data/codebase/v2_4/mrg/ee/RewardGraphQl.yml
@@ -4,6 +4,6 @@ source_repo: magento2ee
 release: 2.4.1
 github_path: app/code/Magento/RewardGraphQl/README.md
 last_modified_at: '2018-01-16 16:07:42 -0600'
-content: |
+content: |-
   **RewardGraphQl** provides type information for the GraphQl module
   to generate reward fields for customer information endpoints.

--- a/src/_data/codebase/v2_4/mrg/ee/RmaGraphQl.yml
+++ b/src/_data/codebase/v2_4/mrg/ee/RmaGraphQl.yml
@@ -4,6 +4,6 @@ source_repo: magento2ee
 release: 2.4.1
 github_path: app/code/Magento/RmaGraphQl/README.md
 last_modified_at: '2018-01-16 16:07:42 -0600'
-content: |
+content: |-
   **RmaGraphQl** provides type information for the GraphQl module
   to generate rma fields for catalog and product information endpoints.

--- a/src/_data/codebase/v2_4/mrg/ee/SalesRuleStaging.yml
+++ b/src/_data/codebase/v2_4/mrg/ee/SalesRuleStaging.yml
@@ -29,4 +29,4 @@ content: "<h2>Magento_SalesRuleStaging module</h2>\n\n## Overview\n\nThe Magento
   Additional information\n\nFor more Magento 2 developer documentation, see [Magento
   2 Developer Documentation](http://devdocs.magento.com). Also, you can track there
   [backward incompatible changes made in a Magento EE mainline after the Magento 2.0
-  release](http://devdocs.magento.com/guides/v2.0/release-notes/changes/ee_changes.html).\n"
+  release](http://devdocs.magento.com/guides/v2.0/release-notes/changes/ee_changes.html)."

--- a/src/_data/codebase/v2_4/mrg/ee/ScalableInventory.yml
+++ b/src/_data/codebase/v2_4/mrg/ee/ScalableInventory.yml
@@ -4,7 +4,7 @@ source_repo: magento2ee
 release: 2.4.1
 github_path: app/code/Magento/ScalableInventory/README.md
 last_modified_at: '2015-09-01 17:12:45 +0300'
-content: |
+content: |-
   Magento\ScalableInventory module provides ability for system extension (CatalogInventory can be configured to work with separate quantity storage).
   Extraction of quantity updates to separate storage will guarantee better scalability for Magento,
   and will allow main server to be optimised for read operations which will reduce latency.

--- a/src/_data/codebase/v2_4/mrg/ee/ScheduledImportExport.yml
+++ b/src/_data/codebase/v2_4/mrg/ee/ScheduledImportExport.yml
@@ -4,6 +4,6 @@ source_repo: magento2ee
 release: 2.4.1
 github_path: app/code/Magento/ScheduledImportExport/README.md
 last_modified_at: '2014-12-17 18:31:49 +0000'
-content: |
+content: |-
   Magento_ScheduledImportExport functionality allows to simplify routine of importing and/or exporting data in the store by automating this process.
   Admin user can create a rule for importing or exporting new data (which could be Products, Customers and Customer Addresses) and specify date and time of the operation.

--- a/src/_data/codebase/v2_4/mrg/ee/SearchStaging.yml
+++ b/src/_data/codebase/v2_4/mrg/ee/SearchStaging.yml
@@ -4,7 +4,7 @@ source_repo: magento2ee
 release: 2.4.1
 github_path: app/code/Magento/SearchStaging/README.md
 last_modified_at: '2016-07-04 12:55:14 +0000'
-content: |
+content: |-
   ## Magento_SearchStaging module
 
   ## Overview

--- a/src/_data/codebase/v2_4/mrg/ee/Staging.yml
+++ b/src/_data/codebase/v2_4/mrg/ee/Staging.yml
@@ -4,7 +4,7 @@ source_repo: magento2ee
 release: 2.4.1
 github_path: app/code/Magento/Staging/README.md
 last_modified_at: '2016-10-19 18:10:05 +0300'
-content: |
+content: |-
   ## Overview
   Magento_Staging module is used for setting up, previewing and managing future store updates.
 

--- a/src/_data/codebase/v2_4/mrg/ee/StagingGraphQl.yml
+++ b/src/_data/codebase/v2_4/mrg/ee/StagingGraphQl.yml
@@ -4,6 +4,6 @@ source_repo: magento2ee
 release: 2.4.1
 github_path: app/code/Magento/StagingGraphQl/README.md
 last_modified_at: '2020-01-14 14:07:38 -0600'
-content: |
+content: |-
   **StagingGraphQl** provides type information for the GraphQl module
   to stage and preview entities.

--- a/src/_data/codebase/v2_4/mrg/ee/Support.yml
+++ b/src/_data/codebase/v2_4/mrg/ee/Support.yml
@@ -4,7 +4,5 @@ source_repo: magento2ee
 release: 2.4.1
 github_path: app/code/Magento/Support/README.md
 last_modified_at: '2015-07-31 14:51:10 +0300'
-content: 'Magento_Support module is used for generation of system reports, which provide
+content: Magento_Support module is used for generation of system reports, which provide
   detailed information about the system environment and Magento instance configuration.
-
-'

--- a/src/_data/codebase/v2_4/mrg/ee/Swat.yml
+++ b/src/_data/codebase/v2_4/mrg/ee/Swat.yml
@@ -4,6 +4,4 @@ source_repo: magento2ee
 release: 2.4.1
 github_path: app/code/Magento/Swat/README.md
 last_modified_at: '2020-07-22 13:02:05 -0500'
-content: 'Magento_Swat module provides access to the Site-Wide Analysis Tool
-
-'
+content: Magento_Swat module provides access to the Site-Wide Analysis Tool

--- a/src/_data/codebase/v2_4/mrg/ee/TargetRule.yml
+++ b/src/_data/codebase/v2_4/mrg/ee/TargetRule.yml
@@ -4,7 +4,5 @@ source_repo: magento2ee
 release: 2.4.1
 github_path: app/code/Magento/TargetRule/README.md
 last_modified_at: '2014-12-17 18:31:49 +0000'
-content: 'Magento_TargetRule module allows to configure the rules for showing related
+content: Magento_TargetRule module allows to configure the rules for showing related
   products.
-
-'

--- a/src/_data/codebase/v2_4/mrg/ee/TargetRuleGraphQl.yml
+++ b/src/_data/codebase/v2_4/mrg/ee/TargetRuleGraphQl.yml
@@ -5,4 +5,4 @@ release: 2.4.1
 github_path: app/code/Magento/TargetRuleGraphQl/README.md
 last_modified_at: '2020-06-25 18:20:29 +0200'
 content: "#Magento_TargetRuleGraphQl \n\nMagento_TargetRuleGraphQl module provides
-  the rules for showing related products.\n"
+  the rules for showing related products."

--- a/src/_data/codebase/v2_4/mrg/ee/VersionsCms.yml
+++ b/src/_data/codebase/v2_4/mrg/ee/VersionsCms.yml
@@ -4,7 +4,7 @@ source_repo: magento2ee
 release: 2.4.1
 github_path: app/code/Magento/VersionsCms/README.md
 last_modified_at: '2017-04-14 11:20:03 -0500'
-content: |
+content: |-
   The Versions CMS module adds a hierarchy feature for CMS pages.
 
   The hierarchy feature organizes CMS pages as a hierarchy tree that allows parent/child relationships between pages.

--- a/src/_data/codebase/v2_4/mrg/ee/VersionsCmsUrlRewrite.yml
+++ b/src/_data/codebase/v2_4/mrg/ee/VersionsCmsUrlRewrite.yml
@@ -7,4 +7,4 @@ last_modified_at: '2020-01-22 14:53:01 +0200'
 content: "The Versions CMS Url Rewrite Module ties up the Store Switcher program with
   implementation of the Hierarchy structure. See also Magento_UrlRewrite and Magento_VersionsCms
   modules. \n\nExtends the Store Switcher program and makes it take into account nodes
-  from the Hierarchy structure.\n"
+  from the Hierarchy structure."

--- a/src/_data/codebase/v2_4/mrg/ee/WebsiteRestriction.yml
+++ b/src/_data/codebase/v2_4/mrg/ee/WebsiteRestriction.yml
@@ -4,7 +4,7 @@ source_repo: magento2ee
 release: 2.4.1
 github_path: app/code/Magento/WebsiteRestriction/README.md
 last_modified_at: '2014-12-17 18:31:49 +0000'
-content: |
+content: |-
   **Website Restriction** enables administrators to restrict all access to the site or restrict site access
   to only logged in customers. You might want to restrict all access when the site is closed for maintenance.
   You might want to restrict site access to only logged in customers if the site is a B2B site or if there is

--- a/src/_data/codebase/v2_4/mrg/msi/Inventory.yml
+++ b/src/_data/codebase/v2_4/mrg/msi/Inventory.yml
@@ -17,4 +17,4 @@ content: "The `Inventory` module is part of the new inventory infrastructure,\nw
   does not recommend using or referring to classes and other entities in the `Inventory`
   module. All public \ninterfaces and extension points related to this module are
   located in the `InventoryApi` module. \nUse the interfaces and extension points
-  defined in `InventoryApi` to extend this module.\n"
+  defined in `InventoryApi` to extend this module."

--- a/src/_data/codebase/v2_4/mrg/msi/InventoryAdminUi.yml
+++ b/src/_data/codebase/v2_4/mrg/msi/InventoryAdminUi.yml
@@ -4,7 +4,7 @@ source_repo: inventory
 release: 1.2.1
 github_path: InventoryAdminUi/README.md
 last_modified_at: '2018-11-09 00:12:40 +0200'
-content: |
+content: |-
   The `InventoryAdminUi` module extends the Magento Admin UI to add Inventory Management functionality.
 
   This module is part of the new inventory infrastructure. The

--- a/src/_data/codebase/v2_4/mrg/msi/InventoryApi.yml
+++ b/src/_data/codebase/v2_4/mrg/msi/InventoryApi.yml
@@ -13,4 +13,4 @@ content: "The `InventoryApi` module provides Inventory Management service contra
   3rd-party developers\ncan use to provide custom inventory functionality.\n\n###
   Public APIs\n\nPublic APIs are defined in the `Api` and `Api/Data` directories.\n\n###
   REST endpoints\n\nThe `etc/webapi.xml` file defines endpoints for managing sources,
-  stocks, stock source links, and source items.\n"
+  stocks, stock source links, and source items."

--- a/src/_data/codebase/v2_4/mrg/msi/InventoryBundleImportExport.yml
+++ b/src/_data/codebase/v2_4/mrg/msi/InventoryBundleImportExport.yml
@@ -4,7 +4,7 @@ source_repo: inventory
 release: 1.2.1
 github_path: InventoryBundleImportExport/README.md
 last_modified_at: '2020-03-13 09:52:30 +0200'
-content: |
+content: |-
   The `InventoryBundleImportExport` module integrates inventory management business logic into Magento's bundle product logic.
 
   This module is part of the new inventory infrastructure. The

--- a/src/_data/codebase/v2_4/mrg/msi/InventoryBundleProduct.yml
+++ b/src/_data/codebase/v2_4/mrg/msi/InventoryBundleProduct.yml
@@ -4,7 +4,7 @@ source_repo: inventory
 release: 1.2.1
 github_path: InventoryBundleProduct/README.md
 last_modified_at: '2018-11-09 00:12:40 +0200'
-content: |
+content: |-
   The `InventoryBundleProduct` module integrates inventory management business logic into Magento's bundle product logic.
 
   This module is part of the new inventory infrastructure. The

--- a/src/_data/codebase/v2_4/mrg/msi/InventoryBundleProductAdminUi.yml
+++ b/src/_data/codebase/v2_4/mrg/msi/InventoryBundleProductAdminUi.yml
@@ -10,4 +10,4 @@ content: "The `InventoryBundleProductAdminUi`extends the Magento Admin UI to add
   the MSI (Multi-Source Inventory) project in more detail.\n\n## Installation details\n\nThis
   module is installed as part of Magento Open Source. It may be disabled if the Inventory
   Management UI\nis provided by a 3rd-party system or if you run a headless version
-  of Magento.\n \n## Extensibility\n\nThere are no extension points or for this module.\n"
+  of Magento.\n \n## Extensibility\n\nThere are no extension points or for this module."

--- a/src/_data/codebase/v2_4/mrg/msi/InventoryBundleProductIndexer.yml
+++ b/src/_data/codebase/v2_4/mrg/msi/InventoryBundleProductIndexer.yml
@@ -4,7 +4,7 @@ source_repo: inventory
 release: 1.2.1
 github_path: InventoryBundleProductIndexer/README.md
 last_modified_at: '2020-02-07 11:00:07 +0200'
-content: |
+content: |-
   The `InventoryBundleProductIndexer` module integrates inventory management business logic into Magento's indexation logic for bundle products.
 
   This module is part of the new inventory infrastructure. The

--- a/src/_data/codebase/v2_4/mrg/msi/InventoryCache.yml
+++ b/src/_data/codebase/v2_4/mrg/msi/InventoryCache.yml
@@ -4,7 +4,7 @@ source_repo: inventory
 release: 1.2.1
 github_path: InventoryCache/README.md
 last_modified_at: '2018-11-09 00:12:40 +0200'
-content: |
+content: |-
   The `InventoryCache` module integrates inventory management business logic into Magento's cache logic.
 
   This module is part of the new inventory infrastructure. The

--- a/src/_data/codebase/v2_4/mrg/msi/InventoryCatalog.yml
+++ b/src/_data/codebase/v2_4/mrg/msi/InventoryCatalog.yml
@@ -12,4 +12,4 @@ content: "The `InventoryCatalog` module integrates inventory management business
   for `InventoryCatalogApi`\nis provided by a 3rd-party module, the module cannot
   be deleted or disabled.\n\n## Extension points and service contracts\n\nAll public
   interfaces related to this module are located in the `InventoryCatalogApi` module.
-  \nUse the interfaces defined in `InventoryCatalogApi` to extend this module.\n"
+  \nUse the interfaces defined in `InventoryCatalogApi` to extend this module."

--- a/src/_data/codebase/v2_4/mrg/msi/InventoryCatalogAdminUi.yml
+++ b/src/_data/codebase/v2_4/mrg/msi/InventoryCatalogAdminUi.yml
@@ -4,7 +4,7 @@ source_repo: inventory
 release: 1.2.1
 github_path: InventoryCatalogAdminUi/README.md
 last_modified_at: '2018-11-09 00:12:40 +0200'
-content: |
+content: |-
   The `InventoryCatalogAdminUi` module extends the Magento Admin UI to add MSI functionality.
 
   This module is part of the new inventory infrastructure. The

--- a/src/_data/codebase/v2_4/mrg/msi/InventoryCatalogApi.yml
+++ b/src/_data/codebase/v2_4/mrg/msi/InventoryCatalogApi.yml
@@ -13,4 +13,4 @@ content: "The `InventoryCatalogApi` module provides service contracts for defaul
   APIs that 3rd-party developers\ncan use to provide custom inventory catalog functionality.\n\n###
   Public APIs\n\nPublic APIs are defined in the `Api` directory.\n\n### REST endpoints\n\nThe
   `etc/webapi.xml` file defines endpoints for assigning, unassigning, and transferring
-  sources in bulk.\n"
+  sources in bulk."

--- a/src/_data/codebase/v2_4/mrg/msi/InventoryCatalogSearch.yml
+++ b/src/_data/codebase/v2_4/mrg/msi/InventoryCatalogSearch.yml
@@ -4,7 +4,7 @@ source_repo: inventory
 release: 1.2.1
 github_path: InventoryCatalogSearch/README.md
 last_modified_at: '2018-11-09 00:12:40 +0200'
-content: |
+content: |-
   The `InventoryCatalogSearch` module integrates inventory management business logic into Magento's search logic.
 
   This module is part of the new inventory infrastructure. The

--- a/src/_data/codebase/v2_4/mrg/msi/InventoryConfigurableProduct.yml
+++ b/src/_data/codebase/v2_4/mrg/msi/InventoryConfigurableProduct.yml
@@ -4,7 +4,7 @@ source_repo: inventory
 release: 1.2.1
 github_path: InventoryConfigurableProduct/README.md
 last_modified_at: '2018-11-09 00:12:40 +0200'
-content: |
+content: |-
   ## InventoryConfigurableProduct module
 
   The `InventoryConfigurableProduct` module integrates inventory management business logic into Magento's configurable product logic.

--- a/src/_data/codebase/v2_4/mrg/msi/InventoryConfigurableProductAdminUi.yml
+++ b/src/_data/codebase/v2_4/mrg/msi/InventoryConfigurableProductAdminUi.yml
@@ -12,4 +12,4 @@ content: "The `InventoryConfigurableProductAdminUi`extends the Magento Admin UI 
   Management UI\nis provided by a 3rd-party system or if you run a headless version
   of Magento.\n \n## Extensibility\n\nThe `InventoryConfigurableProductAdminUi` module
   contains several extension points.\n\n### UI Components\n\nThe `view/adminhtml/ui_component`
-  directory contains extensible UI components.\n"
+  directory contains extensible UI components."

--- a/src/_data/codebase/v2_4/mrg/msi/InventoryConfigurableProductIndexer.yml
+++ b/src/_data/codebase/v2_4/mrg/msi/InventoryConfigurableProductIndexer.yml
@@ -4,7 +4,7 @@ source_repo: inventory
 release: 1.2.1
 github_path: InventoryConfigurableProductIndexer/README.md
 last_modified_at: '2018-11-09 00:12:40 +0200'
-content: |
+content: |-
   The `InventoryConfigurableProductIndexer` module integrates inventory management business logic into Magento's indexation logic for configurable products.
 
   This module is part of the new inventory infrastructure. The

--- a/src/_data/codebase/v2_4/mrg/msi/InventoryConfiguration.yml
+++ b/src/_data/codebase/v2_4/mrg/msi/InventoryConfiguration.yml
@@ -13,4 +13,4 @@ content: "The `InventoryConfiguration` module implements logic for inventory man
   be deleted or disabled.\n\n## Extension points and service contracts\n\nAll public
   interfaces related to this module are located in the `InventoryConfigurationApi`
   module. \nUse the interfaces defined in `InventoryConfigurationApi` to extend this
-  module.\n"
+  module."

--- a/src/_data/codebase/v2_4/mrg/msi/InventoryConfigurationApi.yml
+++ b/src/_data/codebase/v2_4/mrg/msi/InventoryConfigurationApi.yml
@@ -4,7 +4,7 @@ source_repo: inventory
 release: 1.2.1
 github_path: InventoryConfigurationApi/README.md
 last_modified_at: '2018-11-09 00:12:40 +0200'
-content: |
+content: |-
   The `InventoryConfigurationApi` module provides service contracts for inventory management configuration.
 
   This module is part of the new inventory infrastructure. The

--- a/src/_data/codebase/v2_4/mrg/msi/InventoryDistanceBasedSourceSelection.yml
+++ b/src/_data/codebase/v2_4/mrg/msi/InventoryDistanceBasedSourceSelection.yml
@@ -11,4 +11,4 @@ content: "The `InventoryDistanceBasedSourceSelection` module implements logic fo
   module is installed as part of Magento Open Source.\n\n## Extension points and service
   contracts\n\nAll public interfaces related to this module are located in the `InventoryDistanceBasedSourceSelectionApi`
   module. \nUse the interfaces defined in `InventoryDistanceBasedSourceSelectionApi`
-  to extend this module.\n"
+  to extend this module."

--- a/src/_data/codebase/v2_4/mrg/msi/InventoryDistanceBasedSourceSelectionAdminUi.yml
+++ b/src/_data/codebase/v2_4/mrg/msi/InventoryDistanceBasedSourceSelectionAdminUi.yml
@@ -4,7 +4,7 @@ source_repo: inventory
 release: 1.2.1
 github_path: InventoryDistanceBasedSourceSelectionAdminUi/README.md
 last_modified_at: '2018-12-28 10:54:19 +0100'
-content: |
+content: |-
   The `InventoryDistanceBasedSourceSelectionAdminUi` module extends Magento's admin UI with source selection based on distance functionality.
 
   This module is part of the new inventory infrastructure. The

--- a/src/_data/codebase/v2_4/mrg/msi/InventoryDistanceBasedSourceSelectionApi.yml
+++ b/src/_data/codebase/v2_4/mrg/msi/InventoryDistanceBasedSourceSelectionApi.yml
@@ -12,4 +12,4 @@ content: "The `InventoryDistanceBasedSourceSelectionApi` module provides service
   module contains extension points and APIs that 3rd-party developers\ncan use to
   provide custom distance based source selection algorithms.\n\n### Public APIs\n\nPublic
   APIs are defined in the `Api` and `Api/Data` directories.\n\n### REST endpoints\n\nThe
-  `etc/webapi.xml` file defines endpoints for managing distance based algorithms.\n"
+  `etc/webapi.xml` file defines endpoints for managing distance based algorithms."

--- a/src/_data/codebase/v2_4/mrg/msi/InventoryElasticsearch.yml
+++ b/src/_data/codebase/v2_4/mrg/msi/InventoryElasticsearch.yml
@@ -4,7 +4,7 @@ source_repo: inventory
 release: 1.2.1
 github_path: InventoryElasticsearch/README.md
 last_modified_at: '2018-12-21 16:08:11 +0200'
-content: |
+content: |-
   The `InventoryElasticsearch` module provides elastic search support for Inventory Management.
 
   This module is part of the new inventory infrastructure. The

--- a/src/_data/codebase/v2_4/mrg/msi/InventoryExportStock.yml
+++ b/src/_data/codebase/v2_4/mrg/msi/InventoryExportStock.yml
@@ -4,7 +4,7 @@ source_repo: inventory
 release: 1.2.1
 github_path: InventoryExportStock/README.md
 last_modified_at: '2019-04-23 22:46:43 +0300'
-content: |
+content: |-
   The `InventoryExportStock` module provides aggregated stock export functionality.
 
   This module is part of the new inventory infrastructure. The

--- a/src/_data/codebase/v2_4/mrg/msi/InventoryExportStockApi.yml
+++ b/src/_data/codebase/v2_4/mrg/msi/InventoryExportStockApi.yml
@@ -4,7 +4,7 @@ source_repo: inventory
 release: 1.2.1
 github_path: InventoryExportStockApi/README.md
 last_modified_at: '2019-04-23 22:46:43 +0300'
-content: |
+content: |-
   The `InventoryExportStockApi` module provides provides aggregated stock export functionality api.
 
   This module is part of the new inventory infrastructure. The

--- a/src/_data/codebase/v2_4/mrg/msi/InventoryGraphQl.yml
+++ b/src/_data/codebase/v2_4/mrg/msi/InventoryGraphQl.yml
@@ -4,7 +4,7 @@ source_repo: inventory
 release: 1.2.1
 github_path: InventoryGraphQl/README.md
 last_modified_at: '2019-03-30 16:15:21 +0100'
-content: |
+content: |-
   The `InventoryGraphQl` provides type information for the GraphQl module
                          to generate inventory stock fields for product information endpoints.
 

--- a/src/_data/codebase/v2_4/mrg/msi/InventoryGroupedProduct.yml
+++ b/src/_data/codebase/v2_4/mrg/msi/InventoryGroupedProduct.yml
@@ -10,4 +10,4 @@ content: "The `InventoryGroupedProduct` module integrates inventory management b
   the MSI (Multi-Source Inventory) project in more detail.\n\n## Installation details\n\nThis
   module is installed as part of Magento Open Source. It cannot be deleted or disabled.\n
   \n## Extension points and service contracts\n\nThere are no extension points or
-  service contracts for this module.\n"
+  service contracts for this module."

--- a/src/_data/codebase/v2_4/mrg/msi/InventoryGroupedProductAdminUi.yml
+++ b/src/_data/codebase/v2_4/mrg/msi/InventoryGroupedProductAdminUi.yml
@@ -4,7 +4,7 @@ source_repo: inventory
 release: 1.2.1
 github_path: InventoryGroupedProductAdminUi/README.md
 last_modified_at: '2018-11-09 00:12:40 +0200'
-content: |
+content: |-
   The `InventoryGroupedProductAdminUi` module extends Magento's admin UI with inventory management functionality.
 
   This module is part of the new inventory infrastructure. The

--- a/src/_data/codebase/v2_4/mrg/msi/InventoryGroupedProductIndexer.yml
+++ b/src/_data/codebase/v2_4/mrg/msi/InventoryGroupedProductIndexer.yml
@@ -4,7 +4,7 @@ source_repo: inventory
 release: 1.2.1
 github_path: InventoryGroupedProductIndexer/README.md
 last_modified_at: '2018-11-09 00:12:40 +0200'
-content: |
+content: |-
   The `InventoryGroupedProductIndexer` module integrates inventory management business logic into Magento's indexation logic for grouped products.
 
   This module is part of the new inventory infrastructure. The

--- a/src/_data/codebase/v2_4/mrg/msi/InventoryImportExport.yml
+++ b/src/_data/codebase/v2_4/mrg/msi/InventoryImportExport.yml
@@ -11,4 +11,4 @@ content: "The `InventoryImportExport` module provides compatibility between Mage
   module is installed as part of Magento Open Source. It cannot be deleted or disabled.\n\n##
   Extension points and service contracts\n\nThere are no extension points or service
   contracts for this module.\n\n## Additional information\n\nThe `files/sample/stock_sources.csv`
-  file is a template for importing inventory into the system.\n"
+  file is a template for importing inventory into the system."

--- a/src/_data/codebase/v2_4/mrg/msi/InventoryInStorePickupAdminUi.yml
+++ b/src/_data/codebase/v2_4/mrg/msi/InventoryInStorePickupAdminUi.yml
@@ -4,7 +4,7 @@ source_repo: inventory
 release: 1.2.1
 github_path: InventoryInStorePickupAdminUi/README.md
 last_modified_at: '2019-05-19 23:51:00 +0300'
-content: |
+content: |-
   The `InventoryInStorePickupAdminUi` module extends the Magento Admin UI to add Inventory In-Store Pickup functionality.
 
   This module is part of the new inventory infrastructure. The

--- a/src/_data/codebase/v2_4/mrg/msi/InventoryInStorePickupApi.yml
+++ b/src/_data/codebase/v2_4/mrg/msi/InventoryInStorePickupApi.yml
@@ -4,7 +4,7 @@ source_repo: inventory
 release: 1.2.1
 github_path: InventoryInStorePickupApi/README.md
 last_modified_at: '2019-02-11 13:03:35 +1030'
-content: |
+content: |-
   The `InventoryInStorePickupApi` module provides service contracts for In-Store Pickup functionality.
 
   This module is part of the new inventory infrastructure. The

--- a/src/_data/codebase/v2_4/mrg/msi/InventoryInStorePickupMultishipping.yml
+++ b/src/_data/codebase/v2_4/mrg/msi/InventoryInStorePickupMultishipping.yml
@@ -4,7 +4,7 @@ source_repo: inventory
 release: 1.2.1
 github_path: InventoryInStorePickupMultishipping/README.md
 last_modified_at: '2019-09-12 15:55:31 +0300'
-content: |
+content: |-
   The `InventoryInStorePickupMultishipping` module provides business logic for In-Store Pickup functionality on Multishipping Checkout.
   In-Store Pickup Delivery is not available for Multishipping for now.
   Module provide plugin to disable active Multishipping mode when customer will visit the checkout.

--- a/src/_data/codebase/v2_4/mrg/msi/InventoryInStorePickupSales.yml
+++ b/src/_data/codebase/v2_4/mrg/msi/InventoryInStorePickupSales.yml
@@ -13,4 +13,4 @@ content: "The `InventoryInStorePickupSales` module provides business logic for I
   cannot be deleted or disabled.\n\n## Extension points and service contracts\n\nAll
   public interfaces related to this module are located in the `InventoryInStorePickupSalesApi`
   module. \nUse the interfaces defined in `InventoryInStorePickupSalesApi` to extend
-  this module.\n"
+  this module."

--- a/src/_data/codebase/v2_4/mrg/msi/InventoryInStorePickupSalesAdminUi.yml
+++ b/src/_data/codebase/v2_4/mrg/msi/InventoryInStorePickupSalesAdminUi.yml
@@ -4,7 +4,7 @@ source_repo: inventory
 release: 1.2.1
 github_path: InventoryInStorePickupSalesAdminUi/README.md
 last_modified_at: '2019-11-15 17:17:28 +0200'
-content: |
+content: |-
   The `InventoryInStorePickupSalesAdminUi` module extends the Magento Admin UI to add Inventory In-Store Pickup functionality Sales operations enhancement.
 
   This module is part of the new inventory infrastructure. The

--- a/src/_data/codebase/v2_4/mrg/msi/InventoryInStorePickupSalesApi.yml
+++ b/src/_data/codebase/v2_4/mrg/msi/InventoryInStorePickupSalesApi.yml
@@ -4,7 +4,7 @@ source_repo: inventory
 release: 1.2.1
 github_path: InventoryInStorePickupSalesApi/README.md
 last_modified_at: '2019-11-15 17:17:28 +0200'
-content: |+
+content: |-
   The `InventoryInStorePickupSalesApi` module provides service contracts for In-Store Pickup functionality in scope of Sales operations.
 
   This module is part of the new inventory infrastructure. The
@@ -20,4 +20,3 @@ content: |+
 
   The `InventoryInStorePickupSalesApi` module contains extension points and APIs that 3rd-party developers
   can use to provide customization of In-Store Pickup functionality
-

--- a/src/_data/codebase/v2_4/mrg/msi/InventoryInStorePickupShippingApi.yml
+++ b/src/_data/codebase/v2_4/mrg/msi/InventoryInStorePickupShippingApi.yml
@@ -4,7 +4,7 @@ source_repo: inventory
 release: 1.2.1
 github_path: InventoryInStorePickupShippingApi/README.md
 last_modified_at: '2019-05-29 21:29:50 +0300'
-content: |
+content: |-
   The `InventoryInStorePickupShippingApi` module provides service contracts for "In-Store Pickup Delivery Method" implementation of In-Store Pickup functionality.
 
   This module is part of the new inventory infrastructure. The

--- a/src/_data/codebase/v2_4/mrg/msi/InventoryInStorePickupWebapiExtension.yml
+++ b/src/_data/codebase/v2_4/mrg/msi/InventoryInStorePickupWebapiExtension.yml
@@ -13,4 +13,4 @@ content: "The `InventoryInStorePickupWebapiExtension`  is a part of `InStorePick
   be released.\n\nPlease check links for more details:\n* [Original issue in Core
   Repository](https://github.com/magento/magento2/issues/24116)  \n* [Issue in MSI
   Repository](https://github.com/magento-engcom/msi/issues/2507)\n\n\n## Installation
-  details\n\nThis module is installed as part of Magento Open Source. \n"
+  details\n\nThis module is installed as part of Magento Open Source."

--- a/src/_data/codebase/v2_4/mrg/msi/InventoryIndexer.yml
+++ b/src/_data/codebase/v2_4/mrg/msi/InventoryIndexer.yml
@@ -4,7 +4,7 @@ source_repo: inventory
 release: 1.2.1
 github_path: InventoryIndexer/README.md
 last_modified_at: '2018-11-09 00:12:40 +0200'
-content: |
+content: |-
   The `InventoryIndexer` module provides indexation logic for Inventory Management.
 
   This module is part of the new inventory infrastructure. The

--- a/src/_data/codebase/v2_4/mrg/msi/InventoryLowQuantityNotification.yml
+++ b/src/_data/codebase/v2_4/mrg/msi/InventoryLowQuantityNotification.yml
@@ -13,4 +13,4 @@ content: "The `InventoryLowQuantityNotification` module integrates Inventory Man
   module cannot be deleted or disabled.\n\n## Extension points and service contracts\n\nAll
   public interfaces related to this module are located in the `InventoryLowQuantityNotificationApi`
   module. \nUse the interfaces defined in `InventoryLowQuantityNotificationApi` to
-  extend this module.\n"
+  extend this module."

--- a/src/_data/codebase/v2_4/mrg/msi/InventoryLowQuantityNotificationAdminUi.yml
+++ b/src/_data/codebase/v2_4/mrg/msi/InventoryLowQuantityNotificationAdminUi.yml
@@ -4,7 +4,7 @@ source_repo: inventory
 release: 1.2.1
 github_path: InventoryLowQuantityNotificationAdminUi/README.md
 last_modified_at: '2018-11-09 00:12:40 +0200'
-content: |
+content: |-
   The `InventoryLowQuantityNotificationAdminUi` module extends Magento's admin UI with inventory management functionality.
 
   This module is part of the new inventory infrastructure. The

--- a/src/_data/codebase/v2_4/mrg/msi/InventoryLowQuantityNotificationApi.yml
+++ b/src/_data/codebase/v2_4/mrg/msi/InventoryLowQuantityNotificationApi.yml
@@ -13,4 +13,4 @@ content: "The `InventoryLowQuantityNotificationApi` module provides service cont
   points and APIs that 3rd-party developers\ncan use to provide custom low quantity
   notification functionality.\n\n### Public APIs\n\nPublic APIs are defined in the
   `Api` and `Api/Data` directories.\n\n### REST endpoints\n\nThe `etc/webapi.xml`
-  file defines endpoints for managing low quantity notifications.\n"
+  file defines endpoints for managing low quantity notifications."

--- a/src/_data/codebase/v2_4/mrg/msi/InventoryMultiDimensionalIndexerApi.yml
+++ b/src/_data/codebase/v2_4/mrg/msi/InventoryMultiDimensionalIndexerApi.yml
@@ -15,4 +15,4 @@ content: "The `InventoryMultiDimensionalIndexerApi` module  provides functionali
   for resolving \nindex names based on the provided scope. The multi-dimension indexes
   are introduced for the sake of data scalability\nand the ability to reindex data
   in the scope of particular dimension only.\n\nAn aliasing mechanism guarantees zero
-  downtime to make Front-End responsive while Full Reindex being processed.\n"
+  downtime to make Front-End responsive while Full Reindex being processed."

--- a/src/_data/codebase/v2_4/mrg/msi/InventoryProductAlert.yml
+++ b/src/_data/codebase/v2_4/mrg/msi/InventoryProductAlert.yml
@@ -4,7 +4,7 @@ source_repo: inventory
 release: 1.2.1
 github_path: InventoryProductAlert/README.md
 last_modified_at: '2018-11-09 00:12:40 +0200'
-content: |+
+content: |-
   The `InventoryProductAlert` module integrates Inventory Management business logic into Magento's product alert logic.
 
   This module is part of the new inventory infrastructure. The
@@ -18,4 +18,3 @@ content: |+
   ## Extension points and service contracts
 
   There are no extension points or service contracts for this module.
-

--- a/src/_data/codebase/v2_4/mrg/msi/InventoryReservationCli.yml
+++ b/src/_data/codebase/v2_4/mrg/msi/InventoryReservationCli.yml
@@ -4,7 +4,7 @@ source_repo: inventory
 release: 1.2.1
 github_path: InventoryReservationCli/README.md
 last_modified_at: '2019-04-10 12:11:17 +0200'
-content: |
+content: |-
   The `InventoryReservationCli` module provide a cli command which helps the developer to discover inconsistencies on reservation.
 
   This module is part of the new inventory infrastructure. The

--- a/src/_data/codebase/v2_4/mrg/msi/InventoryReservations.yml
+++ b/src/_data/codebase/v2_4/mrg/msi/InventoryReservations.yml
@@ -13,4 +13,4 @@ content: "The `InventoryReservations` module provides logic for handling product
   interfaces related to this module are located in the `InventoryReservationsApi`
   module. \nUse the interfaces defined in `InventoryReservationsApi` to extend this
   module.\n\n## Additional information\n\nThe `InventoryReservations` module creates
-  the `inventory_cleanup_reservations` cron job.\n"
+  the `inventory_cleanup_reservations` cron job."

--- a/src/_data/codebase/v2_4/mrg/msi/InventoryReservationsApi.yml
+++ b/src/_data/codebase/v2_4/mrg/msi/InventoryReservationsApi.yml
@@ -4,7 +4,7 @@ source_repo: inventory
 release: 1.2.1
 github_path: InventoryReservationsApi/README.md
 last_modified_at: '2018-11-09 00:12:40 +0200'
-content: |
+content: |-
   The `InventoryReservationsApi` module provides service contracts for Inventory Management reservations.
 
   This module is part of the new inventory infrastructure. The

--- a/src/_data/codebase/v2_4/mrg/msi/InventorySales.yml
+++ b/src/_data/codebase/v2_4/mrg/msi/InventorySales.yml
@@ -12,4 +12,4 @@ content: "The `InventorySales` module integrates Inventory Management business l
   for `InventorySalesApi`\nis provided by a 3rd-party module, the module cannot be
   deleted or disabled.\n\n## Extension points and service contracts\n\nAll public
   interfaces related to this module are located in the `InventorySalesApi` module.
-  \nUse the interfaces defined in `InventorySalesApi` to extend this module.\n"
+  \nUse the interfaces defined in `InventorySalesApi` to extend this module."

--- a/src/_data/codebase/v2_4/mrg/msi/InventorySalesAdminUi.yml
+++ b/src/_data/codebase/v2_4/mrg/msi/InventorySalesAdminUi.yml
@@ -13,4 +13,4 @@ content: "The `InventorySalesAdminUi` module extends Magento's Admin UI with Inv
   of Magento.\n\n## Extensibility\n\nThe `InventorySalesAdminUi` module contains several
   extension points.\n\n### Layouts\n\nYou can extend and override layouts defined
   in the `view/adminhtml/layout`  directory.\n\n### UI Components\n\nThe `view/adminhtml/ui_component`
-  directory contains extensible UI components.\n"
+  directory contains extensible UI components."

--- a/src/_data/codebase/v2_4/mrg/msi/InventorySalesApi.yml
+++ b/src/_data/codebase/v2_4/mrg/msi/InventorySalesApi.yml
@@ -13,4 +13,4 @@ content: "The `InventorySalesApi` module provides service contracts for inventor
   that 3rd-party developers\ncan use to provide custom inventory catalog functionality.\n\n###
   Public APIs\n\nPublic APIs are defined in the `Api` and `Api/Data` directories.\n\n###
   REST endpoints\n\nThe `etc/webapi.xml` file defines endpoints for determining whether
-  a salable amount of products are available for purchase.\n"
+  a salable amount of products are available for purchase."

--- a/src/_data/codebase/v2_4/mrg/msi/InventorySalesFrontendUi.yml
+++ b/src/_data/codebase/v2_4/mrg/msi/InventorySalesFrontendUi.yml
@@ -10,4 +10,4 @@ content: "The `InventorySalesFrontendUi` module extends Magento's frontend UI wi
   the MSI (Multi-Source Inventory) project in more detail.\n\n## Installation details\n\nThis
   module is installed as part of Magento Open Source. You can remove it if you run
   a headless version of Magento.\n\n## Extension points and service contracts\n\nThere
-  are no extension points or service contracts for this module.\n"
+  are no extension points or service contracts for this module."

--- a/src/_data/codebase/v2_4/mrg/msi/InventorySetupFixtureGenerator.yml
+++ b/src/_data/codebase/v2_4/mrg/msi/InventorySetupFixtureGenerator.yml
@@ -10,4 +10,4 @@ content: "The `InventorySetupFixtureGenerator` module customizes the process of 
   the MSI (Multi-Source Inventory) project in more detail.\n\n## Installation details\n\nThis
   module is installed as part of Magento Open Source. Unless a custom implementation
   \nfor Inventory Data generation is provided by a 3rd-party module, the module cannot
-  be deleted or disabled.\n"
+  be deleted or disabled."

--- a/src/_data/codebase/v2_4/mrg/msi/InventoryShippingAdminUi.yml
+++ b/src/_data/codebase/v2_4/mrg/msi/InventoryShippingAdminUi.yml
@@ -4,7 +4,7 @@ source_repo: inventory
 release: 1.2.1
 github_path: InventoryShippingAdminUi/README.md
 last_modified_at: '2018-11-09 00:12:40 +0200'
-content: |
+content: |-
   The `InventoryShippingAdminUi` module extends Magento's Admin UI with Inventory Management functionality.
 
   This module is part of the new inventory infrastructure. The

--- a/src/_data/codebase/v2_4/mrg/msi/InventorySourceDeductionApi.yml
+++ b/src/_data/codebase/v2_4/mrg/msi/InventorySourceDeductionApi.yml
@@ -8,4 +8,4 @@ content: "The `InventorySourceDeductionApi` module provides service contracts fo
   managing source deductuions when products are sold. \n\nThis module is part of the
   new inventory infrastructure. The\n[Inventory Management overview](https://devdocs.magento.com/guides/v2.3/inventory/index.html)\ndescribes
   the MSI (Multi-Source Inventory) project in more detail.\n\n## Installation details\n\nThis
-  module is installed as part of Magento Open Source. It cannot be deleted or disabled.\n"
+  module is installed as part of Magento Open Source. It cannot be deleted or disabled."

--- a/src/_data/codebase/v2_4/mrg/msi/InventorySourceSelection.yml
+++ b/src/_data/codebase/v2_4/mrg/msi/InventorySourceSelection.yml
@@ -13,4 +13,4 @@ content: "The `InventorySourceSelection` module provides source selection logic 
   cannot be deleted or disabled.\n\n## Extension points and service contracts\n\nAll
   public interfaces related to this module are located in the `InventorySourceSelectionApi`
   module. \nUse the interfaces defined in `InventorySourceSelectionApi` to extend
-  this module.\n"
+  this module."

--- a/src/_data/codebase/v2_4/mrg/msi/InventorySourceSelectionApi.yml
+++ b/src/_data/codebase/v2_4/mrg/msi/InventorySourceSelectionApi.yml
@@ -4,7 +4,7 @@ source_repo: inventory
 release: 1.2.1
 github_path: InventorySourceSelectionApi/README.md
 last_modified_at: '2018-11-09 00:12:40 +0200'
-content: |
+content: |-
   The `InventorySourceSelectionApi` module provides service contracts for source selection algorithms (SSA).
 
   This module is part of the new inventory infrastructure. The

--- a/src/_data/codebase/v2_4/mrg/msi/InventoryVisualMerchandiser.yml
+++ b/src/_data/codebase/v2_4/mrg/msi/InventoryVisualMerchandiser.yml
@@ -4,7 +4,5 @@ source_repo: inventory
 release: 1.2.1
 github_path: InventoryVisualMerchandiser/README.md
 last_modified_at: '2020-07-27 17:15:03 +0300'
-content: 'The Magento_InventoryVisualMerchandiser module adds multi-sourcing capabilities
+content: The Magento_InventoryVisualMerchandiser module adds multi-sourcing capabilities
   to the VisualMerchandiser module
-
-'

--- a/src/_data/codebase/v2_4/mrg/page-builder/CatalogPageBuilderAnalytics.yml
+++ b/src/_data/codebase/v2_4/mrg/page-builder/CatalogPageBuilderAnalytics.yml
@@ -1,0 +1,9 @@
+---
+title: Magento_CatalogPageBuilderAnalytics
+source_repo: magento2-page-builder
+release: v1.5.0
+github_path: app/code/Magento/CatalogPageBuilderAnalytics/README.md
+last_modified_at: '2019-03-05 18:34:09 +0100'
+content: The Magento_CatalogPageBuilderAnalytics module configures data definitions
+  for a data collection related to the PageBuilder module entities to be used in [Advanced
+  Reporting](http://devdocs.magento.com/guides/v2.2/advanced-reporting/modules.html).

--- a/src/_data/codebase/v2_4/mrg/page-builder/CmsPageBuilderAnalytics.yml
+++ b/src/_data/codebase/v2_4/mrg/page-builder/CmsPageBuilderAnalytics.yml
@@ -1,0 +1,9 @@
+---
+title: Magento_CmsPageBuilderAnalytics
+source_repo: magento2-page-builder
+release: v1.5.0
+github_path: app/code/Magento/CmsPageBuilderAnalytics/README.md
+last_modified_at: '2019-03-05 18:34:09 +0100'
+content: The Magento_CmsPageBuilderAnalytics module configures data definitions for
+  a data collection related to the PageBuilder module entities to be used in [Advanced
+  Reporting](http://devdocs.magento.com/guides/v2.2/advanced-reporting/modules.html).

--- a/src/_data/codebase/v2_4/mrg/page-builder/PageBuilder.yml
+++ b/src/_data/codebase/v2_4/mrg/page-builder/PageBuilder.yml
@@ -1,0 +1,55 @@
+---
+title: Magento_PageBuilder
+source_repo: magento2-page-builder
+release: v1.5.0
+github_path: app/code/Magento/PageBuilder/README.md
+last_modified_at: '2018-02-20 21:19:48 -0600'
+content: |-
+  The Magento_PageBuilder module provides an enhancement for the default Magento WYSIWYG editor. It installs an alternative editor in the Admin area for building content.
+
+  The PageBuilder editor can be used on the following content pages:
+
+  * Category Pages
+  * CMS Pages
+  * CMS Blocks
+  * Dynamic Blocks
+
+  ## Enable the module
+
+  The PageBuilder module and the editor is enabled by default after installation.
+
+  The editor itself is enabled globally in the Admin area under *Stores > Configuration > Content Management > Advanced Content Tool > Enable Page Builder*.
+  This setting determines the `is_pagebuilder_enabled` configuration value.
+
+  ## Disable the module
+
+  You can disable the PageBuilder module for a specific field by adding the following entry to a field configuration in an XML configuration file:
+
+  ```
+  <item name="wysiwygConfigData" xsi:type="array">
+      <item name="is_pagebuilder_enabled" xsi:type="boolean">false</item>
+  </item>
+  ```
+
+  ### Example
+
+  The following example disables the PageBuilder editor for the content field.
+
+  ```
+  <form xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="urn:magento:module:Magento_Ui:etc/ui_configuration.xsd">
+      <fieldset name="content" sortOrder="10">
+          <field name="content" formElement="wysiwyg">
+              <argument name="data" xsi:type="array">
+                  <item name="config" xsi:type="array">
+                      <item name="source" xsi:type="string">page</item>
+                      <item name="wysiwygConfigData" xsi:type="array">
+                          <item name="is_pagebuilder_enabled" xsi:type="boolean">false</item>
+                      </item>
+                  </item>
+              </argument>
+          </field>
+      </fieldset>
+  </form>
+  ```
+
+  **Note:** Disabling the editor this way overrides the value of `is_pagebuilder_enabled` for the specified field.

--- a/src/_data/codebase/v2_4/mrg/page-builder/PageBuilderAdminAnalytics.yml
+++ b/src/_data/codebase/v2_4/mrg/page-builder/PageBuilderAdminAnalytics.yml
@@ -1,0 +1,8 @@
+---
+title: Magento_PageBuilderAdminAnalytics
+source_repo: magento2-page-builder
+release: v1.5.0
+github_path: app/code/Magento/PageBuilderAdminAnalytics/README.md
+last_modified_at: '2020-07-24 16:33:05 +0200'
+content: The Magento_PageBuilderAdminAnalytics module tracks Page Builder information
+  through AdminAnalytics.

--- a/src/_data/codebase/v2_4/mrg/page-builder/PageBuilderAnalytics.yml
+++ b/src/_data/codebase/v2_4/mrg/page-builder/PageBuilderAnalytics.yml
@@ -1,0 +1,9 @@
+---
+title: Magento_PageBuilderAnalytics
+source_repo: magento2-page-builder
+release: v1.5.0
+github_path: app/code/Magento/PageBuilderAnalytics/README.md
+last_modified_at: '2018-07-26 15:13:54 +0300'
+content: The Magento_PageBuilderAnalytics module configures data definitions for a
+  data collection related to the PageBuilder module entities to be used in [Advanced
+  Reporting](http://devdocs.magento.com/guides/v2.2/advanced-reporting/modules.html).

--- a/src/_data/toc/module-reference-guide-2_3.yml
+++ b/src/_data/toc/module-reference-guide-2_3.yml
@@ -3,7 +3,7 @@ pages:
   - label: Introduction
     url: /mrg/intro.html
   
-  - label: Open Source (v2.3.6)
+  - label: Core Open Source, 2.3.6
     include_versions: ["2.3"]
     children:
     
@@ -509,7 +509,7 @@ pages:
         url: /mrg/ce/WishlistGraphQl.html
     
   
-  - label: Commerce (v2.3.6)
+  - label: Core Commerce only, 2.3.6
     include_versions: ["2.3"]
     children:
     
@@ -769,7 +769,7 @@ pages:
         url: /mrg/ee/Worldpay.html
     
   
-  - label: B2B (v1.1.6)
+  - label: B2B extension, 1.1.6
     include_versions: ["2.3"]
     children:
     
@@ -840,7 +840,7 @@ pages:
         url: /mrg/b2b/SharedCatalog.html
     
   
-  - label: Inventory Management (v1.1.6)
+  - label: Inventory Management (Open Source), 1.1.6
     include_versions: ["2.3"]
     children:
     
@@ -984,5 +984,22 @@ pages:
     
       - label: InventorySourceSelectionApi
         url: /mrg/msi/InventorySourceSelectionApi.html
+    
+  
+  - label: Page Builder (Commerce), v1.3.3
+    include_versions: ["2.3"]
+    children:
+    
+      - label: CatalogPageBuilderAnalytics
+        url: /mrg/page-builder/CatalogPageBuilderAnalytics.html
+    
+      - label: CmsPageBuilderAnalytics
+        url: /mrg/page-builder/CmsPageBuilderAnalytics.html
+    
+      - label: PageBuilder
+        url: /mrg/page-builder/PageBuilder.html
+    
+      - label: PageBuilderAnalytics
+        url: /mrg/page-builder/PageBuilderAnalytics.html
     
   

--- a/src/_data/toc/module-reference-guide-2_4.yml
+++ b/src/_data/toc/module-reference-guide-2_4.yml
@@ -3,7 +3,7 @@ pages:
   - label: Introduction
     url: /mrg/intro.html
   
-  - label: Open Source (v2.4.1)
+  - label: Core Open Source, 2.4.1
     include_versions: ["2.4"]
     children:
     
@@ -593,7 +593,7 @@ pages:
         url: /mrg/ce/WishlistGraphQl.html
     
   
-  - label: Commerce (v2.4.1)
+  - label: Core Commerce only, 2.4.1
     include_versions: ["2.4"]
     children:
     
@@ -868,7 +868,7 @@ pages:
         url: /mrg/ee/WeeeStaging.html
     
   
-  - label: B2B (v1.3.0)
+  - label: B2B extension, 1.3.0
     include_versions: ["2.4"]
     children:
     
@@ -954,7 +954,7 @@ pages:
         url: /mrg/b2b/SharedCatalog.html
     
   
-  - label: Inventory Management (v1.2.1)
+  - label: Inventory Management (Open Source), 1.2.1
     include_versions: ["2.4"]
     children:
     
@@ -1152,5 +1152,25 @@ pages:
     
       - label: InventoryVisualMerchandiser
         url: /mrg/msi/InventoryVisualMerchandiser.html
+    
+  
+  - label: Page Builder (Commerce), v1.5.0
+    include_versions: ["2.4"]
+    children:
+    
+      - label: CatalogPageBuilderAnalytics
+        url: /mrg/page-builder/CatalogPageBuilderAnalytics.html
+    
+      - label: CmsPageBuilderAnalytics
+        url: /mrg/page-builder/CmsPageBuilderAnalytics.html
+    
+      - label: PageBuilder
+        url: /mrg/page-builder/PageBuilder.html
+    
+      - label: PageBuilderAdminAnalytics
+        url: /mrg/page-builder/PageBuilderAdminAnalytics.html
+    
+      - label: PageBuilderAnalytics
+        url: /mrg/page-builder/PageBuilderAnalytics.html
     
   


### PR DESCRIPTION
## Purpose of this pull request

This pull request (PR) adds Page Builder modules to the Module Reference Guide in both versions 2.3 and 2.4.
Also,
- Removing blank lines and extra spaces at the beginning and at the end of a topic.
- Changing labels in tables of contents to clarify relevance to Magento products.

## Affected DevDocs pages

<!-- REQUIRED List the affected pages on devdocs.magento.com (URLs). Not needed for large numbers of files. -->

-  most of module topics in the MRG [2.3](https://devdocs.magento.com/guides/v2.3/mrg/intro.html) and [2.4](https://devdocs.magento.com/guides/v2.4/mrg/intro.html)

whatsnew
Added Page Builder modules to the Module Reference Guide for [2.4](https://devdocs.magento.com/guides/v2.4/mrg/intro.html) and [2.3](https://devdocs.magento.com/guides/v2.4/mrg/intro.html).