### PR TITLE
Add note to clarify when using guest endpoint

### DIFF
--- a/src/guides/v2.3/rest/tutorials/orders/order-create-order.md
+++ b/src/guides/v2.3/rest/tutorials/orders/order-create-order.md
@@ -25,6 +25,8 @@ When you submit payment information, Magento creates an order and sends an order
 {:.bs-callout-info}
 Use the `V1/guest-carts/<cartId>/payment-information` endpoint to set the payment information on behalf of a guest. Do not include an authorization token.
 
+Also, when using this guest-carts endpoint, it's required to include `email` field in the payload (same level as `paymentMethod` and `billing_address`)
+
 **Endpoint:**
 
 `POST <host>/rest/<store_code>/V1/carts/mine/payment-information`


### PR DESCRIPTION
## Purpose of this pull request
According to this redoc link: https://magento.redoc.ly/2.4.2-guest/tag/guest-cartscartIdpayment-information
The email field is required, but the payload in the example is for logged-in customer. This note helps readers know the difference between 2 endpoints.

## Affected DevDocs pages

https://devdocs.magento.com/guides/v2.4/rest/tutorials/orders/order-create-order.html