### PR TITLE
GraphQL: Add missing category attribute

### DIFF
--- a/src/_includes/graphql/category-filter-input.md
+++ b/src/_includes/graphql/category-filter-input.md
@@ -5,7 +5,8 @@ Attribute | Data type | Description
 `category_uid` | FilterEqualTypeInput | Filters by the unique category ID for a `CategoryInterface` object
 `ids` | FilterEqualTypeInput | Deprecated. Use `category_uid` instead. Filters by the specified category IDs
 `name` | FilterMatchTypeInput | Filters by the display name of the category
-`parent_id` | FilterEqualTypeInput | Filters by the unique parent category ID for a `CategoryInterface` object
+`parent_category_uid` | FilterEqualTypeInput | Filters by the unique parent category ID for a `CategoryInterface` object
+`parent_id` | FilterEqualTypeInput | Deprecated. Use `parent_category_uid` instead
 `url_key` | FilterEqualTypeInput | Filters by the part of the URL that identifies the category
 `url_path` | FilterEqualTypeInput | Filters by the URL path for the category
 


### PR DESCRIPTION
## Purpose of this pull request

This pull request (PR) adds the `parent_category_uid` attribute and deptecates the `parent_id` attribute. These changes were introduced in MC-39836.

## Affected DevDocs pages

<!-- REQUIRED List the affected pages on devdocs.magento.com (URLs). Not needed for large numbers of files. -->

-  ...

## Links to Magento source code

<!--  OPTIONAL - REMOVE THIS SECTION IF NOT USED. If this pull request references a file in a Magento codebase repository, add it here. -->

-  ...

<!--
If you are fixing a GitHub issue, note it using GitHub keyword format (https://help.github.com/en/articles/closing-issues-using-keywords#closing-an-issue-in-a-different-repository) to close the issue when this pull request is merged. Example: `Fixes #1234`

`master` is the default branch. Merged pull requests to `master` go live on the site automatically. Any requested changes to content on the `master` branch must be related to the released codebase. Any content related to future releases goes in the `develop` branch.

See Contribution guidelines (https://github.com/magento/devdocs/blob/master/.github/CONTRIBUTING.md) for more information.
-->
