### PR TITLE
Added yotpo release notes

### DIFF
--- a/src/_data/toc/extensions.yml
+++ b/src/_data/toc/extensions.yml
@@ -50,3 +50,10 @@ pages:
   - label: Vendor Bundled Extensions (VBEs)
     url: /extensions/vendor/
     versionless: true
+    children:
+      - label: Yotpo
+        versionless: true
+        children:
+        - label: Release Notes
+          versionless: true
+          url: /extensions/vendor/yotpo/release-notes.html

--- a/src/_data/vbe.yml
+++ b/src/_data/vbe.yml
@@ -6,10 +6,36 @@ versions:
   - 2.3.4
   - 2.3.5-p1
   - 2.4.0
+  - 2.4.1
+  - 2.4.2
 extensions:
   -
     name: Amazon
     versions:
+      -
+        name: t.b.d
+        support:
+          2.3.0: not supported
+          2.3.1: not supported
+          2.3.2: not supported
+          2.3.3: not supported
+          2.3.4: not supported
+          2.3.5-p1: not supported
+          2.4.0: not supported
+          2.4.1: not supported
+          2.4.2: supported
+      -
+        name: 4.0.4
+        support:
+          2.3.0: not supported
+          2.3.1: not supported
+          2.3.2: not supported
+          2.3.3: not supported
+          2.3.4: not supported
+          2.3.5-p1: not supported
+          2.4.0: not supported
+          2.4.1: supported
+          2.4.2: not supported
       -
         name: 4.0.1
         support:
@@ -20,6 +46,8 @@ extensions:
           2.3.4: not supported
           2.3.5-p1: not supported
           2.4.0: supported
+          2.4.1: not supported
+          2.4.2: not supported
       -
         name: 3.4.1
         support:
@@ -30,6 +58,8 @@ extensions:
           2.3.4: not supported
           2.3.5-p1: supported
           2.4.0: not supported
+          2.4.1: not supported
+          2.4.2: not supported
       -
         name: 3.3.1
         support:
@@ -40,6 +70,8 @@ extensions:
           2.3.4: supported
           2.3.5-p1: not supported
           2.4.0: not supported
+          2.4.1: not supported
+          2.4.2: not supported
       -
         name: 3.2.13
         support:
@@ -50,6 +82,8 @@ extensions:
           2.3.4: not supported
           2.3.5-p1: not supported
           2.4.0: not supported
+          2.4.1: not supported
+          2.4.2: not supported
       -
         name: 3.2.9
         support:
@@ -60,6 +94,8 @@ extensions:
           2.3.4: not supported
           2.3.5-p1: not supported
           2.4.0: not supported
+          2.4.1: not supported
+          2.4.2: not supported
       -
         name: 3.1.4
         support:
@@ -70,6 +106,8 @@ extensions:
           2.3.4: not supported
           2.3.5-p1: not supported
           2.4.0: not supported
+          2.4.1: not supported
+          2.4.2: not supported
       -
         name: 3.0.0
         support:
@@ -80,9 +118,35 @@ extensions:
           2.3.4: not supported
           2.3.5-p1: not supported
           2.4.0: not supported
+          2.4.1: not supported
+          2.4.2: not supported
   -
     name: dotdigital
     versions:
+      -
+        name: t.b.d
+        support:
+          2.3.0: not supported
+          2.3.1: not supported
+          2.3.2: not supported
+          2.3.3: not supported
+          2.3.4: not supported
+          2.3.5-p1: not supported
+          2.4.0: not supported
+          2.4.1: not supported
+          2.4.2: supported
+      -
+        name: 4.8.0
+        support:
+          2.3.0: not supported
+          2.3.1: not supported
+          2.3.2: not supported
+          2.3.3: not supported
+          2.3.4: not supported
+          2.3.5-p1: not supported
+          2.4.0: not supported
+          2.4.1: supported
+          2.4.2: not supported
       -
         name: 4.6.0
         support:
@@ -93,6 +157,8 @@ extensions:
           2.3.4: not supported
           2.3.5-p1: not supported
           2.4.0: supported
+          2.4.1: not supported
+          2.4.2: not supported
       -
         name: 4.4.0
         support:
@@ -103,6 +169,8 @@ extensions:
           2.3.4: not supported
           2.3.5-p1: supported
           2.4.0: not supported
+          2.4.1: not supported
+          2.4.2: not supported
       -
         name: 4.1.0
         support:
@@ -113,6 +181,8 @@ extensions:
           2.3.4: supported
           2.3.5-p1: not supported
           2.4.0: not supported
+          2.4.1: not supported
+          2.4.2: not supported
       -
         name: 3.3.0
         support:
@@ -123,6 +193,8 @@ extensions:
           2.3.4: not supported
           2.3.5-p1: not supported
           2.4.0: not supported
+          2.4.1: not supported
+          2.4.2: not supported
       -
         name: 3.1.2
         support:
@@ -133,6 +205,8 @@ extensions:
           2.3.4: not supported
           2.3.5-p1: not supported
           2.4.0: not supported
+          2.4.1: not supported
+          2.4.2: not supported
       -
         name: 3.1.1
         support:
@@ -143,6 +217,8 @@ extensions:
           2.3.4: not supported
           2.3.5-p1: not supported
           2.4.0: not supported
+          2.4.1: not supported
+          2.4.2: not supported
       -
         name: 3.0.1
         support:
@@ -153,9 +229,35 @@ extensions:
           2.3.4: not supported
           2.3.5-p1: not supported
           2.4.0: not supported
+          2.4.1: not supported
+          2.4.2: not supported
   -
     name: Klarna
     versions:
+      -
+        name: t.b.d
+        support:
+          2.3.0: not supported
+          2.3.1: not supported
+          2.3.2: not supported
+          2.3.3: not supported
+          2.3.4: not supported
+          2.3.5-p1: not supported
+          2.4.0: not supported
+          2.4.1: not supported
+          2.4.2: supported
+      -
+        name: 8.1.0
+        support:
+          2.3.0: not supported
+          2.3.1: not supported
+          2.3.2: not supported
+          2.3.3: not supported
+          2.3.4: not supported
+          2.3.5-p1: not supported
+          2.4.0: not supported
+          2.4.1: supported
+          2.4.2: not supported
       -
         name: 8.0.0
         support:
@@ -166,6 +268,8 @@ extensions:
           2.3.4: not supported
           2.3.5-p1: not supported
           2.4.0: supported
+          2.4.1: not supported
+          2.4.2: not supported
       -
         name: 7.5.0
         support:
@@ -176,6 +280,8 @@ extensions:
           2.3.4: not supported
           2.3.5-p1: supported
           2.4.0: not supported
+          2.4.1: not supported
+          2.4.2: not supported
       -
         name: 7.4.3
         support:
@@ -186,6 +292,8 @@ extensions:
           2.3.4: supported
           2.3.5-p1: not supported
           2.4.0: not supported
+          2.4.1: not supported
+          2.4.2: not supported
       -
         name: 7.3.5
         support:
@@ -196,6 +304,8 @@ extensions:
           2.3.4: not supported
           2.3.5-p1: not supported
           2.4.0: not supported
+          2.4.1: not supported
+          2.4.2: not supported
       -
         name: 7.1.1
         support:
@@ -206,6 +316,8 @@ extensions:
           2.3.4: not supported
           2.3.5-p1: not supported
           2.4.0: not supported
+          2.4.1: not supported
+          2.4.2: not supported
       -
         name: 7.1.0
         support:
@@ -216,6 +328,8 @@ extensions:
           2.3.4: not supported
           2.3.5-p1: not supported
           2.4.0: not supported
+          2.4.1: not supported
+          2.4.2: not supported
       -
         name: 7.0.0
         support:
@@ -226,9 +340,35 @@ extensions:
           2.3.4: not supported
           2.3.5-p1: not supported
           2.4.0: not supported
+          2.4.1: not supported
+          2.4.2: not supported
   -
     name: Vertex
     versions:
+      -
+        name: t.b.d
+        support:
+          2.3.0: not supported
+          2.3.1: not supported
+          2.3.2: not supported
+          2.3.3: not supported
+          2.3.4: not supported
+          2.3.5-p1: not supported
+          2.4.0: not supported
+          2.4.1: not supported
+          2.4.2: supported
+      -
+        name: 4.1.0
+        support:
+          2.3.0: not supported
+          2.3.1: not supported
+          2.3.2: not supported
+          2.3.3: not supported
+          2.3.4: not supported
+          2.3.5-p1: not supported
+          2.4.0: not supported
+          2.4.1: supported
+          2.4.2: not supported
       -
         name: 4.0.0
         support:
@@ -239,6 +379,8 @@ extensions:
           2.3.4: not supported
           2.3.5-p1: not supported
           2.4.0: supported
+          2.4.1: not supported
+          2.4.2: not supported
       -
         name: 3.4.0
         support:
@@ -249,6 +391,8 @@ extensions:
           2.3.4: not supported
           2.3.5-p1: supported
           2.4.0: not supported
+          2.4.1: not supported
+          2.4.2: not supported
       -
         name: 3.3.0
         support:
@@ -259,6 +403,8 @@ extensions:
           2.3.4: supported
           2.3.5-p1: not supported
           2.4.0: not supported
+          2.4.1: not supported
+          2.4.2: not supported
       -
         name: 3.2.0
         support:
@@ -269,6 +415,8 @@ extensions:
           2.3.4: not supported
           2.3.5-p1: not supported
           2.4.0: not supported
+          2.4.1: not supported
+          2.4.2: not supported
       -
         name: 3.1.0
         support:
@@ -279,6 +427,8 @@ extensions:
           2.3.4: not supported
           2.3.5-p1: not supported
           2.4.0: not supported
+          2.4.1: not supported
+          2.4.2: not supported
       -
         name: 3.0.0
         support:
@@ -289,9 +439,35 @@ extensions:
           2.3.4: not supported
           2.3.5-p1: not supported
           2.4.0: not supported
+          2.4.1: not supported
+          2.4.2: not supported
   -
     name: Yotpo
     versions:
+      -
+        name: 3.1.3
+        support:
+          2.3.0: not supported
+          2.3.1: not supported
+          2.3.2: not supported
+          2.3.3: not supported
+          2.3.4: not supported
+          2.3.5-p1: not supported
+          2.4.0: not supported
+          2.4.1: not supported
+          2.4.2: supported
+      -
+        name: 3.1.2
+        support:
+          2.3.0: not supported
+          2.3.1: not supported
+          2.3.2: not supported
+          2.3.3: not supported
+          2.3.4: not supported
+          2.3.5-p1: not supported
+          2.4.0: not supported
+          2.4.1: supported
+          2.4.2: not supported
       -
         name: 3.1.1
         support:
@@ -302,6 +478,8 @@ extensions:
           2.3.4: not supported
           2.3.5-p1: not supported
           2.4.0: supported
+          2.4.1: not supported
+          2.4.2: not supported
       -
         name: 3.1.0
         support:
@@ -312,6 +490,8 @@ extensions:
           2.3.4: not supported
           2.3.5-p1: supported
           2.4.0: not supported
+          2.4.1: not supported
+          2.4.2: not supported
       -
         name: 3.0.1
         support:
@@ -322,6 +502,8 @@ extensions:
           2.3.4: supported
           2.3.5-p1: not supported
           2.4.0: not supported
+          2.4.1: not supported
+          2.4.2: not supported
       -
         name: 3.0.0
         support:
@@ -332,3 +514,5 @@ extensions:
           2.3.4: not supported
           2.3.5-p1: not supported
           2.4.0: not supported
+          2.4.1: not supported
+          2.4.2: not supported

--- a/src/extensions/vendor/yotpo/release-notes.md
+++ b/src/extensions/vendor/yotpo/release-notes.md
@@ -1,0 +1,20 @@
+---
+group: extensions
+title: Yotpo Release Notes
+---
+
+[Yotpo](https://www.yotpo.com/) is a user-generated content marketing platform enabling merchants to gather, curate, manage, and respond to all kinds of user content from just a single platform. Yotpo integrates with Magento to help you to maximize the power of user-generated content.
+
+The release notes include:
+
+-  {:.new}New features
+-  {:.fix}Fixes and improvements
+-  {:.bug}Known issues
+
+## v3.1.3
+
+-  {:.fix}Some users who upgraded from an older version of Magento to one of the latest versions found that the `yotpo_rich_snippets` table was not created. This issue is now fixed and the `yotpo_rich_snippets` table should display correctly.
+
+-  {:.fix}We have improved the mechanism for syncing orders to Yotpo. If an order fails to sync for any reason, this order will be skipped and the process will continue to sync the next order.
+
+-  {:.fix}We have added Google fonts to the Content Security Policies (CSP) whitelist.

--- a/src/extensions/vendor/yotpo/release-notes.md
+++ b/src/extensions/vendor/yotpo/release-notes.md
@@ -13,7 +13,7 @@ The release notes include:
 
 ## v3.1.3
 
--  {:.fix}Some users who upgraded from an older version of Magento to one of the latest versions found that the `yotpo_rich_snippets` table was not created. This issue is now fixed and the `yotpo_rich_snippets` table should display correctly.
+-  {:.fix}Some users who upgraded from an older version of Magento, to one of the latest versions, found that the `yotpo_rich_snippets` table was not created. This issue is now fixed and the `yotpo_rich_snippets` table should display correctly.
 
 -  {:.fix}We have improved the mechanism for syncing orders to Yotpo. If an order fails to sync for any reason, this order will be skipped and the process will continue to sync the next order.
 


### PR DESCRIPTION
## Purpose of this pull request

This pull request (PR):

- Adds a new release notes page for the Yotpo vendor bundled extension (VBE).
- Updates the VBE compatibility matrix for the previous release (2.4.1).
- Adds Yotpo v3.1.3 to the VBE compatibility matrix for the upcoming release (2.4.2).
- Adds placeholders for other VBEs to the compatibility matrix for the upcoming release (2.4.2).

## Affected DevDocs pages

- https://devdocs.magento.com/extensions/vendor/
- https://devdocs.magento.com/extensions/vendor/yotpo/release-notes.html

whatsnew
Added a new [release notes page](https://devdocs.magento.com/extensions/vendor/yotpo/release-notes.html) for the Yotpo vendor bundled extension (VBE).