### PR TITLE
MC-4064_correction: Fix redirects in Upgrade Compatibility Tool section

### DIFF
--- a/src/guides/v2.3/javascript-dev-guide/widgets/widget_gallery.md
+++ b/src/guides/v2.3/javascript-dev-guide/widgets/widget_gallery.md
@@ -587,7 +587,6 @@ This example shows a use case for a gallery widget on any page:
 
 ```html
 <div class="image-gallery"></div>
- 
 <script>
 require ([
     'jquery',

--- a/src/upgrade-compatibility-tool/developer.md
+++ b/src/upgrade-compatibility-tool/developer.md
@@ -2,7 +2,7 @@
 group: software-update-guide
 title: Developer information
 ee_only: True
-redirect from:
+redirect_from:
   - /safe-upgrade-tool/developer.html
 functional_areas:
   - Upgrade

--- a/src/upgrade-compatibility-tool/install.md
+++ b/src/upgrade-compatibility-tool/install.md
@@ -2,7 +2,7 @@
 group: software-update-guide
 title: Install
 ee_only: True
-redirect from:
+redirect_from:
   - /safe-upgrade-tool/install.html
 functional_areas:
   - Upgrade

--- a/src/upgrade-compatibility-tool/introduction.md
+++ b/src/upgrade-compatibility-tool/introduction.md
@@ -2,7 +2,7 @@
 group: software-update-guide
 title: Introduction
 ee_only: True
-redirect from:
+redirect_from:
   - /safe-upgrade-tool/introduction.html
 functional_areas:
   - Upgrade

--- a/src/upgrade-compatibility-tool/prerequisites.md
+++ b/src/upgrade-compatibility-tool/prerequisites.md
@@ -2,7 +2,7 @@
 group: software-update-guide
 title: Prerequisites
 ee_only: True
-redirect from:
+redirect_from:
   - /safe-upgrade-tool/prerequisites.html
 functional_areas:
   - Upgrade

--- a/src/upgrade-compatibility-tool/run.md
+++ b/src/upgrade-compatibility-tool/run.md
@@ -2,7 +2,7 @@
 group: software-update-guide
 title: Run the tool
 ee_only: True
-redirect from:
+redirect_from:
   - /safe-upgrade-tool/run.html
 functional_areas:
   - Upgrade


### PR DESCRIPTION
## Purpose of this pull request

This pull request (PR) fixes the upgrade compatibility tool folder (and pages) with the redirects for old Safe Upgrade Tool links.

## Affected DevDocs pages

This PR modifies the following pages:

- [Introduction page](https://devdocs.magento.com/upgrade-compatibility-tool/introduction.html)
- [Prerequisites page](https://devdocs.magento.com/upgrade-compatibility-tool/prerequisites.html)
- [Install page](https://devdocs.magento.com/upgrade-compatibility-tool/install.html)
- [Run page](https://devdocs.magento.com/upgrade-compatibility-tool/run.html)
- [Developer page](https://devdocs.magento.com/upgrade-compatibility-tool/developer.html)

## Linting issues

Includes a fix for linting issues that appeared after last pull from Master

## Other information

Fixes #8616 