### PR TITLE
Created versioned TOCs for the Installation Guide

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -135,6 +135,18 @@ defaults:
       github_link: false
       feedback_link: false
 
+  - 
+    scope:
+      path: guides/v2.3/install-gde
+    values:
+      group: installation-guide-2_3
+  
+  - 
+    scope:
+      path: guides/v2.4/install-gde
+    values:
+      group: installation-guide
+
 
 ##########################
 # Plugins and extensions #

--- a/src/_data/toc/installation-guide-2_3.yml
+++ b/src/_data/toc/installation-guide-2_3.yml
@@ -23,16 +23,6 @@ pages:
         - label: PHP
           url: /install-gde/prereq/php-settings.html
 
-        - label: Elasticsearch
-          url: /install-gde/prereq/elasticsearch.html
-          children:
-
-            - label: Configure nginx and Elasticsearch
-              url: /install-gde/prereq/es-config-nginx.html
-
-            - label: Configure Apache and Elasticsearch
-              url: /install-gde/prereq/es-config-apache.html      
-
         - label: Get your authentication keys
           url: /install-gde/prereq/connect-auth.html
 
@@ -72,6 +62,45 @@ pages:
 
     - label: Install options
       url: /install-gde/bk-install-guide.html
+
+    - label: Setup Wizard Install
+      children:
+        - label: Installation roadmap (reference)
+          url: /install-gde/install-roadmap_web.html
+
+        - label: Install optional sample data modules
+          url: /install-gde/install/web/install-web-sample-data.html
+          children:
+
+            - label: Install using Composer
+              url: /install-gde/install/web/install-web-sample-data-composer.html
+
+            - label: Install by cloning repositories
+              url: /install-gde/install/web/install-web-sample-data-clone.html
+
+        - label: Setup Wizard installation
+          url: /install-gde/install/web/install-web.html
+          children:
+            - label: Step 1. Readiness check
+              url: /install-gde/install/web/install-web_1-readiness.html
+
+            - label: Step 2. Add a Database
+              url: /install-gde/install/web/install-web_2-db.html
+
+            - label: Step 3. Web Configuration
+              url: /install-gde/install/web/install-web_3-web-conf.html
+
+            - label: Step 4. Customize Your Store
+              url: /install-gde/install/web/install-web_4-customize-store.html
+
+            - label: Step 5. Create Admin Account
+              url: /install-gde/install/web/install-web_5-create-admin.html
+
+            - label: Step 6. Install
+              url: /install-gde/install/web/install-web_6-install.html
+
+        - label: Post-installation
+          url: /install-gde/continue-to-verify.html
 
     - label: Command Line Installation
       url: /install-gde/install/cli/install-cli.html
@@ -186,3 +215,6 @@ pages:
 
             - label: Cannot write to the var/generation directory
               url: /install-gde/trouble/tshoot_var-gen-perms.html
+
+            - label: Installation dependencies not met
+              url: /install-gde/trouble/tshoot_install_depend.html

--- a/src/guides/v2.3/install-gde/bk-install-guide.md
+++ b/src/guides/v2.3/install-gde/bk-install-guide.md
@@ -1,5 +1,4 @@
 ---
-group: installation-guide
 title: How to get the Magento software
 landing-page: Installation Guide
 functional_areas:

--- a/src/guides/v2.3/install-gde/composer.md
+++ b/src/guides/v2.3/install-gde/composer.md
@@ -1,5 +1,4 @@
 ---
-group: installation-guide
 title: Install Magento using Composer
 redirect_from:
   - guides/v2.3/install-gde/prereq/integrator_install.html

--- a/src/guides/v2.3/install-gde/continue-to-install.md
+++ b/src/guides/v2.3/install-gde/continue-to-install.md
@@ -1,5 +1,4 @@
 ---
-group: installation-guide
 subgroup: Z_continue
 title: Installation Options
 menu_title: Next&mdash;Installation part 2, installing

--- a/src/guides/v2.3/install-gde/continue-to-verify.md
+++ b/src/guides/v2.3/install-gde/continue-to-verify.md
@@ -1,5 +1,4 @@
 ---
-group: installation-guide
 subgroup: ZZ_continue
 title:
 menu_title: Next&mdash;Installation part 3, post-installation

--- a/src/guides/v2.3/install-gde/continue-to-verify_cli.md
+++ b/src/guides/v2.3/install-gde/continue-to-verify_cli.md
@@ -1,5 +1,4 @@
 ---
-group: installation-guide
 subgroup: W_continue
 title:
 menu_title: Next&mdash;Installation part 3, post-installation

--- a/src/guides/v2.3/install-gde/install-flow-diagram.md
+++ b/src/guides/v2.3/install-gde/install-flow-diagram.md
@@ -1,5 +1,4 @@
 ---
-group: installation-guide
 subgroup: Getting Started
 title: Installation flow diagram
 menu_title: Installation flow diagram

--- a/src/guides/v2.3/install-gde/install-quick-ref.md
+++ b/src/guides/v2.3/install-gde/install-quick-ref.md
@@ -1,5 +1,4 @@
 ---
-group: installation-guide
 subgroup: 01_resource
 title: Installation quick reference (tutorial)
 menu_title: Installation quick reference (tutorial)

--- a/src/guides/v2.3/install-gde/install-resource-diagram.md
+++ b/src/guides/v2.3/install-gde/install-resource-diagram.md
@@ -1,5 +1,4 @@
 ---
-group: installation-guide
 subgroup: 01_resource
 title: Installation flow diagram
 menu_title: Installation flow diagram

--- a/src/guides/v2.3/install-gde/install-resources-parent.md
+++ b/src/guides/v2.3/install-gde/install-resources-parent.md
@@ -1,5 +1,4 @@
 ---
-group: installation-guide
 subgroup: 01_resource
 title: Helpful resources
 menu_title: Helpful resources

--- a/src/guides/v2.3/install-gde/install-roadmap_cli.md
+++ b/src/guides/v2.3/install-gde/install-roadmap_cli.md
@@ -1,5 +1,4 @@
 ---
-group: installation-guide
 title: Installation roadmap (reference)
 functional_areas:
   - Install

--- a/src/guides/v2.3/install-gde/install-roadmap_part1.md
+++ b/src/guides/v2.3/install-gde/install-roadmap_part1.md
@@ -1,5 +1,4 @@
 ---
-group: installation-guide
 title: Installation roadmap (reference)
 functional_areas:
   - Install

--- a/src/guides/v2.3/install-gde/install-roadmap_trouble.md
+++ b/src/guides/v2.3/install-gde/install-roadmap_trouble.md
@@ -1,5 +1,4 @@
 ---
-group: installation-guide
 title: Installation roadmap (reference)
 functional_areas:
   - Install

--- a/src/guides/v2.3/install-gde/install-roadmap_web.md
+++ b/src/guides/v2.3/install-gde/install-roadmap_web.md
@@ -1,5 +1,4 @@
 ---
-group: installation-guide
 title: Installation roadmap (reference)
 functional_areas:
   - Install

--- a/src/guides/v2.3/install-gde/install/cli/dev_add-update.md
+++ b/src/guides/v2.3/install-gde/install/cli/dev_add-update.md
@@ -1,5 +1,4 @@
 ---
-group: installation-guide
 subgroup: 99_contrib
 title: Add or update components
 menu_title: Add or update components

--- a/src/guides/v2.3/install-gde/install/cli/dev_downgrade.md
+++ b/src/guides/v2.3/install-gde/install/cli/dev_downgrade.md
@@ -1,5 +1,4 @@
 ---
-group: installation-guide
 subgroup: 99_contrib
 title: Change to a released version
 menu_title: Change to a released version

--- a/src/guides/v2.3/install-gde/install/cli/dev_options.md
+++ b/src/guides/v2.3/install-gde/install/cli/dev_options.md
@@ -1,5 +1,4 @@
 ---
-group: installation-guide
 title: Contributing developers&mdash;update, reinstall Magento
 functional_areas:
   - Install

--- a/src/guides/v2.3/install-gde/install/cli/dev_reinstall.md
+++ b/src/guides/v2.3/install-gde/install/cli/dev_reinstall.md
@@ -1,5 +1,4 @@
 ---
-group: installation-guide
 subgroup: 99_contrib
 title: Reinstall the Magento software
 menu_title: Reinstall the Magento software

--- a/src/guides/v2.3/install-gde/install/cli/dev_update-magento.md
+++ b/src/guides/v2.3/install-gde/install/cli/dev_update-magento.md
@@ -1,5 +1,4 @@
 ---
-group: installation-guide
 subgroup: 99_contrib
 title: Update the Magento application
 menu_title: Update the Magento application

--- a/src/guides/v2.3/install-gde/install/cli/install-cli-adminurl.md
+++ b/src/guides/v2.3/install-gde/install/cli/install-cli-adminurl.md
@@ -1,5 +1,4 @@
 ---
-group: installation-guide
 title: Display or change the Admin URI
 functional_areas:
   - Install

--- a/src/guides/v2.3/install-gde/install/cli/install-cli-backup.md
+++ b/src/guides/v2.3/install-gde/install/cli/install-cli-backup.md
@@ -1,5 +1,4 @@
 ---
-group: installation-guide
 title: Back up and roll back the file system, media, and database
 functional_areas:
   - Install

--- a/src/guides/v2.3/install-gde/install/cli/install-cli-install.md
+++ b/src/guides/v2.3/install-gde/install/cli/install-cli-install.md
@@ -1,5 +1,4 @@
 ---
-group: installation-guide
 subgroup: 05_Command-line installation
 title: Install the Magento software
 menu_title: Install the Magento software

--- a/src/guides/v2.3/install-gde/install/cli/install-cli-sample-data-clone.md
+++ b/src/guides/v2.3/install-gde/install/cli/install-cli-sample-data-clone.md
@@ -1,5 +1,4 @@
 ---
-group: installation-guide
 subgroup: 02_sample
 title: Install by cloning repositories
 menu_title: Install by cloning repositories

--- a/src/guides/v2.3/install-gde/install/cli/install-cli-sample-data-composer.md
+++ b/src/guides/v2.3/install-gde/install/cli/install-cli-sample-data-composer.md
@@ -1,5 +1,4 @@
 ---
-group: installation-guide
 subgroup: 02_sample
 title: Install using Composer
 menu_title: Install using Composer

--- a/src/guides/v2.3/install-gde/install/cli/install-cli-sample-data-other.md
+++ b/src/guides/v2.3/install-gde/install/cli/install-cli-sample-data-other.md
@@ -1,5 +1,4 @@
 ---
-group: installation-guide
 subgroup: 05_Command-line installation
 title: Remove sample data modules or update sample data
 menu_title: Remove sample data modules or update sample data

--- a/src/guides/v2.3/install-gde/install/cli/install-cli-sample-data.md
+++ b/src/guides/v2.3/install-gde/install/cli/install-cli-sample-data.md
@@ -1,5 +1,4 @@
 ---
-group: installation-guide
 subgroup: 02_sample
 title: Install optional sample data modules
 menu_title: Install optional sample data modules

--- a/src/guides/v2.3/install-gde/install/cli/install-cli-subcommands-admin.md
+++ b/src/guides/v2.3/install-gde/install/cli/install-cli-subcommands-admin.md
@@ -1,5 +1,4 @@
 ---
-group: installation-guide
 title: Create, edit, or unlock a Magento administrator account
 functional_areas:
   - Install

--- a/src/guides/v2.3/install-gde/install/cli/install-cli-subcommands-consumers.md
+++ b/src/guides/v2.3/install-gde/install/cli/install-cli-subcommands-consumers.md
@@ -1,5 +1,4 @@
 ---
-group: installation-guide
 title: Configure consumer behavior
 functional_areas:
   - Install

--- a/src/guides/v2.3/install-gde/install/cli/install-cli-subcommands-db-status.md
+++ b/src/guides/v2.3/install-gde/install/cli/install-cli-subcommands-db-status.md
@@ -1,5 +1,4 @@
 ---
-group: installation-guide
 subgroup: 05_Command-line installation
 title: Check the Magento database status
 menu_title: Check the Magento database status

--- a/src/guides/v2.3/install-gde/install/cli/install-cli-subcommands-db-upgr.md
+++ b/src/guides/v2.3/install-gde/install/cli/install-cli-subcommands-db-upgr.md
@@ -1,5 +1,4 @@
 ---
-group: installation-guide
 title: Update the Magento database schema and data
 functional_areas:
   - Install

--- a/src/guides/v2.3/install-gde/install/cli/install-cli-subcommands-db.md
+++ b/src/guides/v2.3/install-gde/install/cli/install-cli-subcommands-db.md
@@ -1,5 +1,4 @@
 ---
-group: installation-guide
 title: Create the Magento database schema
 functional_areas:
   - Install

--- a/src/guides/v2.3/install-gde/install/cli/install-cli-subcommands-deployment.md
+++ b/src/guides/v2.3/install-gde/install/cli/install-cli-subcommands-deployment.md
@@ -1,5 +1,4 @@
 ---
-group: installation-guide
 subgroup: 05_Command-line installation
 title: Create or update the deployment configuration
 menu_title: Create or update the deployment configuration

--- a/src/guides/v2.3/install-gde/install/cli/install-cli-subcommands-enable.md
+++ b/src/guides/v2.3/install-gde/install/cli/install-cli-subcommands-enable.md
@@ -1,5 +1,4 @@
 ---
-group: installation-guide
 title: Enable or disable modules
 functional_areas:
   - Install

--- a/src/guides/v2.3/install-gde/install/cli/install-cli-subcommands-lock.md
+++ b/src/guides/v2.3/install-gde/install/cli/install-cli-subcommands-lock.md
@@ -1,5 +1,4 @@
 ---
-group: installation-guide
 title: Configure the lock provider
 functional_areas:
   - Install

--- a/src/guides/v2.3/install-gde/install/cli/install-cli-subcommands-maint.md
+++ b/src/guides/v2.3/install-gde/install/cli/install-cli-subcommands-maint.md
@@ -1,5 +1,4 @@
 ---
-group: installation-guide
 subgroup: 05_Command-line installation
 title: Enable or disable maintenance mode
 menu_title: Enable or disable maintenance mode

--- a/src/guides/v2.3/install-gde/install/cli/install-cli-subcommands-store.md
+++ b/src/guides/v2.3/install-gde/install/cli/install-cli-subcommands-store.md
@@ -1,5 +1,4 @@
 ---
-group: installation-guide
 title: Configure the store
 functional_areas:
   - Install

--- a/src/guides/v2.3/install-gde/install/cli/install-cli-subcommands.md
+++ b/src/guides/v2.3/install-gde/install/cli/install-cli-subcommands.md
@@ -1,5 +1,4 @@
 ---
-group: installation-guide
 subgroup: 05_Command-line installation
 title: Get started with the command-line installation
 menu_title: Get started with the command-line installation

--- a/src/guides/v2.3/install-gde/install/cli/install-cli-theme-uninstall.md
+++ b/src/guides/v2.3/install-gde/install/cli/install-cli-theme-uninstall.md
@@ -1,5 +1,4 @@
 ---
-group: installation-guide
 title: Uninstall themes Composer packages
 functional_areas:
   - Install

--- a/src/guides/v2.3/install-gde/install/cli/install-cli-uninstall-langpk.md
+++ b/src/guides/v2.3/install-gde/install/cli/install-cli-uninstall-langpk.md
@@ -1,5 +1,4 @@
 ---
-group: installation-guide
 title: Uninstall language packages
 functional_areas:
   - Install

--- a/src/guides/v2.3/install-gde/install/cli/install-cli-uninstall-mods.md
+++ b/src/guides/v2.3/install-gde/install/cli/install-cli-uninstall-mods.md
@@ -1,5 +1,4 @@
 ---
-group: installation-guide
 title: Uninstall modules
 functional_areas:
   - Install

--- a/src/guides/v2.3/install-gde/install/cli/install-cli-uninstall.md
+++ b/src/guides/v2.3/install-gde/install/cli/install-cli-uninstall.md
@@ -1,5 +1,4 @@
 ---
-group: installation-guide
 subgroup: 05_Command-line installation
 title: Uninstall or reinstall Magento
 menu_title: Uninstall or reinstall Magento

--- a/src/guides/v2.3/install-gde/install/cli/install-cli.md
+++ b/src/guides/v2.3/install-gde/install/cli/install-cli.md
@@ -1,5 +1,4 @@
 ---
-group: installation-guide
 subgroup: 05_Command-line installation
 title: Install the Magento software using the command line
 menu_title: Install the Magento software using the command line

--- a/src/guides/v2.3/install-gde/install/file-sys-perms-over.md
+++ b/src/guides/v2.3/install-gde/install/file-sys-perms-over.md
@@ -1,5 +1,4 @@
 ---
-group: installation-guide
 subgroup: Prerequisites
 title: Overview of ownership and permissions
 menu_title: Overview of ownership and permissions

--- a/src/guides/v2.3/install-gde/install/get-help.md
+++ b/src/guides/v2.3/install-gde/install/get-help.md
@@ -1,5 +1,4 @@
 ---
-group: installation-guide
 subgroup: YY_Help
 title: Get help with your installation
 menu_title: Get help with your installation

--- a/src/guides/v2.3/install-gde/install/get-software.md
+++ b/src/guides/v2.3/install-gde/install/get-software.md
@@ -1,5 +1,4 @@
 ---
-group: installation-guide
 subgroup: QA_Get
 title: Get the Magento software
 menu_title: Get the Magento software

--- a/src/guides/v2.3/install-gde/install/hosted/hosted_get-ftp.md
+++ b/src/guides/v2.3/install-gde/install/hosted/hosted_get-ftp.md
@@ -1,5 +1,4 @@
 ---
-group: installation-guide
 subgroup: 02_config-hosted
 title: Transfer the Magento software to your hosted system
 menu_title: Transfer the Magento software to your hosted system

--- a/src/guides/v2.3/install-gde/install/hosted/hosted_install.md
+++ b/src/guides/v2.3/install-gde/install/hosted/hosted_install.md
@@ -1,5 +1,4 @@
 ---
-group: installation-guide
 subgroup: 03_install
 title: Install the Magento software
 menu_title: Install the Magento software

--- a/src/guides/v2.3/install-gde/install/hosted/hosted_install_1_readiness.md
+++ b/src/guides/v2.3/install-gde/install/hosted/hosted_install_1_readiness.md
@@ -1,5 +1,4 @@
 ---
-group: installation-guide
 subgroup: 03_install
 title: Step 1. Readiness check
 menu_title: Step 1. Readiness check

--- a/src/guides/v2.3/install-gde/install/hosted/hosted_install_2_db.md
+++ b/src/guides/v2.3/install-gde/install/hosted/hosted_install_2_db.md
@@ -1,5 +1,4 @@
 ---
-group: installation-guide
 subgroup: 03_install
 title: Step 2. Add a database
 menu_title: Step 2. Add a database

--- a/src/guides/v2.3/install-gde/install/hosted/hosted_install_3_web-conf.md
+++ b/src/guides/v2.3/install-gde/install/hosted/hosted_install_3_web-conf.md
@@ -1,5 +1,4 @@
 ---
-group: installation-guide
 subgroup: 03_install
 title: Step 3. Web configuration
 menu_title: Step 3. Web configuration

--- a/src/guides/v2.3/install-gde/install/hosted/hosted_install_4_customize-store.md
+++ b/src/guides/v2.3/install-gde/install/hosted/hosted_install_4_customize-store.md
@@ -1,5 +1,4 @@
 ---
-group: installation-guide
 subgroup: 03_install
 title: Step 4. Customize your store
 menu_title: Step 4. Customize your store

--- a/src/guides/v2.3/install-gde/install/hosted/hosted_install_5_create-admin.md
+++ b/src/guides/v2.3/install-gde/install/hosted/hosted_install_5_create-admin.md
@@ -1,5 +1,4 @@
 ---
-group: installation-guide
 subgroup: 03_install
 title: Step 5. Create Admin account
 menu_title: Step 5. Create Admin account

--- a/src/guides/v2.3/install-gde/install/hosted/hosted_install_6_install.md
+++ b/src/guides/v2.3/install-gde/install/hosted/hosted_install_6_install.md
@@ -1,5 +1,4 @@
 ---
-group: installation-guide
 subgroup: 03_install
 title: Step 6. Install
 menu_title: Step 6. Install

--- a/src/guides/v2.3/install-gde/install/hosted/hosted_start.md
+++ b/src/guides/v2.3/install-gde/install/hosted/hosted_start.md
@@ -1,5 +1,4 @@
 ---
-group: installation-guide
 subgroup: 02_config-hosted
 title: Configure your hosted system
 menu_title: Configure your hosted system

--- a/src/guides/v2.3/install-gde/install/hosted/hosted_start_db.md
+++ b/src/guides/v2.3/install-gde/install/hosted/hosted_start_db.md
@@ -1,5 +1,4 @@
 ---
-group: installation-guide
 subgroup: 02_config-hosted
 title: Configure a database and a database user
 menu_title: Configure a database and a database user

--- a/src/guides/v2.3/install-gde/install/hosted/hosted_start_php.md
+++ b/src/guides/v2.3/install-gde/install/hosted/hosted_start_php.md
@@ -1,5 +1,4 @@
 ---
-group: installation-guide
 subgroup: 02_config-hosted
 title: Configure PHP
 menu_title: Configure PHP

--- a/src/guides/v2.3/install-gde/install/legacy-file-system-perms.md
+++ b/src/guides/v2.3/install-gde/install/legacy-file-system-perms.md
@@ -1,5 +1,4 @@
 ---
-group: installation-guide
 subgroup: 99_app
 title: Appendix&mdash;Magento file system ownership and appendix (legacy)
 menu_title: Appendix&mdash;Magento file system ownership and appendix (legacy)

--- a/src/guides/v2.3/install-gde/install/post-install-config.md
+++ b/src/guides/v2.3/install-gde/install/post-install-config.md
@@ -1,5 +1,4 @@
 ---
-group: installation-guide
 title: Configure the Magento application
 functional_areas:
   - Install

--- a/src/guides/v2.3/install-gde/install/post-install-umask.md
+++ b/src/guides/v2.3/install-gde/install/post-install-umask.md
@@ -1,5 +1,4 @@
 ---
-group: installation-guide
 subgroup: 05_umask
 title: Optionally set a umask
 menu_title: Optionally set a umask

--- a/src/guides/v2.3/install-gde/install/prepare-install.md
+++ b/src/guides/v2.3/install-gde/install/prepare-install.md
@@ -1,5 +1,4 @@
 ---
-group: installation-guide
 title: Update installation dependencies
 functional_areas:
   - Install

--- a/src/guides/v2.3/install-gde/install/sample-data-after-clone.md
+++ b/src/guides/v2.3/install-gde/install/sample-data-after-clone.md
@@ -1,5 +1,4 @@
 ---
-group: installation-guide
 subgroup: T_SampleData
 title: Install by cloning repositories
 menu_title: Install by cloning repositories

--- a/src/guides/v2.3/install-gde/install/sample-data-after-composer.md
+++ b/src/guides/v2.3/install-gde/install/sample-data-after-composer.md
@@ -1,5 +1,4 @@
 ---
-group: installation-guide
 subgroup: T_SampleData
 title: Install using Composer
 menu_title: Install using Composer

--- a/src/guides/v2.3/install-gde/install/sample-data-after-magento.md
+++ b/src/guides/v2.3/install-gde/install/sample-data-after-magento.md
@@ -1,5 +1,4 @@
 ---
-group: installation-guide
 subgroup: T_SampleData
 title: Install sample data after Magento
 menu_title: Install sample data after Magento

--- a/src/guides/v2.3/install-gde/install/sample-data-before-clone.md
+++ b/src/guides/v2.3/install-gde/install/sample-data-before-clone.md
@@ -1,5 +1,4 @@
 ---
-group: installation-guide
 subgroup: T_SampleData
 title: Install by cloning repositories
 menu_title: Install by cloning repositories

--- a/src/guides/v2.3/install-gde/install/sample-data-before-composer.md
+++ b/src/guides/v2.3/install-gde/install/sample-data-before-composer.md
@@ -1,5 +1,4 @@
 ---
-group: installation-guide
 subgroup: T_SampleData
 title: Install using Composer
 menu_title: Install using Composer

--- a/src/guides/v2.3/install-gde/install/sample-data-other-cmds.md
+++ b/src/guides/v2.3/install-gde/install/sample-data-other-cmds.md
@@ -1,5 +1,4 @@
 ---
-group: installation-guide
 subgroup: T_SampleData
 title: Remove sample data modules or update sample data
 menu_title: Remove sample data modules or update sample data

--- a/src/guides/v2.3/install-gde/install/sample-data.md
+++ b/src/guides/v2.3/install-gde/install/sample-data.md
@@ -1,5 +1,4 @@
 ---
-group: installation-guide
 subgroup: T_SampleData
 title: Install, remove, or update optional sample data modules
 menu_title: Install, remove, or update optional sample data modules

--- a/src/guides/v2.3/install-gde/install/verify.md
+++ b/src/guides/v2.3/install-gde/install/verify.md
@@ -1,5 +1,4 @@
 ---
-group: installation-guide
 subgroup: 01_Verify
 title: Verify the installation
 menu_title: Verify the installation

--- a/src/guides/v2.3/install-gde/install/web/install-web-sample-data-clone.md
+++ b/src/guides/v2.3/install-gde/install/web/install-web-sample-data-clone.md
@@ -1,5 +1,4 @@
 ---
-group: installation-guide
 subgroup: 02_sample
 title: Install by cloning repositories
 menu_title: Install by cloning repositories

--- a/src/guides/v2.3/install-gde/install/web/install-web-sample-data-composer.md
+++ b/src/guides/v2.3/install-gde/install/web/install-web-sample-data-composer.md
@@ -1,5 +1,4 @@
 ---
-group: installation-guide
 subgroup: 02_sample
 title: Install using Composer
 menu_title: Install using Composer

--- a/src/guides/v2.3/install-gde/install/web/install-web-sample-data.md
+++ b/src/guides/v2.3/install-gde/install/web/install-web-sample-data.md
@@ -1,5 +1,4 @@
 ---
-group: installation-guide
 subgroup: 02_sample
 title: Install optional sample data modules
 menu_title: Install optional sample data modules

--- a/src/guides/v2.3/install-gde/install/web/install-web.md
+++ b/src/guides/v2.3/install-gde/install/web/install-web.md
@@ -1,5 +1,4 @@
 ---
-group: installation-guide
 subgroup: Wizard
 title: Setup Wizard installation
 menu_title: Setup Wizard installation

--- a/src/guides/v2.3/install-gde/install/web/install-web_1-readiness.md
+++ b/src/guides/v2.3/install-gde/install/web/install-web_1-readiness.md
@@ -1,5 +1,4 @@
 ---
-group: installation-guide
 subgroup: Wizard
 title: Step 1. Readiness check
 menu_title: Step 1. Readiness check

--- a/src/guides/v2.3/install-gde/install/web/install-web_2-db.md
+++ b/src/guides/v2.3/install-gde/install/web/install-web_2-db.md
@@ -1,5 +1,4 @@
 ---
-group: installation-guide
 subgroup: Wizard
 title: Step 2. Add a Database
 menu_title: Step 2. Add a Database

--- a/src/guides/v2.3/install-gde/install/web/install-web_3-web-conf.md
+++ b/src/guides/v2.3/install-gde/install/web/install-web_3-web-conf.md
@@ -1,5 +1,4 @@
 ---
-group: installation-guide
 subgroup: Wizard
 title: Step 3. Web Configuration
 menu_title: Step 3. Web Configuration

--- a/src/guides/v2.3/install-gde/install/web/install-web_4-customize-store.md
+++ b/src/guides/v2.3/install-gde/install/web/install-web_4-customize-store.md
@@ -1,5 +1,4 @@
 ---
-group: installation-guide
 subgroup: Wizard
 title: Step 4. Customize Your Store
 menu_title: Step 4. Customize Your Store

--- a/src/guides/v2.3/install-gde/install/web/install-web_5-create-admin.md
+++ b/src/guides/v2.3/install-gde/install/web/install-web_5-create-admin.md
@@ -1,5 +1,4 @@
 ---
-group: installation-guide
 subgroup: Wizard
 title: Step 5. Create Admin Account
 menu_title: Step 5. Create Admin Account

--- a/src/guides/v2.3/install-gde/install/web/install-web_6-install.md
+++ b/src/guides/v2.3/install-gde/install/web/install-web_6-install.md
@@ -1,5 +1,4 @@
 ---
-group: installation-guide
 subgroup: Wizard
 title: Step 6. Install
 menu_title: Step 6. Install

--- a/src/guides/v2.3/install-gde/prereq/apache.md
+++ b/src/guides/v2.3/install-gde/prereq/apache.md
@@ -1,5 +1,4 @@
 ---
-group: installation-guide
 title: Apache
 functional_areas:
   - Install

--- a/src/guides/v2.3/install-gde/prereq/connect-auth.md
+++ b/src/guides/v2.3/install-gde/prereq/connect-auth.md
@@ -1,5 +1,4 @@
 ---
-group: installation-guide
 subgroup: Prerequisites
 title: Get your authentication keys
 menu_title: Get your authentication keys

--- a/src/guides/v2.3/install-gde/prereq/dev_install.md
+++ b/src/guides/v2.3/install-gde/prereq/dev_install.md
@@ -1,5 +1,4 @@
 ---
-group: installation-guide
 title: (Contributor) Clone the Magento repository
 functional_areas:
   - Install

--- a/src/guides/v2.3/install-gde/prereq/file-sys-perms-over.md
+++ b/src/guides/v2.3/install-gde/prereq/file-sys-perms-over.md
@@ -1,5 +1,4 @@
 ---
-group: installation-guide
 title: Overview of ownership and permissions
 functional_areas:
   - Install

--- a/src/guides/v2.3/install-gde/prereq/file-system-perms.md
+++ b/src/guides/v2.3/install-gde/prereq/file-system-perms.md
@@ -1,5 +1,4 @@
 ---
-group: installation-guide
 subgroup: Prerequisites
 title: Set pre-installation ownership and permissions
 menu_title: Set pre-installation ownership and permissions

--- a/src/guides/v2.3/install-gde/prereq/install-rabbitmq.md
+++ b/src/guides/v2.3/install-gde/prereq/install-rabbitmq.md
@@ -1,5 +1,4 @@
 ---
-group: installation-guide
 title: RabbitMQ
 functional_areas:
   - Install

--- a/src/guides/v2.3/install-gde/prereq/mysql.md
+++ b/src/guides/v2.3/install-gde/prereq/mysql.md
@@ -1,5 +1,4 @@
 ---
-group: installation-guide
 title: MySQL
 redirect_from:
   - guides/v2.3/install-gde/trouble/tshoot_mysql_table-open-cache.html

--- a/src/guides/v2.3/install-gde/prereq/mysql_remote.md
+++ b/src/guides/v2.3/install-gde/prereq/mysql_remote.md
@@ -1,5 +1,4 @@
 ---
-group: installation-guide
 subgroup: Prerequisites
 title: Set up a remote MySQL database connection
 menu_title: Set up a remote MySQL database connection

--- a/src/guides/v2.3/install-gde/prereq/nginx.md
+++ b/src/guides/v2.3/install-gde/prereq/nginx.md
@@ -1,5 +1,4 @@
 ---
-group: installation-guide
 subgroup: Prerequisites
 title: nginx
 menu_title: nginx

--- a/src/guides/v2.3/install-gde/prereq/optional.md
+++ b/src/guides/v2.3/install-gde/prereq/optional.md
@@ -1,5 +1,4 @@
 ---
-group: installation-guide
 title: Optional software
 functional_areas:
   - Install

--- a/src/guides/v2.3/install-gde/prereq/php-settings.md
+++ b/src/guides/v2.3/install-gde/prereq/php-settings.md
@@ -1,5 +1,4 @@
 ---
-group: installation-guide
 title: Required PHP settings
 functional_areas:
   - Install

--- a/src/guides/v2.3/install-gde/prereq/prereq-overview.md
+++ b/src/guides/v2.3/install-gde/prereq/prereq-overview.md
@@ -1,5 +1,4 @@
 ---
-group: installation-guide
 subgroup: Prerequisites
 title: Prerequisites
 menu_node: parent

--- a/src/guides/v2.3/install-gde/prereq/security.md
+++ b/src/guides/v2.3/install-gde/prereq/security.md
@@ -1,5 +1,4 @@
 ---
-group: installation-guide
 subgroup: Prerequisites
 title: SELinux and iptables
 menu_title: SELinux and iptables

--- a/src/guides/v2.3/install-gde/system-requirements.md
+++ b/src/guides/v2.3/install-gde/system-requirements.md
@@ -1,5 +1,4 @@
 ---
-group: installation-guide
 title: Magento 2.3 technology stack requirements
 functional_areas:
   - Install

--- a/src/guides/v2.3/install-gde/trouble/git/tshoot_clone.md
+++ b/src/guides/v2.3/install-gde/trouble/git/tshoot_clone.md
@@ -1,5 +1,4 @@
 ---
-group: installation-guide
 subgroup: 10_github
 title: Cannot clone the Magento GitHub repository
 menu_title: Cannot clone the Magento GitHub repository

--- a/src/guides/v2.3/install-gde/trouble/git/tshoot_git-main.md
+++ b/src/guides/v2.3/install-gde/trouble/git/tshoot_git-main.md
@@ -1,5 +1,4 @@
 ---
-group: installation-guide
 subgroup: 10_github
 title: GitHub errors
 menu_title: GitHub errors

--- a/src/guides/v2.3/install-gde/trouble/git/tshoot_git-pull-origin.md
+++ b/src/guides/v2.3/install-gde/trouble/git/tshoot_git-pull-origin.md
@@ -1,5 +1,4 @@
 ---
-group: installation-guide
 subgroup: 10_github
 title: git pull origin develop fails when updating the Magento software
 menu_title: git pull origin develop fails when updating the Magento software

--- a/src/guides/v2.3/install-gde/trouble/php/tshoot_70pct.md
+++ b/src/guides/v2.3/install-gde/trouble/php/tshoot_70pct.md
@@ -1,5 +1,4 @@
 ---
-group: installation-guide
 subgroup: 03_install
 title: Installation stops at about 70%
 menu_title: Installation stops at about 70%

--- a/src/guides/v2.3/install-gde/trouble/php/tshoot_access-main.md
+++ b/src/guides/v2.3/install-gde/trouble/php/tshoot_access-main.md
@@ -1,5 +1,4 @@
 ---
-group: installation-guide
 subgroup: 02_access
 title: Access issues
 menu_title: Access issues

--- a/src/guides/v2.3/install-gde/trouble/php/tshoot_install-main.md
+++ b/src/guides/v2.3/install-gde/trouble/php/tshoot_install-main.md
@@ -1,5 +1,4 @@
 ---
-group: installation-guide
 subgroup: 03_install
 title: Errors during installation
 menu_title: Errors during installation

--- a/src/guides/v2.3/install-gde/trouble/php/tshoot_mod_access_compat.md
+++ b/src/guides/v2.3/install-gde/trouble/php/tshoot_mod_access_compat.md
@@ -1,5 +1,4 @@
 ---
-group: installation-guide
 subgroup: 02_access
 title: 503 (Service Unavailable) errors accessing Magento software in a web browser
 menu_title: 503 (Service Unavailable) errors accessing Magento software in a web browser

--- a/src/guides/v2.3/install-gde/trouble/php/tshoot_nginx-port.md
+++ b/src/guides/v2.3/install-gde/trouble/php/tshoot_nginx-port.md
@@ -1,5 +1,4 @@
 ---
-group: installation-guide
 subgroup: 03_install
 title: Cannot install using nginx
 menu_title: Cannot install using nginx

--- a/src/guides/v2.3/install-gde/trouble/php/tshoot_opcache.md
+++ b/src/guides/v2.3/install-gde/trouble/php/tshoot_opcache.md
@@ -1,5 +1,4 @@
 ---
-group: installation-guide
 subgroup: 10_php
 title: Resolve an illegal offset error
 menu_title: Resolve an illegal offset error

--- a/src/guides/v2.3/install-gde/trouble/php/tshoot_pdo.md
+++ b/src/guides/v2.3/install-gde/trouble/php/tshoot_pdo.md
@@ -1,5 +1,4 @@
 ---
-group: installation-guide
 title: During installation, fatal PDO error displays
 functional_areas:
   - Install

--- a/src/guides/v2.3/install-gde/trouble/php/tshoot_php-date.md
+++ b/src/guides/v2.3/install-gde/trouble/php/tshoot_php-date.md
@@ -1,5 +1,4 @@
 ---
-group: installation-guide
 subgroup: 10_php
 title: During installation, PHP date warning
 menu_title: During installation, PHP date warning

--- a/src/guides/v2.3/install-gde/trouble/php/tshoot_php-main.md
+++ b/src/guides/v2.3/install-gde/trouble/php/tshoot_php-main.md
@@ -1,5 +1,4 @@
 ---
-group: installation-guide
 subgroup: 10_php
 title: PHP errors
 menu_title: PHP errors

--- a/src/guides/v2.3/install-gde/trouble/php/tshoot_php-set.md
+++ b/src/guides/v2.3/install-gde/trouble/php/tshoot_php-set.md
@@ -1,5 +1,4 @@
 ---
-group: installation-guide
 subgroup: 10_php
 title: PHP settings errors
 menu_title: PHP settings errors

--- a/src/guides/v2.3/install-gde/trouble/php/tshoot_session.md
+++ b/src/guides/v2.3/install-gde/trouble/php/tshoot_session.md
@@ -1,5 +1,4 @@
 ---
-group: installation-guide
 subgroup: 03_install
 title: During installation, exception SessionHandler::read()
 menu_title: During installation, exception SessionHandler::read()

--- a/src/guides/v2.3/install-gde/trouble/php/tshoot_xdebug.md
+++ b/src/guides/v2.3/install-gde/trouble/php/tshoot_xdebug.md
@@ -1,5 +1,4 @@
 ---
-group: installation-guide
 subgroup: 03_install
 title: During installation, xdebug maximum function nesting level error
 menu_title: During installation, xdebug maximum function nesting level error

--- a/src/guides/v2.3/install-gde/trouble/readiness/tshoot_rc_cron.md
+++ b/src/guides/v2.3/install-gde/trouble/readiness/tshoot_rc_cron.md
@@ -1,5 +1,4 @@
 ---
-group: installation-guide
 subgroup: 05_readiness
 title: cron readiness check issues
 menu_title: cron readiness check issues

--- a/src/guides/v2.3/install-gde/trouble/readiness/tshoot_rc_depend.md
+++ b/src/guides/v2.3/install-gde/trouble/readiness/tshoot_rc_depend.md
@@ -1,5 +1,4 @@
 ---
-group: installation-guide
 subgroup: 05_readiness
 title: Component dependency readiness check issues
 menu_title: Component dependency readiness issues

--- a/src/guides/v2.3/install-gde/trouble/readiness/tshoot_rc_main.md
+++ b/src/guides/v2.3/install-gde/trouble/readiness/tshoot_rc_main.md
@@ -1,5 +1,4 @@
 ---
-group: installation-guide
 subgroup: 05_readiness
 title: Readiness check issues
 menu_title: Readiness check issues

--- a/src/guides/v2.3/install-gde/trouble/readiness/tshoot_rc_perms.md
+++ b/src/guides/v2.3/install-gde/trouble/readiness/tshoot_rc_perms.md
@@ -1,5 +1,4 @@
 ---
-group: installation-guide
 subgroup: 05_readiness
 title: File permissions readiness check issues
 menu_title: File permissions readiness check issues

--- a/src/guides/v2.3/install-gde/trouble/readiness/tshoot_rc_php.md
+++ b/src/guides/v2.3/install-gde/trouble/readiness/tshoot_rc_php.md
@@ -1,5 +1,4 @@
 ---
-group: installation-guide
 subgroup: 05_readiness
 title: PHP version readiness check issues
 menu_title: PHP version readiness check issues

--- a/src/guides/v2.3/install-gde/trouble/tshoot_access-browser.md
+++ b/src/guides/v2.3/install-gde/trouble/tshoot_access-browser.md
@@ -1,5 +1,4 @@
 ---
-group: installation-guide
 subgroup: 02_access
 title: Cannot access Magento software in a web browser
 menu_title: Cannot access Magento software in a web browser

--- a/src/guides/v2.3/install-gde/trouble/tshoot_admin.md
+++ b/src/guides/v2.3/install-gde/trouble/tshoot_admin.md
@@ -1,5 +1,4 @@
 ---
-group: installation-guide
 title: Error after logging in to the Magento Admin
 functional_areas:
   - Install

--- a/src/guides/v2.3/install-gde/trouble/tshoot_bundlesampledata.md
+++ b/src/guides/v2.3/install-gde/trouble/tshoot_bundlesampledata.md
@@ -1,5 +1,4 @@
 ---
-group: installation-guide
 subgroup: 03_install
 title: Unknown module Magento_BundleSampleData
 menu_title: Unknown module Magento_BundleSampleData

--- a/src/guides/v2.3/install-gde/trouble/tshoot_composer-fail.md
+++ b/src/guides/v2.3/install-gde/trouble/tshoot_composer-fail.md
@@ -1,5 +1,4 @@
 ---
-group: installation-guide
 subgroup: 03_install
 title: Download fails because of changes in Composer
 menu_title: Download fails because of changes in Composer

--- a/src/guides/v2.3/install-gde/trouble/tshoot_exceptions.md
+++ b/src/guides/v2.3/install-gde/trouble/tshoot_exceptions.md
@@ -1,5 +1,4 @@
 ---
-group: installation-guide
 subgroup: 02_access
 title: Exceptions during installation
 menu_title: Exceptions during installation

--- a/src/guides/v2.3/install-gde/trouble/tshoot_install-issues.md
+++ b/src/guides/v2.3/install-gde/trouble/tshoot_install-issues.md
@@ -1,5 +1,4 @@
 ---
-group: installation-guide
 subgroup: 20_other
 title: Known issues that affect installation
 menu_title: Known issues that affect installation

--- a/src/guides/v2.3/install-gde/trouble/tshoot_install-log.md
+++ b/src/guides/v2.3/install-gde/trouble/tshoot_install-log.md
@@ -1,5 +1,4 @@
 ---
-group: installation-guide
 subgroup: 03_install
 title: Installation fails; cannot create install.log
 menu_title: Installation fails; cannot create install.log

--- a/src/guides/v2.3/install-gde/trouble/tshoot_install_depend.md
+++ b/src/guides/v2.3/install-gde/trouble/tshoot_install_depend.md
@@ -1,5 +1,4 @@
 ---
-group: installation-guide
 subgroup: 02_access
 title: Installation dependencies not met
 menu_title: Installation dependencies not met

--- a/src/guides/v2.3/install-gde/trouble/tshoot_no-styles.md
+++ b/src/guides/v2.3/install-gde/trouble/tshoot_no-styles.md
@@ -1,5 +1,4 @@
 ---
-group: installation-guide
 title: After installing, images and stylesheets do not load; only text displays, no graphics
 functional_areas:
   - Install

--- a/src/guides/v2.3/install-gde/trouble/tshoot_sample-data.md
+++ b/src/guides/v2.3/install-gde/trouble/tshoot_sample-data.md
@@ -1,5 +1,4 @@
 ---
-group: installation-guide
 subgroup: 03_install
 title: Errors installing optional sample data
 menu_title: Errors installing optional sample data

--- a/src/guides/v2.3/install-gde/trouble/tshoot_var-gen-perms.md
+++ b/src/guides/v2.3/install-gde/trouble/tshoot_var-gen-perms.md
@@ -1,5 +1,4 @@
 ---
-group: installation-guide
 subgroup: 02_access
 title: Cannot write to the generated/code directory
 menu_title: Cannot write to the generated/code directory

--- a/src/guides/v2.3/install-gde/trouble/tshoot_wrong-mysql.md
+++ b/src/guides/v2.3/install-gde/trouble/tshoot_wrong-mysql.md
@@ -1,5 +1,4 @@
 ---
-group: installation-guide
 subgroup: 03_install
 title: During installation, Reflection Exception error
 menu_title: During installation, Reflection Exception error

--- a/src/guides/v2.3/install-gde/tutorials/change-docroot-to-pub.md
+++ b/src/guides/v2.3/install-gde/tutorials/change-docroot-to-pub.md
@@ -1,5 +1,4 @@
 ---
-group: installation-guide
 title: Modify docroot to improve security
 ---
 

--- a/src/guides/v2.4/install-gde/bk-install-guide.md
+++ b/src/guides/v2.4/install-gde/bk-install-guide.md
@@ -1,5 +1,4 @@
 ---
-group: installation-guide
 title: How to get the Magento software
 landing-page: Installation Guide
 functional_areas:

--- a/src/guides/v2.4/install-gde/composer.md
+++ b/src/guides/v2.4/install-gde/composer.md
@@ -1,5 +1,4 @@
 ---
-group: installation-guide
 title: Install Magento using Composer
 functional_areas:
   - Install

--- a/src/guides/v2.4/install-gde/continue-to-verify_cli.md
+++ b/src/guides/v2.4/install-gde/continue-to-verify_cli.md
@@ -1,5 +1,4 @@
 ---
-group: installation-guide
 title: Post-installation
 functional_areas:
   - Install

--- a/src/guides/v2.4/install-gde/install-flow-diagram.md
+++ b/src/guides/v2.4/install-gde/install-flow-diagram.md
@@ -1,5 +1,4 @@
 ---
-group: installation-guide
 title: Installation flow
 functional_areas:
   - Install

--- a/src/guides/v2.4/install-gde/install-quick-ref.md
+++ b/src/guides/v2.4/install-gde/install-quick-ref.md
@@ -1,5 +1,4 @@
 ---
-group: installation-guide
 title: Installation quick reference (tutorial)
 functional_areas:
   - Install

--- a/src/guides/v2.4/install-gde/install-resource-diagram.md
+++ b/src/guides/v2.4/install-gde/install-resource-diagram.md
@@ -1,5 +1,4 @@
 ---
-group: installation-guide
 title: Installation flow diagram
 functional_areas:
   - Install

--- a/src/guides/v2.4/install-gde/install-roadmap_cli.md
+++ b/src/guides/v2.4/install-gde/install-roadmap_cli.md
@@ -1,5 +1,4 @@
 ---
-group: installation-guide
 title: Installation roadmap (reference)
 functional_areas:
   - Install

--- a/src/guides/v2.4/install-gde/install-roadmap_part1.md
+++ b/src/guides/v2.4/install-gde/install-roadmap_part1.md
@@ -1,5 +1,4 @@
 ---
-group: installation-guide
 title: Installation roadmap (reference)
 functional_areas:
   - Install

--- a/src/guides/v2.4/install-gde/install/cli/dev_downgrade.md
+++ b/src/guides/v2.4/install-gde/install/cli/dev_downgrade.md
@@ -1,5 +1,4 @@
 ---
-group: installation-guide
 title: Change to a released version
 functional_areas:
   - Install

--- a/src/guides/v2.4/install-gde/install/cli/install-cli-install.md
+++ b/src/guides/v2.4/install-gde/install/cli/install-cli-install.md
@@ -1,5 +1,4 @@
 ---
-group: installation-guide
 subgroup: 05_Command-line installation
 title: Install the Magento software
 menu_title: Install the Magento software

--- a/src/guides/v2.4/install-gde/install/cli/install-cli-sample-data-clone.md
+++ b/src/guides/v2.4/install-gde/install/cli/install-cli-sample-data-clone.md
@@ -1,5 +1,4 @@
 ---
-group: installation-guide
 title: Install by cloning repositories
 functional_areas:
   - Install

--- a/src/guides/v2.4/install-gde/install/cli/install-cli-sample-data-composer.md
+++ b/src/guides/v2.4/install-gde/install/cli/install-cli-sample-data-composer.md
@@ -1,5 +1,4 @@
 ---
-group: installation-guide
 title: Install using Composer
 functional_areas:
   - Install

--- a/src/guides/v2.4/install-gde/install/cli/install-cli-sample-data.md
+++ b/src/guides/v2.4/install-gde/install/cli/install-cli-sample-data.md
@@ -1,5 +1,4 @@
 ---
-group: installation-guide
 title: Install optional sample data modules
 functional_areas:
   - Install

--- a/src/guides/v2.4/install-gde/install/cli/install-cli-subcommands-db-upgr.md
+++ b/src/guides/v2.4/install-gde/install/cli/install-cli-subcommands-db-upgr.md
@@ -1,5 +1,4 @@
 ---
-group: installation-guide
 title: Update the Magento database schema and data
 functional_areas:
   - Install

--- a/src/guides/v2.4/install-gde/install/cli/install-cli-subcommands-deployment.md
+++ b/src/guides/v2.4/install-gde/install/cli/install-cli-subcommands-deployment.md
@@ -1,5 +1,4 @@
 ---
-group: installation-guide
 subgroup: 05_Command-line installation
 title: Create or update the deployment configuration
 menu_title: Create or update the deployment configuration

--- a/src/guides/v2.4/install-gde/install/cli/install-cli-subcommands-enable.md
+++ b/src/guides/v2.4/install-gde/install/cli/install-cli-subcommands-enable.md
@@ -1,5 +1,4 @@
 ---
-group: installation-guide
 title: Enable or disable modules
 functional_areas:
   - Install

--- a/src/guides/v2.4/install-gde/install/cli/install-cli-uninstall.md
+++ b/src/guides/v2.4/install-gde/install/cli/install-cli-uninstall.md
@@ -1,5 +1,4 @@
 ---
-group: installation-guide
 title: Uninstall or reinstall Magento
 functional_areas:
   - Install

--- a/src/guides/v2.4/install-gde/install/cli/install-cli.md
+++ b/src/guides/v2.4/install-gde/install/cli/install-cli.md
@@ -1,5 +1,4 @@
 ---
-group: installation-guide
 title: Install the Magento software using the command line
 functional_areas:
   - Install

--- a/src/guides/v2.4/install-gde/install/get-software.md
+++ b/src/guides/v2.4/install-gde/install/get-software.md
@@ -1,5 +1,4 @@
 ---
-group: installation-guide
 subgroup: QA_Get
 title: Get the Magento software
 menu_title: Get the Magento software

--- a/src/guides/v2.4/install-gde/install/post-install-config.md
+++ b/src/guides/v2.4/install-gde/install/post-install-config.md
@@ -1,5 +1,4 @@
 ---
-group: installation-guide
 title: Configure the Magento application
 functional_areas:
   - Install

--- a/src/guides/v2.4/install-gde/install/prepare-install.md
+++ b/src/guides/v2.4/install-gde/install/prepare-install.md
@@ -1,5 +1,4 @@
 ---
-group: installation-guide
 title: Update installation dependencies
 functional_areas:
   - Install

--- a/src/guides/v2.4/install-gde/prereq/connect-auth.md
+++ b/src/guides/v2.4/install-gde/prereq/connect-auth.md
@@ -1,5 +1,4 @@
 ---
-group: installation-guide
 subgroup: Prerequisites
 title: Get your authentication keys
 menu_title: Get your authentication keys

--- a/src/guides/v2.4/install-gde/prereq/dev_install.md
+++ b/src/guides/v2.4/install-gde/prereq/dev_install.md
@@ -1,5 +1,4 @@
 ---
-group: installation-guide
 title: (Contributor) Clone the Magento repository
 functional_areas:
   - Install

--- a/src/guides/v2.4/install-gde/prereq/elasticsearch.md
+++ b/src/guides/v2.4/install-gde/prereq/elasticsearch.md
@@ -1,5 +1,4 @@
 ---
-group: installation-guide
 title: Elasticsearch
 functional_areas:
   - Configuration

--- a/src/guides/v2.4/install-gde/prereq/es-config-apache.md
+++ b/src/guides/v2.4/install-gde/prereq/es-config-apache.md
@@ -1,5 +1,4 @@
 ---
-group: installation-guide
 title: Configure Apache and Elasticsearch
 redirect_from: 
   - guides/v2.4/config-guide/elasticsearch/es-config-apache.html

--- a/src/guides/v2.4/install-gde/prereq/es-config-nginx.md
+++ b/src/guides/v2.4/install-gde/prereq/es-config-nginx.md
@@ -1,5 +1,4 @@
 ---
-group: installation-guide
 title: Configure nginx and Elasticsearch
 redirect_from: 
   - guides/v2.4/config-guide/elasticsearch/es-config-nginx.html

--- a/src/guides/v2.4/install-gde/prereq/file-system-perms.md
+++ b/src/guides/v2.4/install-gde/prereq/file-system-perms.md
@@ -1,5 +1,4 @@
 ---
-group: installation-guide
 title: Set pre-installation ownership and permissions
 functional_areas:
   - Install

--- a/src/guides/v2.4/install-gde/prereq/mysql.md
+++ b/src/guides/v2.4/install-gde/prereq/mysql.md
@@ -1,5 +1,4 @@
 ---
-group: installation-guide
 title: MySQL
 ---
 

--- a/src/guides/v2.4/install-gde/prereq/mysql_remote.md
+++ b/src/guides/v2.4/install-gde/prereq/mysql_remote.md
@@ -1,5 +1,4 @@
 ---
-group: installation-guide
 title: Set up a remote MySQL database connection
 functional_areas:
   - Install

--- a/src/guides/v2.4/install-gde/prereq/nginx.md
+++ b/src/guides/v2.4/install-gde/prereq/nginx.md
@@ -1,5 +1,4 @@
 ---
-group: installation-guide
 subgroup: Prerequisites
 title: nginx
 menu_title: nginx

--- a/src/guides/v2.4/install-gde/prereq/php-settings.md
+++ b/src/guides/v2.4/install-gde/prereq/php-settings.md
@@ -1,5 +1,4 @@
 ---
-group: installation-guide
 title: Required PHP settings
 functional_areas:
   - Install

--- a/src/guides/v2.4/install-gde/prereq/prereq-overview.md
+++ b/src/guides/v2.4/install-gde/prereq/prereq-overview.md
@@ -1,5 +1,4 @@
 ---
-group: installation-guide
 title: Prerequisites
 functional_areas:
   - Install

--- a/src/guides/v2.4/install-gde/system-requirements.md
+++ b/src/guides/v2.4/install-gde/system-requirements.md
@@ -1,5 +1,4 @@
 ---
-group: installation-guide
 title: Magento 2.4 system requirements
 functional_areas:
   - Install

--- a/src/guides/v2.4/install-gde/trouble/php/tshoot_access-main.md
+++ b/src/guides/v2.4/install-gde/trouble/php/tshoot_access-main.md
@@ -1,5 +1,4 @@
 ---
-group: installation-guide
 title: Access issues
 functional_areas:
   - Install

--- a/src/guides/v2.4/install-gde/tutorials/change-docroot-to-pub.md
+++ b/src/guides/v2.4/install-gde/tutorials/change-docroot-to-pub.md
@@ -1,5 +1,4 @@
 ---
-group: installation-guide
 title: Modify docroot to improve security
 ---
 


### PR DESCRIPTION
## Purpose of this pull request

This pull request (PR) separates the file with table of contents (TOC) for the Installation Guide into two files, one per version, to facilitate further editing:

- `src/_data/toc/installation-guide.yml` for current version
- `src/_data/toc/installation-guide-2_3.yml` for 2.3 version

The groups are assigned to topics via a scope in `_config.yml` to apply different TOCs for symlinks.