### PR TITLE
Update config-remote-storage-aws-s3.md

### DIFF
--- a/src/guides/v2.4/config-guide/remote-storage/config-remote-storage-aws-s3.md
+++ b/src/guides/v2.4/config-guide/remote-storage/config-remote-storage-aws-s3.md
@@ -22,7 +22,7 @@ To enable remote storage with the AWS S3 adapter:
 1. Configure Magento to use the private bucket. See [Remote storage options][options] for a full list of parameters.
 
    ```bash
-   bin/magento setup:config:set --remote-storage-driver="aws-s3" --remote-storage-bucket="<bucket-name>" --remote-storage-region="<region-name>" --remote-storage-prefix="<optional-prefix>" --access-key=<optional-access-key> --secret-key=<optional-secret-key> -n
+   bin/magento setup:config:set --remote-storage-driver="aws-s3" --remote-storage-bucket="<bucket-name>" --remote-storage-region="<region-name>" --remote-storage-prefix="<optional-prefix>" --remote-storage-key=<optional-access-key> --remote-storage-secret=<optional-secret-key> -n
    ```
 
 ## Configure Nginx


### PR DESCRIPTION
## Purpose of this pull request

This pull request (PR) fixes incorrect options for setting remote storage access key and secret.  It conflicts with the correct options page it links to https://devdocs.magento.com/guides/v2.4/config-guide/remote-storage/config-remote-storage.html#remote-storage-options.

## Affected DevDocs pages

<!-- REQUIRED List the affected pages on devdocs.magento.com (URLs). Not needed for large numbers of files. -->

-  https://devdocs.magento.com/guides/v2.4/config-guide/remote-storage/config-remote-storage-aws-s3.html

## Links to Magento source code

<!--  OPTIONAL - REMOVE THIS SECTION IF NOT USED. If this pull request references a file in a Magento codebase repository, add it here. -->

- https://github.com/magento/magento2/blob/2.4-develop/app/code/Magento/RemoteStorage/Setup/ConfigOptionsList.php#L35-L38

<!--
If you are fixing a GitHub issue, note it using GitHub keyword format (https://help.github.com/en/articles/closing-issues-using-keywords#closing-an-issue-in-a-different-repository) to close the issue when this pull request is merged. Example: `Fixes #1234`

`master` is the default branch. Merged pull requests to `master` go live on the site automatically. Any requested changes to content on the `master` branch must be related to the released codebase. Any content related to future releases goes in the `develop` branch.

See Contribution guidelines (https://github.com/magento/devdocs/blob/master/.github/CONTRIBUTING.md) for more information.
-->
