### PR TITLE
MCLOUD-7185: [Magento Cloud] 2FA issues after database sync from prod to stage

### DIFF
--- a/src/cloud/live/stage-prod-migrate.md
+++ b/src/cloud/live/stage-prod-migrate.md
@@ -211,7 +211,7 @@ To migrate a database:
 
    For Pro Staging and Production environments, the name of the database is in the `MAGENTO_CLOUD_RELATIONSHIPS` variable (typically the same as the application name and username).
 
-   If you have configured two-factor authentication it's better to exclude related tables to avoid reconfiguring it after database migration:
+   If you have configured two-factor authentication on the target environment, it is better to exclude related 2FA tables to avoid reconfiguring it after database migration:
 
    ```bash
    mysqldump -h <database host> --user=<database username> --password=<password> --single-transaction --triggers --ignore-table=tfa_user_config --ignore-table=tfa_country_codes <database name> | gzip - > /tmp/database.sql.gz

--- a/src/cloud/live/stage-prod-migrate.md
+++ b/src/cloud/live/stage-prod-migrate.md
@@ -203,16 +203,18 @@ To migrate a database:
 
 1. Create a database dump file in `gzip` format:
 
-   For Starter environments and Pro Integration environments:
-
-   ```bash
-   mysqldump -h <database host> --user=<database username> --password=<password> --single-transaction --triggers main | gzip - > /tmp/database.sql.gz
-   ```
-
-   For Pro Staging and Production environments, the name of the database is in the `MAGENTO_CLOUD_RELATIONSHIPS` variable (typically the same as the application name and username):
-
    ```bash
    mysqldump -h <database host> --user=<database username> --password=<password> --single-transaction --triggers <database name> | gzip - > /tmp/database.sql.gz
+   ```
+
+   For Starter environments and Pro Integration environments, use `main` as the name of the database.
+
+   For Pro Staging and Production environments, the name of the database is in the `MAGENTO_CLOUD_RELATIONSHIPS` variable (typically the same as the application name and username).
+
+   If you have configured two-factor authentication it's better to exclude related tables to avoid reconfiguring it after database migration:
+
+   ```bash
+   mysqldump -h <database host> --user=<database username> --password=<password> --single-transaction --triggers --ignore-table=tfa_user_config --ignore-table=tfa_country_codes <database name> | gzip - > /tmp/database.sql.gz
    ```
 
 1. Transfer the database dump to another remote environment with the `rsync` command:


### PR DESCRIPTION
## Purpose of this pull request

Add information on how to avoid reconfiguring 2FA after DB migration.

## Affected DevDocs pages

-  https://devdocs.magento.com/cloud/live/stage-prod-migrate.html#cloud-live-migrate-db

## Links to Magento source code

-  https://github.com/magento/security-package/tree/develop/TwoFactorAuth
