### PR TITLE
X-Frame-Options ALLOW-FROM flag is deprecated from modern browsers

### DIFF
--- a/src/cloud/env/variables-global.md
+++ b/src/cloud/env/variables-global.md
@@ -137,8 +137,7 @@ Use the `X_FRAME_CONFIGURATION` variable to change the [`X-Frame-Options`]({{ si
 -  `SAMEORIGIN`—(The default Magento setting.) Page can be displayed only in a frame on the same origin as the page itself.
 
 {:.bs-callout-warning}
-`ALLOW-FROM <uri>` option has been deprecated since the browsers supported by Magento has dropped the support of it.
-[Browser Compatibility](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/X-Frame-Options#Browser_compatibility) provides details about this feature.
+The `ALLOW-FROM <uri>` option has been deprecated because Magento-supported browsers no longer support it. See [Browser compatibility](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/X-Frame-Options#Browser_compatibility).
 
 Add the `X_FRAME_CONFIGURATION` environment variable to the `global` stage in the `.magento.env.yaml` file:
 

--- a/src/cloud/env/variables-global.md
+++ b/src/cloud/env/variables-global.md
@@ -135,7 +135,10 @@ Use the `X_FRAME_CONFIGURATION` variable to change the [`X-Frame-Options`]({{ si
 
 -  `DENY`—Page cannot be displayed in a frame.
 -  `SAMEORIGIN`—(The default Magento setting.) Page can be displayed only in a frame on the same origin as the page itself.
--  `ALLOW-FROM` `<uri>`—Page can be displayed only in a frame on the specified origin.
+
+{:.bs-callout-warning}
+`ALLOW-FROM <uri>` option has been deprecated since the browsers supported by Magento has dropped the support of it.
+[Browser Compatibility](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/X-Frame-Options#Browser_compatibility) provides details about this feature.
 
 Add the `X_FRAME_CONFIGURATION` environment variable to the `global` stage in the `.magento.env.yaml` file:
 

--- a/src/guides/v2.3/config-guide/secy/secy-xframe.md
+++ b/src/guides/v2.3/config-guide/secy/secy-xframe.md
@@ -18,7 +18,6 @@ The `X-Frame-Options` header enables you to specify whether or not a browser sho
 
 {:.bs-callout-warning}
 The `ALLOW-FROM <uri>` option has been deprecated because Magento-supported browsers no longer support it. See [Browser compatibility](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/X-Frame-Options#Browser_compatibility).
-[Browser Compatibility](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/X-Frame-Options#Browser_compatibility) provides details about this feature.
 
 {:.bs-callout-warning}
   For security reasons, Magento strongly recommends against running the Magento storefront in a frame.

--- a/src/guides/v2.3/config-guide/secy/secy-xframe.md
+++ b/src/guides/v2.3/config-guide/secy/secy-xframe.md
@@ -17,7 +17,7 @@ The `X-Frame-Options` header enables you to specify whether or not a browser sho
 *  `SAMEORIGIN`: (The default Magento setting.) Page can be displayed only in a frame on the same origin as the page itself.
 
 {:.bs-callout-warning}
-`ALLOW-FROM <uri>` option has been deprecated since the browsers supported by Magento has dropped the support of it.
+The `ALLOW-FROM <uri>` option has been deprecated because Magento-supported browsers no longer support it. See [Browser compatibility](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/X-Frame-Options#Browser_compatibility).
 [Browser Compatibility](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/X-Frame-Options#Browser_compatibility) provides details about this feature.
 
 {:.bs-callout-warning}

--- a/src/guides/v2.3/config-guide/secy/secy-xframe.md
+++ b/src/guides/v2.3/config-guide/secy/secy-xframe.md
@@ -15,10 +15,10 @@ The `X-Frame-Options` header enables you to specify whether or not a browser sho
 
 *  `DENY`: Page cannot be displayed in a frame.
 *  `SAMEORIGIN`: (The default Magento setting.) Page can be displayed only in a frame on the same origin as the page itself.
-*  `ALLOW-FROM <uri>`: Page can be displayed only in a frame on the specified origin.
 
 {:.bs-callout-warning}
-The Chrome and Safari browsers do not support the `ALLOW-FROM` option. [Browser Compatibility](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/X-Frame-Options#Browser_compatibility) provides details about this feature.
+`ALLOW-FROM <uri>` option has been deprecated since the browsers supported by Magento has dropped the support of it.
+[Browser Compatibility](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/X-Frame-Options#Browser_compatibility) provides details about this feature.
 
 {:.bs-callout-warning}
   For security reasons, Magento strongly recommends against running the Magento storefront in a frame.


### PR DESCRIPTION
X-Frame-Options ALLOW-FROM flag is deprecated from modern browsers

## Purpose of this pull request

This pull request (PR) is to note the deprecation of the X-Frame-Options ALLOW-FROM option by the browsers supported by Magento

## Affected DevDocs pages

<!-- REQUIRED List the affected pages on devdocs.magento.com (URLs). Not needed for large numbers of files. -->

-  https://devdocs.magento.com/guides/v2.4/config-guide/secy/secy-xframe.html#overview
- https://devdocs.magento.com/cloud/env/variables-global.html#x_frame_configuration

It is confirmed by the Security PO [here](https://jira.corp.magento.com/browse/MC-41882?focusedCommentId=1675391&page=com.atlassian.jira.plugin.system.issuetabpanels%3Acomment-tabpanel#comment-1675391)