### PR TITLE
Update pickup-locations.md

### DIFF
--- a/src/guides/v2.4/graphql/queries/pickup-locations.md
+++ b/src/guides/v2.4/graphql/queries/pickup-locations.md
@@ -72,6 +72,7 @@ Because `pageSize` is set to 1 and distance by `distance` is applied, result wil
 ```
 
 **Response:**
+For the available Pick Up location, The Response would be looks like.
 
 ```json
 {
@@ -106,6 +107,24 @@ Because `pageSize` is set to 1 and distance by `distance` is applied, result wil
 }
 ```
 
+If Pickup location will not available for the given search term, The Response will be emtpy,
+
+```
+{
+  "data": {
+    "pickupLocations": {
+      "items": [],
+      "total_count": 0,
+      "page_info": {
+        "page_size": 1,
+        "current_page": 1,
+        "total_pages": 0
+      }
+    }
+  }
+}
+```
+
 ## Input attributes
 
 All top-level attributes are optional. If no filters are provided, the query returns a list of pickup locations, assigned to the Sales Channel that is used by the store.
@@ -125,7 +144,7 @@ Use the `AreaInput` to apply filtration by distance. All attributes are required
 Attribute | Data type | Description
 --- | --- | ---
 `radius` | Int! | The radius to the search, in kilometers.
-`search_term` | String! | A combination of either the region, city, or postcode, a colon, and the country code. This value determines the location to use as the center of the search radius.  For example, `Austin:US`.
+`search_term` | String! | A combination of either the region, city, or postcode, a colon, and the country code. This value determines the location to use as the center of the search radius.  Valid Search Term, `Texas:US`|`Austin:US`|`78740:US`. After Colon, You must required to pass Two-letter Country code in Upper case.
 
 ### PickupLocationFilterInput object {#PickupLocationFilterInput}
 

--- a/src/guides/v2.4/graphql/queries/pickup-locations.md
+++ b/src/guides/v2.4/graphql/queries/pickup-locations.md
@@ -72,7 +72,7 @@ Because `pageSize` is set to 1 and distance by `distance` is applied, result wil
 ```
 
 **Response:**
-For the available Pick Up location, The Response would be looks like.
+For the available Pickup location, the response would look like:
 
 ```json
 {
@@ -106,8 +106,7 @@ For the available Pick Up location, The Response would be looks like.
   }
 }
 ```
-
-If Pickup location will not available for the given search term, The Response will be emtpy,
+If the Pickup location is not available for the given search term, the response will be empty:
 
 ```
 {
@@ -144,7 +143,7 @@ Use the `AreaInput` to apply filtration by distance. All attributes are required
 Attribute | Data type | Description
 --- | --- | ---
 `radius` | Int! | The radius to the search, in kilometers.
-`search_term` | String! | A combination of either the region, city, or postcode, a colon, and the country code. This value determines the location to use as the center of the search radius.  Valid Search Term, `Texas:US`|`Austin:US`|`78740:US`. After Colon, You must required to pass Two-letter Country code in Upper case.
+`search_term` | String! | A combination of either the region, city, or postcode, a colon, and the country code. This value determines the location to use as the center of the search radius.  Valid search term - `Texas:US`|`Austin:US`|`78740:US`. After the colon, the two-letter Country code is required to be passed in uppercase.
 
 ### PickupLocationFilterInput object {#PickupLocationFilterInput}
 

--- a/src/guides/v2.4/graphql/queries/pickup-locations.md
+++ b/src/guides/v2.4/graphql/queries/pickup-locations.md
@@ -72,7 +72,8 @@ Because `pageSize` is set to 1 and distance by `distance` is applied, result wil
 ```
 
 **Response:**
-If the Pickup location is not available for the given search term, the response will be empty. 
+
+If the Pickup location is not available for the given search term, the response will be empty.
 For the available Pickup location, the response would look like:
 
 ```json
@@ -126,8 +127,8 @@ Use the `AreaInput` to apply filtration by distance. All attributes are required
 
 Attribute | Data type | Description
 --- | --- | ---
-`radius` | Int! | The radius to the search, in kilometers.
-`search_term` | String! | A combination of either the region, city, or postcode, a colon, and the country code. This value determines the location to use as the center of the search radius.  Valid search terms include Texas:US, Austin:US, and 78740:US. The two-letter country code must be uppercase.
+`radius` | Int! | The radius to the search, in kilometers
+`search_term` | String! | A combination of either the region, city, or postcode, a colon, and the country code. This value determines the location to use as the center of the search radius.  Valid search terms include Texas:US, Austin:US, and 78740:US. The two-letter country code must be uppercase
 
 ### PickupLocationFilterInput object {#PickupLocationFilterInput}
 

--- a/src/guides/v2.4/graphql/queries/pickup-locations.md
+++ b/src/guides/v2.4/graphql/queries/pickup-locations.md
@@ -72,6 +72,7 @@ Because `pageSize` is set to 1 and distance by `distance` is applied, result wil
 ```
 
 **Response:**
+If the Pickup location is not available for the given search term, the response will be empty. 
 For the available Pickup location, the response would look like:
 
 ```json
@@ -106,23 +107,6 @@ For the available Pickup location, the response would look like:
   }
 }
 ```
-If the Pickup location is not available for the given search term, the response will be empty:
-
-```
-{
-  "data": {
-    "pickupLocations": {
-      "items": [],
-      "total_count": 0,
-      "page_info": {
-        "page_size": 1,
-        "current_page": 1,
-        "total_pages": 0
-      }
-    }
-  }
-}
-```
 
 ## Input attributes
 
@@ -143,7 +127,7 @@ Use the `AreaInput` to apply filtration by distance. All attributes are required
 Attribute | Data type | Description
 --- | --- | ---
 `radius` | Int! | The radius to the search, in kilometers.
-`search_term` | String! | A combination of either the region, city, or postcode, a colon, and the country code. This value determines the location to use as the center of the search radius.  Valid search term - `Texas:US`|`Austin:US`|`78740:US`. After the colon, the two-letter Country code is required to be passed in uppercase.
+`search_term` | String! | A combination of either the region, city, or postcode, a colon, and the country code. This value determines the location to use as the center of the search radius.  Valid search terms include Texas:US, Austin:US, and 78740:US. The two-letter country code must be uppercase.
 
 ### PickupLocationFilterInput object {#PickupLocationFilterInput}
 


### PR DESCRIPTION
Modify Response for the pickup location with no result found, Explain Search Term attribute field.

## Purpose of this pull request

This pull request (PR) contains response for the pickup location with no result found. Search term in the pickup location query definition updated.You must have to pass two-letter country code to get actual result otherwise it will throws an error.

## Affected DevDocs pages

https://devdocs.magento.com/guides/v2.4/graphql/queries/pickup-locations.html
