### PR TITLE
Update REST links for 2.4.2

### DIFF
--- a/src/_data/toc/rest-api.yml
+++ b/src/_data/toc/rest-api.yml
@@ -40,15 +40,15 @@ pages:
           children:
 
             - label: Admin REST endpoints
-              url: https://magento.redoc.ly/2.4.1-admin/
+              url: https://magento.redoc.ly/2.4.2-admin/
               include_versions: ["2.4"]
 
             - label: Customer REST endpoints
-              url: https://magento.redoc.ly/2.4.1-customer/
+              url: https://magento.redoc.ly/2.4.2-customer/
               include_versions: ["2.4"]
 
             - label: Guest REST endpoints
-              url: https://magento.redoc.ly/2.4.1-guest/
+              url: https://magento.redoc.ly/2.4.2-guest/
               include_versions: ["2.4"]
 
         - label: Generate a local API reference


### PR DESCRIPTION
## Purpose of this pull request

This pull request (PR) updates the 2.4.x REST endpoint links to 2.4.2.

## Affected DevDocs pages

- https://devdocs.magento.com/guides/v2.4/rest/bk-rest.html