### PR TITLE
TOC changes to match one more logical update to PB org changes

### DIFF
--- a/src/_data/toc/page-builder.yml
+++ b/src/_data/toc/page-builder.yml
@@ -14,6 +14,46 @@ pages:
   url: /page-builder/docs/pagebuilder-examples.html
   versionless: true
 
+- label: 'Administration'
+  versionless: true
+  children:
+
+    - label: Deactivate Page Builder
+      url: /page-builder/docs/administration/deactivate-pagebuilder.html
+      versionless: true
+
+    - label: Upgrade content types
+      url: /page-builder/docs/administration/upgrade-content-types.html
+      versionless: true
+
+    - label: Use for product attributes
+      url: /page-builder/docs/administration/use-for-product-attributes.html
+      versionless: true
+
+- label: Architecture
+  versionless: true
+  children:
+
+    - label: Overview
+      url: /page-builder/docs/architecture/overview.html
+      versionless: true
+
+    - label: Configurations
+      url: /page-builder/docs/architecture/configurations.html
+      versionless: true
+
+    - label: Datastore
+      url: /page-builder/docs/architecture/data-store.html
+      versionless: true
+
+    - label: Events
+      url: /page-builder/docs/architecture/events.html
+      versionless: true
+
+    - label: Knockout bindings
+      url: /page-builder/docs/architecture/knockout-bindings.html
+      versionless: true
+
 - label: 'Content types'
   versionless: true
   children:
@@ -122,104 +162,64 @@ pages:
           url: /page-builder/docs/content-types/extend/add-appearances.html
           versionless: true
 
-    - label: 'Style'
-      versionless: true
-      children:
-
-        - label: Introduction
-          url: /page-builder/docs/content-types/style/introduction.html
-          versionless: true
-
-        - label: Override styles
-          url: /page-builder/docs/content-types/style/override-pagebuilder-styles.html
-          versionless: true
-
-        - label: Use Themes
-          url: /page-builder/docs/content-types/style/use-themes-to-override-styles.html
-          versionless: true
-
-        - label: Use Modules
-          url: /page-builder/docs/content-types/style/use-modules-to-override-styles.html
-          versionless: true
-
-        - label: Use HTML Code
-          url: /page-builder/docs/content-types/style/use-htmlcode-to-override-styles.html
-          versionless: true
-
-    - label: 'Responsive'
-      versionless: true
-      children:
-
-      - label: Introduction
-        url: /page-builder/docs/content-types/responsive/introduction.html
-        versionless: true
-
-      # - label: Configure layouts
-      #   url: /page-builder/docs/content-types/responsive/configurations.html
-      #   versionless: true
-
-      # - label: Use media queries
-      #   url: /page-builder/docs/content-types/responsive/configurations.html
-      #   versionless: true
-
-      - label: Add viewports
-        url: /page-builder/docs/content-types/responsive/add-viewports.html
-        versionless: true
-
-      # - label: Use viewports
-      #   url: /page-builder/docs/content-types/responsive/use-viewports.html
-      #   versionless: true
-
-      - label: Add breakpoints
-        url: /page-builder/docs/content-types/responsive/add-breakpoints.html
-        versionless: true
-
-      - label: Use breakpoints
-        url: /page-builder/docs/content-types/responsive/use-breakpoints.html
-        versionless: true
-
-      - label: Change breakpoints and viewports
-        url: /page-builder/docs/content-types/responsive/change-breakpoints-viewports.html
-        versionless: true
-
-- label: Architecture
+- label: 'Styles'
   versionless: true
   children:
 
-    - label: Overview
-      url: /page-builder/docs/architecture/overview.html
+    - label: Introduction
+      url: /page-builder/docs/styles/introduction.html
       versionless: true
 
-    - label: Configurations
-      url: /page-builder/docs/architecture/configurations.html
+    - label: Override styles
+      url: /page-builder/docs/styles/override-pagebuilder-styles.html
       versionless: true
 
-    - label: Datastore
-      url: /page-builder/docs/architecture/data-store.html
+    - label: Use Themes
+      url: /page-builder/docs/styles/use-themes-to-override-styles.html
       versionless: true
 
-    - label: Events
-      url: /page-builder/docs/architecture/events.html
+    - label: Use Modules
+      url: /page-builder/docs/styles/use-modules-to-override-styles.html
       versionless: true
 
-    - label: Knockout bindings
-      url: /page-builder/docs/architecture/knockout-bindings.html
+    - label: Use HTML Code
+      url: /page-builder/docs/styles/use-htmlcode-to-override-styles.html
       versionless: true
 
-- label: 'Administration'
+- label: 'Viewports'
   versionless: true
   children:
 
-    - label: Deactivate Page Builder
-      url: /page-builder/docs/administration/deactivate-pagebuilder.html
+    - label: Introduction
+      url: /page-builder/docs/viewports/introduction.html
       versionless: true
 
-    - label: Upgrade content types
-      url: /page-builder/docs/administration/upgrade-content-types.html
+    # - label: Configure layouts
+    #   url: /page-builder/docs/viewports/configurations.html
+    #   versionless: true
+
+    # - label: Use media queries
+    #   url: /page-builder/docs/viewports/configurations.html
+    #   versionless: true
+
+    - label: Add viewports
+      url: /page-builder/docs/viewports/add-viewports.html
       versionless: true
 
-    - label: Use for product attributes
-      url: /page-builder/docs/administration/use-for-product-attributes.html
+    # - label: Use viewports
+    #   url: /page-builder/docs/viewports/use-viewports.html
+    #   versionless: true
+
+    - label: Add breakpoints
+      url: /page-builder/docs/viewports/add-breakpoints.html
+      versionless: true
+
+    - label: Use breakpoints
+      url: /page-builder/docs/viewports/use-breakpoints.html
+      versionless: true
+
+    - label: Change breakpoints and viewports
+      url: /page-builder/docs/viewports/change-breakpoints-viewports.html
       versionless: true
 
 - label: BlueFoot migration

--- a/src/_data/whats-new.yml
+++ b/src/_data/whats-new.yml
@@ -16,11 +16,11 @@ entries:
   profile: https://github.com/bdenham
 - description: New Page Builder topics on how to create responsive content. Learn
     about viewports, breakpoints, and how to use them to make your content responsive.
-    The new topics include:<br/>- [Introduction to viewports for responsive content](https://devdocs.magento.com/page-builder/docs/content-types/responsive/introduction.html)<br/>-
-    [Add viewports](https://devdocs.magento.com/page-builder/docs/content-types/responsive/add-viewports.html)<br/>-
-    [Add breakpoints](https://devdocs.magento.com/page-builder/docs/content-types/responsive/add-breakpoints.html)<br/>-
-    [Use breakpoints](https://devdocs.magento.com/page-builder/docs/content-types/responsive/use-breakpoints.html)<br/>-
-    [Change breakpoints and viewports](https://devdocs.magento.com/page-builder/docs/content-types/responsive/change-breakpoints-viewports.html)
+    The new topics include:<br/>- [Introduction to viewports for responsive content](https://devdocs.magento.com/page-builder/docs/viewports/introduction.html)<br/>-
+    [Add viewports](https://devdocs.magento.com/page-builder/docs/viewports/add-viewports.html)<br/>-
+    [Add breakpoints](https://devdocs.magento.com/page-builder/docs/viewports/add-breakpoints.html)<br/>-
+    [Use breakpoints](https://devdocs.magento.com/page-builder/docs/viewports/use-breakpoints.html)<br/>-
+    [Change breakpoints and viewports](https://devdocs.magento.com/page-builder/docs/viewports/change-breakpoints-viewports.html)
   versions: 2.4.x
   type: Major Update
   date: February 23, 2021
@@ -40,11 +40,11 @@ entries:
 - description: New Page Builder topics on how to style content types. Learn how Page
     Builder styles content and how to override these styles to control Page Builder's
     appearance from your themes. The new topics include:<br/>- [How Page Builder styles
-    content](https://devdocs.magento.com/page-builder/docs/content-types/style/introduction.html)<br/>-
-    [Override Page Builder styles](https://devdocs.magento.com/page-builder/docs/content-types/style/override-pagebuilder-styles.html)<br/>-
-    [Use themes to override styles](https://devdocs.magento.com/page-builder/docs/content-types/style/use-themes-to-override-styles.html)<br/>-
-    [Use modules to override styles](https://devdocs.magento.com/page-builder/docs/content-types/style/use-modules-to-override-styles.html)<br/>-
-    [Use HTML Code to override styles](https://devdocs.magento.com/page-builder/docs/content-types/style/use-htmlcode-to-override-styles.html)
+    content](https://devdocs.magento.com/page-builder/docs/styles/introduction.html)<br/>-
+    [Override Page Builder styles](https://devdocs.magento.com/page-builder/docs/styles/override-pagebuilder-styles.html)<br/>-
+    [Use themes to override styles](https://devdocs.magento.com/page-builder/docs/styles/use-themes-to-override-styles.html)<br/>-
+    [Use modules to override styles](https://devdocs.magento.com/page-builder/docs/styles/use-modules-to-override-styles.html)<br/>-
+    [Use HTML Code to override styles](https://devdocs.magento.com/page-builder/docs/styles/use-htmlcode-to-override-styles.html)
   versions: 2.4.x
   type: Major Update
   date: February 22, 2021


### PR DESCRIPTION
## Purpose of this pull request

This pull request (PR) pulls the **styles** and **viewports** directories out of the content types directory and into their own directories on the same level as content types. This makes much more sense because they are technically independent of content types (even though they are often used in content types).

## Affected DevDocs pages

- styles and viewport topics in Page Builder docs
