### PR TITLE
Update whastnew template and rake task

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -78,13 +78,14 @@ task :whatsnew do
   print 'Generating data for the What\'s New digest: $ '.magenta
 
   # Generate tmp/whats-new.yml
-  if since.nil? || since.empty?
-    sh 'bin/whatsup_github', 'since', last_update
-  elsif since.is_a? String
-    sh 'bin/whatsup_github', 'since', since
-  else
-    abort 'The "since" argument must be a string. Example: "jul 4"'
-  end
+  report =
+    if since.nil? || since.empty?
+      `bin/whatsup_github since '#{last_update}'`
+    elsif since.is_a? String
+      `bin/whatsup_github since #{since}`
+    else
+      abort 'The "since" argument must be a string. Example: "jul 4"'
+    end
 
   # Merge generated tmp/whats-new.yml with existing src/_data/whats-new.yml
   generated_data = YAML.load_file generated_file
@@ -94,6 +95,9 @@ task :whatsnew do
 
   puts "Writing updates to #{current_file}"
   File.write current_file, current_data.to_yaml
+
+  abort report if report.include? 'MISSING whatsnew'
+  puts report
 end
 
 desc 'Generate index for Algolia'

--- a/src/whats-new.md
+++ b/src/whats-new.md
@@ -15,9 +15,18 @@ title: What's new on DevDocs
 
 {% assign grouped_by_year = entries | group_by_exp: "entry", "entry.date | date: '%Y'" %}
 
-{% for group in grouped_by_year limit:2 %}
+{% for year_group in grouped_by_year limit:2 %}
 
-## {{ group.name }}
+{% assign grouped_by_month = year_group.items | group_by_exp: "entry", "entry.date | date: '%B'" %}
+## {{ year_group.name }}
+
+{% for month_group in grouped_by_month %}
+### {{ month_group.name }}
+
+{% assign grouped_by_date = month_group.items | group_by: "date" %}
+
+{% for date_group in grouped_by_date %}
+#### {{ date_group.name }}
 
 <table>
   <thead>
@@ -25,25 +34,21 @@ title: What's new on DevDocs
       <th>Description</th>
       <th>Versions</th>
       <th>Type</th>
-      <th>Date</th>
+      <th>Pull request</th>
     </tr>
   </thead>
   <tbody>
-  {% for item in group.items %}
+  {% for item in date_group.items %}
     <tr>
       <td>{{ item.description | markdownify }}</td>
       <td>{{ item.versions }}</td>
       <td>{{ item.type }}</td>
-      <td>
-          {%- if item.link -%}
-              <a href="{{ item.link }}">{{ item.date | date: "%B&nbsp;%e" }}</a>
-          {%- else -%}
-              {{ item.date | date: "%B&nbsp;%e" }}
-          {%- endif -%}
-      </td>
+      <td><a href="{{ item.link }}">{{ item.link | split: "/" | last }}</a></td>
     </tr>
   {% endfor %}
   </tbody>
 </table>
+{% endfor %}<!-- date_group -->
+{% endfor %}<!-- month_group -->
 
-{% endfor %}
+{% endfor %}<!-- year_group -->


### PR DESCRIPTION
## Purpose of this pull request

This pull request (PR) adds grouping by month and date to the Liquid template and makes `rake whasnew` task to return error in case of _MISSING whatsnew_ entries in the report (to be used in automation).

_Preview build: `112/whats-new.html`_

## Affected DevDocs pages

<!-- REQUIRED List the affected pages on devdocs.magento.com (URLs). Not needed for large numbers of files. -->

-  https://devdocs.magento.com/whats-new.html
