### PR TITLE
Update github-integration.md

### DIFF
--- a/src/cloud/integrations/github-integration.md
+++ b/src/cloud/integrations/github-integration.md
@@ -151,3 +151,26 @@ In order to communicate events—such as a push—with your Cloud Git server, yo
 ## Test the integration
 
 To verify the integration works, make a change in the GitHub repository and use the magento-cloud CLI to pull the change into the local environment.
+
+## Remove the integration
+
+You can safely remove the Github integration from your project without affecting your code.
+
+{:.procedure}
+To remove the Github integration:
+
+1. From the terminal, log in to your {{site.data.var.ece}} project.
+
+1. List your integrations. You need the Github integration ID to complete the next step.
+
+   ```bash
+   magento-cloud integration:list
+   ```
+
+1. Delete the integration.
+
+   ```bash
+   magento-cloud integration:delete <project-ID>
+   ```
+
+Also, you can remove the Github integration by logging in to your Github account and revoking the OAuth grant on the account _Settings_ page.


### PR DESCRIPTION
## Remove the Github integration

You can safely remove the Github integration from your project without affecting your code.

{:.procedure}
To remove the Github integration:

1. From the terminal, log in to your {{site.data.var.ece}} project.

1. List your integrations. You need the Github integration ID to complete the next step.

   ```bash
   magento-cloud integration:list
   ```

1. Delete the integration.

   ```bash
   magento-cloud integration:delete <project-ID>
   ```

Also, you can remove the Github integration by logging in to your Github account and revoking the OAuth grant on the account _Settings_ page.

## Purpose of this pull request

This pull request (PR) ...

## Affected DevDocs pages
https://devdocs.magento.com/cloud/integrations/github-integration.html
<!-- REQUIRED List the affected pages on devdocs.magento.com (URLs). Not needed for large numbers of files. -->

-  ...

## Links to Magento source code

<!--  OPTIONAL - REMOVE THIS SECTION IF NOT USED. If this pull request references a file in a Magento codebase repository, add it here. -->

-  ...

<!--
If you are fixing a GitHub issue, note it using GitHub keyword format (https://help.github.com/en/articles/closing-issues-using-keywords#closing-an-issue-in-a-different-repository) to close the issue when this pull request is merged. Example: `Fixes #1234`

`master` is the default branch. Merged pull requests to `master` go live on the site automatically. Any requested changes to content on the `master` branch must be related to the released codebase. Any content related to future releases goes in the `develop` branch.

See Contribution guidelines (https://github.com/magento/devdocs/blob/master/.github/CONTRIBUTING.md) for more information.
-->
