### PR TITLE
Removed outdated Cloud version notes

### DIFF
--- a/src/cloud/project/magento-app-workers.md
+++ b/src/cloud/project/magento-app-workers.md
@@ -37,5 +37,3 @@ workers:
 ```
 
 This example defines a single worker named queue, with a "small" container, and runs the command `php worker.php` on startup. If `worker.php` exits, it is automatically restarted.
-
-For {{site.data.var.ece}} 2.1.x, you can use only workers and [cron jobs]({{ site.baseurl }}/cloud/project/magento-app-properties.html#crons). For {{site.data.var.ece}} 2.2.x, cron jobs launch consumers to process batches of messages, and does not require additional configuration.


### PR DESCRIPTION
## Purpose of this pull request

This pull request (PR) removes references to Cloud 2.1 and 2.2.

## Affected DevDocs pages

https://devdocs.magento.com/cloud/project/magento-app-workers.html