### PR TITLE
Add Braintree entry to VBE compatibility matrix for 2.4.1

### DIFF
--- a/src/_data/vbe.yml
+++ b/src/_data/vbe.yml
@@ -124,6 +124,30 @@ extensions:
     name: Braintree
     versions:
       -
+        name: t.b.d
+        support:
+          2.3.0: not supported
+          2.3.1: not supported
+          2.3.2: not supported
+          2.3.3: not supported
+          2.3.4: not supported
+          2.3.5-p1: not supported
+          2.4.0: not supported
+          2.4.1: not supported
+          2.4.2: supported
+      -
+        name: 4.2.0
+        support:
+          2.3.0: not supported
+          2.3.1: not supported
+          2.3.2: not supported
+          2.3.3: not supported
+          2.3.4: not supported
+          2.3.5-p1: not supported
+          2.4.0: not supported
+          2.4.1: supported
+          2.4.2: not supported
+      -
         name: 4.1.0
         support:
           2.3.0: not supported
@@ -133,6 +157,8 @@ extensions:
           2.3.4: not supported
           2.3.5-p1: not supported
           2.4.0: supported
+          2.4.1: not supported
+          2.4.2: not supported
   -
     name: dotdigital
     versions:


### PR DESCRIPTION
## Purpose of this pull request

This pull request (PR) adds a Braintree entry to the VBE compatibility matrix for 2.4.1.

Related to #8151 

## Affected DevDocs pages

- https://devdocs.magento.com/extensions/vendor/