### PR TITLE
Update product-review-ratings-metadata.md

### DIFF
--- a/src/guides/v2.4/graphql/queries/product-review-ratings-metadata.md
+++ b/src/guides/v2.4/graphql/queries/product-review-ratings-metadata.md
@@ -141,7 +141,7 @@ The `ProductReviewRatingMetadata` object contains the following attributes.
 
 Attribute | Data type | Description
 --- | --- | ---
-`id` | String! | | An encoded rating ID
+`id` | String! | An encoded rating ID
 `name` | String! | The label assigned to an aspect of a product that is being rated, such as quality or price
 `values` | [ProductReviewRatingValueMetadata!]! | A list of product review ratings, sorted by position
 


### PR DESCRIPTION
Formatting issue. Description of the An encoded rating ID in table display as the fourth column value.

## Purpose of this pull request

This pull request (PR) udpate the formatting of the output attribute table data. Extra `<td>&nbsp</td>` tag will be display and broke the table format for the output attributes.

## Affected DevDocs pages

https://devdocs.magento.com/guides/v2.4/graphql/queries/product-review-ratings-metadata.html