### PR TITLE
added the error coverage for removeRewardPointsFromCart mutation

### DIFF
--- a/src/guides/v2.4/graphql/mutations/remove-reward-points.md
+++ b/src/guides/v2.4/graphql/mutations/remove-reward-points.md
@@ -94,3 +94,11 @@ Attribute |  Data Type | Description
  {% include graphql/cart-object-24.md %}
 
 [Cart query output]({{page.baseurl}}/graphql/queries/cart.html#cart-output) provides more information about the `Cart` object.
+
+## Errors
+
+Error | Description
+--- | ---
+`Could not find a cart with ID \"xxxxx\"` | The ID provided in the `cart_id` field is invalid or the cart does not exist for the customer.
+`The cart isn't active` | The cart with the given cart id is unavailable as the items would have been purchased and the cart id becomes inactive.
+`Field removeRewardPointsFromCart.cart_id of required type String! was not provided` | The value specified in the `removeRewardPointsFromCart.cart_id` argument is empty.

--- a/src/guides/v2.4/graphql/mutations/remove-reward-points.md
+++ b/src/guides/v2.4/graphql/mutations/remove-reward-points.md
@@ -100,5 +100,5 @@ Attribute |  Data Type | Description
 Error | Description
 --- | ---
 `Could not find a cart with ID \"xxxxx\"` | The ID provided in the `cart_id` field is invalid or the cart does not exist for the customer.
-`The cart isn't active` | The cart with the given cart id is unavailable as the items would have been purchased and the cart id becomes inactive.
+`The cart isn't active` | The cart with the specified cart ID is unavailable, because the items have been purchased and the cart ID becomes inactive.
 `Field removeRewardPointsFromCart.cart_id of required type String! was not provided` | The value specified in the `removeRewardPointsFromCart.cart_id` argument is empty.


### PR DESCRIPTION
## Purpose of this pull request

This pull request (PR) adds the error coverage for removeRewardPointsFromCart mutation

## Affected DevDocs pages

-  /guides/v2.4/graphql/mutations/remove-reward-points.html