### PR TITLE
Updated Serializer implementations

### DIFF
--- a/src/guides/v2.3/extension-dev-guide/framework/serializer.md
+++ b/src/guides/v2.3/extension-dev-guide/framework/serializer.md
@@ -26,12 +26,22 @@ For security reasons, `SerializerInterface` implementations, such as the Json an
 ### Json (default)
 
 The [`Magento\Framework\Serialize\Serializer\Json`]({{ site.mage2bloburl }}/{{ page.guide_version }}/lib/internal/Magento/Framework/Serialize/Serializer/Json.php){:target="_blank"} class serializes and unserializes data using the [JSON](http://www.json.org/){:target="_blank"} format.
-This class does not unserialize objects.
+
+### JsonHexTag
+
+The [`Magento\Framework\Serialize\Serializer\JsonHexTag`]({{ site.mage2bloburl }}/{{ page.guide_version }}/lib/internal/Magento/Framework/Serialize/Serializer/JsonHexTag.php){:target="_blank"} class serializes and unserializes data using the [JSON](http://www.json.org/){:target="_blank"} format using the `JSON_HEX_TAG` option enabled.
+
+### Base64Json
+
+The [`Magento\Framework\Serialize\Serializer\Base64Json`]({{ site.mage2bloburl }}/{{ page.guide_version }}/lib/internal/Magento/Framework/Serialize/Serializer/Base64Json.php){:target="_blank"} class serializes and encodes in the base64 format, and decodes the base64 encoded string and unserializes data using the [JSON](http://www.json.org/){:target="_blank"} format.
 
 ### Serialize
 
 The [`Magento\Framework\Serialize\Serializer\Serialize`]({{ site.mage2bloburl }}/{{ page.guide_version }}/lib/internal/Magento/Framework/Serialize/Serializer/Serialize.php){:target="_blank"} class is less secure than the Json implementation but provides better performance on large arrays.
-This class does not unserialize objects in [PHP](https://glossary.magento.com/php) 7.
+
+### FormData
+
+The [`Magento\Framework\Serialize\Serializer\FormData`]({{ site.mage2bloburl }}/{{ page.guide_version }}/lib/internal/Magento/Framework/Serialize/Serializer/FormData.php){:target="_blank"} class unserializes the form data using the [JSON](http://www.json.org/){:target="_blank"} format. This class does not serialize objects to a form data format.
 
 {:.bs-callout-warning}
 Magento discourages using the Serialize implementation directly because it can lead to security vulnerabilities. Always use the `SerializerInterface` for serializing and unserializing.


### PR DESCRIPTION
## Purpose of this pull request

This pull request (PR) adds the missing serializer implementions and also their descriptions

## Affected DevDocs pages

-  https://devdocs.magento.com/guides/v2.4/extension-dev-guide/framework/serializer.html

## Links to Magento source code

-  https://github.com/magento/magento2/tree/2.4-develop/lib/internal/Magento/Framework/Serialize/Serializer

whatsnew
Added [descriptions](https://devdocs.magento.com/guides/v2.4/extension-dev-guide/framework/serializer.html) for the JsonHexTag, Base64Json, and FormData serializer implementations.