### PR TITLE
Fix downgrade example

### DIFF
--- a/src/cloud/project/services.md
+++ b/src/cloud/project/services.md
@@ -259,7 +259,7 @@ To downgrade a service version by renaming an existing service:
 
      ```yaml
      mysql:
-         type: mysql:10.3
+         type: mysql:10.4
          disk: 2048
      ```
 
@@ -267,7 +267,7 @@ To downgrade a service version by renaming an existing service:
 
      ```yaml
      mysql2:
-          type: mysql:10.2
+          type: mysql:10.3
           disk: 2048
      ```
 
@@ -298,10 +298,10 @@ To downgrade a service by creating an additional service:
 
    ```yaml
    mysql:
-       type: mysql:10.3
+       type: mysql:10.4
        disk: 2048
    mysql2:
-       type: mysql:10.2
+       type: mysql:10.3
        disk: 2048
    ```
 


### PR DESCRIPTION
Fix versions in example to downgrade MySQL

## Purpose of this pull request

Fix example in instructions to downgrade Cloud service version, to use MYSQL versions that can be downgraded. Current example downgrades from 10.3 to 10.2 which is not supported.

## Affected DevDocs pages

<!-- REQUIRED List the affected pages on devdocs.magento.com (URLs). 

-  https://devdocs.magento.com/cloud/project/services.html#downgrade-version
