### PR TITLE
changed to the right file name

### DIFF
--- a/src/guides/v2.3/frontend-dev-guide/tools/using_grunt.md
+++ b/src/guides/v2.3/frontend-dev-guide/tools/using_grunt.md
@@ -52,9 +52,9 @@ Magento has built-in Grunt tasks configured, but there are still several steps y
 
 ## Grunt configuration file {#grunt_config}
 
-Copy the contents of `themes.js` into `local-themes.js` in the `dev/tools/grunt/configs/` directory.
+Copy the contents of `themes.js` into `themes.loc.js` in the `dev/tools/grunt/configs/` directory.
 
-If installed as described above, Grunt will use the default configuration files located in the `dev/tools/grunt/configs/` directory. You can define your theme in the `local-themes.js` file. The following shows an example of how you can define your theme.
+If installed as described above, Grunt will use the default configuration files located in the `dev/tools/grunt/configs/` directory. You can define your theme in the `themes.loc.js` file. The following shows an example of how you can define your theme.
 
 ```javascript
 <theme>: {
@@ -97,11 +97,11 @@ To use a custom file for Grunt configuration:
    -  value: path to your custom file
 
    Example:
-   If your custom configuration file `local-themes.js` is located in the `<magento_root>/dev/tools/grunt/configs` directory, the following is already set in your `grunt-config.json`:
+   If your custom configuration file `themes.loc.js` is located in the `<magento_root>/dev/tools/grunt/configs` directory, the following is already set in your `grunt-config.json`:
 
    ```json
    {
-       "themes": "dev/tools/grunt/configs/local-themes"
+       "themes": "dev/tools/grunt/configs/themes.loc"
    }
    ```
 


### PR DESCRIPTION
## Purpose of this pull request

This pull request (PR) covers #6414 
- Seems its already fixed on https://devdocs.magento.com/guides/v2.3/frontend-dev-guide/css-topics/css_debug.html#add_theme there is no occurrence of `local-themes.js` in the page.

- Have fixed in using_grunt.html page.
## Affected DevDocs pages

-  https://devdocs.magento.com/guides/v2.3/frontend-dev-guide/tools/using_grunt.html
