### PR TITLE
Correct spelling mistake: availble

### DIFF
--- a/src/guides/v2.3/config-guide/prod/config-reference-envphp.md
+++ b/src/guides/v2.3/config-guide/prod/config-reference-envphp.md
@@ -112,7 +112,7 @@ You can learn more about it at [Encryption Key][encryption-key].
 
 ## db
 
-All database configurations are availble in this node.
+All database configurations are available in this node.
 
 ```conf
 'db' => [
@@ -181,7 +181,7 @@ Learn more about [Magento Modes][magento-modes].
 
 ## queue
 
-Message queue releated configurations are availble in this node.
+Message queue releated configurations are available in this node.
 
 ```conf
 'queue' => [


### PR DESCRIPTION
## Purpose of this pull request

Minor change to correct the spelling mistake of `availble` in `config-reference-envphp.md`

## Affected DevDocs pages

<!-- REQUIRED List the affected pages on devdocs.magento.com (URLs). Not needed for large numbers of files. -->

-  https://devdocs.magento.com/guides/v2.4/config-guide/prod/config-reference-envphp.html

