### PR TITLE
Add data files to the BIC reference page for beta

### DIFF
--- a/src/guides/v2.4/release-notes/backward-incompatible-changes/reference.md
+++ b/src/guides/v2.4/release-notes/backward-incompatible-changes/reference.md
@@ -22,6 +22,12 @@ To view changes in functional tests, refer to [Backward incompatible changes in 
 {:.bs-callout-info}
 Patch releases are primarily focused on delivering security and quality enhancements on a regular basis to help you keep your sites performing at their peak. On an exceptional basis, breaking changes or additional patches or hotfixes may be released to address security or compliance issues and high-impact quality issues. On the module level, these are mostly PATCH-level changes; sometimes MINOR-level changes. See [Release policy]({{site.baseurl}}/release/policy/).
 
+## 2.4.1 - 2.4.2-develop
+
+{% include backward-incompatible-changes/open-source/2.4.1-2.4.2-develop.html %}
+
+{% include backward-incompatible-changes/commerce/2.4.1-2.4.2-develop.html %}
+
 ## 2.4.0 - 2.4.1
 
 {% include backward-incompatible-changes/open-source/2.4.0-2.4.1.md %}


### PR DESCRIPTION
## Purpose of this pull request

This pull request (PR) adds references to the data files for BIC reference so we can publish on the beta site.

## Affected DevDocs pages

<!-- REQUIRED List the affected pages on devdocs.magento.com (URLs). Not needed for large numbers of files. -->

- https://devdocs.magento.com/guides/v2.4/release-notes/backward-incompatible-changes/reference.html