### PR TITLE
Update resource model admin grid tut

### DIFF
--- a/src/guides/v2.3/extension-dev-guide/admin-grid.md
+++ b/src/guides/v2.3/extension-dev-guide/admin-grid.md
@@ -473,6 +473,7 @@ use Magento\Backend\App\Action;
 use Magento\Backend\App\Action\Context;
 use Magento\Framework\View\Result\Page;
 use Magento\Framework\View\Result\PageFactory;
+use Magento\Framework\App\Action\HttpGetActionInterface;
 
 class Index extends Action implements HttpGetActionInterface
 {

--- a/src/guides/v2.3/extension-dev-guide/admin-grid.md
+++ b/src/guides/v2.3/extension-dev-guide/admin-grid.md
@@ -377,6 +377,15 @@ class Collection extends SearchResult
 
 It uses a custom collection file to add custom filters to map, and makes the grid filters work with the ID and name fields. Without `addFilterToMap`, you will not be able to search within the `name` column.
 
+The resource model class translates into `app/code/Dev/Grid/Model/ResourceModel/Category.php`:
+
+```php
+namespace Dev\Grid\Model\ResourceModel;
+
+class Category extends \Magento\Catalog\Model\ResourceModel\Category
+{
+}
+
 ### 5. Column Actions Class
 
 The UI grid file defines a column actions class `Dev\Grid\Ui\Component\Category\Listing\Column\Actions`.

--- a/src/guides/v2.3/extension-dev-guide/admin-grid.md
+++ b/src/guides/v2.3/extension-dev-guide/admin-grid.md
@@ -385,6 +385,7 @@ namespace Dev\Grid\Model\ResourceModel;
 class Category extends \Magento\Catalog\Model\ResourceModel\Category
 {
 }
+```
 
 ### 5. Column Actions Class
 

--- a/src/guides/v2.3/extension-dev-guide/admin-grid.md
+++ b/src/guides/v2.3/extension-dev-guide/admin-grid.md
@@ -377,7 +377,7 @@ class Collection extends SearchResult
 
 It uses a custom collection file to add custom filters to map, and makes the grid filters work with the ID and name fields. Without `addFilterToMap`, you will not be able to search within the `name` column.
 
-The resource model class translates into `app/code/Dev/Grid/Model/ResourceModel/Category.php`:
+The resource model class translates to `app/code/Dev/Grid/Model/ResourceModel/Category.php`:
 
 ```php
 namespace Dev\Grid\Model\ResourceModel;


### PR DESCRIPTION
## Purpose of this pull request

Add some classes so that readers will not need to refer to the git.

Details: When copy/paste from the devdocs, I get some error, this PR fixes the error I encountered
1. Cannot find `HttpGetActionInterface` class
2. Resource Model is defined in the di.xml file but its class code is not in the devdocs (the git however has it)

## Affected DevDocs pages

https://devdocs.magento.com/guides/v2.4/extension-dev-guide/admin-grid.html
