### PR TITLE
Config Guide: Fix link to external file

### DIFF
--- a/src/guides/v2.4/config-guide/prod/config-reference-gitignore.md
+++ b/src/guides/v2.4/config-guide/prod/config-reference-gitignore.md
@@ -1,0 +1,14 @@
+---
+group: configuration-guide
+title: .gitignore reference
+functional_areas:
+  - Configuration
+  - System
+  - Setup
+---
+
+We include a base `.gitignore` file with the {{site.data.var.ce}} project repository. See [the latest Magento `.gitignore`](https://raw.githubusercontent.com/magento/magento2/2.4/.gitignore) file. If you need to add a file that is in the `.gitignore` list, you can use the -f (force) option when staging a commit:
+
+```bash
+git add <path/filename> -f
+```

--- a/src/guides/v2.4/config-guide/prod/config-reference-gitignore.md
+++ b/src/guides/v2.4/config-guide/prod/config-reference-gitignore.md
@@ -1,1 +1,0 @@
-../../../v2.3/config-guide/prod/config-reference-gitignore.md


### PR DESCRIPTION
## Purpose of this pull request

This pull request (PR) updates the link to the `2.4 .gitignore` file. Currently, the link connects to the 2.3 version. I have to break the symlink and create a new 2.4 topic.

## Affected DevDocs pages

https://devdocs.magento.com/guides/v2.4/config-guide/prod/config-reference-gitignore.html