### PR TITLE
Fix shell commands

### DIFF
--- a/src/guides/v2.3/ext-best-practices/extension-coding/example-module-adminpage.md
+++ b/src/guides/v2.3/ext-best-practices/extension-coding/example-module-adminpage.md
@@ -248,8 +248,8 @@ Now that Magento knows how to handle requests for the **Hello World** page, we n
 Create the necessary directories for the files by running the following commands from the module's root directory:
 
 ```bash
-mkdir -pm view/adminhtml/layout
-mkdir -pm view/adminhtml/templates
+mkdir -p view/adminhtml/layout
+mkdir -p view/adminhtml/templates
 ```
 
 These files belong in the `view/adminhtml` directory because the Magento admin area use these files during page generation.


### PR DESCRIPTION
## Purpose of this pull request

This pull request (PR) fixes two shell commands that don’t work as-is because they use an option (`-m`) that requires an argument. It’s probably a typo.

## Affected DevDocs pages

- https://devdocs.magento.com/guides/v2.3/ext-best-practices/extension-coding/example-module-adminpage.html
- https://devdocs.magento.com/guides/v2.4/ext-best-practices/extension-coding/example-module-adminpage.html
