### PR TITLE
Added js unit tests run examples for frontend area

### DIFF
--- a/src/guides/v2.3/test/js/jasmine.md
+++ b/src/guides/v2.3/test/js/jasmine.md
@@ -73,7 +73,11 @@ Example:
 
 ```bash
 grunt spec:backend
-# or for the frontend area
+```
+
+or for the frontend area:
+
+```bash
 grunt spec:luma
 ```
 
@@ -81,7 +85,11 @@ You can also run a single test:
 
 ```bash
 grunt spec:backend --file="/path/to/the/test.js"
-# or for the frontend area
+```
+
+or for the frontend area:
+
+```bash
 grunt spec:luma --file="/path/to/the/test.js"
 ```
 

--- a/src/guides/v2.3/test/js/jasmine.md
+++ b/src/guides/v2.3/test/js/jasmine.md
@@ -73,12 +73,16 @@ Example:
 
 ```bash
 grunt spec:backend
+# or for the frontend area
+grunt spec:luma
 ```
 
 You can also run a single test:
 
 ```bash
 grunt spec:backend --file="/path/to/the/test.js"
+# or for the frontend area
+grunt spec:luma --file="/path/to/the/test.js"
 ```
 
 ## Write a test {#write-test}


### PR DESCRIPTION
## Purpose of this pull request

The grunt command to run js tests for the frontend area is not intuitive based on the currently provided example and raises questions among developers. Added missing examples for such test runs that should make it more clear.

## Affected DevDocs pages

<!-- REQUIRED List the affected pages on devdocs.magento.com (URLs). Not needed for large numbers of files. -->

-  https://devdocs.magento.com/guides/v2.3/test/js/jasmine.html
- https://devdocs.magento.com/guides/v2.4/test/js/jasmine.html (symlinked to 2.3 page content)
