### PR TITLE
MC-40381: [Documentation] Update documentation for DMT not used code migration tool

### DIFF
--- a/src/guides/v2.3/migration/bk-migration-guide.md
+++ b/src/guides/v2.3/migration/bk-migration-guide.md
@@ -21,8 +21,6 @@ We have developed the **Magento 2 Data Migration Tool** to help you efficiently 
 ### Extensions and custom code {#migrate-extensions-code}
 We have been working hard with the development community to help you use your Magento 1 extensions in Magento 2. Now we are proud to present the [Magento Marketplace](https://marketplace.magento.com/){:target="_blank"}, where you can download or purchase the latest versions of your favorite extensions.
 
-Also, we have developed the [Code Migration Toolkit](https://github.com/magento/code-migration){:target="_blank"}, which will help to port your extensions and custom code to Magento 2, significantly reducing your efforts.
-
 More information on developing extensions for Magento 2 is available in the [PHP Developer Guide]({{ page.baseurl }}/extension-dev-guide/bk-extension-dev-guide.html){:target="_blank"}.
 
 ### Themes and customizations {#migrate-themes-customizations}


### PR DESCRIPTION
## Purpose of this pull request

This pull request (PR) is to remove a reference to an obsolete and archived Code Migration Toolkit

## Affected DevDocs pages

-  https://devdocs.magento.com/guides/v2.4/migration/bk-migration-guide.html
-  https://devdocs.magento.com/guides/v2.3/migration/bk-migration-guide.html

Fixes #8441 

<!--
If you are fixing a GitHub issue, note it using GitHub keyword format (https://help.github.com/en/articles/closing-issues-using-keywords#closing-an-issue-in-a-different-repository) to close the issue when this pull request is merged. Example: `Fixes #1234`

`master` is the default branch. Merged pull requests to `master` go live on the site automatically. Any requested changes to content on the `master` branch must be related to the released codebase. Any content related to future releases goes in the `develop` branch.

See Contribution guidelines (https://github.com/magento/devdocs/blob/master/.github/CONTRIBUTING.md) for more information.
-->
