### PR TITLE
add missing email required field and correct billingAddress field name

### DIFF
--- a/src/guides/v2.3/rest/tutorials/orders/order-create-order.md
+++ b/src/guides/v2.3/rest/tutorials/orders/order-create-order.md
@@ -25,6 +25,8 @@ When you submit payment information, Magento creates an order and sends an order
 {:.bs-callout-info}
 Use the `V1/guest-carts/<cartId>/payment-information` endpoint to set the payment information on behalf of a guest. Do not include an authorization token.
 
+This guest-carts endpoint also requires `email` in the payload (same level as `paymentMethod` and `billing_address`)
+
 **Endpoint:**
 
 `POST <host>/rest/<store_code>/V1/carts/mine/payment-information`
@@ -44,7 +46,7 @@ Use the `V1/guest-carts/<cartId>/payment-information` endpoint to set the paymen
   "paymentMethod": {
     "method": "banktransfer"
   },
-  "billingAddress": {
+  "billing_address": {
     "email": "jdoe@example.com",
     "region": "New York",
     "region_id": 43,
@@ -58,8 +60,7 @@ Use the `V1/guest-carts/<cartId>/payment-information` endpoint to set the paymen
     "telephone": "512-555-1111",
     "firstname": "Jane",
     "lastname": "Doe"
-  },
-  "email": "jdoe@example.com"
+  }
 }
 ```
 

--- a/src/guides/v2.3/rest/tutorials/orders/order-create-order.md
+++ b/src/guides/v2.3/rest/tutorials/orders/order-create-order.md
@@ -44,7 +44,7 @@ Use the `V1/guest-carts/<cartId>/payment-information` endpoint to set the paymen
   "paymentMethod": {
     "method": "banktransfer"
   },
-  "billing_address": {
+  "billingAddress": {
     "email": "jdoe@example.com",
     "region": "New York",
     "region_id": 43,
@@ -58,7 +58,8 @@ Use the `V1/guest-carts/<cartId>/payment-information` endpoint to set the paymen
     "telephone": "512-555-1111",
     "firstname": "Jane",
     "lastname": "Doe"
-  }
+  },
+  "email": "jdoe@example.com"
 }
 ```
 


### PR DESCRIPTION
## Purpose of this pull request
Fix the error according to this question: https://magento.stackexchange.com/questions/334702

According to this redoc link: https://magento.redoc.ly/2.4.2-guest/tag/guest-cartscartIdpayment-information
The email is required and also, `billingAddress` is mistyped

## Affected DevDocs pages

<!-- REQUIRED List the affected pages on devdocs.magento.com (URLs). Not needed for large numbers of files. -->

https://devdocs.magento.com/guides/v2.4/rest/tutorials/orders/order-create-order.html

<!--
If you are fixing a GitHub issue, note it using GitHub keyword format (https://help.github.com/en/articles/closing-issues-using-keywords#closing-an-issue-in-a-different-repository) to close the issue when this pull request is merged. Example: `Fixes #1234`

`master` is the default branch. Merged pull requests to `master` go live on the site automatically. Any requested changes to content on the `master` branch must be related to the released codebase. Any content related to future releases goes in the `develop` branch.

See Contribution guidelines (https://github.com/magento/devdocs/blob/master/.github/CONTRIBUTING.md) for more information.
-->
