### PR TITLE
GraphQL: Add bundle product examples to addProductsToCart

### DIFF
--- a/src/guides/v2.4/graphql/mutations/add-products-to-cart.md
+++ b/src/guides/v2.4/graphql/mutations/add-products-to-cart.md
@@ -50,7 +50,7 @@ mutation {
 
 These examples show the minimal payload for adding products, including those with customizable options.
 
-### Add a product to a cart
+### Add a simple product to a cart
 
 The following example adds a simple product to a cart.
 
@@ -244,9 +244,12 @@ mutation {
 }
 ```
 
-### Add a product with entered options
+### Add a simple product with entered options
 
 The following example adds a simple product with a customizable option to the cart. The customizable option allows the shopper to specify a message for engraving.
+
+{:.bs-callout-info}
+The customizable option is not part of the Luma sample data.
 
 **Request:**
 
@@ -317,6 +320,200 @@ mutation {
             "quantity": 1
           }
         ]
+      }
+    }
+  }
+}
+```
+
+## Add a bundle product with selected options to a cart
+
+The following example adds the Sprite Yoga Companion Kit bundle product to the cart. The bundle product is comprised of four simple products, and the selected simple products are specified with a value in the `selected_options` array. Use the `products` query to determine these UID values. Note that each UID value is an encoded value representing the following string:
+
+`bundle/<bundle_option_id>/<bundle_option_selection_id>/<quantity>`
+
+Because the encoded value includes the quantity, the schema does not contain a `quantity` attribute for individual simple products.
+
+In this example, the UID values are encoded versions of these strings:
+
+```text
+bundle/1/1/1
+bundle/2/4/1
+bundle/3/5/1
+bundle/4/8/1
+```
+
+**Request:**
+
+```graphql
+mutation {
+  addProductsToCart(
+    cartId: "ELwvX8VJinGJ9Q2vOXSiCTS4gvCDKP8U"
+    cartItems: [
+      {
+        quantity: 1
+        sku: "24-WG080"
+        selected_options: [
+          "YnVuZGxlLzEvMS8x"
+          "YnVuZGxlLzIvNC8x"
+          "YnVuZGxlLzMvNS8x"
+          "YnVuZGxlLzQvOC8x"
+        ]
+      }
+    ]
+  ) {
+    cart {
+      items {
+        uid
+        product {
+          name
+          sku
+        }
+        quantity
+        ... on BundleCartItem {
+          bundle_options {
+            uid
+            label
+            type
+            values {
+              id
+              label
+              price
+              quantity
+            }
+          }
+        }
+      }
+    }
+  }
+}
+```
+
+**Response:**
+
+```json
+{
+  "data": {
+    "addProductsToCart": {
+      "cart": {
+        "items": [
+          {
+            "uid": "MTQ=",
+            "product": {
+              "name": "Sprite Yoga Companion Kit",
+              "sku": "24-WG080"
+            },
+            "quantity": 1,
+            "bundle_options": [
+              {
+                "uid": "YnVuZGxlLzE=",
+                "label": "Sprite Stasis Ball",
+                "type": "radio",
+                "values": [
+                  {
+                    "id": 1,
+                    "label": "Sprite Stasis Ball 55 cm",
+                    "price": 23,
+                    "quantity": 1
+                  }
+                ]
+              },
+              {
+                "uid": "YnVuZGxlLzI=",
+                "label": "Sprite Foam Yoga Brick",
+                "type": "radio",
+                "values": [
+                  {
+                    "id": 4,
+                    "label": "Sprite Foam Yoga Brick",
+                    "price": 5,
+                    "quantity": 1
+                  }
+                ]
+              },
+              {
+                "uid": "YnVuZGxlLzM=",
+                "label": "Sprite Yoga Strap",
+                "type": "radio",
+                "values": [
+                  {
+                    "id": 5,
+                    "label": "Sprite Yoga Strap 6 foot",
+                    "price": 14,
+                    "quantity": 1
+                  }
+                ]
+              },
+              {
+                "uid": "YnVuZGxlLzQ=",
+                "label": "Sprite Foam Roller",
+                "type": "radio",
+                "values": [
+                  {
+                    "id": 8,
+                    "label": "Sprite Foam Roller",
+                    "price": 19,
+                    "quantity": 1
+                  }
+                ]
+              }
+            ]
+          }
+        ]
+      }
+    }
+  }
+}
+```
+
+### Add a bundle product with entered options to the cart
+
+For `entered_options`, the `uid` attribute contains the encoded entered value. The `value` attribute defines the quantity. If the `BundleProduct.items.options.can_change_quantity` attribute is `false`, then the bundle product definition sets the quantity for the simple product. Otherwise, the shopper decides the quantity.
+
+The Luma sample data does not provide any bundle products with entered options. The following snippet shows how to construct the mutation.
+
+```graphql
+mutation {
+  addProductsToCart(
+    cartId: "ELwvX8VJinGJ9Q2vOXSiCTS4gvCDKP8U"
+    cartItems: [
+      {
+        quantity: 1
+        sku: "bundle1"
+        entered_options: [
+          {
+            uid: "EncodedEnteredValue1"
+            value: 1
+          }
+        ]
+        selected_options: [
+          "EncodedSelectedValue1"
+          "EncodedSelectedValue2"
+        ]
+      }
+    ]
+  ) {
+    cart {
+      items {
+        uid
+        product {
+          name
+          sku
+        }
+        quantity
+        ... on BundleCartItem {
+          bundle_options {
+            uid
+            label
+            type
+            values {
+              id
+              label
+              price
+              quantity
+            }
+          }
+        }
       }
     }
   }


### PR DESCRIPTION
## Purpose of this pull request

This pull request (PR) adds examples of adding bundle products to the `addProductsToCart` mutation.

## Affected DevDocs pages

<!-- REQUIRED List the affected pages on devdocs.magento.com (URLs). Not needed for large numbers of files. -->

-    https://devdocs.magento.com/guides/v2.4/graphql/mutations/add-products-to-cart.html

## Links to Magento source code

<!--  OPTIONAL - REMOVE THIS SECTION IF NOT USED. If this pull request references a file in a Magento codebase repository, add it here. -->

-

<!--
If you are fixing a GitHub issue, note it using GitHub keyword format (https://help.github.com/en/articles/closing-issues-using-keywords#closing-an-issue-in-a-different-repository) to close the issue when this pull request is merged. Example: `Fixes #1234`

`master` is the default branch. Merged pull requests to `master` go live on the site automatically. Any requested changes to content on the `master` branch must be related to the released codebase. Any content related to future releases goes in the `develop` branch.

See Contribution guidelines (https://github.com/magento/devdocs/blob/master/.github/CONTRIBUTING.md) for more information.
-->
