### PR TITLE
Add APCu to 'always installed' list

### DIFF
--- a/src/cloud/project/magento-app-php-application.md
+++ b/src/cloud/project/magento-app-php-application.md
@@ -4,7 +4,7 @@ title: PHP application
 functional_areas:
   - Cloud
   - Setup
-  - Application  
+  - Application
 ---
 
 You can choose which [version of PHP]({{ site.baseurl}}/cloud/project/services.html#service-versions) to run in your `.magento.app.yaml` file:
@@ -46,7 +46,7 @@ The following table shows the supported PHP extensions when deploying {{site.dat
 {:.php-plugins-table}
 | Default extensions | Installed extensions<br>that cannot be uninstalled | Extensions that can be installed<br> and uninstalled as needed|
 |--------------------|---------------------|---------------------|
-| `bcmath`<br> `bz2`<br> `calendar`<br> `exif`<br> `gd`<br> `gettext`<br> `intl`<br> `mysqli`<br> `pcntl`<br> `pdo_mysql`<br> `soap`<br> `sockets`<br>  `sysvmsg`<br> `sysvsem`<br> `sysvshm`<br> `opcache`<br> `zip` |`ctype`<br> `curl`<br> `date`<br> `dom`<br> `fileinfo`<br> `filter`<br> `ftp`<br> `hash`<br> `iconv`<br> `json`<br> `mbstring`<br> `mysqlnd`<br> `openssl`<br> `pcre`<br> `pdo`<br> `pdo_sqlite`<br> `phar`<br> `posix`<br> `readline`<br> `session`<br> `sqlite3`<br> `tokenizer`<br> `xml`<br> `xmlreader`<br> `xmlwriter`<br> |`geoip`<br>`gmp`<br> `igbinary`<br> `imagick`<br> `imap`<br>`ioncube`<br> `ldap`<br> `mailparse`<br> `mcrypt`<br> `msgpack`<br> `mysqli`<br> `oauth`<br> `pdo_mysql`<br> `propro`<br> `pspell`<br> `raphf`<br> `recode`<br> `redis`<br> `shmop` `sockets`<br> `sodium`<br> `ssh2`<br>`tidy`<br> `xdebug`<br> `xmlrpc`<br> `xsl`<br> `yaml`|
+| `bcmath`<br> `bz2`<br> `calendar`<br> `exif`<br> `gd`<br> `gettext`<br> `intl`<br> `mysqli`<br> `pcntl`<br> `pdo_mysql`<br> `soap`<br> `sockets`<br>  `sysvmsg`<br> `sysvsem`<br> `sysvshm`<br> `opcache`<br> `zip` |`apcu`<br> `ctype`<br> `curl`<br> `date`<br> `dom`<br> `fileinfo`<br> `filter`<br> `ftp`<br> `hash`<br> `iconv`<br> `json`<br> `mbstring`<br> `mysqlnd`<br> `openssl`<br> `pcre`<br> `pdo`<br> `pdo_sqlite`<br> `phar`<br> `posix`<br> `readline`<br> `session`<br> `sqlite3`<br> `tokenizer`<br> `xml`<br> `xmlreader`<br> `xmlwriter`<br> |`geoip`<br>`gmp`<br> `igbinary`<br> `imagick`<br> `imap`<br>`ioncube`<br> `ldap`<br> `mailparse`<br> `mcrypt`<br> `msgpack`<br> `mysqli`<br> `oauth`<br> `pdo_mysql`<br> `propro`<br> `pspell`<br> `raphf`<br> `recode`<br> `redis`<br> `shmop` `sockets`<br> `sodium`<br> `ssh2`<br>`tidy`<br> `xdebug`<br> `xmlrpc`<br> `xsl`<br> `yaml`|
 
 The PHP module requirements for {{ site.data.var.ee }} are tied to the Magento version. See [PHP requirements]({{ site.baseurl }}/guides/v2.4/install-gde/prereq/php-settings.html).
 


### PR DESCRIPTION
## Purpose of this pull request
This pull request adds APCu to the list of PHP extensions that are always installed on Magento Cloud. This is a feature request that is being discussed in https://github.com/magento/ece-tools/pull/794

## Affected DevDocs pages
- https://devdocs.magento.com/cloud/project/magento-app-php-application.html