### PR TITLE
Added the error coverage for applyStoreCreditToCart mutation

### DIFF
--- a/src/guides/v2.3/graphql/mutations/apply-store-credit.md
+++ b/src/guides/v2.3/graphql/mutations/apply-store-credit.md
@@ -116,5 +116,5 @@ Attribute |  Data Type | Description
 Error | Description
 --- | ---
 `Could not find a cart with ID \"xxxxx\"` | The ID provided in the `cart_id` field is invalid or the cart does not exist for the customer.
-`The cart isn't active` | The cart with the given cart id is unavailable as the items would have been purchased and the cart id becomes inactive.
+`The cart isn't active` | The cart with the given cart ID is unavailable, because the items have been purchased and the cart ID becomes inactive.
 `Field ApplyStoreCreditToCartInput.cart_id of required type String! was not provided` | The value specified in the `ApplyStoreCreditToCartInput.cart_id` argument is empty.

--- a/src/guides/v2.3/graphql/mutations/apply-store-credit.md
+++ b/src/guides/v2.3/graphql/mutations/apply-store-credit.md
@@ -110,3 +110,11 @@ Attribute |  Data Type | Description
 {% include graphql/cart-object.md %}
 
 [Cart query output]({{page.baseurl}}/graphql/queries/cart.html#cart-output) provides more information about the `Cart` object.
+
+## Errors
+
+Error | Description
+--- | ---
+`Could not find a cart with ID \"xxxxx\"` | The ID provided in the `cart_id` field is invalid or the cart does not exist for the customer.
+`The cart isn't active` | The cart with the given cart id is unavailable as the items would have been purchased and the cart id becomes inactive.
+`Field ApplyStoreCreditToCartInput.cart_id of required type String! was not provided` | The value specified in the `ApplyStoreCreditToCartInput.cart_id` argument is empty.

--- a/src/guides/v2.4/graphql/mutations/apply-store-credit.md
+++ b/src/guides/v2.4/graphql/mutations/apply-store-credit.md
@@ -108,5 +108,5 @@ Attribute |  Data Type | Description
 Error | Description
 --- | ---
 `Could not find a cart with ID \"xxxxx\"` | The ID provided in the `cart_id` field is invalid or the cart does not exist for the customer.
-`The cart isn't active` | The cart with the given cart id is unavailable as the items would have been purchased and the cart id becomes inactive.
+`The cart isn't active` | The cart with the given cart ID is unavailable, because the items have been purchased and the cart ID becomes inactive.
 `Field ApplyStoreCreditToCartInput.cart_id of required type String! was not provided` | The value specified in the `ApplyStoreCreditToCartInput.cart_id` argument is empty.

--- a/src/guides/v2.4/graphql/mutations/apply-store-credit.md
+++ b/src/guides/v2.4/graphql/mutations/apply-store-credit.md
@@ -102,3 +102,9 @@ Attribute |  Data Type | Description
 {% include graphql/cart-object-24.md %}
 
 [Cart query output]({{page.baseurl}}/graphql/queries/cart.html#cart-output) provides more information about the `Cart` object.
+
+Error | Description
+--- | ---
+`Could not find a cart with ID \"xxxxx\"` | The ID provided in the `cart_id` field is invalid or the cart does not exist for the customer.
+`The cart isn't active` | The cart with the given cart id is unavailable as the items would have been purchased and the cart id becomes inactive.
+`Field ApplyStoreCreditToCartInput.cart_id of required type String! was not provided` | The value specified in the `ApplyStoreCreditToCartInput.cart_id` argument is empty.

--- a/src/guides/v2.4/graphql/mutations/apply-store-credit.md
+++ b/src/guides/v2.4/graphql/mutations/apply-store-credit.md
@@ -103,6 +103,8 @@ Attribute |  Data Type | Description
 
 [Cart query output]({{page.baseurl}}/graphql/queries/cart.html#cart-output) provides more information about the `Cart` object.
 
+## Errors
+
 Error | Description
 --- | ---
 `Could not find a cart with ID \"xxxxx\"` | The ID provided in the `cart_id` field is invalid or the cart does not exist for the customer.


### PR DESCRIPTION
## Purpose of this pull request

This pull request (PR) adds the error coverage for applyStoreCreditToCart mutation

## Affected DevDocs pages

-  /guides/v2.4/graphql/mutations/apply-store-credit.html
-  /guides/v2.3/graphql/mutations/apply-store-credit.html