### PR TITLE
Upgrade Bundler from 1.17.3 to 2.1.4, refs #8370

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -188,4 +188,4 @@ DEPENDENCIES
   whatsup_github
 
 BUNDLED WITH
-   1.17.3
+   2.1.4

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -2,7 +2,7 @@ version: '3.6'
 
 services:
   jekyll:
-    image: jekyll/jekyll:latest
+    image: jekyll/jekyll:4.0
     command: jekyll serve --watch --incremental --open-url --livereload
     ports:
       - 4000:4000


### PR DESCRIPTION
## Purpose of this pull request

In this pull request Bundler is upgraded from 1.17.3 to 2.1.4, to resolve #8370

In #8370 I mentioned locking the `jekyll/jekyll` Docker image to `jekyll/jekyll:3` as a possible solution. But locking the version of a Docker image to be compatible with an outdated version of Bundler didn't seem like the right approach.

I did lock the Docker image to `jekyll/jekyll:4.0`, as it is / I find it to be a "Best Practice" to do so.