### PR TITLE
Removed old php version from example

### DIFF
--- a/src/guides/v2.3/ext-best-practices/extension-coding/example-module-adminpage.md
+++ b/src/guides/v2.3/ext-best-practices/extension-coding/example-module-adminpage.md
@@ -48,7 +48,7 @@ For more information see: [`composer.json`]({{ page.baseurl }}/extension-dev-gui
       "AFL-3.0"
     ],
     "require": {
-      "php": "~7.1.3||~7.2.0||~7.3.0"
+      "php": "~7.2.0||~7.3.0"
     },
     "autoload": {
       "files": [ "registration.php" ],


### PR DESCRIPTION
## Purpose of this pull request

This pull request (PR) - php version 7.1 release is no longer supported. So it has been removed.

## Affected DevDocs pages

<!-- REQUIRED List the affected pages on devdocs.magento.com (URLs). Not needed for large numbers of files. -->

-  https://devdocs.magento.com/guides/v2.3/ext-best-practices/extension-coding/example-module-adminpage.html

