### PR TITLE
MCLOUD-6073: Review "Update the metapackage" devdocs which is confusing merchants and support agents

### DIFF
--- a/src/cloud/project/ece-tools-upgrade-project.md
+++ b/src/cloud/project/ece-tools-upgrade-project.md
@@ -27,6 +27,12 @@ Each {{site.data.var.ee}} version requires a different constraint based on the f
 >=current_version <next_version
 ```
 
+where `current_version` is the version of Magento you want to be installed
+
+and `next_version` is the next patch version after your `current_version`.
+
+If you want to install Magento `2.3.5-p2` you still should set `current_version` as `2.3.5` and constraint `">=2.3.5 <2.3.6"` will install the latest available package for 2.3.5
+
 You can always find the latest metapackage constraint in the [`magento-cloud` template](https://github.com/magento/magento-cloud/blob/master/composer.json).
 
 The following example places a constraint for the {{site.data.var.ece}} metapackage to any version greater than or equal to the current version 2.3.4 and lower than next version 2.3.5:

--- a/src/cloud/project/ece-tools-upgrade-project.md
+++ b/src/cloud/project/ece-tools-upgrade-project.md
@@ -27,9 +27,8 @@ Each {{site.data.var.ee}} version requires a different constraint based on the f
 >=current_version <next_version
 ```
 
-where `current_version` is the version of Magento you want to be installed
-
-and `next_version` is the next patch version after your `current_version`.
+-  For `current_version`, specify the Magento version to install.
+-  For `next_version`, specify the next patch version after the value specified in `current_version`.
 
 If you want to install Magento `2.3.5-p2` you still should set `current_version` as `2.3.5` and constraint `">=2.3.5 <2.3.6"` will install the latest available package for 2.3.5
 

--- a/src/cloud/project/ece-tools-upgrade-project.md
+++ b/src/cloud/project/ece-tools-upgrade-project.md
@@ -30,7 +30,7 @@ Each {{site.data.var.ee}} version requires a different constraint based on the f
 -  For `current_version`, specify the Magento version to install.
 -  For `next_version`, specify the next patch version after the value specified in `current_version`.
 
-If you want to install Magento `2.3.5-p2` you still should set `current_version` as `2.3.5` and constraint `">=2.3.5 <2.3.6"` will install the latest available package for 2.3.5
+If you want to install Magento `2.3.5-p2`, set `current_version` to `2.3.5` and the `next_version` to `2.3.6`. The constraint `">=2.3.5 <2.3.6"` installs the latest available package for 2.3.5.
 
 You can always find the latest metapackage constraint in the [`magento-cloud` template](https://github.com/magento/magento-cloud/blob/master/composer.json).
 


### PR DESCRIPTION
## Purpose of this pull request

Clarify how to specify the correct version constraint when upgrading the Magento application deployed on the Cloud platform. (https://jira.corp.magento.com/browse/MCLOUD-6073).

## Affected DevDocs pages

<!-- REQUIRED List the affected pages on devdocs.magento.com (URLs). Not needed for large numbers of files. -->

-  https://devdocs.magento.com/cloud/project/ece-tools-upgrade-project.md

