### PR TITLE
Added -f(force) param to static deploy command

### DIFF
--- a/src/guides/v2.3/howdoi/checkout/checkout_address.md
+++ b/src/guides/v2.3/howdoi/checkout/checkout_address.md
@@ -337,7 +337,7 @@ In your `<your_module_dir>/view/frontend/layout/checkout_index_index.xml` file, 
 1. Deploy static content:
 
    ```bash
-   bin/magento setup:static-content:deploy
+   bin/magento setup:static-content:deploy -f
    ```
 
 1. Then clean the cache:

--- a/src/guides/v2.3/howdoi/checkout/checkout_custom_checkbox.md
+++ b/src/guides/v2.3/howdoi/checkout/checkout_custom_checkbox.md
@@ -217,5 +217,5 @@ define([
 1. Deploy static content:
 
    ```bash
-   bin/magento setup:static-content:deploy
+   bin/magento setup:static-content:deploy -f
    ```

--- a/src/guides/v2.3/howdoi/checkout/checkout_new_field.md
+++ b/src/guides/v2.3/howdoi/checkout/checkout_new_field.md
@@ -216,7 +216,7 @@ class MyBlock extends Template {
 1. Next, deploy static content:
 
    ```bash
-   bin/magento setup:static-content:deploy
+   bin/magento setup:static-content:deploy -f
    ```
 
 1. Then clean the cache:

--- a/src/guides/v2.3/howdoi/checkout/checkout_payment.md
+++ b/src/guides/v2.3/howdoi/checkout/checkout_payment.md
@@ -321,7 +321,7 @@ These steps are required in production mode only, not while in development mode.
 1. Deploy the static contents:
 
    ```bash
-   bin/magento setup:static-content:deploy
+   bin/magento setup:static-content:deploy -f
    ```
 
 1. Clean the cache:


### PR DESCRIPTION
## Purpose of this pull request

This pull request (PR) - For running static-content:deploy command in developer mode we need to add -f param. So it will be useful the developers while using these docs.

## Affected DevDocs pages

<!-- REQUIRED List the affected pages on devdocs.magento.com (URLs). Not needed for large numbers of files. -->

https://devdocs.magento.com/guides/v2.3/howdoi/checkout/checkout_address.html
https://devdocs.magento.com/guides/v2.3/howdoi/checkout/checkout_custom_checkbox.html
https://devdocs.magento.com/guides/v2.3/howdoi/checkout/checkout_new_field.html
https://devdocs.magento.com/guides/v2.3/howdoi/checkout/checkout_payment.html

