### PR TITLE
Remove "Dedicated IP address"

### DIFF
--- a/src/cloud/project/sendgrid.md
+++ b/src/cloud/project/sendgrid.md
@@ -7,7 +7,7 @@ functional_areas:
   - Services
 ---
 
-The SendGrid-based SMTP proxy service provides email authentication, reputation monitoring, and dedicated IP addresses. A basic set up includes 12,000 emails per month and excludes use in marketing campaigns. See [SendGrid and Magento—Email Delivery. Simplified](https://sendgrid.com/partners/magento/).
+The SendGrid-based SMTP proxy service provides email authentication, and reputation monitoring. A basic set up includes 12,000 emails per month and excludes use in marketing campaigns. See [SendGrid and Magento—Email Delivery. Simplified](https://sendgrid.com/partners/magento/).
 
 Magento automates the SendGrid integration for Starter and Pro Integration environments. The Pro Production and Staging environments require manual provisioning and configuration during the IaaS hardware provisioning process.
 


### PR DESCRIPTION
We do not offer dedicated IP addresses for sendgrid.

## Purpose of this pull request

This pull request (PR) urgently remove the statement that we have dedicated IP's for customers with our SendGrid.  This needs to be removed.

## Affected DevDocs pages

<!-- REQUIRED List the affected pages on devdocs.magento.com (URLs). Not needed for large numbers of files. -->

-  ...

## Links to Magento source code

<!--  OPTIONAL - REMOVE THIS SECTION IF NOT USED. If this pull request references a file in a Magento codebase repository, add it here. -->

-  ...

<!--
If you are fixing a GitHub issue, note it using GitHub keyword format (https://help.github.com/en/articles/closing-issues-using-keywords#closing-an-issue-in-a-different-repository) to close the issue when this pull request is merged. Example: `Fixes #1234`

`master` is the default branch. Merged pull requests to `master` go live on the site automatically. Any requested changes to content on the `master` branch must be related to the released codebase. Any content related to future releases goes in the `develop` branch.

See Contribution guidelines (https://github.com/magento/devdocs/blob/master/.github/CONTRIBUTING.md) for more information.
-->
