### PR TITLE
MCLOUD-7173: Update default Disc and DB value. for Magento cloud

### DIFF
--- a/src/cloud/project/magento-app-properties.md
+++ b/src/cloud/project/magento-app-properties.md
@@ -146,7 +146,7 @@ This example shows the default web configuration for a Cloud project configured 
 Defines the persistent disk size of the application in MB.
 
 ```yaml
-disk: 2048
+disk: 5120
 ```
 
 The minimal recommended disk size is 256MB. If you see the error `UserError: Error building the project: Disk size may not be smaller than 128MB`, increase the size to 256MB.

--- a/src/cloud/project/services-mysql.md
+++ b/src/cloud/project/services-mysql.md
@@ -25,7 +25,7 @@ MariaDB 10.1 is the last version that support XtraDB as the storage engine. Vers
    ```yaml
    mysql:
        type: mysql:<version>
-       disk: 2048
+       disk: 5120
    ```
 
    {:.bs-callout-tip}
@@ -69,8 +69,8 @@ If no endpoints are defined, a single endpoint named `mysql` has `admin` access 
 
 ```yaml
 mysql:
-    type: mysql:10.2
-    disk: 2048
+    type: mysql:10.3
+    disk: 5120
     configuration:
         schemas:
             - main

--- a/src/cloud/project/services.md
+++ b/src/cloud/project/services.md
@@ -33,7 +33,7 @@ You can view default versions and disk values in the current, [default `services
 ```yaml
 mysql:
     type: mysql:<version>
-    disk: 2048
+    disk: 5120
 
 redis:
     type: redis:<version>
@@ -88,7 +88,7 @@ The `type` value specifies the service name and version. For example:
 
 ```yaml
 mysql:
-    type: mysql:10.2
+    type: mysql:10.3
 ```
 
 Use [`Service versions`](#service-versions) table to see supported services and their versions
@@ -99,8 +99,8 @@ The `disk` value specifies the size of the persistent disk storage (in MB) to al
 
 ```yaml
 mysql:
-    type: mysql:10.2
-    disk: 2048
+    type: mysql:10.3
+    disk: 5120
 ```
 
 The current default storage amount per project is 5GB, or 5120MB. You can distribute this amount between your application and each of its services.
@@ -138,7 +138,7 @@ To verify relationships in local environment:
    database:
        -
    ...
-           type: 'mysql:10.2'
+           type: 'mysql:10.3'
            port: 3306
    ```
 
@@ -218,7 +218,7 @@ You can upgrade the installed service version by updating the service configurat
    ```yaml
    mysql:
        type: mysql:10.3
-       disk: 2048
+       disk: 5120
    ```
 
 1. Add, commit, and push your code changes.
@@ -260,7 +260,7 @@ To downgrade a service version by renaming an existing service:
      ```yaml
      mysql:
          type: mysql:10.4
-         disk: 2048
+         disk: 5120
      ```
 
    > New `services.yaml` definition
@@ -268,7 +268,7 @@ To downgrade a service version by renaming an existing service:
      ```yaml
      mysql2:
           type: mysql:10.3
-          disk: 2048
+          disk: 5120
      ```
 
 1. Update the relationships in the `.magento.app.yaml` file.
@@ -299,10 +299,10 @@ To downgrade a service by creating an additional service:
    ```yaml
    mysql:
        type: mysql:10.4
-       disk: 2048
+       disk: 5120
    mysql2:
        type: mysql:10.3
-       disk: 2048
+       disk: 5120
    ```
 
 1. Change the relationships configuration in the `.magento.app.yaml` file to use the new service.


### PR DESCRIPTION
## Purpose of this pull request

This pull request (PR) will update information about default disc values.

## Affected DevDocs pages

<!-- REQUIRED List the affected pages on devdocs.magento.com (URLs). Not needed for large numbers of files. -->

-  https://devdocs.magento.com/cloud/project/magento-app-properties.html
- https://devdocs.magento.com/cloud/project/services-mysql.html
- https://devdocs.magento.com/cloud/project/services.html

<!--
If you are fixing a GitHub issue, note it using GitHub keyword format (https://help.github.com/en/articles/closing-issues-using-keywords#closing-an-issue-in-a-different-repository) to close the issue when this pull request is merged. Example: `Fixes #1234`

`master` is the default branch. Merged pull requests to `master` go live on the site automatically. Any requested changes to content on the `master` branch must be related to the released codebase. Any content related to future releases goes in the `develop` branch.

See Contribution guidelines (https://github.com/magento/devdocs/blob/master/.github/CONTRIBUTING.md) for more information.
-->

whatsnew
Default disc space for the application and database in cloud templates were updated from 2GB to 5GB.