### PR TITLE
Update plugins.md

### DIFF
--- a/src/guides/v2.3/extension-dev-guide/plugins.md
+++ b/src/guides/v2.3/extension-dev-guide/plugins.md
@@ -18,7 +18,7 @@ Plugins can not be used on following:
 *  Final classes
 *  Non-public methods
 *  Class methods (such as static methods)
-*  `__construct`
+*  `__construct` and `__destruct`
 *  Virtual types
 *  Objects that are instantiated before `Magento\Framework\Interception` is bootstrapped
 


### PR DESCRIPTION
The `__destruct` is excluded (just like `__construct`), see `\Magento\Framework\Interception\Code\Generator\Interceptor::_getClassMethods()`

## Purpose of this pull request

Update docs regarding plugin development (`__destruct` is an excluded function).

## Affected DevDocs pages

<!-- REQUIRED List the affected pages on devdocs.magento.com (URLs). Not needed for large numbers of files. -->

- https://devdocs.magento.com/guides/v2.4/extension-dev-guide/plugins.html
- https://devdocs.magento.com/guides/v2.3/extension-dev-guide/plugins.html
