### PR TITLE
MC-39970: [Documentation] Incorrect GraphQL response for minimum and …

### DIFF
--- a/src/guides/v2.4/graphql/queries/products.md
+++ b/src/guides/v2.4/graphql/queries/products.md
@@ -1050,12 +1050,12 @@ In the following example, a catalog price rule that provides a 10% discount on a
                 "currency": "USD"
               },
               "final_price": {
-                "value": 61,
+                "value": 54.9,
                 "currency": "USD"
               },
               "discount": {
-                "amount_off": 0,
-                "percent_off": 0
+                "amount_off": 6.1,
+                "percent_off": 10
               }
             },
             "maximum_price": {
@@ -1064,12 +1064,12 @@ In the following example, a catalog price rule that provides a 10% discount on a
                 "currency": "USD"
               },
               "final_price": {
-                "value": 77,
+                "value": 69.3,
                 "currency": "USD"
               },
               "discount": {
-                "amount_off": 0,
-                "percent_off": 0
+                "amount_off": 7.7,
+                "percent_off": 10
               }
             }
           }


### PR DESCRIPTION
## Purpose of this pull request


This pull request (PR) to correct the GraphQL response of "Return minimum and maximum prices and discount information"
The original issue link which is delivered is https://jira.corp.magento.com/browse/MC-39896
## Affected DevDocs pages
Page with the issue:
https://devdocs.magento.com/guides/v2.4/graphql/queries/products.html

Section on the page with the issue: "Return minimum and maximum prices and discount information"
<!-- REQUIRED List the affected pages on devdocs.magento.com (URLs). Not needed for large numbers of files. -->

-  ...

## Links to Magento source code

<!--  OPTIONAL - REMOVE THIS SECTION IF NOT USED. If this pull request references a file in a Magento codebase repository, add it here. -->

-  ...

<!--
If you are fixing a GitHub issue, note it using GitHub keyword format (https://help.github.com/en/articles/closing-issues-using-keywords#closing-an-issue-in-a-different-repository) to close the issue when this pull request is merged. Example: `Fixes #1234`

`master` is the default branch. Merged pull requests to `master` go live on the site automatically. Any requested changes to content on the `master` branch must be related to the released codebase. Any content related to future releases goes in the `develop` branch.

See Contribution guidelines (https://github.com/magento/devdocs/blob/master/.github/CONTRIBUTING.md) for more information.
-->
