### PR TITLE
Add instruction for changing Composer version

### DIFF
--- a/src/cloud/docker/docker-config.md
+++ b/src/cloud/docker/docker-config.md
@@ -29,7 +29,17 @@ When you run composer with Docker commands, you must use the [Docker Hub PHP Ima
 docker run -it  -v $(pwd):/app/:delegated -v ~/.composer/:/root/.composer/:delegated magento/magento-cloud-docker-php:7.3-cli-1.1 bash -c "composer install&&chown www. /app/"
 ```
 
-This command passes in the current working directory as `/app/`, includes composer from `~/.composer/`, and runs the `composer install` command in the container. After this set up, the command  fixes the permissions on the files that have been added or changed.
+This command passes in the current working directory as `/app/`, includes composer from `~/.composer/`, and runs the `composer install` command in the container. After this set up, the command fixes the permissions on the files that have been added or changed.
+
+## Update Composer for Docker
+
+To update the Composer version in Cloud Docker, add the `COMPOSER_VERSION` variable to your `.docker/config.env` file with the version you want to use. For example, to use Composer 2.x with Magento >=2.4.2:
+
+```conf
+COMPOSER_VERSION=2.0.12
+```
+
+When you build your Docker image with this variable, Cloud Docker uses this version to run `composer self-update $COMPOSER_VERSION` for your environment.
 
 ## Run Docker on a custom host and port
 
@@ -51,14 +61,6 @@ Alternatively, you can run the following command to add it to the file:
 
 ```bash
 echo "127.0.0.1 magento2.test" | sudo tee -a /etc/hosts
-```
-
-## Change Composer version
-
-You can change Composer version by adding the following line to the `.docker/config.env` configuration file:
-
-```
-COMPOSER_VERSION=2.0.12
 ```
 
 ## Set up email

--- a/src/cloud/docker/docker-config.md
+++ b/src/cloud/docker/docker-config.md
@@ -55,7 +55,7 @@ echo "127.0.0.1 magento2.test" | sudo tee -a /etc/hosts
 
 ## Change Composer version
 
-You can change Composer version by adding next line in `.docker/config.env` configuration file:
+You can change Composer version by adding the following line to the `.docker/config.env` configuration file:
 
 ```
 COMPOSER_VERSION=2.0.12

--- a/src/cloud/docker/docker-config.md
+++ b/src/cloud/docker/docker-config.md
@@ -53,6 +53,14 @@ Alternatively, you can run the following command to add it to the file:
 echo "127.0.0.1 magento2.test" | sudo tee -a /etc/hosts
 ```
 
+## Change Composer version
+
+You can change Composer version by adding next line in `.docker/config.env` configuration file:
+
+```
+COMPOSER_VERSION=2.0.12
+```
+
 ## Set up email
 
 The default {{ site.data.var.mcd-prod }} configuration includes the [MailHog] service as a replacement for the Sendmail service. Sendmail can cause performance issues in the local Docker environment.


### PR DESCRIPTION
## Purpose of this pull request

This pull request (PR) adds missing instruction on changing the Composer version for the latest Magento versions

<!--
If you are fixing a GitHub issue, note it using GitHub keyword format (https://help.github.com/en/articles/closing-issues-using-keywords#closing-an-issue-in-a-different-repository) to close the issue when this pull request is merged. Example: `Fixes #1234`

`master` is the default branch. Merged pull requests to `master` go live on the site automatically. Any requested changes to content on the `master` branch must be related to the released codebase. Any content related to future releases goes in the `develop` branch.

See Contribution guidelines (https://github.com/magento/devdocs/blob/master/.github/CONTRIBUTING.md) for more information.
-->
