### PR TITLE
Adding word separation for Message Queues Overview

### DIFF
--- a/src/guides/v2.3/config-guide/mq/rabbitmq-overview.md
+++ b/src/guides/v2.3/config-guide/mq/rabbitmq-overview.md
@@ -13,7 +13,7 @@ The following diagram illustrates the Message Queue Framework.
 
 *  An exchange receives messages from publishers and sends them to queues. Although RabbitMQ supports multiple types of exchanges, Magento uses topic exchanges only. A topic includes a routing key, which contains text strings separated by dots. The format for a topic name is <code><i>string1</i>.<i>string2</i></code>..., for example, `customer.created` or `customer.sent.email`.
 
-   The broker allows you to use wildcards when setting rules for forwarding messages.  You can use an asterisk (`*`) to replace _one_ string or a pound sign (`#`) to replace 0 or more strings. For example, `customer.*` would filter on `customer.create` and `customer.delete`, but not `customer.sent.email`. However `customer.#` would filter on `customer.create`,  `customer.delete`, and`customer.sent.email`.
+   The broker allows you to use wildcards when setting rules for forwarding messages.  You can use an asterisk (`*`) to replace _one_ string or a pound sign (`#`) to replace 0 or more strings. For example, `customer.*` would filter on `customer.create` and `customer.delete`, but not `customer.sent.email`. However `customer.#` would filter on `customer.create`,  `customer.delete`, and `customer.sent.email`.
 
 *  A queue is a buffer that stores messages.
 


### PR DESCRIPTION
## Purpose of this pull request

This pull request (PR) adds word separation for Message Queues Overview 
![image](https://user-images.githubusercontent.com/78729171/116697723-34408c00-a9cc-11eb-8507-af3be5e43646.png)


## Affected DevDocs pages

<!-- REQUIRED List the affected pages on devdocs.magento.com (URLs). Not needed for large numbers of files. -->

-  https://devdocs.magento.com/guides/v2.4/config-guide/mq/rabbitmq-overview.html
