### PR TITLE
correct path for di.xml

### DIFF
--- a/src/guides/v2.3/frontend-dev-guide/themes/admin_theme_apply.md
+++ b/src/guides/v2.3/frontend-dev-guide/themes/admin_theme_apply.md
@@ -42,9 +42,9 @@ Each step is described further with more details.
 
 ## Specify the custom Admin theme in `di.xml` {#specify_di}
 
-You need to specify the admin theme to be used in the `<your_module_dir>/etc/adminhtml/di.xml` file. Add it, if the file does not yet exist in your module.
+You need to specify the admin theme to be used in the `<your_module_dir>/etc/di.xml` file. Add it, if the file does not yet exist in your module.
 
-In `<your_module_dir>/etc/adminhtml/di.xml` add the following (replace the placeholders with the vendor name and theme code of your Admin theme):
+In `<your_module_dir>/etc/di.xml` add the following (replace the placeholders with the vendor name and theme code of your Admin theme):
 
 ```xml
 <config xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="urn:magento:framework:ObjectManager/etc/config.xsd">


### PR DESCRIPTION
## Purpose of this pull request

This pull request fixes error
Unable to load theme by specified key: ''
with created admin theme on product edit page when following the devdocs guide.

## Affected DevDocs pages

https://devdocs.magento.com/guides/v2.3/frontend-dev-guide/themes/admin_theme_apply.html#specify_di

Also see discussion here
https://magento.stackexchange.com/questions/302592/unable-to-load-theme-by-specified-key-magento-2-3-4

This seems to be the last related ticket
https://github.com/magento/magento2/issues/26433
that once implemented may make etc/adminhtml/di.xml work (again?). However as of now the proposed changes here avoid creating an unusable admin theme.