### PR TITLE
GraphQL: Add total_giftcard to schema

### DIFF
--- a/src/_includes/graphql/customer-orders-output.md
+++ b/src/_includes/graphql/customer-orders-output.md
@@ -247,6 +247,7 @@ Attribute | Data type | Description
 `shipping_handling` | [ShippingHandling](#ShippingHandling) | The shipping and handling costs for the order
 `subtotal` | Money! | The subtotal of the order, excluding shipping, discounts, and taxes
 `taxes` | [[TaxItem]](#TaxItem)! | An array containing information about taxes on individual orders
+`total_giftcard` | Money | The gift card balance applied to the order
 `total_shipping` | Money! | The shipping costs for the order
 `total_tax` | Money! | The amount of tax applied to the order
 


### PR DESCRIPTION
## Purpose of this pull request

This pull request (PR) adds the `total_giftcard` attribute to the OrderTotal data type, per https://github.com/magento/partners-magento2ee/pull/440.

## Affected DevDocs pages

<!-- REQUIRED List the affected pages on devdocs.magento.com (URLs). Not needed for large numbers of files. -->

-  ...

## Links to Magento source code

<!--  OPTIONAL - REMOVE THIS SECTION IF NOT USED. If this pull request references a file in a Magento codebase repository, add it here. -->

-  ...

<!--
If you are fixing a GitHub issue, note it using GitHub keyword format (https://help.github.com/en/articles/closing-issues-using-keywords#closing-an-issue-in-a-different-repository) to close the issue when this pull request is merged. Example: `Fixes #1234`

`master` is the default branch. Merged pull requests to `master` go live on the site automatically. Any requested changes to content on the `master` branch must be related to the released codebase. Any content related to future releases goes in the `develop` branch.

See Contribution guidelines (https://github.com/magento/devdocs/blob/master/.github/CONTRIBUTING.md) for more information.
-->
