### PR TITLE
Fix typo in various page

### DIFF
--- a/src/guides/v2.3/ui_comp_guide/components/ui-colorpicker.md
+++ b/src/guides/v2.3/ui_comp_guide/components/ui-colorpicker.md
@@ -18,9 +18,9 @@ The ColorPicker component must be a child of the [Listing]({{ page.baseurl }}/ui
 ## Sources files
 
 -  [app/code/Magento/Ui/view/base/ui_component/etc/definition/colorPicker.xsd]({{ site.mage2bloburl }}/{{page.guide_version}}/app/code/Magento/Ui/view/base/ui_component/etc/definition/colorPicker.xsd)
--  [app/code/Magento/Ui/view/base/web/js/form/element/colorPicker.js]({{ site.mage2bloburl }}/{{page.guide_version}}/app/code/Magento/Ui/view/base/web/js/form/element/color-picker.js)
--  [app/code/Magento/Ui/view/base/web/js/lib/knockout/bindings/colorPicker.js]({{ site.mage2bloburl }}/{{page.guide_version}}/app/code/Magento/Ui/view/base/web/js/lib/knockout/bindings/color-picker.js)
--  [app/code/Magento/Ui/view/base/web/templates/form/element/colorPicker.html]({{ site.mage2bloburl }}/{{page.guide_version}}/app/code/Magento/Ui/view/base/web/templates/form/element/color-picker.html)
+-  [app/code/Magento/Ui/view/base/web/js/form/element/color-picker.js]({{ site.mage2bloburl }}/{{page.guide_version}}/app/code/Magento/Ui/view/base/web/js/form/element/color-picker.js)
+-  [app/code/Magento/Ui/view/base/web/js/lib/knockout/bindings/color-picker.js]({{ site.mage2bloburl }}/{{page.guide_version}}/app/code/Magento/Ui/view/base/web/js/lib/knockout/bindings/color-picker.js)
+-  [app/code/Magento/Ui/view/base/web/templates/form/element/color-picker.html]({{ site.mage2bloburl }}/{{page.guide_version}}/app/code/Magento/Ui/view/base/web/templates/form/element/color-picker.html)
 -  [lib/web/jquery/spectrum/spectrum.js]({{ site.mage2bloburl }}/{{page.guide_version}}/lib/web/jquery/spectrum/spectrum.js)
 -  [lib/web/jquery/spectrum/tinycolor.js]({{ site.mage2bloburl }}/{{page.guide_version}}/lib/web/jquery/spectrum/tinycolor.js)
 

--- a/src/guides/v2.3/ui_comp_guide/components/ui-massactions.md
+++ b/src/guides/v2.3/ui_comp_guide/components/ui-massactions.md
@@ -160,7 +160,7 @@ Redefine link to constructor:
 <massaction name="listing_massaction">
     <argument name="data" xsi:type="array">
         <item name="js_config" xsi:type="array">
-            <item name="component" xsi:type="string">Magento_Products/js/grid/massactions</item>
+            <item name="component" xsi:type="string">Magento_Ui/js/grid/massactions</item>
         </item>
     </argument>
 </massaction>

--- a/src/guides/v2.3/ui_comp_guide/concepts/ui_comp_template_literals.md
+++ b/src/guides/v2.3/ui_comp_guide/concepts/ui_comp_template_literals.md
@@ -15,7 +15,7 @@ Template literals allow UI Components to easily assign dynamic values to class p
 
 UI Components are [associated with JavaScript classes]({{ page.baseurl }}/ui_comp_guide/concepts/ui_comp_uiclass_concept.html) to handle behavior on the client side. These should extend one of the core classes to provide a base level of functionality. Inside the child class, a `defaults` property can be provided.
 
-The `defaults` property should be an object and is handled in a special way. Each property of `defaults` becomes a class property upon initialization. This happens in the `initConfig()` method of `lib/core/class.js`. Every item in `defaults` is passed through a `template()` function which evaluates template literals.
+The `defaults` property should be an object and is handled in a special way. Each property of `defaults` becomes a class property upon initialization. This happens in the `initConfig()` method of `magento/module-ui/view/base/web/js/lib/core/class.js`. Every item in `defaults` is passed through a `template()` function which evaluates template literals.
 
 As a result, every `defaults` child property is handled with what could be viewed as a two step process:
 


### PR DESCRIPTION
## Purpose of this pull request

This pull request (PR) will correct some typo mistakes in content devdocs

## Affected DevDocs pages

<!-- REQUIRED List the affected pages on devdocs.magento.com (URLs). Not needed for large numbers of files. -->

https://devdocs.magento.com/guides/v2.3/ui_comp_guide/components/ui-colorpicker.html
https://devdocs.magento.com/guides/v2.3/ui_comp_guide/components/ui-massactions.html
https://devdocs.magento.com/guides/v2.3/ui_comp_guide/concepts/ui_comp_template_literals.html

## Links to Magento source code

<!--  OPTIONAL - REMOVE THIS SECTION IF NOT USED. If this pull request references a file in a Magento codebase repository, add it here. -->

-  ...

<!--
If you are fixing a GitHub issue, note it using GitHub keyword format (https://help.github.com/en/articles/closing-issues-using-keywords#closing-an-issue-in-a-different-repository) to close the issue when this pull request is merged. Example: `Fixes #1234`

`master` is the default branch. Merged pull requests to `master` go live on the site automatically. Any requested changes to content on the `master` branch must be related to the released codebase. Any content related to future releases goes in the `develop` branch.

See Contribution guidelines (https://github.com/magento/devdocs/blob/master/.github/CONTRIBUTING.md) for more information.
-->
