### PR TITLE
Fix Markdown

### DIFF
--- a/src/guides/v2.3/frontend-dev-guide/themes/theme-inherit.md
+++ b/src/guides/v2.3/frontend-dev-guide/themes/theme-inherit.md
@@ -134,8 +134,8 @@ The layouts processing mechanism does not involve fallback. The system collects 
 1. Ancestor theme layouts, starting from the most distant ancestor, recursively until a theme with no parent is reached: `<parent_theme_dir>/<Vendor>_<Module>/layout/`
 
 1. All module layout files in sequence, defined in `app/etc/config.php` respecting the component load order. For each module:
-    *  Layout files for the `base` area: `<module_dir>/view/base/layout/`
-    *  Layout files for the `frontend` area: `<module_dir>/view/frontend/layout/`
+   *  Layout files for the `base` area: `<module_dir>/view/base/layout/`
+   *  Layout files for the `frontend` area: `<module_dir>/view/frontend/layout/`
 
 Unlike templates or images, layout can be not only overridden, but also extended. And the recommended way to customize layout is to extend it by creating theme extending layout files.
 


### PR DESCRIPTION
## Purpose of this pull request

This pull request (PR) fixes [MD007 - Unordered list indentation](https://github.com/DavidAnson/markdownlint/blob/main/doc/Rules.md#md007---unordered-list-indentation). It has not been detected by the GitHub check linting because the linter it uses cannot process an unordered sublist if its parent list is ordered. A note from the official documentation:

> Note: This rule applies to a sublist only if its parent lists are all also unordered (otherwise, extra indentation of ordered lists interferes with the rule).

The violation was detected locally by the `rake test` implementation of the Markdown check.