### PR TITLE
Change incorrect path

### DIFF
--- a/src/guides/v2.4/config-guide/varnish/config-varnish-advanced.md
+++ b/src/guides/v2.4/config-guide/varnish/config-varnish-advanced.md
@@ -29,7 +29,7 @@ Magento defines the following default health check:
 
 Every 5 seconds, this health check calls the `pub/health_check.php` script. This script checks the availability of the server, each database, and Redis (if installed). The script must return a response within 2 seconds. If the script determines that any of these resources are down, it returns a 500 HTTP error code. If this error code is received in 6 out of 10 attempts, the [backend](https://glossary.magento.com/backend) is considered unhealthy.
 
-The `health_check.php` script is located in the `pub` directory. If your Magento root directory is `pub`, then be sure to change the path in the `url` parameter from `/pub/health_check.php` to `health_check.php`.
+The `health_check.php` script is located in the `pub` directory. If your Magento root directory is `pub`, then be sure to change the path in the `url` parameter from `/pub/health_check.php` to `/health_check.php`.
 
 For more information, see the [Varnish health checks](https://varnish-cache.org/docs/6.3/users-guide/vcl-backends.html?highlight=health%20check#health-checks) documentation.
 


### PR DESCRIPTION
I was trying to set up Varnish and was instructed to change the probe url from /pub/health_check.php to health_check.php. Unfortunately this did not work, I tried prepending a '/' which worked. So I think this should be changed in the docs before others waste time on this small thing. So it should be '/health_check.php' instead of 'health_check.php'

## Purpose of this pull request

This pull request (PR) ...

## Affected DevDocs pages

<!-- REQUIRED List the affected pages on devdocs.magento.com (URLs). Not needed for large numbers of files. -->

-  ...

## Links to Magento source code

<!--  OPTIONAL - REMOVE THIS SECTION IF NOT USED. If this pull request references a file in a Magento codebase repository, add it here. -->

-  ...

<!--
If you are fixing a GitHub issue, note it using GitHub keyword format (https://help.github.com/en/articles/closing-issues-using-keywords#closing-an-issue-in-a-different-repository) to close the issue when this pull request is merged. Example: `Fixes #1234`

`master` is the default branch. Merged pull requests to `master` go live on the site automatically. Any requested changes to content on the `master` branch must be related to the released codebase. Any content related to future releases goes in the `develop` branch.

See Contribution guidelines (https://github.com/magento/devdocs/blob/master/.github/CONTRIBUTING.md) for more information.
-->
