### PR TITLE
Remove rake task for page-builder migration repo

### DIFF
--- a/rakelib/update.rake
+++ b/rakelib/update.rake
@@ -24,12 +24,6 @@ namespace :update do
     update_dir 'src/page-builder'
   end
 
-  desc 'Update Page Builder Migration docs'
-  task :pbm do
-    puts 'Updating Page Builder Migration docs'.magenta
-    update_dir 'src/page-builder-migration'
-  end
-
   desc 'Update MFTF docs'
   task :mftf do
     puts 'Updating MFTF docs:'.magenta


### PR DESCRIPTION
## Purpose of this pull request

This pull request (PR) removes the rake task that pulls the page builder migration docs from that repo. We no longer need to pull docs from the migration repo. But more importantly, there is a broken link in a topic from that repo that gets re-added to the local doc set when running `rake update:all`. 