### PR TITLE
MC-40003: [Documentation] Invalid directive for 'X-Frame-Options' header

### DIFF
--- a/src/guides/v2.3/config-guide/secy/secy-xframe.md
+++ b/src/guides/v2.3/config-guide/secy/secy-xframe.md
@@ -31,12 +31,6 @@ Set a value for `X-Frame-Options` in `<magento_root>/app/etc/env.php`. Following
 'x-frame-options' => 'SAMEORIGIN',
 ```
 
-If you want to allow any website to load page, you can use `*`:
-
-```php
-'x-frame-options' => '*',
-```
-
 We require you to edit `env.php` because it's more secure than setting a value in the [Magento Admin](https://glossary.magento.com/magento-admin).
 
 ## Verify your setting for `X-Frame-Options`


### PR DESCRIPTION
## Purpose of this pull request

- https://jira.corp.magento.com/browse/MC-40003 

## Affected DevDocs pages

- https://devdocs.magento.com/guides/v2.3/config-guide/secy/secy-xframe.html
- https://devdocs.magento.com/guides/v2.4/config-guide/secy/secy-xframe.html
