### PR TITLE
Update product-interface-implementations.md

### DIFF
--- a/src/guides/v2.4/graphql/interfaces/product-interface-implementations.md
+++ b/src/guides/v2.4/graphql/interfaces/product-interface-implementations.md
@@ -15,6 +15,7 @@ Product type | Implements | Has product-specific attributes?
 [GroupedProduct]({{ page.baseurl }}/graphql/interfaces/grouped-product.html) | [ProductInterface]({{ page.baseurl }}/graphql/interfaces/product-interface.html), [PhysicalProductInterface]({{ page.baseurl }}/graphql/interfaces/product-interface.html#PhysicalProductInterface), [CustomizableProductInterface]({{ page.baseurl }}/graphql/interfaces/customizable-option-interface.html) | Yes
 [SimpleProduct]({{ page.baseurl }}/graphql/interfaces/simple-product.html) | [ProductInterface]({{ page.baseurl }}/graphql/interfaces/product-interface.html), [PhysicalProductInterface]({{ page.baseurl }}/graphql/interfaces/product-interface.html#PhysicalProductInterface), [CustomizableProductInterface]({{ page.baseurl }}/graphql/interfaces/customizable-option-interface.html) | No
 [VirtualProduct]({{ page.baseurl }}/graphql/interfaces/virtual-product.html) | [ProductInterface]({{ page.baseurl }}/graphql/interfaces/product-interface.html),  [CustomizableProductInterface]({{ page.baseurl }}/graphql/interfaces/customizable-option-interface.html) | No
+[GiftCardProduct]({{ page.baseurl }}/graphql/interfaces/gift-card-product.html) | [ProductInterface]({{ page.baseurl }}/graphql/interfaces/product-interface.html),  [PhysicalProductInterface]({{ page.baseurl }}/graphql/interfaces/product-interface.html#PhysicalProductInterface),[CustomizableProductInterface]({{ page.baseurl }}/graphql/interfaces/customizable-option-interface.html) | Yes
 
 ## Query for product-specific attributes
 


### PR DESCRIPTION
Added Gift Card Product Type in the table of Product interface implementations.

## Purpose of this pull request

This pull request (PR) contain the Gift Card Product type with their dependency on the product interface. Gift card product is the Product type that will be used in the Magento Commerce/B2B.

## Affected DevDocs pages

https://devdocs.magento.com/guides/v2.3/graphql/interfaces/product-interface-implementations.html
https://devdocs.magento.com/guides/v2.4/graphql/interfaces/product-interface-implementations.html