### PR TITLE
Disable the jscpd linter

### DIFF
--- a/.github/workflows/linter.yml
+++ b/.github/workflows/linter.yml
@@ -47,5 +47,6 @@ jobs:
           VALIDATE_ALL_CODEBASE: false
           DEFAULT_BRANCH: master
           VALIDATE_HTML: false
+          VALIDATE_JSCPD: false
           VALIDATE_OPENAPI: false
           MARKDOWN_CONFIG_FILE: .markdownlint.json


### PR DESCRIPTION
## Purpose of this pull request

This pull request (PR) disables the [jscpd](https://github.com/kucherenko/jscpd) linter because it fails the linter check in PRs. The SuperLinter team has added the linter to the list of default linters, which we cannot control (https://github.com/github/super-linter/pull/1032). We can enable it later with appropriate configuration for our projects.