### PR TITLE
Added new page for URL library

### DIFF
--- a/src/_data/toc/php-developer-guide.yml
+++ b/src/_data/toc/php-developer-guide.yml
@@ -265,6 +265,9 @@ pages:
         - label: Array Manager
           url: /extension-dev-guide/framework/array-manager.html
 
+        - label: URL Library
+          url: /extension-dev-guide/framework/url-library.html
+
     - label: Security
       children:
 

--- a/src/guides/v2.3/extension-dev-guide/framework/url-library.md
+++ b/src/guides/v2.3/extension-dev-guide/framework/url-library.md
@@ -25,7 +25,7 @@ The [`Magento\Framework\Url\EncoderInterface`]({{ site.mage2bloburl }}/{{ page.g
 
 The [`Magento\Framework\Url\DecoderInterface`]({{ site.mage2bloburl }}/{{ page.guide_version }}/lib/internal/Magento/Framework/Url/DecoderInterface.php){:target="_blank"} provides a method to `decode` the base64 encoded URL provided to it and also decodes the special characters described in the table below.
 
-|Special Character|Encoded Value|
+|Special Character|Decoded Value|
 |--- |--- |
 | `-` | `+` |
 | `_` | `/` |
@@ -49,7 +49,12 @@ private $encoder;
  */
 private $decoder;
 
-
+/**
+  * QuickCartTaxInput constructor.
+  *
+  * @param EncoderInterface $encoder
+  * @param DecoderInterface $decoder
+  */
 public function __construct(
     EncoderInterface $encoder,
     DecoderInterface $decoder
@@ -59,19 +64,26 @@ public function __construct(
 }
 
 /**
- * Encodes URL to base64 format and escapes special characters
+ * Encodes URL to base64 format and escapes special characters.
+ *
+ * @param string $url
+ *
+ * @return string
  */
-public function encodeURL($url)
+public function encodeURL($url): string
 {
   return $this->encoder->encode($url);
 }
 
 /**
- * Decodes URL from base64 format and special characters
+ * Decodes URL from base64 format and special characters.
+ *
+ * @param string $encodedUrl
+ *
+ * @return string
  */
-public function decodeURL($encodedUrl)
+public function decodeURL($encodedUrl): string
 {
   return $this->decoder->decode($encodedUrl);
 }
-...
 ```

--- a/src/guides/v2.3/extension-dev-guide/framework/url-library.md
+++ b/src/guides/v2.3/extension-dev-guide/framework/url-library.md
@@ -1,0 +1,77 @@
+---
+group: php-developer-guide
+title: URL Library
+contributor_name: Adarsh Manickam
+contributor_link: https://github.com/drpayyne
+---
+
+## Overview
+
+This URL library provides numerous utilities to work with URLs. Some of the most useful URL utilities are described below.
+
+## URL Utilities
+
+### Encoder
+
+The [`Magento\Framework\Url\EncoderInterface`]({{ site.mage2bloburl }}/{{ page.guide_version }}/lib/internal/Magento/Framework/Url/EncoderInterface.php){:target="_blank"} provides a method to `encode` the URL provided to it into a base64 format and also escapes the special charaters described in the table below.
+
+|Special Character|Encoded Value|
+|--- |--- |
+| `+` | `-` |
+| `/` | `_` |
+| `=` | `,` |
+
+### Decoder
+
+The [`Magento\Framework\Url\DecoderInterface`]({{ site.mage2bloburl }}/{{ page.guide_version }}/lib/internal/Magento/Framework/Url/DecoderInterface.php){:target="_blank"} provides a method to `decode` the base64 encoded URL provided to it and also decodes the special characters described in the table below.
+
+|Special Character|Encoded Value|
+|--- |--- |
+| `-` | `+` |
+| `_` | `/` |
+| `,` | `=` |
+
+## Usage
+
+Declare `SerializerInterface` as a [constructor dependency]({{ page.baseurl }}/extension-dev-guide/depend-inj.html) to get an instance of a serializer class.
+
+```php
+use Magento\Framework\Url\DecoderInterface;
+use Magento\Framework\Url\EncoderInterface;
+
+/**
+ * @var EncoderInterface
+ */
+private $encoder;
+
+/**
+ * @var DecoderInterface
+ */
+private $decoder;
+
+
+public function __construct(
+    EncoderInterface $encoder,
+    DecoderInterface $decoder
+) {
+  $this->encoder = $encoder;
+  $this->decoder = $decoder;
+}
+
+/**
+ * Encodes URL to base64 format and escapes special characters
+ */
+public function encodeURL($url)
+{
+  return $this->encoder->encode($url);
+}
+
+/**
+ * Decodes URL from base64 format and special characters
+ */
+public function decodeURL($encodedUrl)
+{
+  return $this->decoder->decode($encodedUrl);
+}
+...
+```

--- a/src/guides/v2.4/extension-dev-guide/framework/url-library.md
+++ b/src/guides/v2.4/extension-dev-guide/framework/url-library.md
@@ -1,0 +1,1 @@
+../../../v2.3/extension-dev-guide/framework/url-library.md


### PR DESCRIPTION
## Purpose of this pull request

This pull request (PR) adds a new page `URL Library` to describe the utilities provided to manage URLs.

## Affected DevDocs pages

-  https://devdocs.magento.com/guides/v2.4/extension-dev-guide/framework/url-library.html

## Links to Magento source code

-  https://github.com/magento/magento2/tree/2.4-develop/lib/internal/Magento/Framework/Url

whatsnew
Added a new topic describing the [URL Library](https://devdocs.magento.com/guides/v2.4/extension-dev-guide/framework/url-library.html).