### PR TITLE
Update product-interface.md

### DIFF
--- a/src/guides/v2.3/graphql/interfaces/product-interface.md
+++ b/src/guides/v2.3/graphql/interfaces/product-interface.md
@@ -16,7 +16,8 @@ The `items` that are returned in a `ProductInterface` array can also contain att
    -  [ConfigurableProduct]({{ page.baseurl }}/graphql/interfaces/configurable-product.html)
    -  [DownloadableProduct]({{ page.baseurl }}/graphql/interfaces/downloadable-product.html)
    -  [GroupedProduct]({{ page.baseurl }}/graphql/interfaces/grouped-product.html)
-   -  [VirtualProduct]({{ page.baseurl }}/graphql/interfaces/virtual-product.html)
+   -  [VirtualProduct]({{ page.baseurl }}/graphql/interfaces/virtual-product.html)   
+   -  [GiftCardProduct]({{ page.baseurl }}/graphql/interfaces/gift-card-product.html)
 
 ## ProductInterface attributes
 


### PR DESCRIPTION
Add Gift Card Product Type to the list of product types.

## Purpose of this pull request

This pull request (PR) add Gift Card Product type link that define their own implementation of ProductInterface.

## Affected DevDocs pages

https://devdocs.magento.com/guides/v2.3/graphql/interfaces/product-interface.html
https://devdocs.magento.com/guides/v2.4/graphql/interfaces/product-interface.html