### PR TITLE
Provide a bit more specificity in favor of #8908

### DIFF
--- a/src/extensions/b2b/index.md
+++ b/src/extensions/b2b/index.md
@@ -19,7 +19,7 @@ For {{site.data.var.ece}} projects, see [Set up Magento B2B module]({{ site.base
    ```
 
    {:.bs-callout-info}
-   You must specify a [Compatible Magento B2B version]({{ site.baseurl }}/release/availability.html#compatibility) in the command.
+   You must specify a [Compatible B2B extension version]({{ site.baseurl }}/release/availability.html#compatibility) in the command, which can be found in the left column of the compatibility table.
 
    If you get an error when trying to install the B2B module for a local instance of {{site.data.var.ee}} for example:
 


### PR DESCRIPTION
## Purpose of this pull request

This pull request provides a bit more specificity in favor of #8908. "Magento B2B Version" can be more easily read as Magento version, than B2B extension version. In order to be perfectly clear, I added the line: which can be found in the left column of the compatibility table

## Affected DevDocs pages

- https://devdocs.magento.com/extensions/b2b/

<!--
If you are fixing a GitHub issue, note it using GitHub keyword format (https://help.github.com/en/articles/closing-issues-using-keywords#closing-an-issue-in-a-different-repository) to close the issue when this pull request is merged. Example: `Fixes #1234`

`master` is the default branch. Merged pull requests to `master` go live on the site automatically. Any requested changes to content on the `master` branch must be related to the released codebase. Any content related to future releases goes in the `develop` branch.

See Contribution guidelines (https://github.com/magento/devdocs/blob/master/.github/CONTRIBUTING.md) for more information.
-->
Fixes #8908
