### PR TITLE
MCLOUD-7153: Support for Remote Storage

### DIFF
--- a/src/cloud/env/variables-deploy.md
+++ b/src/cloud/env/variables-deploy.md
@@ -672,7 +672,7 @@ stage:
 -  **Default**—_Not set_
 -  **Version**—Magento 2.4.2 and later
 
-Configure a _storage adapter_  to store media files in a persistent remote storage container using a storage service such as AWS S3. Use this option to improve performance on Cloud projects with complex, multi-server configurations that must share resources. See [Enable storage adapter]({{site.baseurl}}/guides/v2.4/config-guide/remote-storage/config-remote-storage#enable-storage-adapter.html).
+Configure a _storage adapter_ to store media files in a persistent, remote storage container using a storage service, such as AWS S3. Use the remote storage option to improve performance on Cloud projects with complex, multi-server configurations that must share resources. See [Enable storage adapter]({{site.baseurl}}/guides/v2.4/config-guide/remote-storage/config-remote-storage#enable-storage-adapter.html).
 
 ```yaml
 stage:

--- a/src/cloud/env/variables-deploy.md
+++ b/src/cloud/env/variables-deploy.md
@@ -672,7 +672,7 @@ stage:
 -  **Default**—_Not set_
 -  **Version**—Magento 2.4.2 and later
 
-Provide a configuration for remote storage functionality.
+Configure a _storage adapter_  to store media files in a persistent remote storage container using a storage service such as AWS S3. Use this option to improve performance on Cloud projects with complex, multi-server configurations that must share resources. See [Enable storage adapter]({{site.baseurl}}/guides/v2.4/config-guide/remote-storage/config-remote-storage#enable-storage-adapter.html).
 
 ```yaml
 stage:

--- a/src/cloud/env/variables-deploy.md
+++ b/src/cloud/env/variables-deploy.md
@@ -666,3 +666,23 @@ stage:
   deploy:
     VERBOSE_COMMANDS: "-vv"
 ```
+
+### `REMOTE_STORAGE`
+
+-  **Default**—_Not set_
+-  **Version**—Magento 2.4.2 and later
+
+Provide a configuration for remote storage functionality.
+
+```yaml
+stage:
+  deploy:
+    REMOTE_STORAGE:
+      driver: aws-s3 # Required
+      prefix: cloud # Optional
+      config:
+        bucket: my-bucket # Required
+        region: my-region # Required
+        key: my-key # Optional
+        secret: my-secret-key # Optional
+```


### PR DESCRIPTION
## Purpose of this pull request

https://jira.corp.magento.com/browse/MCLOUD-7153

## Affected DevDocs pages

<!-- REQUIRED List the affected pages on devdocs.magento.com (URLs). Not needed for large numbers of files. -->

-  https://devdocs.magento.com/cloud/env/variables-deploy.html

whatsnew
 Added the `REMOTE_STORAGE` environment variable
to the [Deploy variables](https://devdocs.magento.com/cloud/env/variables-deploy.html) topic in the _Cloud Guide_ . This variable enables Cloud Projects for remote storage of media files using a storage service such as AWS S3.