### PR TITLE
PHP code update for two-level cache in v2.3 devdocs

### DIFF
--- a/src/guides/v2.3/config-guide/cache/two-level-cache.md
+++ b/src/guides/v2.3/config-guide/cache/two-level-cache.md
@@ -20,28 +20,28 @@ Magento stores the hashed data version in Redis, with the suffix ':version' appe
 
 ```php
 'cache' => [
-    [
+    'frontend' => [
         'default' => [
-             'backend' => '\\Magento\\Framework\\Cache\\Backend\\RemoteSynchronizedCache',
-             'backend_options' => [
-                 'remote_backend' => '\\Magento\\Framework\\Cache\\Backend\\Redis',
-                 'remote_backend_options' => [
-                     'persistent' => 0,
-                     'server' => 'localhost',
-                     'database' => '0',
-                     'port' => '6370',
-                     'password' => '',
-                     'compress_data' => '1',
-                 ],
-                 'local_backend' => 'Cm_Cache_Backend_File',
-                 'local_backend_options' => [
-                     'cache_dir' => '/dev/shm/'
-                 ]
-             ],
-             'frontend_options' => [
-                 'write_control' => false,
-             ],
-         ]
+          'backend' => '\\Magento\\Framework\\Cache\\Backend\\RemoteSynchronizedCache',
+            'backend_options' => [
+                'remote_backend' => '\\Magento\\Framework\\Cache\\Backend\\Redis',
+                'remote_backend_options' => [
+                    'persistent' => 0,
+                    'server' => 'localhost',
+                    'database' => '0',
+                    'port' => '6370',
+                    'password' => '',
+                    'compress_data' => '1',
+                ],
+                'local_backend' => 'Cm_Cache_Backend_File',
+                'local_backend_options' => [
+                    'cache_dir' => '/dev/shm/'
+                ]
+            ],
+            'frontend_options' => [
+                'write_control' => false,
+            ],
+        ]
     ],
     'type' => [
         'default' => ['frontend' => 'default'],


### PR DESCRIPTION
## Purpose of this pull request

This pull request (PR) changes the PHP code for two-level cache in v2.3 docs.

## Affected DevDocs pages

-  https://devdocs.magento.com/guides/v2.3/config-guide/cache/two-level-cache.html

## Links to Magento source code

-  Fixes #8272 

![Screenshot from 2020-11-26 14-03-48](https://user-images.githubusercontent.com/52098385/100326736-56367c80-2ff0-11eb-9cbd-75b6d87f7e38.png)
