### PR TITLE
Add release notes for MQP 1.0.11 release

### DIFF
--- a/src/quality-patches/release-notes.md
+++ b/src/quality-patches/release-notes.md
@@ -19,6 +19,12 @@ The [Magento Quality Patches](https://github.com/magento/quality-patches) packag
 See [Apply patches]({{ site.baseurl }}/guides/v2.4/comp-mgr/patching/mqp.html) for instructions on applying patches to your Magento projects.
 See [Patches available in MQP tool](https://support.magento.com/hc/en-us/sections/360010506631-Patches-available-in-MQP-tool-) for additional patch details.
 
+## v1.0.11
+
+-  **MC-38509** _(for Magento `2.3.6, 2.4.1`)_—Fixes the issue where the "Create an Account" button stays disabled after correcting invalid data in the "Create New Customer Account" form.
+-  **MDVA-31006** _(for Magento `2.3.0, 2.3.1`)_—Fixes the issue where duplicated orders appear after placing an order using Paypal Express payment.
+-  **MDVA-25602** _(for Magento `2.3.0`)_—Fixes issue with PayPal Payflow Pro payment method and treating cookies as SameSite=Lax by default in the Chrome 80 browser and API response redirect to customer login page.
+
 ## v1.0.10
 
 Minor fixes for patch versions


### PR DESCRIPTION
## Purpose of this pull request
- Add release notes for MQP 1.0.11 release

## Affected DevDocs pages
- Page https://devdocs.magento.com/quality-patches/release-notes.html

whatsnew
Published [release notes](https://devdocs.magento.com/quality-patches/release-notes.html) for the 1.0.10 Magento Quality Patch (MQP) package release.