### PR TITLE
Updated mcd-release var

### DIFF
--- a/src/_data/var.yml
+++ b/src/_data/var.yml
@@ -31,7 +31,7 @@ mcp-package: magento/magento-cloud-patches
 mcp-release: 1.0.8
 mcd-package: magento/magento-cloud-docker
 mcd-prod: Magento Cloud Docker
-mcd-release: 1.2.0
+mcd-release: 1.2.1
 mcc-prod: Magento Cloud Components
 mcc-package: magento/magento-cloud-components
 mcc-release: 1.0.7


### PR DESCRIPTION
## Purpose of this pull request

This pull request (PR) updates the current Cloud Docker release variable.

## Affected DevDocs pages

https://devdocs.magento.com/cloud/release-notes/cloud-tools.html
