### PR TITLE
env.php configuration values

### DIFF
--- a/src/guides/v2.3/config-guide/prod/config-reference-envphp.md
+++ b/src/guides/v2.3/config-guide/prod/config-reference-envphp.md
@@ -229,7 +229,7 @@ Learn more about session in [x-frame-options][x-frame-options].
 
 ## system
 
-Magento configuration values local rewrite.
+Magento configuration values that cannot be edited in the Magento Admin
 
 ```conf
 'system' => [
@@ -242,7 +242,7 @@ Magento configuration values local rewrite.
   ]
 ```
 
-Learn more configuration values that cannot be edited in the Magento Admin in [env-php-config-set][env-php-config-set].
+Learn more in [env-php-config-set][env-php-config-set].
 
 <!-- Link definitions -->
 [lock-provider-config]: {{ page.baseurl }}/install-gde/install/cli/install-cli-subcommands-lock.html

--- a/src/guides/v2.3/config-guide/prod/config-reference-envphp.md
+++ b/src/guides/v2.3/config-guide/prod/config-reference-envphp.md
@@ -257,4 +257,4 @@ Learn more configuration values that cannot be edited in the Magento Admin in [e
 [downloadable-domains]: {{ page.baseurl }}/reference/cli/magento.html#downloadabledomainsadd
 [change-docroot-to-pub]: {{ page.baseurl }}/install-gde/tutorials/change-docroot-to-pub.html
 [crons]: {{ page.baseurl }}/config-guide/cli/config-cli-subcommands-cron.html
-[env-php-config-set]: {{ page.baseusr }}/config-guide/cli/config-cli-subcommands-config-mgmt-set.md
+[env-php-config-set]: {{ page.baseusr }}/config-guide/cli/config-cli-subcommands-config-mgmt-set.html

--- a/src/guides/v2.3/config-guide/prod/config-reference-envphp.md
+++ b/src/guides/v2.3/config-guide/prod/config-reference-envphp.md
@@ -227,6 +227,23 @@ x-frame-options header can be configured using this node.
 
 Learn more about session in [x-frame-options][x-frame-options].
 
+## system
+
+Magento configuration values local rewrite.
+
+```conf
+'system' => [
+  'default' => [
+    'web' => [
+      'secure' => [
+          'base_url' => 'https://magento.test/'
+      ]
+    ],
+  ]
+```
+
+Learn more configuration values that cannot be edited in the Magento Admin in [env-php-config-set][env-php-config-set].
+
 <!-- Link definitions -->
 [lock-provider-config]: {{ page.baseurl }}/install-gde/install/cli/install-cli-subcommands-lock.html
 [encryption-key]: https://docs.magento.com/m2/ce/user_guide/system/encryption-key.html
@@ -240,3 +257,4 @@ Learn more about session in [x-frame-options][x-frame-options].
 [downloadable-domains]: {{ page.baseurl }}/reference/cli/magento.html#downloadabledomainsadd
 [change-docroot-to-pub]: {{ page.baseurl }}/install-gde/tutorials/change-docroot-to-pub.html
 [crons]: {{ page.baseurl }}/config-guide/cli/config-cli-subcommands-cron.html
+[env-php-config-set]: {{ page.baseusr }}/config-guide/cli/config-cli-subcommands-config-mgmt-set.md

--- a/src/guides/v2.3/config-guide/prod/config-reference-envphp.md
+++ b/src/guides/v2.3/config-guide/prod/config-reference-envphp.md
@@ -238,7 +238,7 @@ Magento configuration values that cannot be edited in the Magento Admin
       'secure' => [
           'base_url' => 'https://magento.test/'
       ]
-    ],
+    ]
   ]
 ```
 

--- a/src/guides/v2.3/config-guide/prod/config-reference-envphp.md
+++ b/src/guides/v2.3/config-guide/prod/config-reference-envphp.md
@@ -26,6 +26,7 @@ The `env.php` file contains the following sections:
 | `resource`                    | Mapping of resource name to a connection                        |
 | `session`                     | Session storage data                                            |
 | `x-frame-options`             | Setting for [x-frame-options][x-frame-options]                  |
+| `system`                      | Configuration values that cannot be edited in the Magento Admin |
 
 ## backend
 

--- a/src/guides/v2.3/config-guide/prod/config-reference-envphp.md
+++ b/src/guides/v2.3/config-guide/prod/config-reference-envphp.md
@@ -230,7 +230,7 @@ Learn more about session in [x-frame-options][x-frame-options].
 
 ## system
 
-Magento configuration values that cannot be edited in the Magento Admin
+Magento configuration values that cannot be edited in the Magento Admin.
 
 ```conf
 'system' => [


### PR DESCRIPTION
## Purpose of this pull request

This pull request (PR) adds info about how to set configuration values that cannot be edited in the Magento Admin directly in env.php

## Affected DevDocs pages

-  https://devdocs.magento.com/guides/v2.4/config-guide/prod/config-reference-envphp.html
