### PR TITLE
Update downloadable-product.md

### DIFF
--- a/src/guides/v2.4/graphql/interfaces/downloadable-product.md
+++ b/src/guides/v2.4/graphql/interfaces/downloadable-product.md
@@ -5,7 +5,7 @@ redirect_from:
   - /guides/v2.4/graphql/product/downloadable-product.html
 ---
 
-The `DownloadableProduct` data type implements `ProductInterface` and `CustomizableProductInterface`. As a result, attributes that are specific to downloadable products can be used when performing a [`products`]({{page.baseurl}}/graphql/queries/products.html) query.
+The `DownloadableProduct` data type implements [`ProductInterface`]({{page.baseurl}}/graphql/interfaces/product-interface.html) and [`CustomizableProductInterface`]({{page.baseurl}}/graphql/interfaces/customizable-option-interface.html). As a result, attributes that are specific to downloadable products can be used when performing a [`products`]({{page.baseurl}}/graphql/queries/products.html) query.
 
 ## Downloadable product
 

--- a/src/guides/v2.4/graphql/interfaces/downloadable-product.md
+++ b/src/guides/v2.4/graphql/interfaces/downloadable-product.md
@@ -13,12 +13,12 @@ The `DownloadableProduct` object contains the following attributes:
 
 Attribute | Type | Description
 --- | --- | ---
-`downloadable_product_links` | [`DownloadableProductLinks`] | An array containing information about the links for this downloadable product
-`downloadable_product_samples` | [`DownloadableProductSamples`] | An array containing information about samples of this downloadable product
+`downloadable_product_links` | [[`DownloadableProductLinks`]](#downloadableProductLinks) | An array containing information about the links for this downloadable product
+`downloadable_product_samples` | [[`DownloadableProductSamples`]](#downloadableProductSamples)  | An array containing information about samples of this downloadable product
 `links_purchased_separately` | Int | A value of 1 indicates that each link in the array must be purchased separately
 `links_title` | String | The heading above the list of downloadable products
 
-### DownloadableProductSamples object
+### DownloadableProductSamples object {#downloadableProductSamples}
 
 The `DownloadableProductSamples` object contains the following attributes:
 
@@ -31,7 +31,7 @@ Attribute | Type | Description
 `sort_order` | Int | A number indicating the sort order
 `title` | String | The display name of the sample
 
-### DownloadableProductLinks object
+### DownloadableProductLinks object {#downloadableProductLinks}
 
 The `DownloadableProductLinks` object contains the following attributes:
 


### PR DESCRIPTION
Added Dynamic links to the Product interface type.

## Purpose of this pull request

This pull request (PR) add the dynamic product interface link and mapping DownloadableProductLinks and DownloadableProductSamples object.

## Affected DevDocs pages

https://devdocs.magento.com/guides/v2.3/graphql/interfaces/downloadable-product.html
https://devdocs.magento.com/guides/v2.4/graphql/interfaces/downloadable-product.html
