### PR TITLE
added errors coverage for billing address mutation

### DIFF
--- a/src/guides/v2.4/graphql/mutations/set-gift-options.md
+++ b/src/guides/v2.4/graphql/mutations/set-gift-options.md
@@ -184,3 +184,16 @@ Attribute |  Data Type | Description
 {% include graphql/cart-object-24.md %}
 
 [Cart query output]({{page.baseurl}}/graphql/queries/cart.html#cart-output) provides more information about the `Cart` object.
+
+## Errors
+
+Error | Description
+--- | ---
+`Could not find a cart with ID "XXX"` | The specified `cart_id` value does not exist in the `quote_id_mask` table.
+`Field SetBillingAddressOnCartInput.cart_id of required type String! was not provided.` | The value specified in the `SetShippingAddressesOnCartInput`.`cart_id` argument is empty.
+`Field CartAddressInput.firstname of required type String! was not provided.` | The value specified in the `shipping_addresses`.`firstname` argument is empty.
+`Field CartAddressInput.lastname of required type String! was not provided.` | The value specified in the `shipping_addresses`.`lastname` argument is empty.
+`Field CartAddressInput.city of required type String! was not provided.` | The value specified in the `shipping_addresses`.`city` argument is empty.
+`Field CartAddressInput.street of required type String! was not provided.` | The value specified in the `shipping_addresses`.`street` argument is empty.
+`Field CartAddressInput.country_code of required type String! was not provided.` | The value specified in the `shipping_addresses`.`country_code` argument is empty.
+`Field SetBillingAddressOnCartInput.billing_address of required type BillingAddressInput! was not provided.` | The `shipping_addresses` input attribute of type `ShippingAddressInput` is missing.


### PR DESCRIPTION
## Purpose of this pull request

This pull request (PR) adds errors coverage for setBillingAddresses mutation

## Affected DevDocs pages

-  https://devdocs.magento.com/guides/v2.4/graphql/mutations/set-billing-address.html