### PR TITLE
GraphQL: Add list of supported cards to Payflow Pro

### DIFF
--- a/src/_includes/graphql/payment-methods/payflow-pro-attributes.md
+++ b/src/_includes/graphql/payment-methods/payflow-pro-attributes.md
@@ -8,7 +8,7 @@ Attribute |  Data Type | Description
 
 ### CreditCardDetailsInput object
 
-The `CreditCardDetailsInput` object must contain all the attributes listed below. Magento supports the following values for `cc_type`. The merchant's payment processor might support only a subset of these values.
+Magento supports the following values for the `cc_type` attribute. The merchant's payment processor might support only a subset of these values.
 
 *  `AE` - American Express
 *  `AU` - Aura
@@ -16,12 +16,14 @@ The `CreditCardDetailsInput` object must contain all the attributes listed below
 *  `DN` - Diners Club
 *  `ELO` - Elo
 *  `HC` - Hipercard
+*  `JCB` - JCB
 *  `MC` - MasterCard
 *  `MD` - Maestro Domestic
 *  `MI` - Maestro International
-*  `JCB` - JCB
 *  `UN` - UnionPay
 *  `VI` - Visa
+
+The `CreditCardDetailsInput` object must contain all the attributes listed below.
 
 Attribute |  Data Type | Description
 --- | --- | ---

--- a/src/_includes/graphql/payment-methods/payflow-pro-attributes.md
+++ b/src/_includes/graphql/payment-methods/payflow-pro-attributes.md
@@ -23,7 +23,7 @@ Magento supports the following values for the `cc_type` attribute. The merchant'
 *  `UN` - UnionPay
 *  `VI` - Visa
 
-The `CreditCardDetailsInput` object must contain all the attributes listed below.
+The `CreditCardDetailsInput` object must contain all of the attributes listed below.
 
 Attribute |  Data Type | Description
 --- | --- | ---

--- a/src/_includes/graphql/payment-methods/payflow-pro-attributes.md
+++ b/src/_includes/graphql/payment-methods/payflow-pro-attributes.md
@@ -8,7 +8,20 @@ Attribute |  Data Type | Description
 
 ### CreditCardDetailsInput object
 
-The `CreditCardDetailsInput` object must contain the following attributes:
+The `CreditCardDetailsInput` object must contain all the attributes listed below. Magento supports the following values for `cc_type`. The merchant's payment processor might support only a subset of these values.
+
+*  `AE` - American Express
+*  `AU` - Aura
+*  `DI` - Discover
+*  `DN` - Diners Club
+*  `ELO` - Elo
+*  `HC` - Hipercard
+*  `MC` - MasterCard
+*  `MD` - Maestro Domestic
+*  `MI` - Maestro International
+*  `JCB` - JCB
+*  `UN` - UnionPay
+*  `VI` - Visa
 
 Attribute |  Data Type | Description
 --- | --- | ---


### PR DESCRIPTION
## Purpose of this pull request

This pull request (PR) adds the list of credit cards that Magento supports to the Payflow Pro documentation. This is the only Magento-developed GraphQL payment method that handles card details directly.

This work is per MC-39519 and internal developer request.

## Affected DevDocs pages

<!-- REQUIRED List the affected pages on devdocs.magento.com (URLs). Not needed for large numbers of files. -->

-  https://devdocs.magento.com/guides/v2.4/graphql/payment-methods/payflow-pro.html

## Links to Magento source code

<!--  OPTIONAL - REMOVE THIS SECTION IF NOT USED. If this pull request references a file in a Magento codebase repository, add it here. -->

-  https://github.com/magento/magento2/blob/2.4-develop/app/code/Magento/Payment/view/base/web/js/model/credit-card-validation/credit-card-number-validator/credit-card-type.js#L13

<!--
If you are fixing a GitHub issue, note it using GitHub keyword format (https://help.github.com/en/articles/closing-issues-using-keywords#closing-an-issue-in-a-different-repository) to close the issue when this pull request is merged. Example: `Fixes #1234`

`master` is the default branch. Merged pull requests to `master` go live on the site automatically. Any requested changes to content on the `master` branch must be related to the released codebase. Any content related to future releases goes in the `develop` branch.

See Contribution guidelines (https://github.com/magento/devdocs/blob/master/.github/CONTRIBUTING.md) for more information.
-->
