### PR TITLE
Added REMOTE_STORAGE deploy variable to Cloud Guide

### DIFF
--- a/src/_data/var.yml
+++ b/src/_data/var.yml
@@ -25,7 +25,7 @@ ece-release-date: November 9, 2020
 csuite: Magento Commerce Cloud Suite
 ct: ece-tools
 ct-repo: magento/ece-tools
-ct-release: 2002.1.3
+ct-release: 2002.1.4
 mcp-prod: Magento Cloud Patches
 mcp-package: magento/magento-cloud-patches
 mcp-release: 1.0.8

--- a/src/cloud/env/variables-deploy.md
+++ b/src/cloud/env/variables-deploy.md
@@ -425,6 +425,26 @@ You must have a Redis service configured in the `.magento.app.yaml` file and in 
 
 The read-only connection is not available for use in the Integration environment or if you use the [`CACHE_CONFIGURATION` variable](#cache_configuration).
 
+### `REMOTE_STORAGE`
+
+-  **Default**—_Not set_
+-  **Version**—Magento 2.4.2 and later
+
+Configure a _storage adapter_ to store media files in a persistent, remote storage container using a storage service, such as AWS S3. Use the remote storage option to improve performance on Cloud projects with complex, multi-server configurations that must share resources. See [Enable storage adapter]({{site.baseurl}}/guides/v2.4/config-guide/remote-storage/config-remote-storage#enable-storage-adapter.html).
+
+```yaml
+stage:
+  deploy:
+    REMOTE_STORAGE:
+      driver: aws-s3 # Required
+      prefix: cloud # Optional
+      config:
+        bucket: my-bucket # Required
+        region: my-region # Required
+        key: my-key # Optional
+        secret: my-secret-key # Optional
+```
+
 ### `RESOURCE_CONFIGURATION`
 
 -  **Default**—Not set

--- a/src/cloud/release-notes/ece-release-notes.md
+++ b/src/cloud/release-notes/ece-release-notes.md
@@ -17,6 +17,14 @@ The `{{site.data.var.ct}}` package uses the following release versioning sequenc
 {:.bs-callout-info}
 See [Upgrades and patches]({{ site.baseurl }}/cloud/project/project-upgrade-parent.html) for information about updating to the latest release of the `{{site.data.var.ct}}` package.
 
+## v2002.1.4
+*Release date: {{ site.data.var.ece-release-date }}*<br/>
+
+**Environment variable updates**–
+
+-  Added the [`REMOTE_STORAGE`]({{site.baseurl}}/cloud/env/variables-deploy.html) environment variable
+to enable Cloud Projects for remote storage of media files using a storage service such as AWS S3.<!--MCLOUD-7153-->
+
 ## v2002.1.3
 *Release date: {{ site.data.var.ece-release-date }}*<br/>
 


### PR DESCRIPTION
Closes #8299

## Purpose of this pull request

This pull request merges changes from PR #8218 and adds release notes for the new REMOTE_STORAGE deployment variable.

## Affected DevDocs pages

- https://devdocs.magento.com/cloud/env/variables-deploy.html#remote_storage
- https://devdocs.magento.com/cloud/release-notes/ece-release-notes.html

whatsnew
Added the `REMOTE_STORAGE` environment variable
to the [Deploy variables](https://devdocs.magento.com/cloud/env/variables-deploy.html) topic in the _Cloud Guide_ . This variable enables Cloud Projects for remote storage of media files using a storage service such as AWS S3.