### PR TITLE
show-password component info and magento code base link added

### DIFF
--- a/src/guides/v2.4/ui_comp_guide/howto/show_or_hide_password_checkbox.md
+++ b/src/guides/v2.4/ui_comp_guide/howto/show_or_hide_password_checkbox.md
@@ -47,6 +47,8 @@ Initialize the "show or hide" password checkbox using the `text/x-magento-init` 
 |`component`|The path to the component’s `.js` file, relative to RequireJS. Here the component path value is `Magento_Customer/js/show-password`|String|
 |`passwordSelector`|The id of the password input field, such as `#pass`.|String|
 
+`Magento_Customer/js/show-password` is the RequireJS file path for the javascript implementation of the "show or hide" password checkbox logic. It is defined in `app/code/Magento/Customer/view/frontend/web/js/show-password.js` file. [`show-password` component][show-password].
+
 ## Example
 
 This example shows the custom implemented company login form template (PHTML file) with the "show or hide" password checkbox.
@@ -94,3 +96,5 @@ This example shows the custom implemented company login form template (PHTML fil
     }
 </script>
 ```
+
+[show-password]: {{ site.mage2bloburl }}/{{ page.guide_version }}/app/code/Magento/Customer/view/frontend/web/js/show-password.js

--- a/src/guides/v2.4/ui_comp_guide/howto/show_or_hide_password_checkbox.md
+++ b/src/guides/v2.4/ui_comp_guide/howto/show_or_hide_password_checkbox.md
@@ -47,7 +47,7 @@ Initialize the "show or hide" password checkbox using the `text/x-magento-init` 
 |`component`|The path to the component’s `.js` file, relative to RequireJS. Here the component path value is `Magento_Customer/js/show-password`|String|
 |`passwordSelector`|The id of the password input field, such as `#pass`.|String|
 
-`Magento_Customer/js/show-password` is the RequireJS file path for the javascript implementation of the "show or hide" password checkbox logic. It is defined in `app/code/Magento/Customer/view/frontend/web/js/show-password.js` file. [`show-password` component][show-password].
+The RequireJS file path for the "show or hide" password checkbox is `Magento_Customer/js/show-password`. It is defined in [`app/code/Magento/Customer/view/frontend/web/js/show-password.js`][show-password].
 
 ## Example
 


### PR DESCRIPTION
## Purpose of this pull request

This pull request (PR) updates show-password component info and Magento code base link.

## Affected DevDocs pages

<!-- REQUIRED List the affected pages on devdocs.magento.com (URLs). Not needed for large numbers of files. -->

-  https://devdocs.magento.com/guides/v2.4/ui_comp_guide/howto/show_or_hide_password_checkbox.html

## Links to Magento source code

<!--  OPTIONAL - REMOVE THIS SECTION IF NOT USED. If this pull request references a file in a Magento codebase repository, add it here. -->

-  https://github.com/magento/magento2/blob/2.4-develop/app/code/Magento/Customer/view/frontend/web/js/show-password.js

<!--
If you are fixing a GitHub issue, note it using GitHub keyword format (https://help.github.com/en/articles/closing-issues-using-keywords#closing-an-issue-in-a-different-repository) to close the issue when this pull request is merged. Example: `Fixes #1234`

`master` is the default branch. Merged pull requests to `master` go live on the site automatically. Any requested changes to content on the `master` branch must be related to the released codebase. Any content related to future releases goes in the `develop` branch.

See Contribution guidelines (https://github.com/magento/devdocs/blob/master/.github/CONTRIBUTING.md) for more information.
-->
