### PR TITLE
Small typo fix in Install Guide

### DIFF
--- a/src/guides/v2.4/install-gde/prereq/mysql.md
+++ b/src/guides/v2.4/install-gde/prereq/mysql.md
@@ -167,12 +167,12 @@ To configure a MySQL database instance:
 
 1. In order for MySQL `TIMESTAMP` fields to follow the preferences and composition expected by Magento's declarative schema architecture, the system variable `explicit_defaults_for_timestamp` must be set to `on`.
 
-   References;
+   References:
 
    *  [MySQL 5.7](https://dev.mysql.com/doc/refman/5.7/en/server-system-variables.html#sysvar_explicit_defaults_for_timestamp)
    *  [MariaDB](https://mariadb.com/kb/en/server-system-variables/#explicit_defaults_for_timestamp)
 
-   If this setting is not enabled, `setup:db:status` will always report that `Declarative Schema is not up to date`.
+   If this setting is not enabled, `bin/magento setup:db:status` will always report that the `Declarative Schema is not up to date`.
 
 {:.bs-callout-info}
 The `explicit_defaults_for_timestamp` setting is deprecated. This setting controls deprecated TIMESTAMP behaviors that will be removed in a future MySQL release. When those behaviors are removed, the `explicit_defaults_for_timestamp` setting will be removed as well.


### PR DESCRIPTION
## Purpose of this pull request

This pull request (PR) fixes a typo in the Install guide MySQL page.

## Affected DevDocs pages

https://devdocs.magento.com/guides/v2.4/install-gde/prereq/mysql.html