### PR TITLE
added error coverage for remove-store-credit mutation

### DIFF
--- a/src/guides/v2.4/graphql/mutations/remove-store-credit.md
+++ b/src/guides/v2.4/graphql/mutations/remove-store-credit.md
@@ -95,3 +95,10 @@ Attribute |  Data Type | Description
 {% include graphql/cart-object-24.md %}
 
 [Cart query output]({{page.baseurl}}/graphql/queries/cart.html#cart-output) provides more information about the `Cart` object.
+
+## Errors
+
+Error | Description
+--- | ---
+`Please specify a valid customer.` | The mutation requires a valid authorization token.
+`Required parameter "cart_id" is missing` | The value specified in `cart_id` is empty.


### PR DESCRIPTION
## Purpose of this pull request

This pull request (PR) covers the error coverage of removeStoreCreditFromCart mutation 

## Affected DevDocs pages

<!-- REQUIRED List the affected pages on devdocs.magento.com (URLs). Not needed for large numbers of files. -->

-  https://devdocs.magento.com/guides/v2.4/graphql/mutations/remove-store-credit.html

