### PR TITLE
Add a hint about composer cache clean on the Cloud environment

### DIFF
--- a/src/cloud/setup/first-time-setup-import-import.md
+++ b/src/cloud/setup/first-time-setup-import-import.md
@@ -307,7 +307,7 @@ bin/magento cache:clean
 After the [cache](https://glossary.magento.com/cache) flushes, enter `exit` to close the SSH tunnel.
 
 {:.bs-callout-info}
-To clear composer cache on Cloud environment use [magento-cloud project:clear-build-cache](https://devdocs.magento.com/guides/v2.4/reference/cli/magento-cloud.html) command.
+To clear composer cache on Cloud environment use [magento-cloud project:clear-build-cache]({{ site.baseurl }}/guides/v2.4/reference/cli/magento-cloud.html) command.
 
 ## Verify the import {#verify}
 

--- a/src/cloud/setup/first-time-setup-import-import.md
+++ b/src/cloud/setup/first-time-setup-import-import.md
@@ -307,7 +307,7 @@ bin/magento cache:clean
 After the [cache](https://glossary.magento.com/cache) flushes, enter `exit` to close the SSH tunnel.
 
 {:.bs-callout-tip}
-Use the [magento-cloud project:clear-build-cache]({{ site.baseurl }}/guides/v2.4/reference/cli/magento-cloud.html#projectclear-build-cache) command to clear a project's build cache (such as composer cache, etc) in the remote environment.
+Use the [magento-cloud project:clear-build-cache]({{ site.baseurl }}/guides/v2.4/reference/cli/magento-cloud.html#projectclear-build-cache) command to clear a project's build cache (such as composer cache, etc.) in the remote environment.
 
 ## Verify the import {#verify}
 

--- a/src/cloud/setup/first-time-setup-import-import.md
+++ b/src/cloud/setup/first-time-setup-import-import.md
@@ -306,6 +306,9 @@ bin/magento cache:clean
 
 After the [cache](https://glossary.magento.com/cache) flushes, enter `exit` to close the SSH tunnel.
 
+{:.bs-callout-info}
+To clear composer cache on Cloud environment use [magento-cloud project:clear-build-cache](https://devdocs.magento.com/guides/v2.4/reference/cli/magento-cloud.html) command.
+
 ## Verify the import {#verify}
 
 To verify everything imported properly, perform the following tasks in your local Cloud development environment:

--- a/src/cloud/setup/first-time-setup-import-import.md
+++ b/src/cloud/setup/first-time-setup-import-import.md
@@ -306,8 +306,8 @@ bin/magento cache:clean
 
 After the [cache](https://glossary.magento.com/cache) flushes, enter `exit` to close the SSH tunnel.
 
-{:.bs-callout-info}
-To clear composer cache on Cloud environment use [magento-cloud project:clear-build-cache]({{ site.baseurl }}/guides/v2.4/reference/cli/magento-cloud.html) command.
+{:.bs-callout-tip}
+Use the [magento-cloud project:clear-build-cache]({{ site.baseurl }}/guides/v2.4/reference/cli/magento-cloud.html#projectclear-build-cache) command to clear a project's build cache (such as composer cache, etc) in the remote environment.
 
 ## Verify the import {#verify}
 


### PR DESCRIPTION
## Purpose of this pull request

This pull request (PR) describes a hint about composer cache clean on the Cloud environment
https://github.com/magento/devdocs/issues/8889
## Affected DevDocs pages

<!-- REQUIRED List the affected pages on devdocs.magento.com (URLs). Not needed for large numbers of files. -->

-  https://devdocs.magento.com/cloud/setup/first-time-setup-import-import.html

