### PR TITLE
Update config-reference-gitignore.md

### DIFF
--- a/src/guides/v2.4/config-guide/prod/config-reference-gitignore.md
+++ b/src/guides/v2.4/config-guide/prod/config-reference-gitignore.md
@@ -1,1 +1,1 @@
-../../../v2.3/config-guide/prod/config-reference-gitignore.md
+../../../v2.4/config-guide/prod/config-reference-gitignore.md


### PR DESCRIPTION
## Purpose of this pull request

This pull request (PR) updates link to the 2.4 `.gitignore` file instead of 2.3.

## Affected DevDocs pages

<!-- REQUIRED List the affected pages on devdocs.magento.com (URLs). Not needed for large numbers of files. -->

-  ...

## Links to Magento source code

<!--  OPTIONAL - REMOVE THIS SECTION IF NOT USED. If this pull request references a file in a Magento codebase repository, add it here. -->

-  ...

<!--
If you are fixing a GitHub issue, note it using GitHub keyword format (https://help.github.com/en/articles/closing-issues-using-keywords#closing-an-issue-in-a-different-repository) to close the issue when this pull request is merged. Example: `Fixes #1234`

`master` is the default branch. Merged pull requests to `master` go live on the site automatically. Any requested changes to content on the `master` branch must be related to the released codebase. Any content related to future releases goes in the `develop` branch.

See Contribution guidelines (https://github.com/magento/devdocs/blob/master/.github/CONTRIBUTING.md) for more information.
-->
