### PR TITLE
Update customizable-option-interface.md

### DIFF
--- a/src/guides/v2.4/graphql/interfaces/customizable-option-interface.md
+++ b/src/guides/v2.4/graphql/interfaces/customizable-option-interface.md
@@ -236,15 +236,6 @@ The following query returns information about the customizable options configure
           sort_order
           option_id
         }
-        ... on CustomizableFieldOption {
-            textField: value {
-              uid
-              sku
-              price
-              price_type
-              max_characters
-            }
-          }
       }
     }
   }
@@ -279,9 +270,10 @@ The following query returns information about the customizable options configure
 ```
 
 The following query returns information about the customizable options configured for the product with a `sku` of `xyz` with Custom Option type Text Field.
+
 - Custom option Option Type is text field with required field.
-- Option Title is Favorite Color.
-- Price is $5, Price Type is Fixed, Option SKU favoriteColorSku and Max. Characters is 20.
+- Option Title is `Favorite Color`.
+- Price is `$5`, Price Type is `Fixed`, Option SKU is `favoriteColorSku` and Max. Characters is `20`.
 
 **Request:**
 

--- a/src/guides/v2.4/graphql/interfaces/customizable-option-interface.md
+++ b/src/guides/v2.4/graphql/interfaces/customizable-option-interface.md
@@ -236,6 +236,15 @@ The following query returns information about the customizable options configure
           sort_order
           option_id
         }
+        ... on CustomizableFieldOption {
+            textField: value {
+              uid
+              sku
+              price
+              price_type
+              max_characters
+            }
+          }
       }
     }
   }
@@ -260,6 +269,77 @@ The following query returns information about the customizable options configure
               "required": false,
               "sort_order": 1,
               "option_id": 1
+            }
+          ]
+        }
+      ]
+    }
+  }
+}
+```
+
+The following query returns information about the customizable options configured for the product with a `sku` of `xyz` with Custom Option type Text Field.
+- Custom option Option Type is text field with required field.
+- Option Title is Favorite Color.
+- Price is $5, Price Type is Fixed, Option SKU favoriteColorSku and Max. Characters is 20.
+
+**Request:**
+
+```graphql
+{
+  products(filter: { sku: { eq: "xyz" } }) {
+    items {
+      id
+      name
+      sku
+      __typename
+      ... on CustomizableProductInterface {
+        options {
+          title
+          required
+          sort_order
+          option_id
+          ... on CustomizableFieldOption {
+            value {
+              uid
+              sku
+              price
+              price_type
+              max_characters
+            }
+          }
+        }
+      }
+    }
+  }
+}
+```
+
+**Response:**
+
+```json
+{
+  "data": {
+    "products": {
+      "items": [
+        {
+          "id": 10,
+          "name": "Savvy Shoulder Tote",
+          "sku": "24-WB05",
+          "__typename": "SimpleProduct",
+          "options": [
+            {
+              "title": "Favorite Color",
+              "required": true,
+              "sort_order": 2,
+              "option_id": 2,
+              "value": {
+                "uid": "Y3VzdG9tLW9wdGlvbi8y",
+                "sku": "favoriteColorSku",
+                "price": 5,
+                "price_type": "FIXED",
+                "max_characters": 20
+              }
             }
           ]
         }

--- a/src/guides/v2.4/graphql/interfaces/customizable-option-interface.md
+++ b/src/guides/v2.4/graphql/interfaces/customizable-option-interface.md
@@ -271,9 +271,9 @@ The following query returns information about the customizable options configure
 
 The following query returns information about the customizable options configured for the product with a `sku` of `xyz` with Custom Option type Text Field.
 
-- Custom option Option Type is text field with required field.
-- Option Title is `Favorite Color`.
-- Price is `$5`, Price Type is `Fixed`, Option SKU is `favoriteColorSku` and Max. Characters is `20`.
+*  Custom option Option Type is text field with required field.
+*  Option Title is `Favorite Color`.
+*  Price is `$5`, Price Type is `Fixed`, Option SKU is `favoriteColorSku` and Max. Characters is `20`.
 
 **Request:**
 


### PR DESCRIPTION
Added Example of the Custom option type text field.

## Purpose of this pull request

This pull request (PR) contains the exact demo of the custom option with text field type. In the article one of the example is given but its basic example but not configured with the customizable option type case. I have added demo for the Custom option type Text field.

## Affected DevDocs pages

https://devdocs.magento.com/guides/v2.4/graphql/interfaces/customizable-option-interface.html