### PR TITLE
MCLOUD-7120: Add command which validate .magento.env.yaml locally before push

### DIFF
--- a/src/cloud/project/magento-env-yaml.md
+++ b/src/cloud/project/magento-env-yaml.md
@@ -115,7 +115,7 @@ stage:
 
 ## Validate configuration file
 
-To validate the configuration file before pushing it to the environment you can use the command:
+Use the following CLI command to validate the `.magento.env.yaml` configuration file before pushing changes to the remote Cloud environment.
 
 ```bash
 php ./vendor/bin/ece-tools cloud:config:validate

--- a/src/cloud/project/magento-env-yaml.md
+++ b/src/cloud/project/magento-env-yaml.md
@@ -112,3 +112,13 @@ stage:
   deploy:
     CLEAN_STATIC_FILES: false
 ```
+
+## Validate configuration file
+
+To validate the configuration file before pushing it to the environment you can use the next command:
+
+```bash
+php ./vendor/bin/ece-tools cloud:config:validate
+```
+
+The command will show a list of problems in the `.magento.env.yaml` file if the configuration is not valid. 

--- a/src/cloud/project/magento-env-yaml.md
+++ b/src/cloud/project/magento-env-yaml.md
@@ -123,7 +123,7 @@ php ./vendor/bin/ece-tools cloud:config:validate
 
 The command will show a list of problems in the `.magento.env.yaml` file if the configuration is not valid, for example:
 
-```yaml
+```terminal
 Environment configuration is not valid. Correct the following items in your .magento.env.yaml file:
 The SCD_THREADS variable contains an invalid value of type string. Use the following type: integer.
 The SCD_STRATEGY variable contains an invalid value fast. Use one of the available value options: compact, quick, standard.

--- a/src/cloud/project/magento-env-yaml.md
+++ b/src/cloud/project/magento-env-yaml.md
@@ -121,4 +121,11 @@ Use the following CLI command to validate the `.magento.env.yaml` configuration 
 php ./vendor/bin/ece-tools cloud:config:validate
 ```
 
-The command will show a list of problems in the `.magento.env.yaml` file if the configuration is not valid. 
+The command will show a list of problems in the `.magento.env.yaml` file if the configuration is not valid, for example:
+
+```yaml
+Environment configuration is not valid. Correct the following items in your .magento.env.yaml file:
+The SCD_THREADS variable contains an invalid value of type string. Use the following type: integer.
+The SCD_STRATEGY variable contains an invalid value fast. Use one of the available value options: compact, quick, standard.
+The NOT_EXIST_OPTION variable is not allowed in configuration.
+``` 

--- a/src/cloud/project/magento-env-yaml.md
+++ b/src/cloud/project/magento-env-yaml.md
@@ -115,7 +115,7 @@ stage:
 
 ## Validate configuration file
 
-To validate the configuration file before pushing it to the environment you can use the next command:
+To validate the configuration file before pushing it to the environment you can use the command:
 
 ```bash
 php ./vendor/bin/ece-tools cloud:config:validate

--- a/src/cloud/project/magento-env-yaml.md
+++ b/src/cloud/project/magento-env-yaml.md
@@ -121,7 +121,7 @@ Use the following CLI command to validate the `.magento.env.yaml` configuration 
 php ./vendor/bin/ece-tools cloud:config:validate
 ```
 
-The command will show a list of problems in the `.magento.env.yaml` file if the configuration is not valid, for example:
+The following sample response provides a list of items to correct:
 
 ```terminal
 Environment configuration is not valid. Correct the following items in your .magento.env.yaml file:


### PR DESCRIPTION
## Purpose of this pull request

This pull request (PR) will add information about a new command in `ece-tools`

## Affected DevDocs pages

<!-- REQUIRED List the affected pages on devdocs.magento.com (URLs). Not needed for large numbers of files. -->

-  https://devdocs.magento.com/cloud/project/magento-env-yaml.html

<!--
If you are fixing a GitHub issue, note it using GitHub keyword format (https://help.github.com/en/articles/closing-issues-using-keywords#closing-an-issue-in-a-different-repository) to close the issue when this pull request is merged. Example: `Fixes #1234`

`master` is the default branch. Merged pull requests to `master` go live on the site automatically. Any requested changes to content on the `master` branch must be related to the released codebase. Any content related to future releases goes in the `develop` branch.

See Contribution guidelines (https://github.com/magento/devdocs/blob/master/.github/CONTRIBUTING.md) for more information.
-->
