### PR TITLE
Remove  from pages because index.php removed from Magento v2.4

### DIFF
--- a/src/_includes/php-dev/composer-types.md
+++ b/src/_includes/php-dev/composer-types.md
@@ -7,4 +7,4 @@ The following table discusses the component types that Magento Marketplace suppo
 |Theme|magento2-theme|Code that modifies the look and feel of the storefront or Magento Admin.|
 |Language package|magento2-language|Translations for the storefront or Admin.|
 |Library|magento2-library|Support for libraries located in `lib/internal` instead of in the `vendor` directory.|
-|Component|magento2-component|The package formed of the files that must be located in root (index.php, .htaccess, etc). This includes `dev/tests` and `setup` as well for now.|
+|Component|magento2-component|The package formed of the files that must be located in root (.htaccess, etc). This includes `dev/tests` and `setup` as well for now.|

--- a/src/guides/v2.4/architecture/archi_perspectives/components/modules/mod_and_areas.md
+++ b/src/guides/v2.4/architecture/archi_perspectives/components/modules/mod_and_areas.md
@@ -1,1 +1,78 @@
-../../../../../v2.3/architecture/archi_perspectives/components/modules/mod_and_areas.md
+---
+group: architecture-guide
+title: Modules and areas
+menu_title: Modules and areas
+---
+
+## Overview {#m2arch-module-areas-overview}
+
+An *area* is a logical component that organizes code for optimized request processing. Magento uses areas to streamline web service calls by loading only the dependent code for the specified area.  Each of the default areas defined by Magento can contain completely different code on how to process URLs and requests.
+
+For example, if you are invoking a REST web service call, rather than load all the code related to generating user [HTML](https://glossary.magento.com/html) pages, you can specify a separate area that loads code whose scope is limited to answering  REST calls.
+
+### Magento area types
+
+Magento is organized into these main areas:
+
+*  **Magento Admin** (`adminhtml`): entry point for this area is `pub/index.php`. The [Admin](https://glossary.magento.com/admin) panel area includes the code needed for store management. The /app/design/adminhtml directory contains all the code for components you'll see while working in the Admin panel.
+
+*  **Storefront** (`frontend`): entry point for this area is `pub/index.php`. The storefront (or `frontend`)  contains template and [layout](https://glossary.magento.com/layout) files that define the appearance of your [storefront](https://glossary.magento.com/storefront).
+
+*  **Basic** (`base`): used as a fallback for files absent in `adminhtml` and `frontend` areas.
+
+*  **Cron** (`crontab`): In `pub/cron.php`, the [`\Magento\Framework\App\Cron`]({{ site.mage2bloburl }}/{{ page.guide_version }}/lib/internal/Magento/Framework/App/Cron.php#L68-L70){:target="_blank"} class always loads the 'crontab' area.
+
+You can also send requests to Magento using the SOAP, REST and GraphQL APIs. These three areas
+
+*  **Web API REST** (`webapi_rest`): entry point for this area is `pub/index.php`. The REST area has a front controller that understands how to do [URL](https://glossary.magento.com/url) lookups for REST-based URLs.
+
+*  **GraphQL** (`graphql`): entry point for this area is `pub/index.php`.
+
+*  **Web API SOAP** (`webapi_soap`): entry point for this area is `pub/index.php`.
+
+## How areas work with modules {#m2arch-module-using}
+
+Modules define which resources are visible and accessible in an area, as well as an area's behavior. The same [module](https://glossary.magento.com/module) can influence several areas. For instance, the RMA module is represented partly in the `adminhtml` area and partly in the `frontend` area.
+
+If your [extension](https://glossary.magento.com/extension) works in several different areas, ensure it has separate behavior and view components for each area.
+
+Each area declares itself within a module. All resources specific for an area are located within the same module as well.
+
+You can enable or disable an area within a module. If this module is enabled, it injects an area's routers into the general application's routing process. If this module is disabled, Magento will not load an area's routers and, as a result, an area's resources and specific functionality are not available.
+
+### Module/area interaction guidelines
+
+*  Modules should not depend on other modules' areas.
+
+*  Disabling an area does not result in disabling the modules related to it.
+
+*  Areas are registered in the [Dependency Injection](https://glossary.magento.com/dependency-injection) framework `di.xml` file.
+
+### Note about Magento request processing
+
+Magento processes a URL request by first stripping off the base URL. The first path segment of the remaining URL identifies the request area.
+
+After the area name, the URI segment specifies the *frontname*. When an HTTP request arrives, Magento extracts the handle from the URL and interprets it as follows:
+
+```http
+[frontName]/[controller folder]/[controller class]
+```
+
+The `frontName` is a value defined in the module. Using `catalog/product/view` as an example:
+
+*  `catalog` is the [frontName]({{ site.mage2bloburl }}/{{ page.guide_version }}/app/code/Magento/Catalog/etc/frontend/routes.xml#L10) in the module area's `routes.xml` file
+*  `product` is in the [controller folder]({{ site.mage2bloburl }}/{{ page.guide_version }}/app/code/Magento/Catalog/Controller/Product)
+*  `view` is the [controller class]({{ site.mage2bloburl }}/{{ page.guide_version }}/app/code/Magento/Catalog/Controller/Product/View.php)
+
+For deeper directory structures, the controller folders are separated with an underscore (`_`). For example:
+
+```text
+catalog/product_compare/add = Magento/Catalog/Controller/Product/Compare/Add.php
+```
+
+Note that only the **execute()** method of any given controller is executed.
+
+{:.ref-header}
+Related topics
+
+[Module overview]({{page.baseurl}}/architecture/archi_perspectives/components/modules/mod_intro.html)

--- a/src/guides/v2.4/comp-mgr/prereq/prereq_compman-checklist.md
+++ b/src/guides/v2.4/comp-mgr/prereq/prereq_compman-checklist.md
@@ -121,7 +121,6 @@ drwxrwx---.  4 magento_user apache   4096 Jun  7 07:53 dev
 -rw-rw----.  1 magento_user apache   2926 Apr 27 21:23 Gruntfile.js
 -rw-rw----.  1 magento_user apache   7592 Apr 27 21:23 .htaccess
 -rw-rw----.  1 magento_user apache   6419 Apr 27 21:23 .htaccess.sample
--rw-rw----.  1 magento_user apache   1358 Apr 27 21:23 index.php
 drwxrwx---.  4 magento_user apache   4096 Jun  7 07:53 lib
 -rw-rw----.  1 magento_user apache  10376 Apr 27 21:23 LICENSE_AFL.txt
 -rw-rw----.  1 magento_user apache  30634 Apr 27 21:23 LICENSE_EE.txt

--- a/src/guides/v2.4/config-guide/db-profiler/db-profiler.md
+++ b/src/guides/v2.4/config-guide/db-profiler/db-profiler.md
@@ -1,1 +1,92 @@
-../../../v2.3/config-guide/db-profiler/db-profiler.md
+---
+group: configuration-guide
+title: Configure the database profiler
+contributor_name: Atish Goswami
+contributor_link: http://atishgoswami.com
+functional_areas:
+  - Configuration
+  - System
+  - Setup
+---
+
+## About the database profiler
+
+The Magento database profiler displays all queries executed on a page, including the time for each query and what parameters were executed.
+
+## Step 1: Modify the deployment configuration
+
+Modify `<magento_root>/app/etc/env.php` to add the following reference to the [database profiler class]({{ site.mage2bloburl }}/{{ page.guide_version }}/lib/internal/Magento/Framework/DB/Profiler.php):
+
+```php?start_inline=1
+        'profiler' => [
+            'class' => '\Magento\Framework\DB\Profiler',
+            'enabled' => true,
+        ],
+```
+
+An example follows:
+
+```php?start_inline=1
+ 'db' =>
+  array (
+    'table_prefix' => '',
+    'connection' =>
+    array (
+      'default' =>
+      array (
+        'host' => 'localhost',
+        'dbname' => 'magento',
+        'username' => 'magento',
+        'password' => 'magento',
+        'model' => 'mysql4',
+        'engine' => 'innodb',
+        'initStatements' => 'SET NAMES utf8;',
+        'active' => '1',
+        'profiler' => [
+            'class' => '\Magento\Framework\DB\Profiler',
+            'enabled' => true,
+        ],
+      ),
+    ),
+  ),
+  ```
+
+## Step 2: Configure the output
+
+Configure the output in your Magento application boostrap file; this might be `<magento_root>/index.php` or it could be located in a web server virtual host configuration.
+
+The following example displays results in a three-column table:
+
+*  Total time (displays the total amount of time to run all queries on the page)
+*  SQL (displays all SQL queries; the row header displays the count of queries)
+*  Query Params (displays the parameters for each SQL query)
+
+To configure the output, add the following after the `$bootstrap->run($app);` line in your bootstrap file:
+
+```php?start_inline=1
+/** @var \Magento\Framework\App\ResourceConnection $res */
+$res = \Magento\Framework\App\ObjectManager::getInstance()->get('Magento\Framework\App\ResourceConnection');
+/** @var Magento\Framework\DB\Profiler $profiler */
+$profiler = $res->getConnection('read')->getProfiler();
+echo "<table cellpadding='0' cellspacing='0' border='1'>";
+echo "<tr>";
+echo "<th>Time <br/>[Total Time: ".$profiler->getTotalElapsedSecs()." secs]</th>";
+echo "<th>SQL [Total: ".$profiler->getTotalNumQueries()." queries]</th>";
+echo "<th>Query Params</th>";
+echo "</tr>";
+foreach ($profiler->getQueryProfiles() as $query) {
+    /** @var Zend_Db_Profiler_Query $query*/
+    echo '<tr>';
+    echo '<td>', number_format(1000 * $query->getElapsedSecs(), 2), 'ms', '</td>';
+    echo '<td>', $query->getQuery(), '</td>';
+    echo '<td>', json_encode($query->getQueryParams()), '</td>';
+    echo '</tr>';
+}
+echo "</table>";
+```
+
+## Step 3: View the results
+
+Go to any page in your [storefront](https://glossary.magento.com/storefront) or [Magento Admin](https://glossary.magento.com/magento-admin) to view the results. A sample follows:
+
+![Sample database profiler results]({{ site.baseurl }}/common/images/config_db-profiler-results.png){:width="800px"}

--- a/src/guides/v2.4/config-guide/db-profiler/db-profiler.md
+++ b/src/guides/v2.4/config-guide/db-profiler/db-profiler.md
@@ -53,7 +53,7 @@ An example follows:
 
 ## Step 2: Configure the output
 
-Configure the output in your Magento application boostrap file; this might be `<magento_root>/index.php` or it could be located in a web server virtual host configuration.
+Configure the output in your Magento application boostrap file; this might be `<magento_root>/pub/index.php` or it could be located in a web server virtual host configuration.
 
 The following example displays results in a three-column table:
 

--- a/src/guides/v2.4/config-guide/deployment/pipeline/example/environment-variables.md
+++ b/src/guides/v2.4/config-guide/deployment/pipeline/example/environment-variables.md
@@ -1,1 +1,193 @@
-../../../../../v2.3/config-guide/deployment/pipeline/example/environment-variables.md
+---
+group: configuration-guide
+title: Using environment variables
+functional_areas:
+  - Configuration
+  - Deploy
+  - System
+  - Setup
+---
+
+This example shows how to set shared, system-specific, and sensitive values in your development system, then set all the values in your production system using a combination of the shared configuration, `config.php`, and PHP environment variables.
+
+These configuration settings can be shared between the development and production systems:
+
+VAT Number and Store Name from **Stores** > Settings > **Configuration** > General > **General**
+
+These configuration settings are either system-specific or sensitive, as indicated:
+
+*  Send Emails To (sensitive) from **Stores** > Settings > **Configuration** > General > **Contacts**
+*  Default Email Domain (system-specific) from **Stores** > Settings > **Configuration** > Customers > **Customer Configuration** > **Create New Account Options**
+
+You can use the same procedure to configure any settings in the following references:
+
+*  [Sensitive and system-specific configuration paths reference]({{ page.baseurl }}/config-guide/prod/config-reference-sens.html)
+*  [Payment configuration paths reference]({{ page.baseurl }}/config-guide/prod/config-reference-payment.html)
+*  [Other configuration paths reference]({{ page.baseurl }}/config-guide/prod/config-reference-most.html)
+*  [Magento Enterprise B2B Extension configuration paths reference]({{ page.baseurl }}/config-guide/prod/config-reference-b2b.html)
+
+## Before you begin
+
+Before you begin, set up file system permissions and ownership as discussed in [Prerequisite for your development, build, and production systems]({{ page.baseurl }}/config-guide/deployment/pipeline/technical-details.html#config-deploy-prereq).
+
+## Assumptions
+
+This topic provides an example of modifying the production system configuration. You can choose different configuration options if you wish.
+
+For the purposes of this example, we assume the following:
+
+*  You use Git source control
+*  The development system is available in a Git remote repository named `mconfig`
+*  Your Git working branch is named `m2.2_deploy`
+
+## Step 1: Set the configuration in the development system {#deploy-sens-setconfig}
+
+To set the default locale and weight units in your development system:
+
+1. Log in to the Magento Admin.
+1. Click **Stores** > Settings > **Configuration** > General > **General**.
+1. If you have more than one website available, use the **Store View** list in the upper left corner to switch to a different website as the following figure shows.
+
+   ![Switch websites]({{ site.baseurl }}/common/images/config_split-deploy_switch-website.png){:width="250px"}
+
+1. In the right pane, expand **Store Information**.
+1. If necessary, clear the **Use Default** checkbox next to the **VAT Number** field.
+1. Enter a number in the field (for example, `12345`).
+1. In the **Store Name** field, enter a value (like `My Store`).
+1. Click **Save Config**.
+1. Use the **Store View** list to select the **Default Config** as the following figure shows.
+
+   ![Switch to the default config]({{ site.baseurl }}/common/images/config_split-deploy_default-config.png){:width="200px"}
+
+1. In the left navigation, under General, click **Contacts**.
+1. Clear the **Use Default** checkbox next to the **Send Emails To** field.
+1. Enter an e-mail address in the field.
+1. Click **Save Config**.
+1. In the left pane, click Customers > **Customer Configuration**.
+1. In the right pane, expand **Create New Account Options**.
+1. Clear the **Use system value** checkbox next to the **Default Email Domain** field.
+1. Enter a domain name in the field.
+1. Click **Save Config**.
+1. If prompted, flush the cache.
+
+## Step 2: Update the configuration
+
+Now that you've changed the configuration in the Magento Admin, write the shared configuration to a file as discussed in this section.
+
+{% include config/split-deploy/example_save-shared-config.md %}
+
+Note that even though `app/etc/env.php` (the system-specific configuration) was updated, don't check it in to source control. You'll create the same configuration settings on your production system later in this procedure.
+
+## Step 3: Update your build system and generate files
+
+Now that you've committed your changes to the shared configuration to source control, you can pull those changes in your build system, compile code, and generate static files. The last step is to pull those changes to your production system.
+
+{% include config/split-deploy/example_build-sync.md %}
+
+## Step 4: Update the production system
+
+The last step in the process is to update your production system. You must do it in two parts:
+
+*  [Update the sensitive and system-specific settings](#config-split-verify-sens)
+*  [Update the shared settings](#config-split-verify-shared)
+
+### Update the sensitive and system-specific settings {#config-split-verify-sens}
+
+To set the sensitive and system-specific settings using environment variables, you must know the following:
+
+*  Each setting's scope
+
+   If you followed the instructions in [Step 1](#deploy-sens-setconfig), the scope for Send Emails To is global (that is, the Default Config scope) and the scope for Default Email Domain is website.
+
+   You must know the website's code to set the Default Email Domain configuration value. See [Use environment variables to override configuration settings]({{ page.baseurl }}/config-guide/prod/config-reference-var-name.html) for more information on finding it.
+*  Each setting's configuration path
+
+   The configuration paths used in this example follow:
+
+   | Setting name  | Configuration path |
+   |--------------|--------------|
+   | Send Emails To | `contact/email/recipient_email` |
+   | Default Email Domain | `customer/create_account/email_domain` |
+
+   You can find all sensitive and system-specific configuration paths in [Sensitive and system-specific configuration paths reference]({{ page.baseurl }}/config-guide/prod/config-reference-sens.html).
+
+#### Convert configuration paths to variable names
+
+As discussed in [Use environment variables to override configuration settings]({{ page.baseurl }}/config-guide/prod/config-reference-var-name.html), the format of variables is:
+
+```text
+<SCOPE>__<SYSTEM__VARIABLE__NAME>
+```
+
+The value of `<SCOPE>` is `CONFIG__DEFAULT__` for global scope or `CONFIG__WEBSITES__<WEBSITE CODE>` for website scope.
+
+To find the value of `<SYSTEM__VARIABLE__NAME>`, replace each `/` character in the configuration path with two underscores.
+
+The variable names follow:
+
+| Name  | Config path | Variable name |
+|--------------|--------------|--------------|
+| Send Emails To | `contact/email/recipient_email` | `CONFIG__DEFAULT__CONTACT__EMAIL__RECIPIENT_EMAIL` |
+| Default Email Domain | `customer/create_account/email_domain` | `CONFIG__WEBSITES__BASE__CUSTOMER__CREATE_ACCOUNT__EMAIL_DOMAIN` |
+
+{:.bs-callout-info}
+The preceding table has a sample website code, `BASE`, for the Default Email Domain configuration setting. Replace `BASE` with the appropriate website code for your store.
+
+#### Set the variables using environment variables
+
+You can set the variable values in the Magento `index.php` using the following format:
+
+```php
+$_ENV['VARIABLE'] = 'value';
+```
+
+To set variable values:
+
+1. Log in to your production system as, or switch to, the [Magento file system owner](https://glossary.magento.com/magento-file-system-owner).
+1. Open `<Magento root dir>/pub/index.php` in a text editor.
+1. Anywhere in `index.php`, set values for the variables similar to the following:
+
+   ```php
+   $_ENV['CONFIG__DEFAULT__CONTACT__EMAIL__RECIPIENT_EMAIL'] = 'myname@example.com';
+   $_ENV['CONFIG__WEBSITES__BASE__CUSTOMER__CREATE_ACCOUNT__EMAIL_DOMAIN'] = 'magento.com';
+   ```
+
+1. Save your changes to `pub/index.php` and exit the text editor.
+1. Continue with the next section.
+
+### Update the shared settings {#config-split-verify-shared}
+
+This section discusses how to pull all the changes you made on your development and build systems, which updates the shared configuration settings (Store Name and VAT Number).
+
+{% include config/split-deploy/example_update-prod.md %}
+
+### Verify configuration settings in the Magento Admin
+
+This section discusses how you can verify the configuration settings in your production system Admin.
+
+To verify the configuration settings:
+
+1. Log in to your production system's Magento Admin.
+1. Click **Stores** > Settings > **Configuration** > General > **General**.
+1. Use the **Store View** list in the upper left corner to switch to a different website.
+
+   The shared configuration options you set in the development system are displayed similar to the following.
+
+   ![Check settings in the production system]({{ site.baseurl }}/common/images/config_split-deploy_verify_storeinfo.png){:width="650px"}
+
+    {:.bs-callout-info}
+   The **Store Name** field is editable in the website scope but if you switch to the Default Config scope, it is not editable. This is the result of how you set the options in the development system. The value of **VAT Number** is not editable in website scope.
+
+1. If you haven't already done so, switch to Default Config scope.
+1. In the left navigation, under General, click **Contacts**.
+
+   The **Send Emails To** field is not editable, as the following figure shows. This is a sensitive setting.
+
+   ![Check settings in the production system]({{ site.baseurl }}/common/images/config_split-deploy_verify_contacts.png){:width="400px"}
+
+1. In the left pane, click Customers > **Customer Configuration**.
+1. In the right pane, expand **Create New Account Options**.
+
+   The value of the **Default Email Domain** field is displayed as follows. This is a system-specific setting.
+
+   ![Check settings in the production system]({{ site.baseurl }}/common/images/config_split-defaultdomain.png){:width="400px"}


### PR DESCRIPTION
## Purpose of this pull request

This pull request (PR) removed `index.php` from pages because index.php removed from Magento v2.4

## Affected DevDocs pages

https://devdocs.magento.com/guides/v2.4/config-guide/db-profiler/db-profiler.html
https://devdocs.magento.com/guides/v2.4/architecture/archi_perspectives/components/modules/mod_and_areas.html
https://devdocs.magento.com/guides/v2.4/comp-mgr/prereq/prereq_compman-checklist.html
https://devdocs.magento.com/guides/v2.4/config-guide/deployment/pipeline/example/environment-variables.html
https://devdocs.magento.com/guides/v2.4/extension-dev-guide/prepare/dev-modtypes.html
https://devdocs.magento.com/guides/v2.4/extension-dev-guide/package/package_module.html
