### PR TITLE
Add instructions for reverting from a split database to a single database implementation

### DIFF
--- a/src/_data/toc/configuration-guide.yml
+++ b/src/_data/toc/configuration-guide.yml
@@ -367,6 +367,9 @@ pages:
         - label: Set up optional database replication
           url: /config-guide/multi-master/multi-master_slavedb.html
 
+    - label: Configure a single database from a split database
+      url: /config-guide/revert-split-database.html
+
     - label: Custom Logging
       url: /config-guide/log/log-intro.html
       children:

--- a/src/guides/v2.4/config-guide/revert-split-database.md
+++ b/src/guides/v2.4/config-guide/revert-split-database.md
@@ -1,0 +1,1 @@
+../../v2.3/config-guide/revert-split-database.md


### PR DESCRIPTION
## Purpose of this pull request

This pull request (PR) adds a new topic with instructions for reverting from a split database to a single database implementation.

See internal build `128/guides/v2.4/config-guide/revert-split-database.html`.

## Affected DevDocs pages

- https://devdocs.magento.com/guides/v2.4/config-guide/revert-split-database.html
- https://devdocs.magento.com/guides/v2.3/config-guide/revert-split-database.html

whatsnew
Added a new topic with instructions for[ reverting from a split database to a single database ](https://devdocs.magento.com/guides/v2.4/config-guide/revert-split-database.html)implementation