### PR TITLE
add discount object to the invoice item interface table

### DIFF
--- a/src/_includes/graphql/invoice-item-interface.md
+++ b/src/_includes/graphql/invoice-item-interface.md
@@ -1,9 +1,18 @@
 Attribute | Data type | Description
 --- | --- | ---
-`discounts` | [Discount] | Contains information about the final discount amount for the base product, including discounts on options
+`discounts` | [`[Discount]`](#discount) | Contains information about the final discount amount for the base product, including discounts on options
 `id` | ID! | The unique ID of the invoice item
 `order_item` | OrderItemInterface | Contains details about an individual order item
 `product_name` | String | The name of the base product
 `product_sale_price` | Money! | The sale price for the base product including selected options
 `product_sku` | String! | The SKU of the base product
 `quantity_invoiced` | Float |The number of invoiced items
+
+### Discount object {#discount}
+
+The `Discount` object contains the following attributes:
+
+Attribute | Type | Description
+--- | --- | ---
+`amount` | Money! | The amount of the discount
+`label` | String! | A description of the discount


### PR DESCRIPTION
## Purpose of this pull request

This pull request (PR) add Discount Object to the Invoice item interface table section. Click on [Discount] link shows the discount object available attribute fields.

## Affected DevDocs pages

https://devdocs.magento.com/guides/v2.4/graphql/interfaces/credit-memo-item-interface.html
https://devdocs.magento.com/guides/v2.4/graphql/interfaces/invoice-item-interface.html
https://devdocs.magento.com/guides/v2.4/graphql/interfaces/order-item-interface.html