### PR TITLE
magento/devdocs #8928 : Add description about data  import from configuration files

### DIFF
--- a/src/guides/v2.3/install-gde/install/cli/install-cli-subcommands-deployment.md
+++ b/src/guides/v2.3/install-gde/install/cli/install-cli-subcommands-deployment.md
@@ -54,18 +54,18 @@ The following table discusses the meanings of installation parameters and values
 
 ## Import configuration data
 
-When you set up a production system, you should _import_ configuration settings from `config.php` and `env.php` into the database.
+When setting up a production system, it's good practice to import configuration settings from `config.php` and `env.php` into the database.
 These settings include configuration paths and values, websites, stores, store views, and themes.
 
 After importing websites, stores, store views, and themes, you can create product attributes and apply them to websites, stores, and store views, on the production system.
 
-On your production system, run the following command to import data from the configuration files (`config.php` and `env.php`) to the database:
+On the production system, run the following command to import data from the configuration files (`config.php` and `env.php`) to the database:
 
 ```bash
 bin/magento app:config:import [-n, --no-interaction]
 ```
 
-Use the optional `[-n, --no-interaction]` flag to import data without additional confirmations.
+The optional `[-n, --no-interaction]` flag allows the command to run without additional confirmations.
 
 For additional information, please, check the [Import data from configuration files]({{ page.baseurl }}/config-guide/cli/config-cli-subcommands-config-mgmt-import.html)
 

--- a/src/guides/v2.3/install-gde/install/cli/install-cli-subcommands-deployment.md
+++ b/src/guides/v2.3/install-gde/install/cli/install-cli-subcommands-deployment.md
@@ -52,6 +52,23 @@ The following table discusses the meanings of installation parameters and values
 |`--db-init-statements`|Advanced MySQL configuration parameter. Uses database initialization statements to run when connecting to the MySQL database.<br><br>Default is `SET NAMES utf8;`.<br><br>Consult a reference similar to [this one](http://dev.mysql.com/doc/refman/5.6/en/server-options.html) before you set any values.|No|
 |`--http-cache-hosts`|Comma-separated list of HTTP cache gateway hosts to which to send purge requests. (For example, Varnish servers.) Use this parameter to specify the host or hosts to purge in the same request. (It doesn't matter if you have only one host or many hosts.)<br><br>Format must be `<hostname or ip>:<listen port>`, where you can omit `<listen port>` if it's port 80. For example, `--http-cache-hosts=192.0.2.100,192.0.2.155:6081`. Do not separate hosts with a space character.|No|
 
+## Import configuration data
+
+When you set up a production system, you should _import_ configuration settings from `config.php` and `env.php` into the database.
+These settings include configuration paths and values, websites, stores, store views, and themes.
+
+After importing websites, stores, store views, and themes, you can create product attributes and apply them to websites, stores, and store views, on the production system.
+
+On your production system, run the following command to import data from the configuration files (`config.php` and `env.php`) to the database:
+
+```bash
+bin/magento app:config:import [-n, --no-interaction]
+```
+
+Use the optional `[-n, --no-interaction]` flag to import data without any interaction.
+
+If you enter `bin/magento app:config:import` without the optional flag, you're required to confirm the changes.
+
 {% include install/sens-data.md %}
 
 If applicable, continue your Magento software installation:

--- a/src/guides/v2.3/install-gde/install/cli/install-cli-subcommands-deployment.md
+++ b/src/guides/v2.3/install-gde/install/cli/install-cli-subcommands-deployment.md
@@ -65,9 +65,9 @@ On your production system, run the following command to import data from the con
 bin/magento app:config:import [-n, --no-interaction]
 ```
 
-Use the optional `[-n, --no-interaction]` flag to import data without any interaction.
+Use the optional `[-n, --no-interaction]` flag to import data without additional confirmations.
 
-If you enter `bin/magento app:config:import` without the optional flag, you're required to confirm the changes.
+For additional information, please, check the [Import data from configuration files]({{ page.baseurl }}/config-guide/cli/config-cli-subcommands-config-mgmt-import.html)
 
 {% include install/sens-data.md %}
 


### PR DESCRIPTION
## Purpose of this pull request

This pull request (PR) fixes https://github.com/magento/devdocs/issues/8928

## Affected DevDocs pages

<!-- REQUIRED List the affected pages on devdocs.magento.com (URLs). Not needed for large numbers of files. -->

-  https://devdocs.magento.com/guides/v2.4/install-gde/install/cli/install-cli-subcommands-deployment.html

## Links to Magento source code

<!--  OPTIONAL - REMOVE THIS SECTION IF NOT USED. If this pull request references a file in a Magento codebase repository, add it here. -->

-  https://devdocs.magento.com/guides/v2.4/config-guide/cli/config-cli-subcommands-config-mgmt-set.html
- https://devdocs.magento.com/guides/v2.4/config-guide/cli/config-cli-subcommands-config-mgmt-import.html
