### PR TITLE
Patch widget_gallery configuration typo

### DIFF
--- a/src/guides/v2.3/javascript-dev-guide/widgets/widget_gallery.md
+++ b/src/guides/v2.3/javascript-dev-guide/widgets/widget_gallery.md
@@ -79,7 +79,7 @@ Example of declarative initialization:
                     "<breakpoint_name>": {
                         "conditions": {
                             "max-width": "767px"
-                        }
+                        },
                         "options": {}
                     }
                 }


### PR DESCRIPTION
## Purpose of this pull request

This pull request (PR) fixes a typo in example widget configuration. A missing comma might be misleading.

## Affected DevDocs pages

-  https://github.com/magento/devdocs/blob/master/src/guides/v2.3/javascript-dev-guide/widgets/widget_gallery.md

## Links to Magento source code
