### PR TITLE
Add release note for opcache flush option

### DIFF
--- a/src/cloud/release-notes/ece-release-notes.md
+++ b/src/cloud/release-notes/ece-release-notes.md
@@ -20,9 +20,13 @@ See [Upgrades and patches]({{ site.baseurl }}/cloud/project/project-upgrade-pare
 ## v2002.1.4
 *Release date: {{ site.data.var.ece-release-date }}*<br/>
 
+- {:.new}Added support for the `opcache.enable_cli` PHP option to flush the opcache before running the deploy hook. This configuration resets the cache configuration and ensures that the current configuration settings are applied on each deployment.<!--MCLOUD-7015-->
+
 **Environment variable updates**–
 
--  Added the [`REMOTE_STORAGE`]({{site.baseurl}}/cloud/env/variables-deploy.html#remote_storage) environment variable to enable Cloud Projects for remote storage of media files using a storage service such as AWS S3.<!--MCLOUD-7153-->
+-  {:.new}Added the [`REMOTE_STORAGE`]({{site.baseurl}}/cloud/env/variables-deploy.html#remote_storage) environment variable to enable Cloud Projects for remote storage of media files using a storage service such as AWS S3.<!--MCLOUD-7153-->
+
+
 
 ## v2002.1.3
 *Release date: {{ site.data.var.ece-release-date }}*<br/>

--- a/src/cloud/release-notes/ece-release-notes.md
+++ b/src/cloud/release-notes/ece-release-notes.md
@@ -20,7 +20,7 @@ See [Upgrades and patches]({{ site.baseurl }}/cloud/project/project-upgrade-pare
 ## v2002.1.4
 *Release date: {{ site.data.var.ece-release-date }}*<br/>
 
-- {:.new}Added support for the `opcache.enable_cli` PHP option to flush the opcache before running the deploy hook. This configuration resets the cache configuration and ensures that the current configuration settings are applied on each deployment.<!--MCLOUD-7015-->
+- {:.new}Added support for the `opcache.enable_cli` PHP option to flush the opcache before running the deploy hook. This configuration resets the cache configuration to ensure that the current configuration settings are applied on each deployment.<!--MCLOUD-7015-->
 
 **Environment variable updates**–
 


### PR DESCRIPTION
## Purpose of this pull request

Added release note for addition of the `opcache.enable_cli`  PHP option for resetting  cache configuration when deploying Magento on the Cloud platform. (MCLOUD-7015)

## Affected DevDocs pages
- https://devdocs.magento.com/cloud/release-notes/ece-release-notes.html
