### PR TITLE
Removed -f param from static-content:deploy command

### DIFF
--- a/src/guides/v2.3/howdoi/checkout/checkout_carrier.md
+++ b/src/guides/v2.3/howdoi/checkout/checkout_carrier.md
@@ -184,7 +184,7 @@ You must add `<your-validation-name>` like `%carrier%-rates-validation` - where 
 1. Deploy static content:
 
 ```bash
-bin/magento setup:static-content:deploy -f
+bin/magento setup:static-content:deploy
 ```
 
 1. Clean the cache:


### PR DESCRIPTION
## Purpose of this pull request

This pull request (PR) : -f param only needed in developer mode. So, removing it.

## Affected DevDocs pages

<!-- REQUIRED List the affected pages on devdocs.magento.com (URLs). Not needed for large numbers of files. -->

-  https://devdocs.magento.com/guides/v2.4/howdoi/checkout/checkout_carrier.html

