### PR TITLE
Call to MySQL cli should not have a space before password value

### DIFF
--- a/src/cloud/project/services-mysql.md
+++ b/src/cloud/project/services-mysql.md
@@ -158,7 +158,7 @@ Accessing the MariaDB database directly requires you to use a SSH to log in to t
    -  For Pro, use the following command with hostname, port number, username, and password retrieved from the `$MAGENTO_CLOUD_RELATIONSHIPS` variable.
 
       ```bash
-      mysql -h <hostname> -P <number> -u <username> -p <password>
+      mysql -h <hostname> -P <number> -u <username> -p'<password>'
       ```
 
 ## Connect to secondary database


### PR DESCRIPTION
## Purpose of this pull request

This pull request (PR) fixes incorrect usage example in an article [Set up MySQL service](https://devdocs.magento.com/cloud/project/services-mysql.html).

The example contains a space between MySQL cli password flag `-p` and the value `password` as in `-p password`.
However, this syntax is incorrect. The correct syntax is `mysql -h localhost -u myname -ppassword mydb` as per MySQL documentation: https://dev.mysql.com/doc/refman/8.0/en/connecting.html

## Affected DevDocs pages

-  https://devdocs.magento.com/cloud/project/services-mysql.html