### PR TITLE
Link to Fastly DNS config info for apex domains

### DIFF
--- a/src/cloud/cdn/configure-fastly.md
+++ b/src/cloud/cdn/configure-fastly.md
@@ -184,7 +184,7 @@ To update your DNS configuration for development:
    | mcstaging.your-domain.com | prod.magentocloud.map.fastly.net
 
    When the CNAME records are live, Magento provisions certificates and uploads the SSL/TLS certificates.
-   
+
    {:.bs-callout-info}
    If you plan to use apex domains (`your-domain.com`) for your Production environment, you must configure A records to point to the Fastly server IP addresses. See [Update DNS configuration with production settings]({{ site.baseurl }}/cloud/live/site-launch-checklist.html#dns).
 

--- a/src/cloud/cdn/configure-fastly.md
+++ b/src/cloud/cdn/configure-fastly.md
@@ -184,6 +184,9 @@ To update your DNS configuration for development:
    | mcstaging.your-domain.com | prod.magentocloud.map.fastly.net
 
    When the CNAME records are live, Magento provisions certificates and uploads the SSL/TLS certificates.
+   
+   {:.bs-callout-info}
+   If you plan to use apex domains (`your-domain.com`) for your Production environment, you must configure A records to point to the Fastly server IP addresses. See [Update DNS configuration with production settings]({{ site.baseurl }}/cloud/live/site-launch-checklist.html#dns).
 
 1. Add ACME challenge CNAME records for domain validation and pre-provisioning of Production SSL/TLS certificates, for example:
 

--- a/src/cloud/cdn/configure-fastly.md
+++ b/src/cloud/cdn/configure-fastly.md
@@ -186,7 +186,7 @@ To update your DNS configuration for development:
    When the CNAME records are live, Magento provisions certificates and uploads the SSL/TLS certificates.
 
    {:.bs-callout-info}
-   If you plan to use apex domains (`your-domain.com`) for your Production environment, you must configure A records to point to the Fastly server IP addresses. See [Update DNS configuration with production settings]({{ site.baseurl }}/cloud/live/site-launch-checklist.html#dns).
+   If you plan to use apex domains (`your-domain.com`) for your Production site, you must configure DNS address records (A records) to point to the Fastly server IP addresses. See [Update DNS configuration with production settings]({{ site.baseurl }}/cloud/live/site-launch-checklist.html#dns).
 
 1. Add ACME challenge CNAME records for domain validation and pre-provisioning of Production SSL/TLS certificates, for example:
 


### PR DESCRIPTION
## Purpose of this pull request

Per customer feedback, updated the Fastly set up instructions for
DNS configuration settings for development environment to include
link to instructions for setting up A records for apex domains.

## Affected DevDocs pages

- https://devdocs.magento.com/cloud/cdn/configure-fastly.html