### PR TITLE
Add Error message on the product type

### DIFF
--- a/src/guides/v2.3/graphql/mutations/add-bundle-products.md
+++ b/src/guides/v2.3/graphql/mutations/add-bundle-products.md
@@ -247,8 +247,8 @@ Attribute |  Data Type | Description
 
 Error | Description
 --- | ---
+`Could not find a cart with ID "XXX"` | The specified `cart_id` value does not exist in the `quote_id_mask` table.
 `Could not find a product with SKU "XXX"` | A simple product with the SKU specified in the `data.sku` argument does not exist.
-`Could not find a cart with ID "XXX"` | The specified `cart_id` value does not exist in the `quote_id_mask` database table.
 `Required parameter "cart_id" is missing` | The `cart_id` argument is omitted or contains an empty value.
 
 ## Related topics

--- a/src/guides/v2.3/graphql/mutations/add-configurable-products.md
+++ b/src/guides/v2.3/graphql/mutations/add-configurable-products.md
@@ -144,10 +144,12 @@ Attribute |  Data Type | Description
 
 Error | Description
 --- | ---
+`Could not find a cart with ID "XXX"` | The specified `cart_id` value does not exist in the `quote_id_mask` table.
 `Could not add the product with SKU configurable to the shopping cart: The product that was requested doesn't exist. Verify the product and try again.` | The simple product with the SKU specified in the `data`.`sku` attribute does not exist.
 `Could not find a product with SKU "XXX"` | The configurable product with SKU specified in the `parent_sku` argument does not exist.
 `Could not find specified product.` | The simple product specified in the `data`.`sku` argument is not assigned to the configurable product provided in the `parent_sku` attribute.
 `Required parameter "cart_id" is missing` | The `cart_id` argument was omitted or contains an empty value.
+`Required parameter "cart_items" is missing` | The `cart_items` argument was omitted or contains an empty array.
 `Required parameter "email" is missing` | The `email` argument was omitted or contains an empty value.
 `The requested qty is not available` | The requested quantity specified `data`.`quantity` is not available.
 

--- a/src/guides/v2.3/graphql/mutations/add-downloadable-products.md
+++ b/src/guides/v2.3/graphql/mutations/add-downloadable-products.md
@@ -258,6 +258,8 @@ Attribute |  Data Type | Description
 
 Error | Description
 --- | ---
+`Could not find a cart with ID "XXX"` | The specified `cart_id` value does not exist in the `quote_id_mask` table.
+`Could not find a product with SKU "YYY"` | A product with the SKU specified in the `data`.`sku` argument does not exist.
 `Required parameter "cart_id" is missing` | The mutation does not contain a `cart_id` argument.
 `Required parameter "cart_items" is missing` | The `cart_items` argument is empty or is not of type `array`.
 `Please specify product link(s).` | You tried to add a downloadable product in which the `Links can be purchased separately` option is enabled, but you did not specify individual product links.

--- a/src/guides/v2.4/graphql/mutations/add-bundle-products.md
+++ b/src/guides/v2.4/graphql/mutations/add-bundle-products.md
@@ -242,8 +242,8 @@ Attribute |  Data Type | Description
 
 Error | Description
 --- | ---
-`Could not find a product with SKU "XXX"` | A simple product with the SKU specified in the `data.sku` argument does not exist.
 `Could not find a cart with ID "XXX"` | The specified `cart_id` value does not exist in the `quote_id_mask` database table.
+`Could not find a product with SKU "XXX"` | A simple product with the SKU specified in the `data.sku` argument does not exist.
 `Required parameter "cart_id" is missing` | The `cart_id` argument is omitted or contains an empty value.
 
 ## Related topics

--- a/src/guides/v2.4/graphql/mutations/add-configurable-products.md
+++ b/src/guides/v2.4/graphql/mutations/add-configurable-products.md
@@ -139,10 +139,12 @@ Attribute |  Data Type | Description
 
 Error | Description
 --- | ---
+`Could not find a cart with ID "XXX"` | The specified `cart_id` value does not exist in the `quote_id_mask` table.
 `Could not add the product with SKU configurable to the shopping cart: The product that was requested doesn't exist. Verify the product and try again.` | The simple product with the SKU specified in the `data`.`sku` attribute does not exist.
 `Could not find a product with SKU "XXX"` | The configurable product with SKU specified in the `parent_sku` argument does not exist.
 `Could not find specified product.` | The simple product specified in the `data`.`sku` argument is not assigned to the configurable product provided in the `parent_sku` attribute.
 `Required parameter "cart_id" is missing` | The `cart_id` argument was omitted or contains an empty value.
+`Required parameter "cart_items" is missing` | The `cart_items` argument was omitted or contains an empty array.
 `Required parameter "email" is missing` | The `email` argument was omitted or contains an empty value.
 `The requested qty is not available` | The requested quantity specified `data`.`quantity` is not available.
 

--- a/src/guides/v2.4/graphql/mutations/add-downloadable-products.md
+++ b/src/guides/v2.4/graphql/mutations/add-downloadable-products.md
@@ -261,6 +261,8 @@ Attribute |  Data Type | Description
 
 Error | Description
 --- | ---
+`Could not find a cart with ID "XXX"` | The specified `cart_id` value does not exist in the `quote_id_mask` database table.
+`Could not find a product with SKU "YYY"` | A product with the SKU specified in the `data`.`sku` argument does not exist.
 `Required parameter "cart_id" is missing` | The mutation does not contain a `cart_id` argument.
 `Required parameter "cart_items" is missing` | The `cart_items` argument is empty or is not of type `array`.
 `Please specify product link(s).` | You tried to add a downloadable product in which the `Links can be purchased separately` option is enabled, but you did not specify individual product links.


### PR DESCRIPTION
## Purpose of this pull request

This pull request (PR) contains the Error message that will be faced during the add different type of product to the cart using GraphQL mutation.

## Affected DevDocs pages

https://devdocs.magento.com/guides/v2.3/graphql/mutations/add-configurable-products.html
https://devdocs.magento.com/guides/v2.4/graphql/mutations/add-configurable-products.html
https://devdocs.magento.com/guides/v2.3/graphql/mutations/add-bundle-products.html
https://devdocs.magento.com/guides/v2.4/graphql/mutations/add-bundle-products.html
https://devdocs.magento.com/guides/v2.3/graphql/mutations/add-downloadable-products.html
https://devdocs.magento.com/guides/v2.4/graphql/mutations/add-downloadable-products.html