### PR TITLE
GraphQL: setGiftOptionsOnCart is Commerce only

### DIFF
--- a/src/_data/toc/graphql.yml
+++ b/src/_data/toc/graphql.yml
@@ -451,6 +451,7 @@ pages:
 
         - label: setGiftOptionsOnCart mutation
           url: /graphql/mutations/set-gift-options.html
+          edition: ee-only
           exclude_versions: ["2.3"]
 
         - label: setGuestEmailOnCart mutation

--- a/src/guides/v2.4/graphql/mutations/set-gift-options.md
+++ b/src/guides/v2.4/graphql/mutations/set-gift-options.md
@@ -1,6 +1,7 @@
 ---
 group: graphql
 title: setGiftOptionsOnCart mutation
+ee_only: true
 ---
 
 The `setGiftOptionsOnCart` mutation allows the buyer to set the following gift options on the cart level:


### PR DESCRIPTION
## Purpose of this pull request

This pull request (PR) fixes #8698 by adding notification that the `setGiftOptionsOnCart` mutation is for Magento Commerce.

## Affected DevDocs pages

<!-- REQUIRED List the affected pages on devdocs.magento.com (URLs). Not needed for large numbers of files. -->

-  ...

## Links to Magento source code

<!--  OPTIONAL - REMOVE THIS SECTION IF NOT USED. If this pull request references a file in a Magento codebase repository, add it here. -->

-  ...

<!--
If you are fixing a GitHub issue, note it using GitHub keyword format (https://help.github.com/en/articles/closing-issues-using-keywords#closing-an-issue-in-a-different-repository) to close the issue when this pull request is merged. Example: `Fixes #1234`

`master` is the default branch. Merged pull requests to `master` go live on the site automatically. Any requested changes to content on the `master` branch must be related to the released codebase. Any content related to future releases goes in the `develop` branch.

See Contribution guidelines (https://github.com/magento/devdocs/blob/master/.github/CONTRIBUTING.md) for more information.
-->
