### PR TITLE
Update directory-currency.md

### DIFF
--- a/src/guides/v2.3/graphql/queries/directory-currency.md
+++ b/src/guides/v2.3/graphql/queries/directory-currency.md
@@ -12,7 +12,7 @@ Use the `currency` query to return information about the store's currency config
 ## Example usage
 
 
-The following query returns the currency for the current instance of Magento that is configured for multiple currencies, USD and EUR. The default (base) currency for the store is US Dollar (USD). The response includes a list of currencies in the `available_currency_codes` attribute as well as a set of exchange rates.
+The following query returns the currency for an instance of Magento that is configured for multiple currencies, USD and EUR. The default (base) currency for the store is US Dollar (USD). The response includes a list of currencies in the `available_currency_codes` attribute as well as a set of exchange rates.
 
 **Request:**
 

--- a/src/guides/v2.3/graphql/queries/directory-currency.md
+++ b/src/guides/v2.3/graphql/queries/directory-currency.md
@@ -55,7 +55,7 @@ query {
 }
 ```
 
-The following query returns the currency for the current instance of Magento with multiple currencies such as USD and EURO. The default(base) currency for the store is US Dollar(USD). The GraphQL query will be same , but the response will be different based on the available currency. A list of arrays of the currency will be displayed in the `available_currency_codes` attribute while the `exchange_rates` attribute contains the array of `currency_to` and rate value for the respective currency.
+The following query returns the currency for the current instance of Magento with multiple currencies such as USD and EURO. The default(base) currency for the store is US Dollar(USD). The GraphQL query will be same, but the response will be different based on the available currency. A list of arrays of the currency will be displayed in the `available_currency_codes` attribute while the `exchange_rates` attribute contains the array of `currency_to` and rate value for the respective currency.
 
 **Request:**
 

--- a/src/guides/v2.3/graphql/queries/directory-currency.md
+++ b/src/guides/v2.3/graphql/queries/directory-currency.md
@@ -11,7 +11,7 @@ Use the `currency` query to return information about the store's currency config
 
 ## Example usage
 
-The following query returns the currency for the current instance of Magento:
+The following query returns the currency for the current instance of Magento with single currency USD:
 
 **Request:**
 
@@ -45,6 +45,55 @@ query {
         "USD"
       ],
       "exchange_rates": [
+        {
+          "currency_to": "USD",
+          "rate": 1
+        }
+      ]
+    }
+  }
+}
+```
+
+The following query returns the currency for the current instance of Magento with multiple currency such as USD and EURO. Default(Base) Currency for the store is US Dollar(USD). GraphQL query will be same but response will be different based on available currency. List of arrays of the currency will be displayed in available_currency_codes attribute while exchange_rates attribute contains the array of currency_to and rate vaule for respective currency.
+
+**Request:**
+
+```graphql
+query {
+    currency {
+        base_currency_code
+        base_currency_symbol
+        default_display_currency_code
+        default_display_currency_symbol
+        available_currency_codes
+        exchange_rates {
+            currency_to
+            rate
+        }
+    }
+}
+```
+
+**Response:**
+
+```json
+{
+  "data": {
+    "currency": {
+      "base_currency_code": "USD",
+      "base_currency_symbol": "$",
+      "default_display_currency_code": "USD",
+      "default_display_currency_symbol": "$",
+      "available_currency_codes": [
+        "EUR",
+        "USD"
+      ],
+      "exchange_rates": [
+        {
+          "currency_to": "EUR",
+          "rate": 0.7067
+        },
         {
           "currency_to": "USD",
           "rate": 1

--- a/src/guides/v2.3/graphql/queries/directory-currency.md
+++ b/src/guides/v2.3/graphql/queries/directory-currency.md
@@ -55,7 +55,7 @@ query {
 }
 ```
 
-The following query returns the currency for the current instance of Magento with multiple currency such as USD and EURO. Default(Base) Currency for the store is US Dollar(USD). GraphQL query will be same but response will be different based on available currency. List of arrays of the currency will be displayed in available_currency_codes attribute while exchange_rates attribute contains the array of currency_to and rate vaule for respective currency.
+The following query returns the currency for the current instance of Magento with multiple currencies such as USD and EURO. The default(base) currency for the store is US Dollar(USD). The GraphQL query will be same , but the response will be different based on the available currency. A list of arrays of the currency will be displayed in the `available_currency_codes` attribute while the `exchange_rates` attribute contains the array of `currency_to` and rate value for the respective currency.
 
 **Request:**
 

--- a/src/guides/v2.3/graphql/queries/directory-currency.md
+++ b/src/guides/v2.3/graphql/queries/directory-currency.md
@@ -11,8 +11,7 @@ Use the `currency` query to return information about the store's currency config
 
 ## Example usage
 
-
-The following query returns the currency for an instance of Magento that is configured for multiple currencies, USD and EUR. The default (base) currency for the store is US Dollar (USD). The response includes a list of currencies in the `available_currency_codes` attribute as well as a set of exchange rates.
+The following query returns currency information for an instance of Magento that is configured for multiple currencies, USD and EUR. The default (base) currency for the store is US Dollar (USD). The response includes a list of currencies in the `available_currency_codes` attribute as well as a set of exchange rates.
 
 **Request:**
 

--- a/src/guides/v2.3/graphql/queries/directory-currency.md
+++ b/src/guides/v2.3/graphql/queries/directory-currency.md
@@ -11,51 +11,8 @@ Use the `currency` query to return information about the store's currency config
 
 ## Example usage
 
-The following query returns the currency for the current instance of Magento with single currency USD:
 
-**Request:**
-
-```graphql
-query {
-    currency {
-        base_currency_code
-        base_currency_symbol
-        default_display_currency_code
-        default_display_currency_symbol
-        available_currency_codes
-        exchange_rates {
-            currency_to
-            rate
-        }
-    }
-}
-```
-
-**Response:**
-
-```json
-{
-  "data": {
-    "currency": {
-      "base_currency_code": "USD",
-      "base_currency_symbol": "$",
-      "default_display_currency_code": "USD",
-      "default_display_currency_symbol": "$",
-      "available_currency_codes": [
-        "USD"
-      ],
-      "exchange_rates": [
-        {
-          "currency_to": "USD",
-          "rate": 1
-        }
-      ]
-    }
-  }
-}
-```
-
-The following query returns the currency for the current instance of Magento with multiple currencies such as USD and EURO. The default(base) currency for the store is US Dollar(USD). The GraphQL query will be same, but the response will be different based on the available currency. A list of arrays of the currency will be displayed in the `available_currency_codes` attribute while the `exchange_rates` attribute contains the array of `currency_to` and rate value for the respective currency.
+The following query returns the currency for the current instance of Magento that is configured for multiple currencies, USD and EUR. The default (base) currency for the store is US Dollar (USD). The response includes a list of currencies in the `available_currency_codes` attribute as well as a set of exchange rates.
 
 **Request:**
 


### PR DESCRIPTION
Directory Currency GraphQL with Multiple currency as the response. How Base currency and other currency of the store will be response of the query.

## Purpose of this pull request
An Example for the multi currency store such as USD and EURO. Default Example given in the dev docs is for the single currency only. I have given an example with two currency for the website. Check with GraphQL response and apply solutions.

## Affected DevDocs pages
https://devdocs.magento.com/guides/v2.3/graphql/queries/directory-currency.html
https://devdocs.magento.com/guides/v2.4/graphql/queries/directory-currency.html