### PR TITLE
privatelink updates needed - Clarifications

### DIFF
--- a/src/cloud/project/privatelink-service.md
+++ b/src/cloud/project/privatelink-service.md
@@ -25,7 +25,7 @@ The PrivateLink service integration for {{site.data.var.ece}} projects includes 
 -  You cannot establish SSH connections using PrivateLink. For SSH, use the Magento SSH capabilities. See [Enable SSH keys][].
 -  Magento support does not cover troubleshooting AWS PrivateLink issues beyond initial enablement.
 -  Customers are responsible for costs associated with managing their own VPC.
--  You cannot use the HTTPS (443) protocol to connect to Magento Commerce over PrivateLink.
+-  You cannot use the HTTPS protocol (port 443) to connect to Magento Commerce over PrivateLink.
 -  PrivateDNS is not available 
 
 ## PrivateLink connection types

--- a/src/cloud/project/privatelink-service.md
+++ b/src/cloud/project/privatelink-service.md
@@ -62,7 +62,7 @@ Enabling PrivateLink can take up to 5 business days. Providing incomplete, or in
    -  **Magento Cloud Project ID**–Provide the {{site.data.var.ece}} Pro project ID. You can get the Project ID and other project information using the folllowing [Magento Cloud CLI][] command:  ```magento-cloud project:info```
    -  **Connection type**–Specify unidirectional or bidirectional for connection type
    -  **Service endpoint**–For bidirectional PrivateLink connections, provide the DNS URL for the VPC service endpoint that Magento must connect to, for example `com.amazonaws.vpce.<cloud-region>.vpce-svc-<service-id>`.
-   -  **Service endopoint access granted**-Ensure that your service endpoint has the principle set to allow access to= `arn:aws:iam::402592597372:root`.  If this is not set the bi-direction connection to access the service in your VPC cannot be added and will delay the setup.
+   -  **Service endpoint access granted**-Provide the Magento account principal with access to this service endpoint: `arn:aws:iam::402592597372:root`. If this access is not provided, the bidirectional PrivateLink connection to the service in your VPC will not be added, which will delay the setup.
 
 ### Enablement workflow
 

--- a/src/cloud/project/privatelink-service.md
+++ b/src/cloud/project/privatelink-service.md
@@ -25,7 +25,8 @@ The PrivateLink service integration for {{site.data.var.ece}} projects includes 
 -  You cannot establish SSH connections using PrivateLink. For SSH, use the Magento SSH capabilities. See [Enable SSH keys][].
 -  Magento support does not cover troubleshooting AWS PrivateLink issues beyond initial enablement.
 -  Customers are responsible for costs associated with managing their own VPC.
--  You cannot use the HTTPS protocol to connect to Magento Commerce over PrivateLink.
+-  You cannot use the HTTPS (443) protocol to connect to Magento Commerce over PrivateLink.
+-  PrivateDNS is not available 
 
 ## PrivateLink connection types
 
@@ -61,6 +62,7 @@ Enabling PrivateLink can take up to 5 business days. Providing incomplete, or in
    -  **Magento Cloud Project ID**–Provide the {{site.data.var.ece}} Pro project ID. You can get the Project ID and other project information using the folllowing [Magento Cloud CLI][] command:  ```magento-cloud project:info```
    -  **Connection type**–Specify unidirectional or bidirectional for connection type
    -  **Service endpoint**–For bidirectional PrivateLink connections, provide the DNS URL for the VPC service endpoint that Magento must connect to, for example `com.amazonaws.vpce.<cloud-region>.vpce-svc-<service-id>`.
+   -  **Service endopoint access granted**-Ensure that your service endpoint has the principle set to allow access to= `arn:aws:iam::402592597372:root`.  If this is not set the bi-direction connection to access the service in your VPC cannot be added and will delay the setup.
 
 ### Enablement workflow
 
@@ -89,7 +91,7 @@ The following workflow outlines the enablement process for PrivateLink integrati
 
    -  **Magento** supplies the Magento account principal (root user for AWS or Azure account) and requests access to the customer VPC endpoint service.
 
-   -  **Customer** enables Magento access to the endpoint service in customer VPC.
+   -  **Customer** enables Magento access to the endpoint service in customer VPC.  There is prereq of ensuring principle access= `arn:aws:iam::402592597372:root`
 
       -  Update the customer endpoint service configuration to accept requests initiated from Magento account. See the Cloud platform documentation for instructions:
 

--- a/src/cloud/project/privatelink-service.md
+++ b/src/cloud/project/privatelink-service.md
@@ -91,7 +91,7 @@ The following workflow outlines the enablement process for PrivateLink integrati
 
    -  **Magento** supplies the Magento account principal (root user for AWS or Azure account) and requests access to the customer VPC endpoint service.
 
-   -  **Customer** enables Magento access to the endpoint service in customer VPC.  There is prereq of ensuring principle access= `arn:aws:iam::402592597372:root`
+   -  **Customer** enables Magento access to the endpoint service in the customer VPC. This assumes that the Magento account principal has access to `arn:aws:iam::402592597372:root`, as previously described in the **Service endpoint access granted** prerequisite.
 
       -  Update the customer endpoint service configuration to accept requests initiated from Magento account. See the Cloud platform documentation for instructions:
 


### PR DESCRIPTION
Needed to clarify what https is (its 443) as well as ensuring that I added what the principle needs to be filled out with for easier access.   arn:aws:iam::402592597372:root

## Purpose of this pull request
This pull request (PR) clarifies the PrivateLink setup by adding port 443 along with explicit instruction for giving access to the Magento account principal to the service endpoint.

## Affected DevDocs pages
src/cloud/project/privatelink-service.md 

