### PR TITLE
Cloud: fix code block in Snapshots topic

### DIFF
--- a/src/cloud/project/project-webint-snap.md
+++ b/src/cloud/project/project-webint-snap.md
@@ -122,7 +122,7 @@ By default, this command creates backups for all database connections that are s
 You can also backup only selected databases by appending the database names to the command, for example:
 
 ```bash
-php vendor/bin/ece-tools -- main sales
+php vendor/bin/ece-tools -- main sales ```
 
 For help, use the command: ```php vendor/bin/ece-tools db-dump --help ```
 

--- a/src/cloud/project/project-webint-snap.md
+++ b/src/cloud/project/project-webint-snap.md
@@ -122,9 +122,10 @@ By default, this command creates backups for all database connections that are s
 You can also backup only selected databases by appending the database names to the command, for example:
 
 ```bash
-php vendor/bin/ece-tools -- main sales ```
+php vendor/bin/ece-tools -- main sales
+```
 
-For help, use the command: ```php vendor/bin/ece-tools db-dump --help ```
+For help, use the command: `php vendor/bin/ece-tools db-dump --help`
 
 {:.procedure}
 To create a database dump:


### PR DESCRIPTION
Added ``` to command bash
php vendor/bin/ece-tools -- main sales to format correctly in the section titled Dump your database {#db-dump}

## Purpose of this pull request

This pull request (PR) ...

## Affected DevDocs pages

<!-- REQUIRED List the affected pages on devdocs.magento.com (URLs). Not needed for large numbers of files. -->

Snapshots and backup management: https://devdocs.magento.com/cloud/project/project-webint-snap.html
