### PR TITLE
usecase of the command bin/magento dev:source-theme:deploy

### DIFF
--- a/src/guides/v2.3/config-guide/cli/config-cli-subcommands-less-sass.md
+++ b/src/guides/v2.3/config-guide/cli/config-cli-subcommands-less-sass.md
@@ -80,3 +80,13 @@ To create LESS files for the adminhtml, enter the following command:
 ```bash
 bin/magento dev:source-theme:deploy --locale="en_US" --area="adminhtml" --theme="Magento/backend" css/styles css/styles-old
 ```
+
+## Common issue faced by Developer when working
+
+In the development stage, when you are working with css, Js, knockout js and knockout template, the developer faces below issues
+
+-  The changes in css , knockout js and knockout templates are not affecting on frontend when page load.
+
+-  The developer has to delete the pub static folder or run static content deploy command every time when changes in js and knockout template file.
+
+If you are facing this kind of issue in development then create symlinks

--- a/src/guides/v2.3/config-guide/cli/config-cli-subcommands-less-sass.md
+++ b/src/guides/v2.3/config-guide/cli/config-cli-subcommands-less-sass.md
@@ -81,12 +81,16 @@ To create LESS files for the adminhtml, enter the following command:
 bin/magento dev:source-theme:deploy --locale="en_US" --area="adminhtml" --theme="Magento/backend" css/styles css/styles-old
 ```
 
-## Common issue faced by Developer when working
+## Common issues faced by developers when working
 
-In the development stage, when you are working with css, Js, knockout js and knockout template, the developer faces below issues
+In the development stage, when you are working with CSS, JS, Knockout JS and Knockout template, the developer may face the following issues:
 
--  The changes in css , knockout js and knockout templates are not affecting on frontend when page load.
+-  The changes in CSS , Knockout JS and Knockout templates are not reflected on frontend when page loads.
 
--  The developer has to delete the pub static folder or run static content deploy command every time when changes in js and knockout template file.
+-  The developer has to delete the `pub/static` folder or run static content deploy command every time when there are changes in CSS , JS and Knockout template files.
 
-If you are facing this kind of issue in development then create symlinks
+Build symlinks if you're having trouble with this in growth.
+
+Once we create symlink it direct point to pub/static file and we don't need to run static content deploy command all the time.
+
+A symlink will point the file to destination to avoid any issues.


### PR DESCRIPTION
## Purpose of this pull request

This pull request (PR) of the use case of the command bin/Magento dev:source-theme: deploy

## Affected DevDocs pages

<!-- REQUIRED List the affected pages on devdocs.magento.com (URLs). Not needed for large numbers of files. -->

- https://devdocs.magento.com/guides/v2.3/config-guide/cli/config-cli-subcommands-less-sass.html

<!--
If you are fixing a GitHub issue, note it using GitHub keyword format (https://help.github.com/en/articles/closing-issues-using-keywords#closing-an-issue-in-a-different-repository) to close the issue when this pull request is merged. Example: `Fixes #1234`

`master` is the default branch. Merged pull requests to `master` go live on the site automatically. Any requested changes to content on the `master` branch must be related to the released codebase. Any content related to future releases goes in the `develop` branch.

See Contribution guidelines (https://github.com/magento/devdocs/blob/master/.github/CONTRIBUTING.md) for more information.
-->
