### PR TITLE
Fix wrong cli command

### DIFF
--- a/src/guides/v2.3/test/static/static_test_execution.md
+++ b/src/guides/v2.3/test/static/static_test_execution.md
@@ -49,7 +49,7 @@ To run the static tests on a subset of files, create a new testsuite for phpunit
 1. Navigate to the Magento base directory and run:
 
    ```bash
-   ./vendor/bin/phpunit --testsuite="Local Test Suite" -c dev/tests/static/phpunit.xml.dist
+   ./vendor/bin/phpunit --testsuite="Local Test Suite" -c dev/tests/static/phpunit.xml
    ```
 
 As a result of this process, you can run PHP static tests on a subset of files. It is also possible to run other types of static tests by following the same process with other testsuites.


### PR DESCRIPTION
As per steps, the testsuite is defined in phpunit.xml and not phpunit.xml.dist. To run the tests we have to use phpunit.xml file

## Purpose of this pull request

This pull request (PR) corrects the wrong example cli command to run static tests
The testsuite as per the previous steps are defined in phpunit.xml and not in phpunit.xml.dist
So we have to supply phpunit.xml as parameter

## Affected DevDocs pages

<!-- REQUIRED List the affected pages on devdocs.magento.com (URLs). Not needed for large numbers of files. -->

-  https://devdocs.magento.com/guides/v2.3/test/static/static_test_execution.html



<!--
If you are fixing a GitHub issue, note it using GitHub keyword format (https://help.github.com/en/articles/closing-issues-using-keywords#closing-an-issue-in-a-different-repository) to close the issue when this pull request is merged. Example: `Fixes #1234`

`master` is the default branch. Merged pull requests to `master` go live on the site automatically. Any requested changes to content on the `master` branch must be related to the released codebase. Any content related to future releases goes in the `develop` branch.

See Contribution guidelines (https://github.com/magento/devdocs/blob/master/.github/CONTRIBUTING.md) for more information.
-->
