### PR TITLE
Wrong table name in devdoc

### DIFF
--- a/src/guides/v2.3/config-guide/prod/config-reference-var-name.md
+++ b/src/guides/v2.3/config-guide/prod/config-reference-var-name.md
@@ -140,7 +140,7 @@ To get these values from the database:
 1. Use the following SQL queries to find the relevant values:
 
    ```shell
-   SELECT * FROM STORES;
+   SELECT * FROM STORE;
    SELECT * FROM STORE_WEBSITE;
    ```
 


### PR DESCRIPTION
## Purpose of this pull request

This pull request (PR) fix a Wrong table name in devdoc

## Affected DevDocs pages

<!-- REQUIRED List the affected pages on devdocs.magento.com (URLs). Not needed for large numbers of files. -->

- https://devdocs.magento.com/guides/v2.4/config-guide/prod/config-reference-var-name.html
- https://devdocs.magento.com/guides/v2.3/config-guide/prod/config-reference-var-name.html


<!--
If you are fixing a GitHub issue, note it using GitHub keyword format (https://help.github.com/en/articles/closing-issues-using-keywords#closing-an-issue-in-a-different-repository) to close the issue when this pull request is merged. Example: `Fixes #1234`

`master` is the default branch. Merged pull requests to `master` go live on the site automatically. Any requested changes to content on the `master` branch must be related to the released codebase. Any content related to future releases goes in the `develop` branch.

See Contribution guidelines (https://github.com/magento/devdocs/blob/master/.github/CONTRIBUTING.md) for more information.
-->
