### PR TITLE
magento/devdocs#8666 Adding instruction - how to stop queue workers.

### DIFF
--- a/src/_includes/config/split-deploy/example_update-prod.md
+++ b/src/_includes/config/split-deploy/example_update-prod.md
@@ -13,8 +13,24 @@ To update the production system:
 
    For additional options, such as the ability to set an IP address whitelist, see [`magento maintenance:enable`]({{ page.baseurl }}/install-gde/install/cli/install-cli-subcommands-maint.html).
 
-1. If you use {{site.data.var.ee}}, stop queue workers. TBD
+1. If you use {{site.data.var.ee}}, stop queue workers.
 
+   Add changes to the app/etc/env.php:
+
+   ```bash
+   'cron_consumers_runner' => [
+           'cron_run' => false
+       ]
+   ```
+
+   Update the configuration:
+
+   ```bash
+   php bin/magento app:config:import
+   ```
+
+   And `kill` active consumer processes.
+   
 1. Pull code from source control.
 
    The Git command follows:

--- a/src/_includes/config/split-deploy/example_update-prod.md
+++ b/src/_includes/config/split-deploy/example_update-prod.md
@@ -30,7 +30,7 @@ To update the production system:
    ```
 
    And `kill` active consumer processes.
-   
+
 1. Pull code from source control.
 
    The Git command follows:

--- a/src/_includes/config/split-deploy/example_update-prod.md
+++ b/src/_includes/config/split-deploy/example_update-prod.md
@@ -40,7 +40,7 @@ To update the production system:
    ```bash
    kill -9 1234
    ```
-   
+
 1. Pull code from source control.
 
    The Git command follows:

--- a/src/_includes/config/split-deploy/example_update-prod.md
+++ b/src/_includes/config/split-deploy/example_update-prod.md
@@ -23,14 +23,23 @@ To update the production system:
        ]
    ```
 
-   Update the configuration:
+1. Update the configuration:
 
    ```bash
-   php bin/magento app:config:import
+   bin/magento app:config:import
    ```
 
-   Finally, `kill` active consumer processes.
+1. Finally, `kill` active consumer processes.
 
+   ```bash
+   kill SIGNAL PID
+   ```
+
+    Where `SIGNAL` is the signal to be sent and `PID` is the Process ID to be killed.
+
+   ```bash
+   kill -9 1234
+   ```
 1. Pull code from source control.
 
    The Git command follows:

--- a/src/_includes/config/split-deploy/example_update-prod.md
+++ b/src/_includes/config/split-deploy/example_update-prod.md
@@ -40,6 +40,7 @@ To update the production system:
    ```bash
    kill -9 1234
    ```
+   
 1. Pull code from source control.
 
    The Git command follows:

--- a/src/_includes/config/split-deploy/example_update-prod.md
+++ b/src/_includes/config/split-deploy/example_update-prod.md
@@ -15,7 +15,7 @@ To update the production system:
 
 1. If you use {{site.data.var.ee}}, stop queue workers.
 
-   Add changes to the app/etc/env.php:
+   Set `cron_run` to `false` in `app/etc/env.php`, e.g.:
 
    ```bash
    'cron_consumers_runner' => [
@@ -29,7 +29,7 @@ To update the production system:
    php bin/magento app:config:import
    ```
 
-   And `kill` active consumer processes.
+   Finally, `kill` active consumer processes.
 
 1. Pull code from source control.
 


### PR DESCRIPTION
## Purpose of this pull request
This pull request (PR) adds the example to instruction about how to stop queue consumers.

Fixes #8666 

## Affected DevDocs pages
-  https://devdocs.magento.com/guides/v2.4/config-guide/deployment/pipeline/example/shared-configuration.html

## Links to Magento source code
-  guides/v2.4/config-guide/deployment/pipeline/example/shared-configuration.md