### PR TITLE
Adde link to source Magnifier widget page

### DIFF
--- a/src/guides/v2.3/javascript-dev-guide/widgets/widget_gallery_mg.md
+++ b/src/guides/v2.3/javascript-dev-guide/widgets/widget_gallery_mg.md
@@ -9,7 +9,7 @@ In Magento it is used by the [gallery]({{ page.baseurl }}/javascript-dev-guide/w
 
 ![Magnifier widget]({{site.baseurl}}/common/images/magnifier-widget.png){:width="650px"}
 
-The Magnifier widget source is located in [lib/web/magnifier/magnify.js]({{ site.mage2bloburl }}/{{ page.guide_version }}/lib/web/magnifier/magnify.js). 
+The Magnifier widget source is located in [lib/web/magnifier/magnify.js]({{ site.mage2bloburl }}/{{ page.guide_version }}/lib/web/magnifier/magnify.js).
 
 ## Initialize magnifier {#magnifier_init}
 

--- a/src/guides/v2.3/javascript-dev-guide/widgets/widget_gallery_mg.md
+++ b/src/guides/v2.3/javascript-dev-guide/widgets/widget_gallery_mg.md
@@ -9,7 +9,7 @@ In Magento it is used by the [gallery]({{ page.baseurl }}/javascript-dev-guide/w
 
 ![Magnifier widget]({{site.baseurl}}/common/images/magnifier-widget.png){:width="650px"}
 
-The Magnifier widget source is located in `lib/web/magnifier/magnify.js`.
+The Magnifier widget source is located in [lib/web/magnifier/magnify.js]({{ site.mage2bloburl }}/{{ page.guide_version }}/lib/web/magnifier/magnify.js). 
 
 ## Initialize magnifier {#magnifier_init}
 


### PR DESCRIPTION
## Purpose of this pull request

This pull request add link to source code for Magnifier widget
 **Before** 
 
<img width="533" alt="Screenshot 2021-05-12 at 15 59 19" src="https://user-images.githubusercontent.com/13517181/117978935-0ef03e00-b33b-11eb-95b2-3fcdf9c27d20.png">

 **After**
<img width="526" alt="Screenshot 2021-05-12 at 15 59 04" src="https://user-images.githubusercontent.com/13517181/117978953-144d8880-b33b-11eb-8826-d6dd01b717c2.png">


## Affected DevDocs pages
<!-- REQUIRED List the affected pages on devdocs.magento.com (URLs). Not needed for large numbers of files. -->
https://devdocs.magento.com/guides/v2.3/javascript-dev-guide/widgets/widget_gallery_mg.html
