### PR TITLE
Inventory 1.2.2 release notes.

### DIFF
--- a/src/guides/v2.3/inventory/release-notes.md
+++ b/src/guides/v2.3/inventory/release-notes.md
@@ -23,11 +23,11 @@ The release notes include:
 ### v1.2.2
 {{site.data.var.im}} 1.2.2 (module version: `magento/inventory-metapackage = 1.2.2`) is supported with version 2.4.2 and compatible with version 2.4.0 of {{site.data.var.ce}}, {{site.data.var.ee}}, and {{site.data.var.ece}}.
 
--  {:.fix} Fixed several issue related to the composite product visibility on the frontend.
+-  {:.fix} Fixed several issues related to the composite product visibility on the frontend.
 
 -  {:.fix} Improved cart page performance during quantity update on B2B.
 
--  {:.fix} Several bug fixes targeted to resolve issues with in-store pickup, mass updates and inventory threshold.
+-  {:.fix} Several bug fixes targeted to resolve issues with in-store pickup, mass updates, and inventory threshold.
 
 -  {:.new} **Functional tests.** Introduced new functional tests and provided fixes for existing tests to make them more stable.
 

--- a/src/guides/v2.3/inventory/release-notes.md
+++ b/src/guides/v2.3/inventory/release-notes.md
@@ -31,7 +31,6 @@ The release notes include:
 
 -  {:.new} **Functional tests.** Introduced new functional tests and provided fixes for existing tests to make them more stable.
 
-
 ### v1.2.1
 {{site.data.var.im}} 1.2.1 (module version: `magento/inventory-metapackage = 1.2.1`) is supported with version 2.4.1 and compatible with version 2.4.0 of {{site.data.var.ce}}, {{site.data.var.ee}}, and {{site.data.var.ece}}.
 

--- a/src/guides/v2.3/inventory/release-notes.md
+++ b/src/guides/v2.3/inventory/release-notes.md
@@ -20,6 +20,18 @@ The release notes include:
 -  {:.fix}Fixes and improvements
 -  {:.bug}Known issues
 
+### v1.2.2
+{{site.data.var.im}} 1.2.2 (module version: `magento/inventory-metapackage = 1.2.2`) is supported with version 2.4.2 and compatible with version 2.4.0 of {{site.data.var.ce}}, {{site.data.var.ee}}, and {{site.data.var.ece}}.
+
+-  {:.fix} Fixed several issue related to the composite product visibility on the frontend.
+
+-  {:.fix} Improved cart page performance during quantity update on B2B.
+
+-  {:.fix} Several bug fixes targeted to resolve issues with in-store pickup, mass updates and inventory threshold. 
+
+-  {:.new} **Functional tests.** Introduced new functional tests and provided fixes for existing tests to make them more stable.
+
+
 ### v1.2.1
 {{site.data.var.im}} 1.2.1 (module version: `magento/inventory-metapackage = 1.2.1`) is supported with version 2.4.1 and compatible with version 2.4.0 of {{site.data.var.ce}}, {{site.data.var.ee}}, and {{site.data.var.ece}}.
 

--- a/src/guides/v2.3/inventory/release-notes.md
+++ b/src/guides/v2.3/inventory/release-notes.md
@@ -27,7 +27,7 @@ The release notes include:
 
 -  {:.fix} Improved cart page performance during quantity update on B2B.
 
--  {:.fix} Several bug fixes targeted to resolve issues with in-store pickup, mass updates and inventory threshold. 
+-  {:.fix} Several bug fixes targeted to resolve issues with in-store pickup, mass updates and inventory threshold.
 
 -  {:.new} **Functional tests.** Introduced new functional tests and provided fixes for existing tests to make them more stable.
 


### PR DESCRIPTION
## Purpose of this pull request

This pull request (PR) adds release notes for Inventory 1.2.2.

## Affected DevDocs pages

- https://devdocs.magento.com/guides/v2.3/inventory/release-notes.html

whatsnew
Published release notes for [Inventory](https://devdocs.magento.com/guides/v2.3/inventory/release-notes.html) 1.2.2.