### PR TITLE
Extension name format not showing

### DIFF
--- a/src/guides/v2.3/extension-dev-guide/build/enable-module.md
+++ b/src/guides/v2.3/extension-dev-guide/build/enable-module.md
@@ -28,7 +28,7 @@ After you have built the component and are ready to enable it in your Magento en
    bin/magento module:status <extension-name>
    ```
 
-   An extension name uses the format: <VendorName>_<ComponentName>.
+   An extension name uses the format: VendorName_ComponentName.
 
    Sample response:
 

--- a/src/guides/v2.3/extension-dev-guide/build/enable-module.md
+++ b/src/guides/v2.3/extension-dev-guide/build/enable-module.md
@@ -28,7 +28,7 @@ After you have built the component and are ready to enable it in your Magento en
    bin/magento module:status <extension-name>
    ```
 
-   An extension name uses the format: VendorName_ComponentName.
+   An extension name uses the format: `<VendorName>_<ComponentName>`.
 
    Sample response:
 


### PR DESCRIPTION
## Purpose of this pull request

This pull request (PR) Extension name format not showing on the Frontend view.

![extension-format-not-showing](https://user-images.githubusercontent.com/82952634/118229737-2568d780-b4aa-11eb-9188-da4057d4c87b.png)

## Affected DevDocs pages

https://devdocs.magento.com/guides/v2.4/extension-dev-guide/build/enable-module.html
