### PR TITLE
Updated the command in sample-data-rc1-cli-24.md file

### DIFF
--- a/src/_includes/install/sampledata/file-sys-perms-digest-24.md
+++ b/src/_includes/install/sampledata/file-sys-perms-digest-24.md
@@ -1,0 +1,69 @@
+### Apply file system permissions and ownership {#rc1-samp-ownership}
+
+As part of the sample data upgrade process, you must apply current file system permission and ownership as discussed in the following sections.
+Failure to do so will cause your upgrade to fail.
+
+For more information about file system ownership and permissions, see [Overview of ownership and permissions].
+
+#### One-user ownership and permissions
+
+If you run the Magento application as one user (which is typical of shared hosting environments), change file system permissions and ownership as follows:
+
+```bash
+cd <magento_root>
+```
+
+```bash
+chmod -R g+w var vendor pub/static pub/media app/etc
+```
+
+```bash
+chmod u+x bin/magento
+```
+
+To optionally enter all commands on one line, enter the following assuming Magento is installed in `/var/www/html/magento2`:
+
+```bash
+cd /var/www/html/magento2 && chmod -R g+w var vendor pub/static pub/media app/etc && chmod u+x bin/magento
+```
+
+After you set file system permissions, manually clear the `var/cache`, `var/page_cache`, and `generated` directories.
+
+A sample command follows:
+
+```bash
+rm -rf var/cache/* var/page_cache/* generated/*
+```
+
+#### Two-user ownership and permissions
+
+If you run the Magento application with two users, enter the following commands as a user with `root` privileges:
+
+```bash
+cd <magento_root>
+```
+
+```bash
+find var vendor pub/static pub/media app/etc -type f -exec chmod g+w {} +
+```
+
+```bash
+find var vendor pub/static pub/media app/etc -type d -exec chmod g+ws {} +
+```
+
+```bash
+chown -R :<web server group> .
+```
+
+```bash
+chmod u+x bin/magento
+```
+
+To optionally enter all commands on one line, enter the following assuming Magento is installed in `/var/www/html/magento2` and the web server group name is `apache`:
+
+```bash
+cd /var/www/html/magento2 && find var vendor pub/static pub/media app/etc -type f -exec chmod g+w {} + && find var vendor pub/static pub/media app/etc -type d -exec chmod g+ws {} + && chown -R :apache . && chmod u+x bin/magento
+```
+
+<!-- Link definitions -->
+[Overview of ownership and permissions]: {{ page.baseurl }}/install-gde/prereq/file-sys-perms-over.html

--- a/src/_includes/install/sampledata/sample-data-rc1-cli-24.md
+++ b/src/_includes/install/sampledata/sample-data-rc1-cli-24.md
@@ -65,12 +65,12 @@ After you have reset file system permissions:
 
 1. If you have not done so already, log in to your Magento server as, or switch to, the Magento file system owner.
 1. Change to your Magento installation directory.
-1. Manually clear the `var/cache`, `var/page_cache`, and `var/generation` directories.
+1. Manually clear the `var/cache`, `var/page_cache`, and `generated` directories.
 
    A sample command follows:
 
    ```bash
-   rm -rf var/cache/* var/page_cache/* var/generation/*
+   rm -rf var/cache/* var/page_cache/* generated/*
    ```
 
 1. Upgrade Magento:

--- a/src/_includes/install/sampledata/sample-data-rc1-cli-24.md
+++ b/src/_includes/install/sampledata/sample-data-rc1-cli-24.md
@@ -79,7 +79,7 @@ After you have reset file system permissions:
    bin/magento setup:upgrade
    ```
 
-{% include install/sampledata/file-sys-perms-digest.md %}
+{% include install/sampledata/file-sys-perms-digest-24.md %}
 
 <!-- Link definitions -->
 [Magento file system owner]: {{ page.baseurl }}/install-gde/prereq/file-sys-perms-over.html


### PR DESCRIPTION
## Purpose of this pull request

In the latest Magento 2.4, there should not be a var/generation folder. This pull request (PR) updates the command.

## Affected DevDocs pages

-  https://devdocs.magento.com/guides/v2.4/comp-mgr/cli/cli-rc1-samp.html

## Links to Magento source code

-  Fixes #8275 
![Screenshot from 2020-12-01 12-41-11](https://user-images.githubusercontent.com/52098385/100709095-80fb4900-33d3-11eb-8882-23cc5c7ea4d5.png)
