### PR TITLE
Add reference to the order item options for the OrderItemInterface attributes page and dynamic link in Invoice attribute page.

### DIFF
--- a/src/_includes/graphql/invoice-item-interface.md
+++ b/src/_includes/graphql/invoice-item-interface.md
@@ -2,7 +2,7 @@ Attribute | Data type | Description
 --- | --- | ---
 `discounts` | [Discount] | Contains information about the final discount amount for the base product, including discounts on options
 `id` | ID! | The unique ID of the invoice item
-`order_item` | OrderItemInterface | Contains details about an individual order item
+`order_item` | [OrderItemInterface]({{page.baseurl}}/graphql/interfaces/order-item-interface.html) | Contains details about an individual order item
 `product_name` | String | The name of the base product
 `product_sale_price` | Money! | The sale price for the base product including selected options
 `product_sku` | String! | The SKU of the base product

--- a/src/_includes/graphql/order-item-interface.md
+++ b/src/_includes/graphql/order-item-interface.md
@@ -1,7 +1,7 @@
 Attribute |  Data Type | Description
 --- | --- | ---
 `discounts` | [Discount] | Final discount information for the product
-`entered_options` | [OrderItemOption] | The entered option for the base product, such as a logo or image
+`entered_options` | [`[OrderItemOption]`](#OrderItemOption) | The entered option for the base product, such as a logo or image
 `id` | ID! | The unique identifier for the order item
 `product_name` | String | The name of the base product
 `product_sale_price` | Money! | The sale price of the base product, including selected options
@@ -14,5 +14,12 @@ Attribute |  Data Type | Description
 `quantity_refunded` | Float | The number of refunded items
 `quantity_returned` | Float | The number of returned items
 `quantity_shipped` | Float | The number of shipped items
-`selected_options` | [OrderItemOption] | The selected options for the base product, such as color or size
+`selected_options` | [`[OrderItemOption]`](#OrderItemOption) | The selected options for the base product, such as color or size
 `status` | String | The status of the order item
+
+#### OrderItemOption attributes {#OrderItemOption}
+
+Attribute | Data type | Description
+--- | --- | ---
+`label` | String! | The name of the option
+`value` | String! | The value of the option


### PR DESCRIPTION
## Purpose of this pull request

This pull request (PR) Add attribute fields of the [OrderItemOption] object. Add new table to display all the field of the [OrderItemOption] object and add one dynamic link to the invoice page with Order Item Interface.

## Affected DevDocs pages

https://devdocs.magento.com/guides/v2.4/graphql/interfaces/order-item-interface.html
https://devdocs.magento.com/guides/v2.4/graphql/interfaces/invoice-item-interface.html