### PR TITLE
[AWS S3] MC-38901: Add release notes

### DIFF
--- a/src/guides/v2.4/release-notes/open-source-2-4-2.md
+++ b/src/guides/v2.4/release-notes/open-source-2-4-2.md
@@ -142,6 +142,12 @@ See the following articles for updates on features and changes for this release:
 
 *  [Yotpo Product Reviews]({{ site.baseurl }}/extensions/vendor/yotpo/release-notes.html)
 
+### AWS S3 support for the file storage
+
+This release adds a new functionality which allows using an AWS S3 remote storage for media files and import/export files.
+
+For more information see a [remote storage]({{ site.baseurl }}/extensions/vendor/yotpo/release-notes.html documentation.
+
 ## Fixed issues
 
 We have fixed hundreds of issues in the Magento 2.4.2 core code.

--- a/src/guides/v2.4/release-notes/open-source-2-4-2.md
+++ b/src/guides/v2.4/release-notes/open-source-2-4-2.md
@@ -142,11 +142,15 @@ See the following articles for updates on features and changes for this release:
 
 *  [Yotpo Product Reviews]({{ site.baseurl }}/extensions/vendor/yotpo/release-notes.html)
 
-### AWS S3 support for the file storage
+### AWS S3 support enhancements
 
-This release adds a new functionality which allows using an AWS S3 remote storage for media files and import/export files.
+Amazon Simple Storage Service (AWS S3) support has been enhanced to include support for:
 
-For more information see a [remote storage]({{ site.baseurl }}/guides/v2.4/config-guide/remote-storage/config-remote-storage.html) documentation.
+*  Object storage and future extensibility
+
+*  [Storing media files]({{ page.baseurl }}/config-guide/remote-storage/config-remote-storage.html) on AWS S3
+
+Support for AWS S3 has been added to all modules including B2B, PageBuilder, and Adobe Stock Integration.
 
 ## Fixed issues
 

--- a/src/guides/v2.4/release-notes/open-source-2-4-2.md
+++ b/src/guides/v2.4/release-notes/open-source-2-4-2.md
@@ -146,7 +146,7 @@ See the following articles for updates on features and changes for this release:
 
 This release adds a new functionality which allows using an AWS S3 remote storage for media files and import/export files.
 
-For more information see a [remote storage]({{ site.baseurl }}/extensions/vendor/yotpo/release-notes.html documentation.
+For more information see a [remote storage]({{ site.baseurl }}/guides/v2.4/config-guide/remote-storage/config-remote-storage.html) documentation.
 
 ## Fixed issues
 


### PR DESCRIPTION
## Purpose of this pull request

This pull request (PR) adds an entry for the AWS S3 Remote Storage feature to the Open Source release notes.

It already exists in the Commerce release notes.

## Affected DevDocs pages

- https://devdocs.magento.com/guides/v2.4/release-notes/open-source-2-4-2.html