### PR TITLE
Whatsnew fix

### DIFF
--- a/src/_data/whats-new.yml
+++ b/src/_data/whats-new.yml
@@ -14,6 +14,16 @@ entries:
   link: https://github.com/magento/devdocs/pull/8488
   contributor: jeff-matthews
   profile: https://github.com/jeff-matthews
+- description: "- [Cloud Docker 1.2.1 release notes](https://devdocs.magento.com/cloud/release-notes/mcd-release-notes.html).<br/>-
+    New Cloud Docker build command option for generating a Docker configuration without
+    a [TLS container](https://devdocs.magento.com/cloud/docker/docker-containers-service.html#tls-container).<br/>-
+    New Cloud Docker build commands for configuring NGINX for the [Web container](https://devdocs.magento.com/cloud/docker/docker-containers-service.html#web-container)."
+  versions: ''
+  type: Major Update
+  date: December 22, 2020
+  link: https://github.com/magento/devdocs/pull/8429
+  contributor: bdenham
+  profile: https://github.com/bdenham
 - description: Added a new topic with instructions for [reverting from a split database
     to a single database](https://devdocs.magento.com/guides/v2.4/config-guide/revert-split-database.html)
     implementation.

--- a/src/_data/whats-new.yml
+++ b/src/_data/whats-new.yml
@@ -14,7 +14,7 @@ entries:
   link: https://github.com/magento/devdocs/pull/8488
   contributor: jeff-matthews
   profile: https://github.com/jeff-matthews
-- description: Published release notes for [Cloud Docker 1.2.1 release notes](https://devdocs.magento.com/cloud/release-notes/mcd-release-notes.html).
+- description: Published release notes for [Cloud Docker 1.2.1 release notes](https://devdocs.magento.com/cloud/release-notes/mcd-release-notes.html#v121).
   versions: 2.4.x
   type: Major Update
   date: December 22, 2020

--- a/src/_data/whats-new.yml
+++ b/src/_data/whats-new.yml
@@ -14,7 +14,7 @@ entries:
   link: https://github.com/magento/devdocs/pull/8488
   contributor: jeff-matthews
   profile: https://github.com/jeff-matthews
-- description: Published release notes for [Cloud Docker 1.2.1 release notes](https://devdocs.magento.com/cloud/release-notes/mcd-release-notes.html#v121).
+- description: Published release notes for [Cloud Docker 1.2.1](https://devdocs.magento.com/cloud/release-notes/mcd-release-notes.html#v121).
   versions: 2.4.x
   type: Major Update
   date: December 22, 2020

--- a/src/_data/whats-new.yml
+++ b/src/_data/whats-new.yml
@@ -14,11 +14,8 @@ entries:
   link: https://github.com/magento/devdocs/pull/8488
   contributor: jeff-matthews
   profile: https://github.com/jeff-matthews
-- description: "- [Cloud Docker 1.2.1 release notes](https://devdocs.magento.com/cloud/release-notes/mcd-release-notes.html).<br/>-
-    New Cloud Docker build command option for generating a Docker configuration without
-    a [TLS container](https://devdocs.magento.com/cloud/docker/docker-containers-service.html#tls-container).<br/>-
-    New Cloud Docker build commands for configuring NGINX for the [Web container](https://devdocs.magento.com/cloud/docker/docker-containers-service.html#web-container)."
-  versions: ''
+- description: Published release notes for [Cloud Docker 1.2.1 release notes](https://devdocs.magento.com/cloud/release-notes/mcd-release-notes.html).
+  versions: 2.4.x
   type: Major Update
   date: December 22, 2020
   link: https://github.com/magento/devdocs/pull/8429


### PR DESCRIPTION
## Purpose of this pull request

This pull request (PR) adds the Cloud Docker 1.2.1 release to the whats new page.

## Affected DevDocs pages

https://devdocs.magento.com/whats-new.html

![image](https://user-images.githubusercontent.com/1828494/104375068-6810a800-54e8-11eb-96b5-7d71d3ae712c.png)
