### PR TITLE
Add upgrade command for deployment pipeline

### DIFF
--- a/src/_includes/config/split-deploy/example_build-sync.md
+++ b/src/_includes/config/split-deploy/example_build-sync.md
@@ -10,22 +10,22 @@ To update your build system:
    git pull mconfig m2.2_deploy
    ```
 
-1. Run upgrade Magento:
+1. Run the upgrade command:
 
    ```bash
-   php bin/magento setup:upgrade
+   bin/magento setup:upgrade
    ```
 
 1. Compile code:
 
    ```bash
-   php bin/magento setup:di:compile
+   bin/magento setup:di:compile
    ```
 
 1. After code has been compiled, generate static view files:
 
    ```bash
-   php bin/magento setup:static-content:deploy -f
+   bin/magento setup:static-content:deploy -f
    ```
 
 1. Check the changes into source control.

--- a/src/_includes/config/split-deploy/example_build-sync.md
+++ b/src/_includes/config/split-deploy/example_build-sync.md
@@ -10,6 +10,12 @@ To update your build system:
    git pull mconfig m2.2_deploy
    ```
 
+1. Run upgrade Magento:
+
+   ```bash
+   php bin/magento setup:upgrade
+   ```
+
 1. Compile code:
 
    ```bash


### PR DESCRIPTION
## Purpose of this pull request

This pull request (PR) add missing upgrade command for deployment pipeline

## Affected DevDocs pages

<!-- REQUIRED List the affected pages on devdocs.magento.com (URLs). Not needed for large numbers of files. -->

https://devdocs.magento.com/guides/v2.4/config-guide/deployment/pipeline/example/shared-configuration.html
https://devdocs.magento.com/guides/v2.4/config-guide/deployment/pipeline/example/cli.html
https://devdocs.magento.com/guides/v2.4/config-guide/deployment/pipeline/example/environment-variables.html

## Links to Magento source code

<!--  OPTIONAL - REMOVE THIS SECTION IF NOT USED. If this pull request references a file in a Magento codebase repository, add it here. -->

-  ...

<!--
If you are fixing a GitHub issue, note it using GitHub keyword format (https://help.github.com/en/articles/closing-issues-using-keywords#closing-an-issue-in-a-different-repository) to close the issue when this pull request is merged. Example: `Fixes #1234`

`master` is the default branch. Merged pull requests to `master` go live on the site automatically. Any requested changes to content on the `master` branch must be related to the released codebase. Any content related to future releases goes in the `develop` branch.

See Contribution guidelines (https://github.com/magento/devdocs/blob/master/.github/CONTRIBUTING.md) for more information.
-->
