### PR TITLE
[DOCS] MCLOUD-7322: Removing elasticsearch plugins from services.yaml

### DIFF
--- a/src/cloud/project/services-elastic.md
+++ b/src/cloud/project/services-elastic.md
@@ -200,31 +200,25 @@ If you use the ElasticSuite third-party plugin, you must [update the `{{site.dat
 When setting up ElasticSuite, add the configuration settings to the `ELASTICSUITE_CONFIGURATION` deploy variable. This configuration saves the settings across deployments.
 
 ### Remove plugins for Elasticsearch
-Removing the plugin entries from `elasticsearch:` in `magento/services.yaml` does not uninstall or disable them as you might expect. This is intentional to prevent possible loss or corruption of data that depends on these plugins. To disable an Elasticsearch plugin, you must take the additional step of reindexing your Elasticsearch data as follows:
+Removing the plugin entries from `elasticsearch:` in `magento/services.yaml` does not uninstall or disable them as you might expect. You must take the additional step of reindexing your Elasticsearch data. This is intentional to prevent possible loss or corruption of data that depends on these plugins.
 
-**To disable Elasticsearch plugins from your Magento instance:**
+**To remove Elasticsearch plugins:**
 
 1. Remove the Elasticsearch plugin entries from your `magento/services.yaml` file.
 
-1. Reindex the Catalog Search index:
+2. Reindex the Catalog Search index:
 
     ```bash
     bin/magento indexer:reindex catalogsearch_fulltext
     ```
 
-1. Clean the cache:
+3. Clean the cache:
 
     ```bash
     bin/magento cache:clean
     ```
 
-**To uninstall Elasticsearch plugins permanently:**
-
-1. Remove the Elasticsearch plugin entries from your `magento/services.yaml` file.
-
-1. Commit the service changes to your Cloud repo.
-
-Uninstalling an Elasticsearch plugin is not strictly necessary. A disabled plugin has very little impact on the server. If you think you may use the plugin again, disabling the plugin is the least intrusive option for your environment.
+4. Commit the service changes to your Cloud repo.
 
 {:.bs-callout-tip}
 For details on using or troubleshooting the Elasticsuite plugin with Magento, see the [Elasticsuite documentation](https://github.com/Smile-SA/elasticsuite).

--- a/src/cloud/project/services-elastic.md
+++ b/src/cloud/project/services-elastic.md
@@ -205,20 +205,18 @@ Removing the plugin entries from `elasticsearch:` in `.magento/services.yaml` do
 **To remove Elasticsearch plugins:**
 
 1. Remove the Elasticsearch plugin entries from your `.magento/services.yaml` file.
-
-2. Reindex the Catalog Search index:
+1. Commit the `.magento/services.yaml` changes to your Cloud repo.
+1. Reindex the Catalog Search index:
 
     ```bash
     bin/magento indexer:reindex catalogsearch_fulltext
     ```
 
-3. Clean the cache:
+1. Clean the cache:
 
     ```bash
     bin/magento cache:clean
     ```
-
-4. Commit the `.magento/services.yaml` changes to your Cloud repo.
 
 {:.bs-callout-tip}
 For details on using or troubleshooting the Elasticsuite plugin with Magento, see the [Elasticsuite documentation](https://github.com/Smile-SA/elasticsuite).

--- a/src/cloud/project/services-elastic.md
+++ b/src/cloud/project/services-elastic.md
@@ -200,7 +200,7 @@ If you use the ElasticSuite third-party plugin, you must [update the `{{site.dat
 When setting up ElasticSuite, add the configuration settings to the `ELASTICSUITE_CONFIGURATION` deploy variable. This configuration saves the settings across deployments.
 
 ### Remove plugins for Elasticsearch
-Removing the plugin entries from `elasticsearch:` in `.magento/services.yaml` does not uninstall or disable them as you might expect. You must take the additional step of reindexing your Elasticsearch data. This is intentional to prevent possible loss or corruption of data that depends on these plugins.
+Removing the plugin entries from `elasticsearch:` in `.magento/services.yaml` does not uninstall or disable them as you might expect. You must take the additional step of reindexing your Elasticsearch data. This behavior is intentional to prevent possible loss or corruption of data that depends on these plugins.
 
 **To remove Elasticsearch plugins:**
 

--- a/src/cloud/project/services-elastic.md
+++ b/src/cloud/project/services-elastic.md
@@ -205,6 +205,20 @@ Removing the plugin entries from `elasticsearch:` in `.magento/services.yaml` do
 **To remove Elasticsearch plugins:**
 
 1. Remove the Elasticsearch plugin entries from your `.magento/services.yaml` file.
+1. Add, commit, and push your code changes.
+
+   ```bash
+   git add -A
+   ```
+
+   ```bash
+   git commit -m "Remove Elasticsearch plugin"
+   ```
+
+   ```bash
+   git push origin <branch-name>
+   ```
+
 1. Commit the `.magento/services.yaml` changes to your Cloud repo.
 1. Reindex the Catalog Search index:
 

--- a/src/cloud/project/services-elastic.md
+++ b/src/cloud/project/services-elastic.md
@@ -200,11 +200,11 @@ If you use the ElasticSuite third-party plugin, you must [update the `{{site.dat
 When setting up ElasticSuite, add the configuration settings to the `ELASTICSUITE_CONFIGURATION` deploy variable. This configuration saves the settings across deployments.
 
 ### Remove plugins for Elasticsearch
-Removing the plugin entries from `elasticsearch:` in `magento/services.yaml` does not uninstall or disable them as you might expect. You must take the additional step of reindexing your Elasticsearch data. This is intentional to prevent possible loss or corruption of data that depends on these plugins.
+Removing the plugin entries from `elasticsearch:` in `.magento/services.yaml` does not uninstall or disable them as you might expect. You must take the additional step of reindexing your Elasticsearch data. This is intentional to prevent possible loss or corruption of data that depends on these plugins.
 
 **To remove Elasticsearch plugins:**
 
-1. Remove the Elasticsearch plugin entries from your `magento/services.yaml` file.
+1. Remove the Elasticsearch plugin entries from your `.magento/services.yaml` file.
 
 2. Reindex the Catalog Search index:
 
@@ -218,7 +218,7 @@ Removing the plugin entries from `elasticsearch:` in `magento/services.yaml` doe
     bin/magento cache:clean
     ```
 
-4. Commit the service changes to your Cloud repo.
+4. Commit the `.magento/services.yaml` changes to your Cloud repo.
 
 {:.bs-callout-tip}
 For details on using or troubleshooting the Elasticsuite plugin with Magento, see the [Elasticsuite documentation](https://github.com/Smile-SA/elasticsuite).

--- a/src/cloud/project/services-elastic.md
+++ b/src/cloud/project/services-elastic.md
@@ -182,9 +182,9 @@ If you need to restart the [Elasticsearch](https://www.elastic.co) service, you 
 
 -  After you set up the Elasticsearch service for your project, use the Magento Admin UI to test the Elasticsearch connection and customize Elasticsearch settings for {{ site.data.var.ee }}.
 
-### Elasticsearch plugins
+### Add plugins for Elasticsearch
 
-Optionally, you can add Elasticsearch plugins by adding the `configuration:plugins` section to the `.magento/services.yaml` file. For example, the following code enables the ICU analysis and Phonetic analysis plugins.
+Optionally, you can add plugins for Elasticsearch by adding the `configuration:plugins` section to the Elasticsearch service in the `.magento/services.yaml` file. For example, the following code enables the ICU analysis and Phonetic analysis plugins.
 
 ```yaml
 elasticsearch:
@@ -198,6 +198,33 @@ elasticsearch:
 
 If you use the ElasticSuite third-party plugin, you must [update the `{{site.data.var.ct}}` package]({{ site.baseurl }}/cloud/project/ece-tools-update.html) to version 2002.0.19 or later.
 When setting up ElasticSuite, add the configuration settings to the `ELASTICSUITE_CONFIGURATION` deploy variable. This configuration saves the settings across deployments.
+
+### Remove plugins for Elasticsearch
+Removing the plugin entries from `elasticsearch:` in `magento/services.yaml` does not uninstall or disable them as you might expect. This is intentional to prevent possible loss or corruption of data that depends on these plugins. To disable an Elasticsearch plugin, you must take the additional step of reindexing your Elasticsearch data as follows:
+
+**To disable Elasticsearch plugins from your Magento instance:**
+
+1. Remove the Elasticsearch plugin entries from your `magento/services.yaml` file.
+
+1. Reindex the Catalog Search index:
+
+    ```bash
+    bin/magento indexer:reindex catalogsearch_fulltext
+    ```
+
+1. Clean the cache:
+
+    ```bash
+    bin/magento cache:clean
+    ```
+
+**To uninstall Elasticsearch plugins permanently:**
+
+1. Remove the Elasticsearch plugin entries from your `magento/services.yaml` file.
+
+1. Commit the service changes to your Cloud repo.
+
+Uninstalling an Elasticsearch plugin is not strictly necessary. A disabled plugin has very little impact on the server. If you think you may use the plugin again, disabling the plugin is the least intrusive option for your environment.
 
 {:.bs-callout-tip}
 For details on using or troubleshooting the Elasticsuite plugin with Magento, see the [Elasticsuite documentation](https://github.com/Smile-SA/elasticsuite).


### PR DESCRIPTION
## Purpose of this pull request

This pull request (PR) updates the docs on removing Elasticsearch plugins.

## Affected DevDocs pages

https://devdocs.magento.com/cloud/project/services-elastic.html#elasticsearch-plugins

whatsnew
Instructions on how to remove plugins from the [Elasticsearch service](https://devdocs.magento.com/cloud/project/services-elastic.html#additional-search-configuration). 
