### PR TITLE
MC-39142: [Documentation] Update documentation for DMT timezone settings

### DIFF
--- a/src/guides/v2.3/migration/migration-migrate-follow-up.md
+++ b/src/guides/v2.3/migration/migration-migrate-follow-up.md
@@ -39,7 +39,7 @@ The tool does not migrate timezone settings, so you must manually configure the 
 By default, Magento stores time data in the UTC-0 zone in the database and displays it according to the current timezone settings.
 If time data has already been saved in the database in a zone other than UTC-0, you must convert the existing time to UTC-0 using the Data Migration Tool’s `\Migration\Handler\Timezone` handler.
 
-In the following example, the Magento 1 has been wrongly saving time in UTC-7 to the database, for example, due to faulty 3rd party extension. To convert the customer account creation time to UTC-0 upon migration properly, add the following rule to map-customer.xml:
+In the following example, Magento 1 has been incorrectly saving time in the UTC-7 zone in the database (for example, due to a faulty third-party extension). To properly convert the customer account creation time to the UTC-0 zone upon migration, add the following rule to the `map-customer.xml` file:
 
 ```xml
 <?xml version="1.0" encoding="UTF-8"?>

--- a/src/guides/v2.3/migration/migration-migrate-follow-up.md
+++ b/src/guides/v2.3/migration/migration-migrate-follow-up.md
@@ -36,7 +36,7 @@ After migration, Customer Segments must be resaved from the [Admin](https://glos
 ### Configure time zone
 
 The tool does not migrate timezone settings, so you must manually configure the timezone after migration at **Stores** > **Configuration** > **Locale Options** > **Timezone**.
-By default, Magento stores time data in UTC-0 zone in the database and displays it according to current Timezone settings.
+By default, Magento stores time data in the UTC-0 zone in the database and displays it according to the current timezone settings.
 If time data has already been saved in the database in a zone other than UTC-0, you must convert the existing time to UTC-0 using the Data Migration Tool’s `\Migration\Handler\Timezone` handler.
 
 In the following example, the Magento 1 has been wrongly saving time in UTC-7 to the database, for example, due to faulty 3rd party extension. To convert the customer account creation time to UTC-0 upon migration properly, add the following rule to map-customer.xml:

--- a/src/guides/v2.3/migration/migration-migrate-follow-up.md
+++ b/src/guides/v2.3/migration/migration-migrate-follow-up.md
@@ -37,7 +37,7 @@ After migration, Customer Segments must be resaved from the [Admin](https://glos
 
 The tool does not migrate timezone settings, so you must manually configure the timezone after migration at **Stores** > **Configuration** > **Locale Options** > **Timezone**.
 By default, Magento stores time data in UTC-0 zone in the database and displays it according to current Timezone settings.
-If time data already saved in the database in the zone different from UTC-0, developer or administrator need to convert the existing time to UTC-0 using the Data Migration Tool’s \Migration\Handler\Timezone handler.
+If time data has already been saved in the database in a zone other than UTC-0, you must convert the existing time to UTC-0 using the Data Migration Tool’s `\Migration\Handler\Timezone` handler.
 
 In the following example, the Magento 1 has been wrongly saving time in UTC-7 to the database, for example, due to faulty 3rd party extension. To convert the customer account creation time to UTC-0 upon migration properly, add the following rule to map-customer.xml:
 

--- a/src/guides/v2.3/migration/migration-migrate-follow-up.md
+++ b/src/guides/v2.3/migration/migration-migrate-follow-up.md
@@ -33,11 +33,13 @@ Reference numbers for Orders, Invoices, Shipments, Credit Memos, and RMA migrate
 
 After migration, Customer Segments must be resaved from the [Admin](https://glossary.magento.com/admin) Panel to get them up and running.
 
-### Configure time zone offset
+### Configure time zone
 
-If your Magento 1 server has the time zone set to anything other than UTC, you must configure the offset to migrate timestamp fields. To transform time to a different time zone, use the Data Migration Tool's `\Migration\Handler\Timezone` handler.
+The tool does not migrate Timezone settings and administrator should manually configure them after the migration at Magento 2 Admin panel > Stores > Configuration > Locale Options > Timezone.
+By default, Magento stores time data in UTC-0 zone in the database and displays it according to current Timezone settings.
+If time data already saved in the database in the zone different from UTC-0, developer or administrator need to convert the existing time to UTC-0 using the Data Migration Tool’s \Migration\Handler\Timezone handler.
 
-In the following example, the Magento 1 server timezone is UTC-7. To convert the customer account creation date properly, add the following rule to `map-customer.xml`:
+In the following example, the Magento 1 has been wrongly saving time in UTC-7 to the database, for example, due to faulty 3rd party extension. To convert the customer account creation time to UTC-0 upon migration properly, add the following rule to map-customer.xml:
 
 ```xml
 <?xml version="1.0" encoding="UTF-8"?>

--- a/src/guides/v2.3/migration/migration-migrate-follow-up.md
+++ b/src/guides/v2.3/migration/migration-migrate-follow-up.md
@@ -35,7 +35,7 @@ After migration, Customer Segments must be resaved from the [Admin](https://glos
 
 ### Configure time zone
 
-The tool does not migrate Timezone settings and administrator should manually configure them after the migration at Magento 2 Admin panel > Stores > Configuration > Locale Options > Timezone.
+The tool does not migrate timezone settings, so you must manually configure the timezone after migration at **Stores** > **Configuration** > **Locale Options** > **Timezone**.
 By default, Magento stores time data in UTC-0 zone in the database and displays it according to current Timezone settings.
 If time data already saved in the database in the zone different from UTC-0, developer or administrator need to convert the existing time to UTC-0 using the Data Migration Tool’s \Migration\Handler\Timezone handler.
 


### PR DESCRIPTION
## Purpose of this pull request

This pull request (PR) is to update the data migration tool documentation for timezone conversion handler to make it cleared that if time is saved in the database in the zone different from UTC-0, it must be converted to UTC-0 upon migration. Based on data from MC-39142.

## Affected DevDocs pages

<!-- REQUIRED List the affected pages on devdocs.magento.com (URLs). Not needed for large numbers of files. -->

-  https://devdocs.magento.com/guides/v2.4/migration/migration-migrate-follow-up.html#configure-time-zone-offset
