### PR TITLE
GraphQL: Add mutations for managing gift registrants

### DIFF
--- a/src/_data/toc/graphql.yml
+++ b/src/_data/toc/graphql.yml
@@ -210,6 +210,11 @@ pages:
         - label: addDownloadableProductsToCart mutation
           url: /graphql/mutations/add-downloadable-products.html
 
+        - label: addGiftRegistryRegistrants mutation
+          url: /graphql/mutations/add-gift-registry-registrants.html
+          edition: ee-only
+          exclude_versions: ["2.3"]
+
         - label: addProductsToCompareList mutation
           url: /graphql/mutations/add-products-to-compare-list.html
           exclude_versions: ["2.3"]
@@ -441,6 +446,11 @@ pages:
           edition: ee-only
           exclude_versions: ["2.3"]
 
+        - label: removeGiftRegistryRegistrants mutation
+          url: /graphql/mutations/remove-gift-registry-registrants.html
+          edition: ee-only
+          exclude_versions: ["2.3"]
+
         - label: removeItemFromCart mutation
           url: /graphql/mutations/remove-item.html
 
@@ -561,6 +571,11 @@ pages:
 
         - label: updateGiftRegistry mutation
           url: /graphql/mutations/update-gift-registry.html
+          edition: ee-only
+          exclude_versions: ["2.3"]
+
+        - label: update-gift-registry-registrants mutation
+          url: /graphql/mutations/update-gift-registry-registrants.html
           edition: ee-only
           exclude_versions: ["2.3"]
 

--- a/src/guides/v2.4/graphql/mutations/add-gift-registry-registrants.md
+++ b/src/guides/v2.4/graphql/mutations/add-gift-registry-registrants.md
@@ -3,7 +3,7 @@ group: graphql
 title: addGiftRegistryRegistrants mutation
 
 ---
-The `addGiftRegistryRegistrants` mutation add a registrant to the specified gift registry.
+The `addGiftRegistryRegistrants` mutation adds a registrant to the specified gift registry.
 
 This mutation requires a valid [customer authentication token]({{page.baseurl}}/graphql/mutations/generate-customer-token.html).
 

--- a/src/guides/v2.4/graphql/mutations/add-gift-registry-registrants.md
+++ b/src/guides/v2.4/graphql/mutations/add-gift-registry-registrants.md
@@ -1,0 +1,107 @@
+---
+group: graphql
+title: addGiftRegistryRegistrants mutation
+
+---
+The `addGiftRegistryRegistrants` mutation .
+
+This mutation requires a valid [customer authentication token]({{page.baseurl}}/graphql/mutations/generate-customer-token.html).
+
+
+## Syntax
+
+```graphql
+mutation {
+  addGiftRegistryRegistrants(
+    giftRegistryUid: ID!,
+    registrants: [AddGiftRegistryRegistrantInput!]!
+  ) {
+    AddGiftRegistryRegistrantsOutput
+  }
+}
+```
+
+## Example usage
+
+The following example adds a registrant to the specified gift registry.
+
+**Request:**
+
+```graphql
+mutation {
+  addGiftRegistryRegistrants (
+    giftRegistryUid: "W9YcRai9JmzGglqP3p0USodTTM3BmjjY", 
+    registrants: {
+        firstname: "Monique"
+        lastname: "Resendez"
+        email: "monique@example.com"
+    }
+  ){
+    gift_registry {
+      uid
+      event_name
+      registrants {
+        firstname
+        lastname
+      }
+    }
+  }
+}
+```
+
+**Response:**
+
+```json
+{
+  "data": {
+    "addGiftRegistryRegistrants": {
+      "gift_registry": {
+        "uid": "W9YcRai9JmzGglqP3p0USodTTM3BmjjY",
+        "event_name": "Theo's 45th Birthday",
+        "registrants": [
+          {
+            "firstname": "Stacey",
+            "lastname": "Gaines"
+          },
+          {
+            "firstname": "Monique",
+            "lastname": "Resendez"
+          }
+        ]
+      }
+    }
+  }
+}
+```
+
+## Input attributes
+
+The `addGiftRegistryRegistrants` mutation requires the following input.
+
+Attribute |  Data Type | Description
+--- | --- | ---
+`dynamic_attributes` | [[GiftRegistryDynamicAttributeInput](#GiftRegistryDynamicAttributeInput)] | An array of attributes that define elements of the gift registry. Each attribute is specified as a code-value pair
+`email` | String! | The email address of the registrant
+`firstname` | String! | The first name of the registrant
+`lastname` | String! | The last name of the registrant
+
+### GiftRegistryDynamicAttributeInput attributes {#GiftRegistryDynamicAttributeInput}
+
+The `GiftRegistryDynamicAttributeInput` object contains the following attributes:
+
+Attribute |  Data Type | Description
+--- | --- | ---
+`code` | ID! | A unique key for an additional attribute of the event
+`value` | String! | A corresponding value for the code
+
+## Output attributes
+
+The `AddGiftRegistryRegistrantsOutput` output object contains the following attribute.
+
+Attribute |  Data Type | Description
+--- | --- | ---
+`gift_registry` | [GiftRegistry](#GiftRegistry) | The gift registry after adding registrants
+
+### GiftRegistry attributes {#GiftRegistry}
+
+{% include graphql/gift-registry.md %}

--- a/src/guides/v2.4/graphql/mutations/add-gift-registry-registrants.md
+++ b/src/guides/v2.4/graphql/mutations/add-gift-registry-registrants.md
@@ -3,10 +3,9 @@ group: graphql
 title: addGiftRegistryRegistrants mutation
 
 ---
-The `addGiftRegistryRegistrants` mutation .
+The `addGiftRegistryRegistrants` mutation add a registrant to the specified gift registry.
 
 This mutation requires a valid [customer authentication token]({{page.baseurl}}/graphql/mutations/generate-customer-token.html).
-
 
 ## Syntax
 
@@ -32,15 +31,16 @@ mutation {
   addGiftRegistryRegistrants (
     giftRegistryUid: "W9YcRai9JmzGglqP3p0USodTTM3BmjjY", 
     registrants: {
-        firstname: "Monique"
+        firstname: "Monica"
         lastname: "Resendez"
-        email: "monique@example.com"
+        email: "monica@example.com"
     }
   ){
     gift_registry {
       uid
       event_name
       registrants {
+        uid
         firstname
         lastname
       }
@@ -60,11 +60,13 @@ mutation {
         "event_name": "Theo's 45th Birthday",
         "registrants": [
           {
+            "uid": "Mg==",
             "firstname": "Stacey",
             "lastname": "Gaines"
           },
           {
-            "firstname": "Monique",
+            "uid": "OA==",
+            "firstname": "Monica",
             "lastname": "Resendez"
           }
         ]

--- a/src/guides/v2.4/graphql/mutations/create-gift-registry.md
+++ b/src/guides/v2.4/graphql/mutations/create-gift-registry.md
@@ -52,8 +52,8 @@ mutation {
       registrants: [
         {
           firstname: "Julie"
-          lastname: "Mao"
-          email: "juliemao@example.com"
+          lastname: "Rao"
+          email: "julierao@example.com"
           dynamic_attributes: [{ 
             code: "role"
             value: "Bride" }]
@@ -141,7 +141,7 @@ mutation {
   "data": {
     "createGiftRegistry": {
       "gift_registry": {
-        "uid": "D0R6d2B7aZWOQuuWftHZ0iwuexQPgaei",
+        "uid": "iSJHFdAtF8YBM5ALgNyNIgQmnbOW9t69",
         "event_name": "Bill and Julie's wedding",
         "message": "Help us celebrate Bill and Julie's wedding, which will be held on May 1, 2021",
         "owner_name": "Veronica Costello",
@@ -149,10 +149,10 @@ mutation {
         "status": "ACTIVE",
         "registrants": [
           {
-            "uid": "NQ==",
+            "uid": "OQ==",
             "firstname": "Julie",
-            "lastname": "Mao",
-            "email": "juliemao@example.com",
+            "lastname": "Rao",
+            "email": "julierao@example.com",
             "dynamic_attributes": [
               {
                 "code": "role",
@@ -162,7 +162,7 @@ mutation {
             ]
           },
           {
-            "uid": "Ng==",
+            "uid": "MTA=",
             "firstname": "Bill",
             "lastname": "Preston",
             "email": "bpreston@example.com",
@@ -194,6 +194,8 @@ mutation {
         }
       }
     }
+  }
+}
 ```
 
 ## Input attributes

--- a/src/guides/v2.4/graphql/mutations/create-gift-registry.md
+++ b/src/guides/v2.4/graphql/mutations/create-gift-registry.md
@@ -200,10 +200,6 @@ mutation {
 
 The `CreateGiftRegistryInput` input object defines the gift registry.
 
-### CreateGiftRegistryInput attributes
-
-The `CreateGiftRegistryInput` object contains the following attributes:
-
 Attribute |  Data Type | Description
 --- | --- | ---
 `dynamic_attributes` | [[GiftRegistryDynamicAttributeInput](#GiftRegistryDynamicAttributeInput)] | An array of attributes that define elements of the gift registry. Each attribute is specified as a code-value pair

--- a/src/guides/v2.4/graphql/mutations/remove-gift-registry-registrants.md
+++ b/src/guides/v2.4/graphql/mutations/remove-gift-registry-registrants.md
@@ -3,7 +3,7 @@ group: graphql
 title: removeGiftRegistryRegistrants mutation
 
 ---
-The `removeGiftRegistryRegistrants` mutation .
+The `removeGiftRegistryRegistrants` mutation removes one or more registrants from the specified gift registry.
 
 This mutation requires a valid [customer authentication token]({{page.baseurl}}/graphql/mutations/generate-customer-token.html).
 

--- a/src/guides/v2.4/graphql/mutations/remove-gift-registry-registrants.md
+++ b/src/guides/v2.4/graphql/mutations/remove-gift-registry-registrants.md
@@ -27,13 +27,44 @@ The following example removes a registrant from the specified gift registry.
 **Request:**
 
 ```graphql
-
+mutation{
+  removeGiftRegistryRegistrants(
+      giftRegistryUid: "W9YcRai9JmzGglqP3p0USodTTM3BmjjY", 
+      registrantsUid: "OA=="
+    ){
+    gift_registry {
+      uid
+      registrants {
+        uid
+        firstname
+        lastname
+        email
+      }
+    }
+  }
+}
 ```
 
 **Response:**
 
 ```json
-
+{
+  "data": {
+    "removeGiftRegistryRegistrants": {
+      "gift_registry": {
+        "uid": "W9YcRai9JmzGglqP3p0USodTTM3BmjjY",
+        "registrants": [
+          {
+            "uid": "Mg==",
+            "firstname": "Stacey",
+            "lastname": "Gaines",
+            "email": "staceyg@example.com"
+          }
+        ]
+      }
+    }
+  }
+}
 ```
 
 ## Input attributes

--- a/src/guides/v2.4/graphql/mutations/remove-gift-registry-registrants.md
+++ b/src/guides/v2.4/graphql/mutations/remove-gift-registry-registrants.md
@@ -1,8 +1,8 @@
 ---
 group: graphql
 title: removeGiftRegistryRegistrants mutation
-
 ---
+
 The `removeGiftRegistryRegistrants` mutation removes one or more registrants from the specified gift registry.
 
 This mutation requires a valid [customer authentication token]({{page.baseurl}}/graphql/mutations/generate-customer-token.html).

--- a/src/guides/v2.4/graphql/mutations/remove-gift-registry-registrants.md
+++ b/src/guides/v2.4/graphql/mutations/remove-gift-registry-registrants.md
@@ -1,0 +1,58 @@
+---
+group: graphql
+title: removeGiftRegistryRegistrants mutation
+
+---
+The `removeGiftRegistryRegistrants` mutation .
+
+This mutation requires a valid [customer authentication token]({{page.baseurl}}/graphql/mutations/generate-customer-token.html).
+
+## Syntax
+
+```graphql
+mutation {
+  removeGiftRegistryRegistrants(
+    giftRegistryUid: ID!,
+    registrantsUid: [ID!]!
+  ) {
+    RemoveGiftRegistryRegistrantsOutput
+  }
+}
+```
+
+## Example usage
+
+The following example removes a registrant from the specified gift registry.
+
+**Request:**
+
+```graphql
+
+```
+
+**Response:**
+
+```json
+
+```
+
+## Input attributes
+
+The `removeGiftRegistryRegistrants` mutation requires the following input.
+
+Attribute |  Data Type | Description
+--- | --- | ---
+`giftRegistryRegistrantUid` | ID! | The unique ID of a `giftRegistryRegistrant` object
+`registrantsUid` | [ID!]! | An array of registrant IDs to remove
+
+## Output attributes
+
+The `RemoveGiftRegistryRegistrantsOutput` output object contains the following attribute.
+
+Attribute |  Data Type | Description
+--- | --- | ---
+`gift_registry` | [GiftRegistry](#GiftRegistry) | The gift registry after adding registrants
+
+### GiftRegistry attributes {#GiftRegistry}
+
+{% include graphql/gift-registry.md %}

--- a/src/guides/v2.4/graphql/mutations/update-gift-registry-registrants.md
+++ b/src/guides/v2.4/graphql/mutations/update-gift-registry-registrants.md
@@ -113,7 +113,7 @@ The `UpdateGiftRegistryRegistrantsOutput` output object contains the following a
 
 Attribute |  Data Type | Description
 --- | --- | ---
-`gift_registry` | [GiftRegistry](#GiftRegistry) | The gift registry after adding registrants
+`gift_registry` | [GiftRegistry](#GiftRegistry) | The gift registry after updating registrants
 
 ### GiftRegistry attributes {#GiftRegistry}
 

--- a/src/guides/v2.4/graphql/mutations/update-gift-registry-registrants.md
+++ b/src/guides/v2.4/graphql/mutations/update-gift-registry-registrants.md
@@ -1,0 +1,75 @@
+---
+group: graphql
+title: updateGiftRegistryRegistrants mutation
+
+---
+The `updateGiftRegistryRegistrants` mutation .
+
+This mutation requires a valid [customer authentication token]({{page.baseurl}}/graphql/mutations/generate-customer-token.html).
+
+## Syntax
+
+```graphql
+mutation {
+  updateGiftRegistryRegistrants(
+    giftRegistryUid: ID!,
+    registrants: [UpdateGiftRegistryRegistrantInput!]!
+  ) {
+    UpdateGiftRegistryRegistrantsOutput
+  }
+}
+```
+
+## Example usage
+
+The following example updates a registrant to the specified gift registry.
+
+**Request:**
+
+```graphql
+
+```
+
+**Response:**
+
+```json
+
+```
+
+## Input attributes
+
+The `updateGiftRegistryRegistrants` mutation requires the following input.
+
+Attribute |  Data Type | Description
+--- | --- | ---
+`dynamic_attributes` | [[GiftRegistryDynamicAttributeInput](#GiftRegistryDynamicAttributeInput)] | An array of attributes that define elements of the gift registry. Each attribute is specified as a code-value pair
+`email` | String! | The email address of the registrant
+`firstname` | String! | The first name of the registrant
+`lastname` | String! | The last name of the registrant
+
+giftRegistryRegistrantUid: ID! @doc(description: "The unique ID of a `giftRegistryRegistrant` object")
+firstname: String @doc(description: "The updated first name of the registrant")
+lastname: String @doc(description: "The updated last name of the registrant")
+email: String @doc(description: "The updated email address of the registrant")
+dynamic_attributes: [GiftRegistryDynamicAttributeInput] @doc(description: "As a result of the update, only the values of provided attributes will be affected. If the attribute is missing in the request, its value will not be changed")
+
+### GiftRegistryDynamicAttributeInput attributes {#GiftRegistryDynamicAttributeInput}
+
+The `GiftRegistryDynamicAttributeInput` object contains the following attributes:
+
+Attribute |  Data Type | Description
+--- | --- | ---
+`code` | ID! | A unique key for an additional attribute of the event
+`value` | String! | A corresponding value for the code
+
+## Output attributes
+
+The `AddGiftRegistryRegistrantsOutput` output object contains the following attribute.
+
+Attribute |  Data Type | Description
+--- | --- | ---
+`gift_registry` | [GiftRegistry](#GiftRegistry) | The gift registry after adding registrants
+
+### GiftRegistry attributes {#GiftRegistry}
+
+{% include graphql/gift-registry.md %}

--- a/src/guides/v2.4/graphql/mutations/update-gift-registry-registrants.md
+++ b/src/guides/v2.4/graphql/mutations/update-gift-registry-registrants.md
@@ -3,7 +3,7 @@ group: graphql
 title: updateGiftRegistryRegistrants mutation
 
 ---
-The `updateGiftRegistryRegistrants` mutation .
+The `updateGiftRegistryRegistrants` mutation updates properties of one or more registrants of the specified gify registry.
 
 This mutation requires a valid [customer authentication token]({{page.baseurl}}/graphql/mutations/generate-customer-token.html).
 
@@ -22,18 +22,59 @@ mutation {
 
 ## Example usage
 
-The following example updates a registrant to the specified gift registry.
+The following example updates a registrant's e-mail address.
 
 **Request:**
 
 ```graphql
-
+mutation{
+  updateGiftRegistryRegistrants(
+      giftRegistryUid: "W9YcRai9JmzGglqP3p0USodTTM3BmjjY", 
+      registrants: {
+          giftRegistryRegistrantUid: "OA=="
+          email: "new-email@example.com"
+        }
+    )
+    {
+    gift_registry {
+      uid
+      registrants {
+        uid
+        firstname
+        lastname
+        email
+      }
+    }
+  }
+}
 ```
 
 **Response:**
 
 ```json
-
+{
+  "data": {
+    "updateGiftRegistryRegistrants": {
+      "gift_registry": {
+        "uid": "W9YcRai9JmzGglqP3p0USodTTM3BmjjY",
+        "registrants": [
+          {
+            "uid": "Mg==",
+            "firstname": "Stacey",
+            "lastname": "Gaines",
+            "email": "staceyg@example.com"
+          },
+          {
+            "uid": "OA==",
+            "firstname": "Monica",
+            "lastname": "Resendez",
+            "email": "new-email@example.com"
+          }
+        ]
+      }
+    }
+  }
+}
 ```
 
 ## Input attributes
@@ -42,20 +83,24 @@ The `updateGiftRegistryRegistrants` mutation requires the following input.
 
 Attribute |  Data Type | Description
 --- | --- | ---
-`dynamic_attributes` | [[GiftRegistryDynamicAttributeInput](#GiftRegistryDynamicAttributeInput)] | An array of attributes that define elements of the gift registry. Each attribute is specified as a code-value pair
-`email` | String! | The email address of the registrant
-`firstname` | String! | The first name of the registrant
-`lastname` | String! | The last name of the registrant
+`giftRegistryRegistrantUid` | ID! | The unique ID of a `giftRegistryRegistrant` object
+`registrants` | [UpdateGiftRegistryRegistrantInput!]! | An array of registrants to update
 
-giftRegistryRegistrantUid: ID! @doc(description: "The unique ID of a `giftRegistryRegistrant` object")
-firstname: String @doc(description: "The updated first name of the registrant")
-lastname: String @doc(description: "The updated last name of the registrant")
-email: String @doc(description: "The updated email address of the registrant")
-dynamic_attributes: [GiftRegistryDynamicAttributeInput] @doc(description: "As a result of the update, only the values of provided attributes will be affected. If the attribute is missing in the request, its value will not be changed")
+### UpdateGiftRegistryRegistrantInput attributes
+
+The `UpdateGiftRegistryRegistrantInput` object can contain the following attributes:
+
+Attribute |  Data Type | Description
+--- | --- | ---
+`dynamic_attributes` | [[GiftRegistryDynamicAttributeInput](#GiftRegistryDynamicAttributeInput)] | As a result of the update, only the values of provided attributes will be affected. If the attribute is missing in the request, its value will not be changed
+`email` | String | The updated email address of the registrant
+`firstname` | String | The updated first name of the registrant
+`giftRegistryRegistrantUid` | ID! | The unique ID of a `giftRegistryRegistrant` object
+`lastname` | String | The updated last name of the registrant
 
 ### GiftRegistryDynamicAttributeInput attributes {#GiftRegistryDynamicAttributeInput}
 
-The `GiftRegistryDynamicAttributeInput` object contains the following attributes:
+The `GiftRegistryDynamicAttributeInput` object can contain the following attributes:
 
 Attribute |  Data Type | Description
 --- | --- | ---
@@ -64,7 +109,7 @@ Attribute |  Data Type | Description
 
 ## Output attributes
 
-The `AddGiftRegistryRegistrantsOutput` output object contains the following attribute.
+The `UpdateGiftRegistryRegistrantsOutput` output object contains the following attribute.
 
 Attribute |  Data Type | Description
 --- | --- | ---


### PR DESCRIPTION
## Purpose of this pull request

This pull request (PR) adds the three mutations that manage gift registry registrants. It fixes #8603 

## Affected DevDocs pages

<!-- REQUIRED List the affected pages on devdocs.magento.com (URLs). Not needed for large numbers of files. -->

-  ...

## Links to Magento source code

<!--  OPTIONAL - REMOVE THIS SECTION IF NOT USED. If this pull request references a file in a Magento codebase repository, add it here. -->

-  ...

<!--
If you are fixing a GitHub issue, note it using GitHub keyword format (https://help.github.com/en/articles/closing-issues-using-keywords#closing-an-issue-in-a-different-repository) to close the issue when this pull request is merged. Example: `Fixes #1234`

`master` is the default branch. Merged pull requests to `master` go live on the site automatically. Any requested changes to content on the `master` branch must be related to the released codebase. Any content related to future releases goes in the `develop` branch.

See Contribution guidelines (https://github.com/magento/devdocs/blob/master/.github/CONTRIBUTING.md) for more information.
-->
