### PR TITLE
Added a legal disclaimer about the "date_of_birth" customer attribute

### DIFF
--- a/src/_includes/graphql/create-customer.md
+++ b/src/_includes/graphql/create-customer.md
@@ -1,6 +1,6 @@
 Attribute |  Data Type | Description
 --- | --- | ---
-`date_of_birth` | String | The customer’s date of birth
+`date_of_birth` | String | The customer’s date of birth. In keeping with current security and privacy best practices, be sure you are aware of any potential legal and security risks associated with the storage of customers’ full date of birth (month, day, year) along with other personal identifiers, such as full name, before collecting or processing such data.
 `dob` | String | Deprecated. Use `date_of_birth` instead. The customer’s date of birth
 `email` | String | The customer’s email address. Required to create a customer
 `firstname` | String | The customer’s first name. Required to create a customer

--- a/src/_includes/graphql/customer-input-24.md
+++ b/src/_includes/graphql/customer-input-24.md
@@ -2,7 +2,7 @@ Attribute |  Data Type | Description
 --- | --- | ---
 `addresses` | [CustomerAddress](#customerAddressInput) | An array containing the customer's shipping and billing addresses
 `created_at` | String | Timestamp indicating when the account was created
-`date_of_birth` | String | The customer's date of birth
+`date_of_birth` | String | The customer's date of birth. In keeping with current security and privacy best practices, be sure you are aware of any potential legal and security risks associated with the storage of customers’ full date of birth (month, day, year) along with other personal identifiers, such as full name, before collecting or processing such data.
 `default_billing` | String | The ID assigned to the billing address
 `default_shipping` | String | The ID assigned to the shipping address
 `dob` | String | Deprecated. Use `date_of_birth` instead. The customer's date of birth

--- a/src/_includes/graphql/customer-input.md
+++ b/src/_includes/graphql/customer-input.md
@@ -2,7 +2,7 @@ Attribute |  Data Type | Description
 --- | --- | ---
 `addresses` | [CustomerAddress](#customerAddressInput) | An array containing the customer's shipping and billing addresses
 `created_at` | String | Timestamp indicating when the account was created
-`date_of_birth` | String | The customer's date of birth
+`date_of_birth` | String | The customer's date of birth. In keeping with current security and privacy best practices, be sure you are aware of any potential legal and security risks associated with the storage of customers’ full date of birth (month, day, year) along with other personal identifiers, such as full name, before collecting or processing such data.
 `default_billing` | String | The ID assigned to the billing address
 `default_shipping` | String | The ID assigned to the shipping address
 `dob` | String | Deprecated. Use `date_of_birth` instead. The customer's date of birth

--- a/src/_includes/graphql/customer-output-24.md
+++ b/src/_includes/graphql/customer-output-24.md
@@ -18,7 +18,7 @@ Attribute |  Data Type | Description
 --- | --- | ---
 `addresses` | {{ customeraddress_text }}  | An array containing the customer's shipping and billing addresses
 `created_at` | String | Timestamp indicating when the account was created
-`date_of_birth` | String | The customer's date of birth
+`date_of_birth` | String | The customer's date of birth. In keeping with current security and privacy best practices, be sure you are aware of any potential legal and security risks associated with the storage of customers’ full date of birth (month, day, year) along with other personal identifiers, such as full name, before collecting or processing such data.
 `default_billing` | String | The ID assigned to the billing address
 `default_shipping` | String | The ID assigned to the shipping address
 `dob` | String | Deprecated. Use `date_of_birth` instead. The customer's date of birth

--- a/src/_includes/graphql/customer-output.md
+++ b/src/_includes/graphql/customer-output.md
@@ -2,7 +2,7 @@ Attribute |  Data Type | Description
 --- | --- | ---
 `addresses` | [CustomerAddress](#customerAddressOutput)  | An array containing the customer's shipping and billing addresses
 `created_at` | String | Timestamp indicating when the account was created
-`date_of_birth` | String | The customer's date of birth
+`date_of_birth` | String | The customer's date of birth. In keeping with current security and privacy best practices, be sure you are aware of any potential legal and security risks associated with the storage of customers’ full date of birth (month, day, year) along with other personal identifiers, such as full name, before collecting or processing such data.
 `default_billing` | String | The ID assigned to the billing address
 `default_shipping` | String | The ID assigned to the shipping address
 `dob` | String | Deprecated. Use `date_of_birth` instead. The customer's date of birth

--- a/src/compliance/privacy/pi-data-reference-m2.md
+++ b/src/compliance/privacy/pi-data-reference-m2.md
@@ -45,7 +45,7 @@ Magento 2 primarily stores customer-specific information in customer, address, o
 
 ### Customer data {#customer-data}
 
-Magento 2 stores the following customer attributes:
+Magento 2 can be figured to store the following customer attributes:
 
 -  Date of Birth
 -  Email
@@ -55,6 +55,9 @@ Magento 2 stores the following customer attributes:
 -  Middle Name/Initial
 -  Name Prefix
 -  Name Suffix
+
+{:.bs-callout-info}
+In keeping with current security and privacy best practices, be sure you are aware of any potential legal and security risks associated with the storage of customers’ full date of birth (month, day, year) along with other personal identifiers, such as full name, before collecting or processing such data.
 
 #### `customer_entity` and 'customer_entity' references
 

--- a/src/guides/v2.3/config-guide/prod/config-reference-most.md
+++ b/src/guides/v2.3/config-guide/prod/config-reference-most.md
@@ -405,7 +405,7 @@ Prefix Dropdown Options | `customer/address/prefix_options` | <!-- ![Not EE-only
 Show Middle Name (initial) | `customer/address/middlename_show` | <!-- ![Not EE-only]({{ site.baseurl }}/common/images/red-x.png) --> |
 Show Suffix | `customer/address/suffix_show` | <!-- ![Not EE-only]({{ site.baseurl }}/common/images/red-x.png) --> |
 Suffix Dropdown Options | `customer/address/suffix_options` | <!-- ![Not EE-only]({{ site.baseurl }}/common/images/red-x.png) --> |
-Show Date of Birth | `customer/address/dob_show` | <!-- ![Not EE-only]({{ site.baseurl }}/common/images/red-x.png) --> |
+Show Date of Birth | `customer/address/dob_show`<br>In keeping with current security and privacy best practices, be sure you are aware of any potential legal and security risks associated with the storage of customers’ full date of birth (month, day, year) along with other personal identifiers, such as full name, before collecting or processing such data.| <!-- ![Not EE-only]({{ site.baseurl }}/common/images/red-x.png) --> |
 Show Tax/VAT Number | `customer/address/taxvat_show` | <!-- ![Not EE-only]({{ site.baseurl }}/common/images/red-x.png) --> |
 Show Gender | `customer/address/gender_show` | <!-- ![Not EE-only]({{ site.baseurl }}/common/images/red-x.png) --> |
 Enable Store Credit Functionality | `customer/magento_customerbalance/is_enabled` | ![EE-only]({{ site.baseurl }}/common/images/cloud_ee.png) |

--- a/src/guides/v2.3/extension-dev-guide/configuration/sensitive-and-environment-settings.md
+++ b/src/guides/v2.3/extension-dev-guide/configuration/sensitive-and-environment-settings.md
@@ -28,6 +28,9 @@ Examples of sensitive information include:
 *  E-mail addresses
 *  Any personally identifiable information (e.g., address, phone number, date of birth, government identification number, etc.)
 
+{:.bs-callout-info}
+In keeping with current security and privacy best practices, be sure you are aware of any potential legal and security risks associated with the storage of customers’ full date of birth (month, day, year) along with other personal identifiers, such as full name, before collecting or processing such data.
+
 ### Environment or system-specific values
 
 _Environment_ or _system-specific_ values are unique to the system where Magento is deployed.

--- a/src/guides/v2.3/graphql/develop/resolvers.md
+++ b/src/guides/v2.3/graphql/develop/resolvers.md
@@ -284,13 +284,16 @@ input CustomerInput {
     lastname: String @doc(description: "The customer's family name")
     suffix: String @doc(description: "A value such as Sr., Jr., or III")
     email: String @doc(description: "The customer's email address. Required")
-    date_of_birth: String @doc(description: "The customer's date of birth")
+    date_of_birth: String @doc(description: "The customer's date of birth.")
     taxvat: String @doc(description: "The customer's Tax/VAT number (for corporate customers)")
     gender: Int @doc(description: "The customer's gender(Male - 1, Female - 2)")
     password: String @doc(description: "The customer's password")
     is_subscribed: Boolean @doc(description: "Indicates whether the customer is subscribed to the company's newsletter")
 }
 ```
+
+{:.bs-callout-info}
+In keeping with current security and privacy best practices, be sure you are aware of any potential legal and security risks associated with the storage of customers’ full date of birth (month, day, year) along with other personal identifiers, such as full name, before collecting or processing such data.
 
 The `createCustomer` mutation returns `CustomerOutput` object
 
@@ -319,7 +322,9 @@ type Customer @doc(description: "Customer defines the customer name and address 
     addresses: [CustomerAddress] @doc(description: "An array containing the customer's shipping and billing addresses")
     gender: Int @doc(description: "The customer's gender (Male - 1, Female - 2)")
 }
-```
+
+{:.bs-callout-info}
+In keeping with current security and privacy best practices, be sure you are aware of any potential legal and security risks associated with the storage of customers’ full date of birth (month, day, year) along with other personal identifiers, such as full name, before collecting or processing such data.
 
 The following example shows the `createCustomer` mutation in action:
 

--- a/src/guides/v2.4/config-guide/prod/config-reference-most.md
+++ b/src/guides/v2.4/config-guide/prod/config-reference-most.md
@@ -406,7 +406,7 @@ Prefix Dropdown Options | `customer/address/prefix_options` | <!-- ![Not EE-only
 Show Middle Name (initial) | `customer/address/middlename_show` | <!-- ![Not EE-only]({{ site.baseurl }}/common/images/red-x.png) --> |
 Show Suffix | `customer/address/suffix_show` | <!-- ![Not EE-only]({{ site.baseurl }}/common/images/red-x.png) --> |
 Suffix Dropdown Options | `customer/address/suffix_options` | <!-- ![Not EE-only]({{ site.baseurl }}/common/images/red-x.png) --> |
-Show Date of Birth | `customer/address/dob_show` | <!-- ![Not EE-only]({{ site.baseurl }}/common/images/red-x.png) --> |
+Show Date of Birth | `customer/address/dob_show`<br>In keeping with current security and privacy best practices, be sure you are aware of any potential legal and security risks associated with the storage of customers’ full date of birth (month, day, year) along with other personal identifiers, such as full name, before collecting or processing such data.| <!-- ![Not EE-only]({{ site.baseurl }}/common/images/red-x.png) --> |
 Show Tax/VAT Number | `customer/address/taxvat_show` | <!-- ![Not EE-only]({{ site.baseurl }}/common/images/red-x.png) --> |
 Show Gender | `customer/address/gender_show` | <!-- ![Not EE-only]({{ site.baseurl }}/common/images/red-x.png) --> |
 Enable Store Credit Functionality | `customer/magento_customerbalance/is_enabled` | ![EE-only]({{ site.baseurl }}/common/images/cloud_ee.png) |

--- a/src/guides/v2.4/graphql/mutations/create-customer-v2.md
+++ b/src/guides/v2.4/graphql/mutations/create-customer-v2.md
@@ -61,7 +61,7 @@ The following table lists the attributes you can use as input for the `createCus
 
 Attribute |  Data Type | Description
 --- | --- | ---
-`date_of_birth` | String | The customer’s date of birth
+`date_of_birth` | String | The customer’s date of birth. In keeping with current security and privacy best practices, be sure you are aware of any potential legal and security risks associated with the storage of customers’ full date of birth (month, day, year) along with other personal identifiers, such as full name, before collecting or processing such data.
 `dob` | String | Deprecated. Use `date_of_birth` instead. The customer’s date of birth
 `email` | String! | The customer’s email address
 `firstname` | String! | The customer’s first name

--- a/src/guides/v2.4/graphql/mutations/update-customer-v2.md
+++ b/src/guides/v2.4/graphql/mutations/update-customer-v2.md
@@ -56,7 +56,7 @@ The following table lists the attributes you can use as input for the `updateCus
 
 Attribute |  Data Type | Description
 --- | --- | ---
-`date_of_birth` | String | The customer’s date of birth
+`date_of_birth` | String | The customer’s date of birth. In keeping with current security and privacy best practices, be sure you are aware of any potential legal and security risks associated with the storage of customers’ full date of birth (month, day, year) along with other personal identifiers, such as full name, before collecting or processing such data.
 `dob` | String | Deprecated. Use `date_of_birth` instead. The customer’s date of birth
 `firstname` | String | The customer’s first name
 `gender` | Int | The customer's gender (Male - 1, Female - 2)


### PR DESCRIPTION
## Purpose of this pull request

This pull request (PR) adds a legal disclaimer to places in the docs where we reference the `date_of_birth` attribute of the `customer` database entity.

- See internal ticket `DOC-244` for more details.
- See internal staging build `#138` for HTML preview.

The `dob` attribute exists in the REST API reference docs as well, however, we will address that separately from this pull request.

## Affected DevDocs pages

- https://devdocs.magento.com/compliance/privacy/pi-data-reference-m2.html#customer-data
- https://devdocs.magento.com/guides/v2.4/config-guide/prod/config-reference-most.html#customer-configuration-paths
- https://devdocs.magento.com/guides/v2.3/config-guide/prod/config-reference-most.html#customer-configuration-paths
- https://devdocs.magento.com/guides/v2.4/extension-dev-guide/configuration/sensitive-and-environment-settings.html#sensitive-values
- https://devdocs.magento.com/guides/v2.3/extension-dev-guide/configuration/sensitive-and-environment-settings.html#sensitive-values
- https://devdocs.magento.com/guides/v2.4/graphql/mutations/update-customer.html
- https://devdocs.magento.com/guides/v2.4/graphql/mutations/create-customer.html
- https://devdocs.magento.com/guides/v2.4/graphql/mutations/create-customer-v2.html
- https://devdocs.magento.com/guides/v2.4/graphql/mutations/update-customer-v2.html
- https://devdocs.magento.com/guides/v2.4/graphql/mutations/change-customer-password.html
- https://devdocs.magento.com/guides/v2.4/graphql/mutations/update-customer-email.html
- https://devdocs.magento.com/guides/v2.4/graphql/queries/customer.html
- https://devdocs.magento.com/guides/v2.4/graphql/develop/resolvers.html

whatsnew
Added a [legal disclaimer](https://devdocs.magento.com/compliance/privacy/pi-data-reference-m2.html#customer-data) to references of the `date_of_birth` attribute of the `customer` database entity.