### PR TITLE
Remove space before opening braces in style less code standards

### DIFF
--- a/src/guides/v2.3/coding-standards/code-standard-less.md
+++ b/src/guides/v2.3/coding-standards/code-standard-less.md
@@ -731,11 +731,11 @@ For mixins grouping use the double underscore "__" prefix.
 **Example:**
 
 ```css
-.extend__clearfix (...) {
+.extend__clearfix(...) {
     ...
 }
 
-.vendor-prefix__flex-direction (...) {
+.vendor-prefix__flex-direction(...) {
     ...
 }
 ```


### PR DESCRIPTION
## Purpose of this pull request

This pull request update for clear confusing unneccessary in doc
In less mixins before open braces no need white space

## Affected DevDocs pages

<!-- REQUIRED List the affected pages on devdocs.magento.com (URLs). Not needed for large numbers of files. -->

https://devdocs.magento.com/guides/v2.3/coding-standards/code-standard-less.html
https://devdocs.magento.com/guides/v2.4/coding-standards/code-standard-less.html

## Links to Magento source code

<!--  OPTIONAL - REMOVE THIS SECTION IF NOT USED. If this pull request references a file in a Magento codebase repository, add it here. -->

-  ...

<!--
If you are fixing a GitHub issue, note it using GitHub keyword format (https://help.github.com/en/articles/closing-issues-using-keywords#closing-an-issue-in-a-different-repository) to close the issue when this pull request is merged. Example: `Fixes #1234`

`master` is the default branch. Merged pull requests to `master` go live on the site automatically. Any requested changes to content on the `master` branch must be related to the released codebase. Any content related to future releases goes in the `develop` branch.

See Contribution guidelines (https://github.com/magento/devdocs/blob/master/.github/CONTRIBUTING.md) for more information.
-->
