### PR TITLE
Added notification callouts to relevant pages, explaining that MFTF checks are not required by EQP

### DIFF
--- a/src/marketplace/sellers/mftf-magento.md
+++ b/src/marketplace/sellers/mftf-magento.md
@@ -3,6 +3,8 @@ group: marketplace-sellers
 title: MFTF Magento-supplied Tests
 ---
 
+{:.bs-callout-info} At this stage, the MFTF Magento-supplied check is not required to pass technical review. The pass/fail status of this check is ignored. We are still observing the behavior of this set of tests and will start requiring these tests at a later time, with sufficient notice.
+
 ## Overview
 
 The Magento Functional Testing Framework (MFTF) is a browser-based acceptance testing framework used to validate the functionality of a Magento site. Running Magento-supplied MFTF tests aids Extension Quality Program (EQP) QA efforts in assessing critical functionality of a Magento instance with the extension installed.

--- a/src/marketplace/sellers/mftf-vendor.md
+++ b/src/marketplace/sellers/mftf-vendor.md
@@ -3,7 +3,11 @@ group: marketplace-sellers
 title: MFTF Vendor-supplied Tests
 ---
 
+{:.bs-callout-info} At this stage, the MFTF Vendor-supplied check is not required to pass technical review. The pass/fail status of this check is ignored. We are still observing the behavior of this set of tests and will start requiring these tests at a later time, with sufficient notice.
+
 ## Overview
+
+This check runs the MFTF tests supplied by the vendor as a part of the extension package.
 
 The Magento Functional Testing Framework (MFTF) is a browser-based acceptance testing framework used to validate the functionality of a Magento site. Running vendor-supplied MFTF tests helps to ensure that the extension functionality is operating as expected for the end user.
 


### PR DESCRIPTION
## Purpose of this pull request

This PR clarifies a common question regarding MFTF Magento and Vendor checks by adding a notification area on top of their dev docs pages explaining that they are NOT required to pass EQP.

## Affected DevDocs pages

<!-- REQUIRED List the affected pages on devdocs.magento.com (URLs). Not needed for large numbers of files. -->

-  https://devdocs.magento.com/marketplace/sellers/mftf-vendor.html
- https://devdocs.magento.com/marketplace/sellers/mftf-magento.html

