### PR TITLE
Fix array attribute

### DIFF
--- a/src/guides/v2.3/graphql/develop/extend-existing-schema.md
+++ b/src/guides/v2.3/graphql/develop/extend-existing-schema.md
@@ -111,8 +111,8 @@ The following example adds an array-item to the `extendedConfigData` array withi
 <?xml version="1.0" ?>
 <config xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="urn:magento:framework:ObjectManager/etc/config.xsd">
   <type name="Magento\StoreGraphQl\Model\Resolver\Store\StoreConfigDataProvider">
-    <arguments xsi:type="array">
-      <argument name="extendedConfigData">
+    <arguments>
+      <argument name="extendedConfigData" xsi:type="array">
         <item name="section_group_field" xsi:type="string">section/group/field</item>
       </argument>
     </arguments>


### PR DESCRIPTION
## Purpose of this pull request

xsi:type was on the incorrect element, this causes Magento CLI to throw a fatal error

## Affected DevDocs pages

-  https://devdocs.magento.com/guides/v2.4/graphql/develop/extend-existing-schema.html#extend-configuration-data
