### PR TITLE
Install Guide copy edit and cleanup

### DIFF
--- a/src/_data/toc/installation-guide.yml
+++ b/src/_data/toc/installation-guide.yml
@@ -1,7 +1,7 @@
 label: Installation Guide
 pages:
 
-    - label: Installation flow diagram
+    - label: Installation flow
       url: /install-gde/install-flow-diagram.html
     
     - label: Magento system requirements

--- a/src/_includes/install/composer-overview_24.md
+++ b/src/_includes/install/composer-overview_24.md
@@ -7,4 +7,4 @@ We use [Composer](https://getcomposer.org/) to manage Magento components and the
 -  Use the Magento software in a production environment
 
 {:.bs-callout-info}
-You can also [download](https://magento.com/tech-resources/download) an archive file for a specific version of Magento in either ZIP or TAR format. Installing Magento from an archive lacks the advantages of using Composer. Contributing developers should use the [git-based]({{ page.baseurl }}/install/cli/dev_options.html) installation method.
+You can also [download](https://magento.com/tech-resources/download) an archive file for a specific version of Magento in either ZIP or TAR format. Installing Magento from an archive lacks the advantages of using Composer. Contributing developers should use the [git-based]({{ page.baseurl }}/install-gde/cli/dev_options.html) installation method.

--- a/src/_includes/install/composer-overview_24.md
+++ b/src/_includes/install/composer-overview_24.md
@@ -1,7 +1,10 @@
-We use [Composer](https://getcomposer.org/){:target="_blank"} to manage Magento components and their dependencies. Using Composer to get the Magento software [metapackage](https://glossary.magento.com/metapackage) provides the following advantages:
+We use [Composer](https://getcomposer.org/) to manage Magento components and their dependencies. Using Composer to get the Magento software [metapackage](https://glossary.magento.com/metapackage) provides the following advantages:
 
 -  Reuse third-party libraries without bundling them with source code
 -  Reduce extension conflicts and compatibility issues by using a component-based architecture with robust dependency management
 -  Adhere to [PHP-Framework Interoperability Group (FIG)](https://www.php-fig.org/) standards
 -  Repackage Magento Open Source with other components
 -  Use the Magento software in a production environment
+
+{:.bs-callout-info}
+You can also [download](https://magento.com/tech-resources/download) an archive file for a specific version of Magento in either ZIP or TAR format. Installing Magento from an archive lacks the advantages of using Composer. Contributing developers should use the [git-based]({{ site.baseurl }}/install/cli/dev_options.html) installation method.

--- a/src/_includes/install/composer-overview_24.md
+++ b/src/_includes/install/composer-overview_24.md
@@ -7,4 +7,4 @@ We use [Composer](https://getcomposer.org/) to manage Magento components and the
 -  Use the Magento software in a production environment
 
 {:.bs-callout-info}
-You can also [download](https://magento.com/tech-resources/download) an archive file for a specific version of Magento in either ZIP or TAR format. Installing Magento from an archive lacks the advantages of using Composer. Contributing developers should use the [git-based]({{ site.baseurl }}/install/cli/dev_options.html) installation method.
+You can also [download](https://magento.com/tech-resources/download) an archive file for a specific version of Magento in either ZIP or TAR format. Installing Magento from an archive lacks the advantages of using Composer. Contributing developers should use the [git-based]({{ page.baseurl }}/install/cli/dev_options.html) installation method.

--- a/src/_includes/install/composer-overview_24.md
+++ b/src/_includes/install/composer-overview_24.md
@@ -7,4 +7,4 @@ We use [Composer](https://getcomposer.org/) to manage Magento components and the
 -  Use the Magento software in a production environment
 
 {:.bs-callout-info}
-You can also [download](https://magento.com/tech-resources/download) an archive file for a specific version of Magento in either ZIP or TAR format. Installing Magento from an archive lacks the advantages of using Composer. Contributing developers should use the [git-based]({{ page.baseurl }}/install-gde/cli/dev_options.html) installation method.
+You can also [download](https://magento.com/tech-resources/download) an archive file for a specific version of Magento in either ZIP or TAR format. Installing Magento from an archive lacks the advantages of using Composer. Contributing developers should use the [git-based]({{ page.baseurl }}/install-gde/install/cli/dev_options.html) installation method.

--- a/src/_includes/install/flow-diagram-24.md
+++ b/src/_includes/install/flow-diagram-24.md
@@ -8,9 +8,9 @@ The diagram shows the following:
 
 1. Get the Magento software.
 
-   *  If you are more technical and you are familiar with Composer, get a {{site.data.var.ce}} or {{site.data.var.ee}}  [metapackage]({{page.baseurl}}/install-gde/composer.html).
+   *  (Recommended) Get the {{site.data.var.ce}} or {{site.data.var.ee}} [Composer metapackage]({{page.baseurl}}/install-gde/composer.html) to manage Magento components and their dependencies.
 
-   *  If you want to contribute to the {{site.data.var.ce}} codebase or customize the Magento application, [clone]({{ page.baseurl }}/install-gde/prereq/dev_install.html) the Magento 2 GitHub repository. (This method requires familiarity with both GitHub and Composer.)
+   *  If you want to contribute to the {{site.data.var.ce}} codebase or customize the Magento application, [clone]({{ page.baseurl }}/install-gde/prereq/dev_install.html) the Magento 2 GitHub repository. This method requires familiarity with both GitHub and Composer.
 
 1. Install the Magento software using the command line.
 

--- a/src/guides/v2.4/install-gde/install-flow-diagram.md
+++ b/src/guides/v2.4/install-gde/install-flow-diagram.md
@@ -1,10 +1,6 @@
 ---
 group: installation-guide
-subgroup: Getting Started
-title: Installation flow diagram
-menu_title: Installation flow diagram
-menu_order: 2
-menu_node:
+title: Installation flow
 functional_areas:
   - Install
   - System


### PR DESCRIPTION
## Purpose of this pull request

This pull request (PR):

- Removes "diagram" from the install flow topic title and TOC
- Replaces the "If you are more technical..." bullet from the diagram topic with more concise info for getting Magento using Composer as the recommended install option.
- Adds a note to the Install Magento using Composer topic about packages being available via archive and adds mention of using git install info if you are a contributing developer. 

## Affected DevDocs pages

<!-- REQUIRED List the affected pages on devdocs.magento.com (URLs). Not needed for large numbers of files. -->

- https://devdocs.magento.com/guides/v2.4/install-gde/install-flow-diagram.html
- https://devdocs.magento.com/guides/v2.4/install-gde/composer.html