### PR TITLE
Magento/devdocs. Issue #8897.Set docroot - remove mention of setup wizard in 2.37

### DIFF
--- a/src/cloud/before/before-setup-env-install.md
+++ b/src/cloud/before/before-setup-env-install.md
@@ -72,7 +72,7 @@ Set the `docroot` to the `/magento` directory until you complete all setup.
 
 For the Production environment, set the `docroot` to `/magento/pub`, which helps restrict access to vulnerable areas of the system. The webserver `docroot` should be set to `/magento/pub` only after Magento is installed (including any upgrades and patches), configured, and static files generated and populated in `/magento/pub`. Alternatively, you could create a subdomain (for example, `install.domain.com`) and configure your webserver `docroot` to the Magento installed root folder.
 
-## Set file system permissions and ownership{#file-system-permissions}
+## Set file system permissions and ownership {#file-system-permissions}
 
 After you have installed Magento, you need to set the file system permissions and ownership.
 

--- a/src/cloud/before/before-setup-env-install.md
+++ b/src/cloud/before/before-setup-env-install.md
@@ -68,11 +68,11 @@ To create authentication keys through the Magento Marketplace:
 
 ## Set the docroot
 
-Set the `docroot` to the `/magento` directory until you complete all setup. If you change the `docroot` to `/magento/pub` prior to completion, you will encounter issues running the Web Setup Wizard.
+Set the `docroot` to the `/magento` directory until you complete all setup.
 
 For the Production environment, set the `docroot` to `/magento/pub`, which helps restrict access to vulnerable areas of the system. The webserver `docroot` should be set to `/magento/pub` only after Magento is installed (including any upgrades and patches), configured, and static files generated and populated in `/magento/pub`. Alternatively, you could create a subdomain (for example, `install.domain.com`) and configure your webserver `docroot` to the Magento installed root folder.
 
-## Set file system permissions and ownership {#file-system-permissions}
+## Set file system permissions and ownership{#file-system-permissions}
 
 After you have installed Magento, you need to set the file system permissions and ownership.
 

--- a/src/cloud/before/before-setup-env-install.md
+++ b/src/cloud/before/before-setup-env-install.md
@@ -68,7 +68,7 @@ To create authentication keys through the Magento Marketplace:
 
 ## Set the docroot
 
-Set the `docroot` to the `/magento` directory until you complete all setup.
+Set the `docroot` to the `/magento` directory until you complete the setup.
 
 For the Production environment, set the `docroot` to `/magento/pub`, which helps restrict access to vulnerable areas of the system. The webserver `docroot` should be set to `/magento/pub` only after Magento is installed (including any upgrades and patches), configured, and static files generated and populated in `/magento/pub`. Alternatively, you could create a subdomain (for example, `install.domain.com`) and configure your webserver `docroot` to the Magento installed root folder.
 


### PR DESCRIPTION
## Purpose of this pull request

This pull request (PR) fixes an issue https://github.com/magento/devdocs/issues/8897
## Affected DevDocs pages

<!-- REQUIRED List the affected pages on devdocs.magento.com (URLs). Not needed for large numbers of files. -->

-  https://devdocs.magento.com/cloud/before/before-setup-env-install.html#set-the-docroot
