### PR TITLE
MC-40582: Update the install page with how to download the SUT tool via command line

### DIFF
--- a/src/_includes/layout/page-header.html
+++ b/src/_includes/layout/page-header.html
@@ -44,7 +44,7 @@
 
   {% if page.url contains "safe-upgrade-tool/" %}
   <div class="message-banner">
-    This tool is an ALPHA version with limited scope, available for all Magento Commerce merchants, only validating PHP Magento APIs and GraphQL schema. If you are a Magento Commerce user you can download it at the <a href="https://repo.magento.com/">Magento repo</a>.
+    This tool is an ALPHA version with limited scope, available for all Magento Commerce merchants, and only validating PHP Magento APIs and GraphQL schema. If you are a Magento Commerce user you can download it at the <a href="https://repo.magento.com/">Magento repo</a>.
   </div>
   {% endif %}
 

--- a/src/_includes/layout/page-header.html
+++ b/src/_includes/layout/page-header.html
@@ -44,7 +44,7 @@
 
   {% if page.url contains "safe-upgrade-tool/" %}
   <div class="message-banner">
-    This tool is still in ALPHA with limited scope. If you are a Magento Commerce user you can download it at <a href="https://repo.magento.com/">Magento repo</a>.
+    This tool is an ALPHA version with limited scope, available for all Magento Commerce merchants, only validating PHP Magento APIs and GraphQL schema. If you are a Magento Commerce user you can download it at the <a href="https://repo.magento.com/">Magento repo</a>.
   </div>
   {% endif %}
 

--- a/src/quality-patches/release-notes.md
+++ b/src/quality-patches/release-notes.md
@@ -40,7 +40,7 @@ See [Patches available in MQP tool](https://support.magento.com/hc/en-us/section
 -  **MDVA-20376** _(for Magento `>=2.3.2 <2.3.4`)_—Fixes the issue with the 'No such entity with customerId = 1' error in the exception.log for logged in customers after order placement.
 -  **MDVA-23764** _(for Magento `>=2.3.2 <2.3.5`)_—Fixes the bug in JsFooterPlugin.php that affects the display of dynamic blocks.
 -  **MDVA-13203** _(for Magento `>=2.3.0 <2.4.2`)_—Fixes the issue where the 'Integrity constrain violation search_tmp_* table' error appears after a full reindex.
-d-  **MDVA-23426** _(for Magento `>=2.3.3 <2.3.5`)_—Fixes the issue where notification emails sent by Magento contain a blank body with content being added as attachment.
+-  **MDVA-23426** _(for Magento `>=2.3.3 <2.3.5`)_—Fixes the issue where notification emails sent by Magento contain a blank body with content being added as attachment.
 -  **MDVA-22150** _(for Magento `>=2.3.1 <2.3.4`)_—Fixes the issue where customers with a configurable product in cart and a coupon applied, cannot login if that configurable product is disabled in Admin.
 -  **MDVA-32545** _(for Magento `>=2.3.0 <2.4.2`)_—Fixes the issue where invoices are not sent out automatically when creating orders from Admin.
 -  **MDVA-32714** _(for Magento `>=2.3.4 <2.4.1`)_—Fixes the issue where customer group price is not working in GraphQL product query.

--- a/src/safe-upgrade-tool/install.md
+++ b/src/safe-upgrade-tool/install.md
@@ -8,20 +8,17 @@ functional_areas:
 
 The Safe Upgrade Tool ALPHA (SUT) is a command line (CLI) tool that checks a Magento instance against a specific version by analyzing all the non-Magento modules installed on it.
 
-{:.bs-callout-warning}
-At the moment this is an ALPHA version with limited scope, available for all Magento Commerce merchants, only validating PHP Magento APIs and GraphQL schema.
-
 ## Workflow
 
 The following diagram shows the expected workflow when running the SUT:
 
 ![SUT Diagram](img/mvp-diagram-v2.png)
 
-### Who is the SUT for?
+## Who is the SUT for?
 
 The following use case describes the typical process for a Magento partner to upgrade a client's Magento instance:
 
-1. A partner's Software Engineer downloads the SUT package from the [Magento repository](https://repo.magento.com/) and executes it during the beta phase of the newest Magento release.
+1. A partner's Software Engineer downloads the SUT package from the [Magento repository](https://repo.magento.com/) and executes it during the beta phase of the newest Magento release. See the [Download SUT section]({{site.baseurl}}/safe-upgrade-tool/install.html#download-SUT) for more information.
 1. The Software Engineer sees that there are several customized areas broken in the inventory and catalog modules and they also get a complexity score of X. See the [Developer information guide]({{site.baseurl}}/safe-upgrade-tool/developer.html) for more information on the complexity score.
 1. With this information, the Software Engineer is able to understand the complexity of the upgrade and is able to relay this information back to the partner's Account Manager.
 1. The Account Manager creates a timeline and cost for the Magento upgrade, which allows them to get their manager's approval.
@@ -31,7 +28,7 @@ The following use case describes the typical process for a Magento partner to up
 
 ![SUT audience](img/audience-sut.png)
 
-#### Contact SUT
+### Contact SUT
 
 To connect with the SUT team:
 
@@ -53,11 +50,27 @@ If you are running SUT against a Magento instance with large modules and files, 
 
 Magento best practice is not to have 2 modules with the same name, if this happens SUT will show a segmentation fault error in which case you have to analyze each module independently with the option `-m`:
 
-  ```bash
-  bin/sut upgrade:check /(instance_path) --coming-version=2.4.1 -m /(module_path)
-  ```
+```bash
+bin/sut upgrade:check /(instance_path) --coming-version=2.4.1 -m /(module_path)
+```
 
 If you get memory issues while executing SUT it is recommended to use the `-m` command to run the tool against a specific module.
+
+## Download SUT
+
+To download SUT, run the following command:
+
+```bash
+composer create-project magento/safe-upgrade-tool sut  --repository https://repo.magento.com
+```
+
+As SUT is an independent tool, if you try to run:
+
+```bash
+composer require magento/safe-upgrade-tool 
+```
+
+It might add the SUT as a dependency for a Magento project.
 
 ## Install
 

--- a/src/safe-upgrade-tool/install.md
+++ b/src/safe-upgrade-tool/install.md
@@ -18,7 +18,7 @@ The following diagram shows the expected workflow when running the SUT:
 
 The following use case describes the typical process for a Magento partner to upgrade a client's Magento instance:
 
-1. A partner's Software Engineer downloads the SUT package from the [Magento repository](https://repo.magento.com/) and executes it during the beta phase of the newest Magento release. See the [Download SUT section]({{site.baseurl}}/safe-upgrade-tool/install.html#download-SUT) for more information.
+1. A partner's Software Engineer downloads the SUT package from the [Magento repository](https://repo.magento.com/) and executes it during the beta phase of the newest Magento release. See the [Download SUT section]({{site.baseurl}}/safe-upgrade-tool/install.html#download-sut) for more information.
 1. The Software Engineer sees that there are several customized areas broken in the inventory and catalog modules and they also get a complexity score of X. See the [Developer information guide]({{site.baseurl}}/safe-upgrade-tool/developer.html) for more information on the complexity score.
 1. With this information, the Software Engineer is able to understand the complexity of the upgrade and is able to relay this information back to the partner's Account Manager.
 1. The Account Manager creates a timeline and cost for the Magento upgrade, which allows them to get their manager's approval.

--- a/src/safe-upgrade-tool/install.md
+++ b/src/safe-upgrade-tool/install.md
@@ -67,7 +67,7 @@ composer create-project magento/safe-upgrade-tool sut  --repository https://repo
 As SUT is an independent tool, if you try to run:
 
 ```bash
-composer require magento/safe-upgrade-tool 
+composer require magento/safe-upgrade-tool
 ```
 
 It might add the SUT as a dependency for a Magento project.

--- a/src/safe-upgrade-tool/introduction.md
+++ b/src/safe-upgrade-tool/introduction.md
@@ -15,6 +15,3 @@ The SUT returns a list of errors and warnings that you must address before upgra
 It is distributed as a Composer package with every release of a Magento version. See [Developer]({{site.baseurl}}/safe-upgrade-tool/developer.html) topic for more information.
 
 Refer to the [Install]({{site.baseurl}}/safe-upgrade-tool/install.html) for first steps with SUT.
-
-{:.bs-callout-warning}
-At the moment this is an ALPHA version with limited scope, available for all Magento Commerce merchants, only validating PHP Magento APIs and GraphQL schema.

--- a/src/safe-upgrade-tool/run.md
+++ b/src/safe-upgrade-tool/run.md
@@ -29,7 +29,7 @@ We recommend running the following command to avoid memory limitations:
 php -d memory_limit=-1 /bin/sut
 ```
 
-As well, it is recommended to use the `-m` command to run the tool against a specific module.
+We also recommend using the `-m` command to run the tool against a specific module.
 
 To see SUT command options and help:
 

--- a/src/safe-upgrade-tool/run.md
+++ b/src/safe-upgrade-tool/run.md
@@ -12,9 +12,6 @@ The SUT identifies potential problems that must be fixed in your custom code bef
 
 The tool returns a list of errors and warnings that you must address before upgrading to a new version of Magento.
 
-{:.bs-callout-warning}
-At the moment this is an ALPHA version with limited scope, only validating PHP Magento APIs and GraphQL schema.
-
 ## Use SUT
 
 Execute the tool by running the following command:
@@ -24,9 +21,15 @@ bin/sut upgrade:check INSTALLATION_DIR
 ```
 
 {:.bs-callout-info}
-We recommend running `php -d memory_limit=-1 /bin/sut` to avoid memory limitations. As well, it is recommended to use the `-m` command to run the tool against a specific module.
-
 The `INSTALLATION_DIR` value is the directory where your Magento instance is located.
+
+We recommend running the following command to avoid memory limitations:
+
+```bash
+php -d memory_limit=-1 /bin/sut
+```
+
+As well, it is recommended to use the `-m` command to run the tool against a specific module.
 
 To see SUT command options and help:
 


### PR DESCRIPTION
## Purpose of this pull request

This pull request (PR) updates the install page from the Safe Upgrade Tool (SUT) topics with how to download the SUT tool via command line.

## Affected DevDocs pages

This PR modifies the following pages:

- [SUT welcome page](https://devdocs.magento.com/safe-upgrade-tool/introduction.html)
- [Prerequisites for SUT](https://devdocs.magento.com/safe-upgrade-tool/prerequisites.html)
- [SUT installation page](https://devdocs.magento.com/safe-upgrade-tool/install.html)
- [SUT use page](https://devdocs.magento.com/safe-upgrade-tool/run.html)
- Page-header in devdocs project for the SUT ALPHA release.

## Other information

JIRA [MC-40582](https://jira.corp.magento.com/browse/MC-40582)

whats new
Updated the [Install Safe Upgrade Tool](https://devdocs.magento.com/safe-upgrade-tool/install.html) topic with information on how to download the Safe Upgrade Tool via command line.
