### PR TITLE
Use "jekyll/jekyll:3.8.6" so it is locked, rather than "latest"

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -2,7 +2,7 @@ version: '3.6'
 
 services:
   jekyll:
-    image: jekyll/jekyll:latest
+    image: jekyll/jekyll:3.8.6
     command: jekyll serve --watch --incremental --open-url --livereload
     ports:
       - 4000:4000


### PR DESCRIPTION
## Purpose of this pull request
As explained by @hguthrie in #8370, the latest image (`jekyll/jekyll:latest`) uses Ruby 2.7.0. Devdocs is using Ruby 2.6.6.

By locking the image used in Docker Compose we make sure that it stays on Ruby 2.6.6 rather than unexpectedly use Ruby 2.7.0 (or any other version) because the `latest` tag changed.

https://github.com/magento/devdocs/issues/8370#issuecomment-744767065 

Docker Compose is provided by a contributor as a nice and quick solution to run Devdocs. I do believe that even though it is provided as a "nice and quick" / "nice to have" thing, if you do so it should be maintained as well.

It's a simple and easy change which keeps other developers from being annoyed 🎉 👍 
