### PR TITLE
Magento_Ui module directory path updated

### DIFF
--- a/src/guides/v2.3/ui_comp_guide/concepts/ui_comp_uiclass_concept.md
+++ b/src/guides/v2.3/ui_comp_guide/concepts/ui_comp_uiclass_concept.md
@@ -7,7 +7,7 @@ title: About the uiClass library
 
 The `uiClass` is an abstract class from which all components are extended. The `uiClass` is a low-level class and is rarely used as direct parent for UI components' classes.
 
-`uiClass` source code is `<UI_Module_dir>/view/base/web/js/lib/core/class.js`, in the {{site.data.var.ce}} GitHub repository: [app/code/Magento/Ui/view/base/web/js/lib/core/class.js]({{ site.mage2bloburl }}/{{ page.guide_version }}/app/code/Magento/Ui/view/base/web/js/lib/core/class.js)
+`uiClass` source code is `<Magento_Ui_module_dir>/view/base/web/js/lib/core/class.js`, in the {{site.data.var.ce}} GitHub repository: [app/code/Magento/Ui/view/base/web/js/lib/core/class.js]({{ site.mage2bloburl }}/{{ page.guide_version }}/app/code/Magento/Ui/view/base/web/js/lib/core/class.js)
 
 ## Commonly used uiClass methods
 

--- a/src/guides/v2.3/ui_comp_guide/concepts/ui_comp_uicollection_concept.md
+++ b/src/guides/v2.3/ui_comp_guide/concepts/ui_comp_uicollection_concept.md
@@ -7,7 +7,7 @@ title: About the uiCollection class
 
 The `uiCollection` library class should be used as a base class by any components that contain a collection of child UI components.  `uiCollection` inherits from the [uiElement class]({{ page.baseurl }}/ui_comp_guide/concepts/ui_comp_uielement_concept.html).
 
-`uiCollection` source code is `<UI_Module_dir>/view/base/web/js/lib/core/collection.js`, in the {{site.data.var.ce}} GitHub repository: [app/code/Magento/Ui/view/base/web/js/lib/core/collection.js]({{ site.mage2bloburl }}/{{ page.guide_version }}/app/code/Magento/Ui/view/base/web/js/lib/core/collection.js).
+`uiCollection` source code is `<Magento_Ui_module_dir>/view/base/web/js/lib/core/collection.js`, in the {{site.data.var.ce}} GitHub repository: [app/code/Magento/Ui/view/base/web/js/lib/core/collection.js]({{ site.mage2bloburl }}/{{ page.guide_version }}/app/code/Magento/Ui/view/base/web/js/lib/core/collection.js).
 
 ## Commonly used `uiCollection` methods
 
@@ -82,7 +82,7 @@ The `uiCollection` class implements the following methods:
 
 ## uiCollection template {#uicollection_template}
 
-The `uiCollection` template is `<UI_Module_dir>/view/base/web/templates/collection.html`, in the {{site.data.var.ce}} GitHub repository: [`app/code/Magento/Ui/view/base/web/templates/collection.html`]({{ site.mage2bloburl }}/{{ page.guide_version }}/app/code/Magento/Ui/view/base/web/templates/collection.html).
+The `uiCollection` template is `<Magento_Ui_module_dir>/view/base/web/templates/collection.html`, in the {{site.data.var.ce}} GitHub repository: [`app/code/Magento/Ui/view/base/web/templates/collection.html`]({{ site.mage2bloburl }}/{{ page.guide_version }}/app/code/Magento/Ui/view/base/web/templates/collection.html).
 
 This template performs only one task: renders child templates if they exist.
 

--- a/src/guides/v2.3/ui_comp_guide/concepts/ui_comp_uielement_concept.md
+++ b/src/guides/v2.3/ui_comp_guide/concepts/ui_comp_uielement_concept.md
@@ -8,7 +8,7 @@ title: About the uiElement class
 The `uiElement` class is a direct successor of the [uiClass library]({{ page.baseurl }}/ui_comp_guide/concepts/ui_comp_uiclass_concept.html).
 When creating a new component, use the `uiElement` class as a direct parent, if your component will be the last in the components hierarchy chain.
 
-`uiElement` source code is `<UI_Module_dir>/view/base/web/js/lib/core/element/element.js`, in the {{site.data.var.ce}} GitHub repository: [app/code/Magento/Ui/view/base/web/js/lib/core/element/element.js]({{ site.mage2bloburl }}/{{ page.guide_version }}/app/code/Magento/Ui/view/base/web/js/lib/core/element/element.js).
+`uiElement` source code is `<Magento_Ui_module_dir>/view/base/web/js/lib/core/element/element.js`, in the {{site.data.var.ce}} GitHub repository: [app/code/Magento/Ui/view/base/web/js/lib/core/element/element.js]({{ site.mage2bloburl }}/{{ page.guide_version }}/app/code/Magento/Ui/view/base/web/js/lib/core/element/element.js).
 
 ## Commonly used `uiElement` methods
 


### PR DESCRIPTION
## Purpose of this pull request

This pull request (PR) updates the Magento_Ui module directory path.

To maintain consistency in the docs, I have updated the module path value with _Magento_Ui_module_dir_.

## Affected DevDocs pages

<!-- REQUIRED List the affected pages on devdocs.magento.com (URLs). Not needed for large numbers of files. -->

- https://devdocs.magento.com/guides/v2.3/ui_comp_guide/concepts/ui_comp_uiclass_concept.html
- https://devdocs.magento.com/guides/v2.3/ui_comp_guide/concepts/ui_comp_uielement_concept.html
- https://devdocs.magento.com/guides/v2.3/ui_comp_guide/concepts/ui_comp_uicollection_concept.html
- https://devdocs.magento.com/guides/v2.4/ui_comp_guide/concepts/ui_comp_uiclass_concept.html
- https://devdocs.magento.com/guides/v2.4/ui_comp_guide/concepts/ui_comp_uielement_concept.html
- https://devdocs.magento.com/guides/v2.4/ui_comp_guide/concepts/ui_comp_uicollection_concept.html


<!--
If you are fixing a GitHub issue, note it using GitHub keyword format (https://help.github.com/en/articles/closing-issues-using-keywords#closing-an-issue-in-a-different-repository) to close the issue when this pull request is merged. Example: `Fixes #1234`

`master` is the default branch. Merged pull requests to `master` go live on the site automatically. Any requested changes to content on the `master` branch must be related to the released codebase. Any content related to future releases goes in the `develop` branch.

See Contribution guidelines (https://github.com/magento/devdocs/blob/master/.github/CONTRIBUTING.md) for more information.
-->
