### PR TITLE
Update README link to docker

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ This site is built by [Jekyll](https://jekyllrb.com/), which is an open-source t
 You can build the site locally in the following ways:
 
 -  [Installing the project dependencies locally](#build-locally) (Mac, Linux)
--  [Using Docker (docker-compose)](#docker-docker-compose) (Mac, Linux, Windows)
+-  [Using Docker (docker-compose)](https://github.com/magento/devdocs/wiki/Build-DevDocs-with-Docker) (Mac, Linux, Windows)
 -  [Using a Vagrant virtual machine](https://github.com/magento-devdocs/vagrant-for-magento-devdocs) (Mac, Linux, Windows)
 -  [Build DevDocs in Windows](https://github.com/magento/devdocs/wiki/Build-DevDocs-in-Windows) (Windows 7 & 10)
 -  [Building older versions of the documentation](https://github.com/magento/devdocs/wiki/Build-DevDocs-with-Docker)


### PR DESCRIPTION
This pull request (PR) fixes a dead link to the Docker build section in the readme file. The section was removed some time ago and placed in the wiki, but the readme link still pointed to the old section. This PR changes the link to point to the wiki.