### PR TITLE
Fixing incorrect table name in SQL

### DIFF
--- a/src/guides/v2.3/config-guide/prod/config-reference-var-name.md
+++ b/src/guides/v2.3/config-guide/prod/config-reference-var-name.md
@@ -140,7 +140,7 @@ To get these values from the database:
 1. Use the following SQL queries to find the relevant values:
 
    ```shell
-   SELECT * FROM STORES;
+   SELECT * FROM STORE;
    SELECT * FROM STORE_WEBSITE;
    ```
 


### PR DESCRIPTION
## Purpose of this pull request

This pull request (PR) fixes an incorrect db table name in sample.

## Affected DevDocs pages

https://devdocs.magento.com/guides/v2.3/config-guide/prod/config-reference-var-name.html
https://devdocs.magento.com/guides/v2.4/config-guide/prod/config-reference-var-name.html

Replaces #8380.