### PR TITLE
Add instructions for reverting from a split database to a single database

### DIFF
--- a/src/_data/toc/configuration-guide.yml
+++ b/src/_data/toc/configuration-guide.yml
@@ -353,6 +353,9 @@ pages:
         - label: Set up optional database replication
           url: /config-guide/multi-master/multi-master_slavedb.html
 
+    - label: Configure a single database from a split database
+      url: /config-guide/revert-split-database.html
+
     - label: Custom Logging
       url: /config-guide/log/log-intro.html
       children:

--- a/src/_data/toc/configuration-guide.yml
+++ b/src/_data/toc/configuration-guide.yml
@@ -353,7 +353,7 @@ pages:
         - label: Set up optional database replication
           url: /config-guide/multi-master/multi-master_slavedb.html
 
-    - label: Configure a single database from a split database
+    - label: Revert from a split database to a single database
       url: /config-guide/revert-split-database.html
 
     - label: Custom Logging

--- a/src/guides/v2.3/config-guide/revert-split-database.md
+++ b/src/guides/v2.3/config-guide/revert-split-database.md
@@ -1,6 +1,6 @@
 ---
 group: configuration-guide
-title: Configure a single database from a split database
+title: Revert from a split database to a single database
 ee_only: true
 functional_areas:
   - Configuration
@@ -8,7 +8,7 @@ functional_areas:
   - Setup
 ---
 
-The [split database]({{ page.baseurl }}/config-guide/multi-master/multi-master.html) feature was deprecated in version 2.4.2 of {{ site.data.var.ee }} and {{ site.data.var.ce }}. Follow these instructions to revert from a split database to a single database implementation.
+The [split database]({{ page.baseurl }}/config-guide/multi-master/multi-master.html) feature was deprecated in version 2.4.2 of {{ site.data.var.ee }}. Follow these instructions to revert from a split database to a single database implementation.
 
 ## Revert a split database implementation
 
@@ -52,8 +52,7 @@ In this example, we log in to all three databases, which are installed on the sa
    mysql -h "magento2-mysql" -u root -p -e "DROP DATABASE magento_quote;"
    ```
 
-1. Remove the deployment configuration for `checkout` and `sales` in the `connections` section of the `env.php` file.
-1. Remove the deployment configuration for `checkout` and `sales` in the `resources` section of the `env.php` file.
+1. Remove the deployment configuration for `checkout` and `sales` in the `connections` and `resources` sections of the `env.php` file.
 1. Restore foreign keys:
 
    ```bash

--- a/src/guides/v2.3/config-guide/revert-split-database.md
+++ b/src/guides/v2.3/config-guide/revert-split-database.md
@@ -67,6 +67,3 @@ To verify that your single database implementation is working properly, perform 
 1. Verify that foreign keys have been restored. For example, the `QUOTE_STORE_ID_STORE_STORE_ID` key in the `quote` database table.
 1. Verify that customers can place orders from the storefront.
 1. Verify that orders created before reverting the split database to a single database are available in the Admin.
-
-{:.bs-callout-tip}
-After configuration, the single `magento_main` database should contain 435 tables.

--- a/src/guides/v2.3/config-guide/revert-split-database.md
+++ b/src/guides/v2.3/config-guide/revert-split-database.md
@@ -14,7 +14,7 @@ The [split database]({{ page.baseurl }}/config-guide/multi-master/multi-master.h
 
 Reverting from a split database to a single database implementation involves creating backups of the `magento_quote` and `magento_sales` databases before loading them into the single `magento_main` database.
 
-In this example, all three databases are installed on the same host named `magento2-mysql`.
+In this example, we log in to all three databases, which are installed on the same host (`magento2-mysql`) as the "root" user. You must replace these values with the appropriate values for your databases.
 
 1. Create a backup of the `magento_quote` database:
 

--- a/src/guides/v2.4/config-guide/revert-split-database.md
+++ b/src/guides/v2.4/config-guide/revert-split-database.md
@@ -1,0 +1,1 @@
+../../v2.3/config-guide/revert-split-database.md


### PR DESCRIPTION
## Purpose of this pull request

This pull request (PR) adds a new topic with instructions for reverting from a split database to a single database implementation.

See internal build `128/guides/v2.4/config-guide/revert-split-database.html`.

## Affected DevDocs pages

- https://devdocs.magento.com/guides/v2.4/config-guide/revert-split-database.html
- https://devdocs.magento.com/guides/v2.3/config-guide/revert-split-database.html

whatsnew
Added a new topic with instructions for[ reverting from a split database to a single database ](https://devdocs.magento.com/guides/v2.4/config-guide/revert-split-database.html)implementation