### PR TITLE
Update category.md

### DIFF
--- a/src/guides/v2.4/graphql/queries/category.md
+++ b/src/guides/v2.4/graphql/queries/category.md
@@ -205,8 +205,22 @@ Attribute | Data type | Description
 
 ## Output attributes {#Categories}
 
+### CategoryTree object
+
 The query returns a `CategoryTree` object, which implements [`CategoryInterface`]({{page.baseurl}}/graphql/interfaces/category-interface.html). The `CategoryTree` object can contain the following attribute, as we as all attributes defined in `CategoryInterface`:
 
 Attribute | Data type | Description
 --- | --- | ---
 `children` | `CategoryTree` | An array containing the next level of subcategories. By default, you can specify up to 10 levels of child categories
+
+## Breadcrumb object {#Breadcrumb}
+
+The Breadcrumb object can contain the following attributes.
+
+Attribute | Data type | Description
+--- | --- | ---
+`category_id` | `Int` | Category ID
+`category_name` | `Int` | Category name
+`category_level` | `Int` | Category level
+`category_url_key` | `Int` | Category URL key
+`category_url_path` | `Int` | Category URL path

--- a/src/guides/v2.4/graphql/queries/category.md
+++ b/src/guides/v2.4/graphql/queries/category.md
@@ -220,7 +220,7 @@ The Breadcrumb object can contain the following attributes.
 Attribute | Data type | Description
 --- | --- | ---
 `category_id` | `Int` | Category ID
-`category_name` | `Int` | Category name
+`category_name` | `String` | Category name
 `category_level` | `Int` | Category level
-`category_url_key` | `Int` | Category URL key
-`category_url_path` | `Int` | Category URL path
+`category_url_key` | `String` | Category URL key
+`category_url_path` | `String` | Category URL path

--- a/src/guides/v2.4/graphql/queries/category.md
+++ b/src/guides/v2.4/graphql/queries/category.md
@@ -219,8 +219,8 @@ The Breadcrumb object can contain the following attributes.
 
 Attribute | Data type | Description
 --- | --- | ---
-`category_id` | `Int` | Category ID
-`category_name` | `String` | Category name
-`category_level` | `Int` | Category level
-`category_url_key` | `String` | Category URL key
-`category_url_path` | `String` | Category URL path
+`category_id` | Int | Category ID
+`category_name` | String | Category name
+`category_level` | Int | Category level
+`category_url_key` | String | Category URL key
+`category_url_path` | String | Category URL path


### PR DESCRIPTION
Added Breadcrumb object Output attribute list.

## Purpose of this pull request

This pull request (PR) contains the additional Breadcrumb object Output attribute list. Page has given breadcrumb example but not defined breadcrumb attribute list.

## Affected DevDocs pages

https://devdocs.magento.com/guides/v2.3/graphql/queries/category.html#Categories
https://devdocs.magento.com/guides/v2.4/graphql/queries/category.html#Categories