### PR TITLE
Enable MD linter in SuperLinter's workflow

### DIFF
--- a/.github/ISSUE_TEMPLATE/NEW_FEATURE.md
+++ b/.github/ISSUE_TEMPLATE/NEW_FEATURE.md
@@ -36,4 +36,3 @@ Issues that do not comply with our Code of Conduct or do not contain enough info
 
 Feel free to remove this section before creating this issue.
 -->
-

--- a/.github/workflows/linter.yml
+++ b/.github/workflows/linter.yml
@@ -19,11 +19,6 @@ on:
     branches:
       - master
       - 2.*-develop
-#     paths-ignore:
-#       - '**.html'
-#       - '**.xml'
-    paths:
-      - '**.md'
 
 ###############
 # Set the Job #

--- a/.github/workflows/linter.yml
+++ b/.github/workflows/linter.yml
@@ -54,4 +54,4 @@ jobs:
           VALIDATE_ALL_CODEBASE: false
           DEFAULT_BRANCH: master
           VALIDATE_HTML: false
-          VALIDATE_MARKDOWN: false
+          MARKDOWN_CONFIG_FILE: .markdownlint.json

--- a/.github/workflows/linter.yml
+++ b/.github/workflows/linter.yml
@@ -47,7 +47,7 @@ jobs:
       - name: Lint Code Base
         uses: github/super-linter@v3
         env:
-          VALIDATE_ALL_CODEBASE: true
+          VALIDATE_ALL_CODEBASE: false
           DEFAULT_BRANCH: master
           VALIDATE_HTML: false
           MARKDOWN_CONFIG_FILE: .markdownlint.json

--- a/.github/workflows/linter.yml
+++ b/.github/workflows/linter.yml
@@ -20,7 +20,6 @@ on:
       - master
       - 2.*-develop
     paths-ignore:
-      - '**.md'
       - '**.html'
       - '**.xml'
 

--- a/.github/workflows/linter.yml
+++ b/.github/workflows/linter.yml
@@ -22,6 +22,8 @@ on:
     paths-ignore:
       - '**.html'
       - '**.xml'
+    paths:
+      - '**.md'
 
 ###############
 # Set the Job #
@@ -50,7 +52,7 @@ jobs:
       - name: Lint Code Base
         uses: github/super-linter@v3
         env:
-          VALIDATE_ALL_CODEBASE: false
+          VALIDATE_ALL_CODEBASE: true
           DEFAULT_BRANCH: master
           VALIDATE_HTML: false
           MARKDOWN_CONFIG_FILE: .markdownlint.json

--- a/.github/workflows/linter.yml
+++ b/.github/workflows/linter.yml
@@ -19,9 +19,9 @@ on:
     branches:
       - master
       - 2.*-develop
-    paths-ignore:
-      - '**.html'
-      - '**.xml'
+#     paths-ignore:
+#       - '**.html'
+#       - '**.xml'
     paths:
       - '**.md'
 

--- a/_checks/html_check_hook.rb
+++ b/_checks/html_check_hook.rb
@@ -33,7 +33,7 @@ Jekyll::Hooks.register :site, :post_write do |site|
     if url_ignore
       url_ignore.push(jekyll_excludes_as_regex).flatten!.uniq!
     else
-      checks_config['html-proofer'].merge!(url_ignore: jekyll_excludes_as_regex)
+      checks_config['html-proofer'][:url_ignore] = jekyll_excludes_as_regex
     end
 
     # Read configuration options for html-proofer

--- a/src/cloud/cdn/configure-fastly.md
+++ b/src/cloud/cdn/configure-fastly.md
@@ -209,7 +209,7 @@ To update your DNS configuration for development:
 
    -  Use the Magento CLI to change the base URL for your store.
 
-      ```
+      ```bash
       php bin/magento setup:store-config:set --base-url="https://mcstaging.your-domain.com/"
       ```
 

--- a/src/cloud/live/site-launch-checklist.md
+++ b/src/cloud/live/site-launch-checklist.md
@@ -77,7 +77,7 @@ To update DNS configuration for site launch:
 
    -  Use the Magento CLI to change the base URL for your store.
 
-      ```
+      ```bash
       php bin/magento setup:store-config:set --base-url="https://www.your-domain.com/"
       ```
 

--- a/src/guides/v2.3/frontend-dev-guide/layouts/layout-create.md
+++ b/src/guides/v2.3/frontend-dev-guide/layouts/layout-create.md
@@ -56,4 +56,3 @@ The new page layout displays in all `Layout` dropdowns.
 On the storefront, there is a new footer for those pages that use the `3 Columns Double Footer` layout.
 
 ![Storefront two footers layout]({{ site.baseurl }}/common/images/fdg/custom_layout_footer_bottom.png)
-

--- a/src/guides/v2.3/install-gde/system-requirements.md
+++ b/src/guides/v2.3/install-gde/system-requirements.md
@@ -163,4 +163,3 @@ There is a known issue with `xdebug` that can affect Magento installations or ac
 [Elasticsearch]: {{page.baseurl}}/config-guide/elasticsearch/es-overview.html
 [Elasticsearch PHP client]: https://github.com/elastic/elasticsearch-php
 [RabbitMQ]: {{page.baseurl}}/config-guide/mq/rabbitmq-overview.html
-

--- a/src/guides/v2.4/extension-dev-guide/versioning/mftf-tests-codebase-changes.md
+++ b/src/guides/v2.4/extension-dev-guide/versioning/mftf-tests-codebase-changes.md
@@ -25,15 +25,15 @@ Types of changes:
 
 The approach of defining what each release should include was taken from [Semantic Versioning](https://semver.org/).
 
-   3-component version numbers
-   ---------------------------
-   ```text
-    X.Y.Z
-    | | |
-    | | +-- Backward Compatible changes (bug fixes)
-    | +---- Backward Compatible changes (new features)
-    +------ Backward Incompatible changes
-   ```
+3-component version numbers:
+
+```text
+   X.Y.Z
+   | | |
+   | | +-- Backward Compatible changes (bug fixes)
+   | +---- Backward Compatible changes (new features)
+   +------ Backward Incompatible changes
+```
 
 ### Z release
 

--- a/src/guides/v2.4/release-notes/commerce-2-4-1.md
+++ b/src/guides/v2.4/release-notes/commerce-2-4-1.md
@@ -664,7 +664,7 @@ We have fixed hundreds of issues in the Magento 2.4.1 core code.
 
 <!--- ENGCOM-7193-->
 
-*   `sales_clean_quotes` no longer loads all expired quotes at once. Previously, Magento failed with this fatal error because all expired quotes were loaded simultaneously: `PHP Fatal error: Allowed memory size of 2147483648 bytes exhausted (tried to allocate 20480 bytes) in /path/to/magento2/vendor/magento/framework/Model/AbstractModel.php on line 359`,
+*  `sales_clean_quotes` no longer loads all expired quotes at once. Previously, Magento failed with this fatal error because all expired quotes were loaded simultaneously: `PHP Fatal error: Allowed memory size of 2147483648 bytes exhausted (tried to allocate 20480 bytes) in /path/to/magento2/vendor/magento/framework/Model/AbstractModel.php on line 359`,
 
 ### CSS
 

--- a/src/guides/v2.4/release-notes/open-source-2-4-1.md
+++ b/src/guides/v2.4/release-notes/open-source-2-4-1.md
@@ -561,7 +561,7 @@ _Fix submitted by Michał Derlatka in pull request [29256](https://github.com/ma
 
 <!--- ENGCOM-7193-->
 
-*   `sales_clean_quotes` no longer loads all expired quotes at once. Previously, Magento failed with this fatal error because all expired quotes were loaded simultaneously: `PHP Fatal error: Allowed memory size of 2147483648 bytes exhausted (tried to allocate 20480 bytes) in /path/to/magento2/vendor/magento/framework/Model/AbstractModel.php on line 359`,
+*  `sales_clean_quotes` no longer loads all expired quotes at once. Previously, Magento failed with this fatal error because all expired quotes were loaded simultaneously: `PHP Fatal error: Allowed memory size of 2147483648 bytes exhausted (tried to allocate 20480 bytes) in /path/to/magento2/vendor/magento/framework/Model/AbstractModel.php on line 359`,
 
 ### CSS
 

--- a/src/marketplace/sellers/installation-and-varnish-tests.md
+++ b/src/marketplace/sellers/installation-and-varnish-tests.md
@@ -24,7 +24,7 @@ The Installation and Varnish tests complete the following checks:
    -  Verify ability to add the extension to the [Magento project](https://devdocs.magento.com/guides/v2.4/install-gde/install-quick-ref.html#get-the-magento-software) with [Composer](https://getcomposer.org/).
    -  After adding and enabling the extension, verify successful Magento installation.
    -  Verify that you can [compile Magento code](https://devdocs.magento.com/guides/v2.4/config-guide/cli/config-cli-subcommands-compiler.html).
-  -  Verify that you can [deploy static content](https://devdocs.magento.com/guides/v2.4/config-guide/cli/config-cli-subcommands-static-view.html).
+   -  Verify that you can [deploy static content](https://devdocs.magento.com/guides/v2.4/config-guide/cli/config-cli-subcommands-static-view.html).
    -  Verify that you can [enable Magento Production mode](https://devdocs.magento.com/guides/v2.4/config-guide/cli/config-cli-subcommands-mode.html).
    -  Check that you can [reindex all data](https://devdocs.magento.com/guides/v2.4/config-guide/cli/config-cli-subcommands-index.html) with the installed extension.
 


### PR DESCRIPTION
## Purpose of this pull request

This pull request (PR) configures SuperLinter's workflow to enable Markdown checking. We did this before, but the linter didn't work as expected because of incorrect configuration of the workflow.

By default, the Markdown linter uses configuration from the `.markdown-lint.yml`. To enable reuse of the configuration in Visual Studio Code via a symlink locally, we use the `.markdownlint.json` filename.

Tested on the entire content, the tool even found some violations that were not previously detected by `mdl`.

Related topics:
- https://github.com/github/super-linter#environment-variables
- https://marketplace.visualstudio.com/items?itemName=DavidAnson.vscode-markdownlint