### PR TITLE
Update url-resolver.md

### DIFF
--- a/src/guides/v2.3/graphql/queries/url-resolver.md
+++ b/src/guides/v2.3/graphql/queries/url-resolver.md
@@ -15,9 +15,9 @@ The `urlResolver` query returns the canonical URL for a specified product, categ
 
 ## Example usage
 
-### Query the URL's information
+### URL Resolver for the Product type
 
-The following query returns information about the URL containing `joust-duffle-bag.html`.
+The following query returns information about the URL containing `joust-duffle-bag.html` for the type Product.
 
 **Request:**
 
@@ -47,13 +47,77 @@ The following query returns information about the URL containing `joust-duffle-b
 }
 ```
 
+### URL Resolver for the Category type
+
+The following query returns information about the URL containing `gear/bags.html` for the type Category.
+
+**Request:**
+
+```graphql
+{
+  urlResolver(url: "gear/bags.html") {
+    id
+    relative_url
+    redirectCode
+    type
+  }
+}
+```
+
+**Response:**
+
+```json
+{
+  "data": {
+    "urlResolver": {
+      "id": 4,
+      "relative_url": "gear/bags.html",
+      "redirectCode": 0,
+      "type": "CATEGORY"
+    }
+  }
+}
+```
+
+### URL Resolver for the Category type
+
+The following query returns information about the URL containing `no-route` for the type CMS Page.
+
+**Request:**
+
+```graphql
+{
+  urlResolver(url: "no-route") {
+    id
+    relative_url
+    redirectCode
+    type
+  }
+}
+```
+
+**Response:**
+
+```json
+{
+  "data": {
+    "urlResolver": {
+      "id": 1,
+      "relative_url": "no-route",
+      "redirectCode": 0,
+      "type": "CMS_PAGE"
+    }
+  }
+}
+```
+
 ## Input attributes
 
 The `urlResolver` query contains the following attribute.
 
 Attribute | Type | Description
 --- | --- | ---
-`url` | String | The requested URL. To query for product and category pages, the `url` value must contain the URL key and suffix. For CMS page queries, the `url` value must contain the URL key only.
+`url` | String | The requested URL. To query for product and category pages, the `url` value must contain the URL key and suffix. For Category page queries. the `url` value must contain the full path of the URL key. For CMS page queries, the `url` value must contain the URL key only.
 
 ## Output attributes
 

--- a/src/guides/v2.3/graphql/queries/url-resolver.md
+++ b/src/guides/v2.3/graphql/queries/url-resolver.md
@@ -15,9 +15,9 @@ The `urlResolver` query returns the canonical URL for a specified product, categ
 
 ## Example usage
 
-### URL Resolver for the Product type
+### URL resolver for a product
 
-The following query returns information about the URL containing `joust-duffle-bag.html` for the type Product.
+The following query returns information about the URL containing `joust-duffle-bag.html` for a product.
 
 **Request:**
 
@@ -47,9 +47,9 @@ The following query returns information about the URL containing `joust-duffle-b
 }
 ```
 
-### URL Resolver for the Category type
+### URL resolver for a category
 
-The following query returns information about the URL containing `gear/bags.html` for the type Category.
+The following query returns information about the URL containing `gear/bags.html` for category page.
 
 **Request:**
 
@@ -79,9 +79,9 @@ The following query returns information about the URL containing `gear/bags.html
 }
 ```
 
-### URL Resolver for CMS Page
+### URL resolver for a CMS page
 
-The following query returns information about the URL containing `no-route` for the type CMS Page.
+The following query returns information about the URL containing `no-route` for a CMS page.
 
 **Request:**
 
@@ -117,7 +117,7 @@ The `urlResolver` query contains the following attribute.
 
 Attribute | Type | Description
 --- | --- | ---
-`url` | String | The requested URL. To query for product and category pages, the `url` value must contain the URL key and suffix. For Category page queries, the `url` value must contain the full path of the URL key. For CMS page queries, the `url` value must contain the URL key only.
+`url` | String | The requested URL. To query for product and category pages, the `url` value must contain the URL key and suffix. For category page queries, the `url` value must contain the full path of the URL key. For CMS page queries, the `url` value must contain the URL key only.
 
 ## Output attributes
 

--- a/src/guides/v2.3/graphql/queries/url-resolver.md
+++ b/src/guides/v2.3/graphql/queries/url-resolver.md
@@ -79,7 +79,7 @@ The following query returns information about the URL containing `gear/bags.html
 }
 ```
 
-### URL Resolver for the Category type
+### URL Resolver for CMS Page
 
 The following query returns information about the URL containing `no-route` for the type CMS Page.
 
@@ -117,7 +117,7 @@ The `urlResolver` query contains the following attribute.
 
 Attribute | Type | Description
 --- | --- | ---
-`url` | String | The requested URL. To query for product and category pages, the `url` value must contain the URL key and suffix. For Category page queries. the `url` value must contain the full path of the URL key. For CMS page queries, the `url` value must contain the URL key only.
+`url` | String | The requested URL. To query for product and category pages, the `url` value must contain the URL key and suffix. For Category page queries, the `url` value must contain the full path of the URL key. For CMS page queries, the `url` value must contain the URL key only.
 
 ## Output attributes
 


### PR DESCRIPTION
Add Example of the Category page and CMS page URL Resolver Queries.

## Purpose of this pull request

This pull request (PR) contains the additional example of the Category page and CMS Page queries. For the Category Page you have to pass `url` value will be full url of the category path.

## Affected DevDocs pages

https://devdocs.magento.com/guides/v2.3/graphql/queries/url-resolver.html
https://devdocs.magento.com/guides/v2.4/graphql/queries/url-resolver.html