### PR TITLE
Correct SFTP configuration instructions

### DIFF
--- a/src/cloud/env/environments-ssh.md
+++ b/src/cloud/env/environments-ssh.md
@@ -118,20 +118,13 @@ You need the following requirements to sFTP into cloud environments:
 *  You need to use a client that supports SSH key authentication for sFTP and use your SSH public key.
 *  Your public SSH key must be added to the target environment. For Starter environments and Pro Integration environments, you can add it through the Project Web Interface. For Pro Staging and Production, you must enter a [Support ticket]({{ site.baseurl }}/cloud/trouble/trouble.html) with your public key attached. **Never provide your private SSH key.**
 
-When configuring sFTP, use your SSH public key and the following information for access:
+When configuring sFTP, use your SSH access destination (see [SSH to an Environment](#ssh), example `<project-id-name>@<cloud-host>`) and the following information for access:
 
-*  Username: All content before the `@` in your public SSH key.
+*  Username: All content before the `@` in your SSH access destination.
 *  Password: You do not need a password for sFTP. sFTP access uses the SSH key based authentication.
-*  Host: All content after the `@` in your public SSH key.
+*  Host: All content after the `@` in your SSH access destination.
 *  Port: 22, which is the default SSH port.
-
-To add your SSH public key information to your client:
-
-1. Use a text editor to open your generated SSH public key. Locate and edit the file in the directory location you generated it into.
-1. Copy and paste all content before the `@` in the file for the client Username.
-1. Leave Password empty.
-1. Copy and paste all content after the `@` in the file for the client Host.
-1. For the Port, enter 22.
+*  Private Key: If necessary, let the SFTP client know where to find your private key
 
 Depending on the client, you may need to enter additional options and setup to complete SSH authentication for sFTP. Review the documentation for your selected client.
 

--- a/src/cloud/env/environments-ssh.md
+++ b/src/cloud/env/environments-ssh.md
@@ -118,7 +118,7 @@ You need the following requirements to sFTP into cloud environments:
 *  You need to use a client that supports SSH key authentication for sFTP and use your SSH public key.
 *  Your public SSH key must be added to the target environment. For Starter environments and Pro Integration environments, you can add it through the Project Web Interface. For Pro Staging and Production, you must enter a [Support ticket]({{ site.baseurl }}/cloud/trouble/trouble.html) with your public key attached. **Never provide your private SSH key.**
 
-When configuring sFTP, use your SSH access destination (see [SSH to an Environment](#ssh), example `<project-id-name>@<cloud-host>`) and the following information for access:
+When configuring sFTP, use the information from your [SSH access environment command](#ssh) (`<project-id>-<environment-id>--<app-name>@ssh<cloud-host>`) and the following information:
 
 *  Username: All content before the `@` in your SSH access destination.
 *  Password: You do not need a password for sFTP. sFTP access uses the SSH key based authentication.

--- a/src/cloud/env/environments-ssh.md
+++ b/src/cloud/env/environments-ssh.md
@@ -124,7 +124,7 @@ When configuring sFTP, use the information from your [SSH access environment com
 *  Password: You do not need a password for sFTP. sFTP access uses the SSH key based authentication.
 *  Host: All content after the `@` in your SSH access.
 *  Port: 22, which is the default SSH port.
-*  SSH Private Key: If necessary, let the sFTP client know where to find your private key. By default, the private keys are stored in the `~/.ssh`directory.
+*  SSH Private Key: If necessary, provide the location of your private key to the sFTP client. By default, private keys are stored in the `~/.ssh` directory.
 
 Depending on the client, you may need to enter additional options and setup to complete SSH authentication for sFTP. Review the documentation for your selected client.
 

--- a/src/cloud/env/environments-ssh.md
+++ b/src/cloud/env/environments-ssh.md
@@ -124,7 +124,7 @@ When configuring sFTP, use your SSH access destination (see [SSH to an Environme
 *  Password: You do not need a password for sFTP. sFTP access uses the SSH key based authentication.
 *  Host: All content after the `@` in your SSH access destination.
 *  Port: 22, which is the default SSH port.
-*  Private Key: If necessary, let the SFTP client know where to find your private key
+*  SSH Private Key: If necessary, let the sFTP client know where to find your private key. By default, the private keys are stored in the `~/.ssh`directory. 
 
 Depending on the client, you may need to enter additional options and setup to complete SSH authentication for sFTP. Review the documentation for your selected client.
 

--- a/src/cloud/env/environments-ssh.md
+++ b/src/cloud/env/environments-ssh.md
@@ -122,7 +122,7 @@ When configuring sFTP, use the information from your [SSH access environment com
 
 *  Username: All content before the `@` in your SSH access destination.
 *  Password: You do not need a password for sFTP. sFTP access uses the SSH key based authentication.
-*  Host: All content after the `@` in your SSH access destination.
+*  Host: All content after the `@` in your SSH access.
 *  Port: 22, which is the default SSH port.
 *  SSH Private Key: If necessary, let the sFTP client know where to find your private key. By default, the private keys are stored in the `~/.ssh`directory.
 

--- a/src/cloud/env/environments-ssh.md
+++ b/src/cloud/env/environments-ssh.md
@@ -124,7 +124,7 @@ When configuring sFTP, use your SSH access destination (see [SSH to an Environme
 *  Password: You do not need a password for sFTP. sFTP access uses the SSH key based authentication.
 *  Host: All content after the `@` in your SSH access destination.
 *  Port: 22, which is the default SSH port.
-*  SSH Private Key: If necessary, let the sFTP client know where to find your private key. By default, the private keys are stored in the `~/.ssh`directory. 
+*  SSH Private Key: If necessary, let the sFTP client know where to find your private key. By default, the private keys are stored in the `~/.ssh`directory.
 
 Depending on the client, you may need to enter additional options and setup to complete SSH authentication for sFTP. Review the documentation for your selected client.
 


### PR DESCRIPTION
## Purpose of this pull request

This pull request (PR) corrects the instructions for configuring an SFTP client; specifically the steps for finding the "host" and "username" values. This PR also removes a second, seemingly redundant set of steps that duplicated the incorrect method of discovering the "host" and "username" values.

## Affected DevDocs pages

<!-- REQUIRED List the affected pages on devdocs.magento.com (URLs). Not needed for large numbers of files. -->

-  https://devdocs.magento.com/cloud/env/environments-ssh.html

<!--
If you are fixing a GitHub issue, note it using GitHub keyword format (https://help.github.com/en/articles/closing-issues-using-keywords#closing-an-issue-in-a-different-repository) to close the issue when this pull request is merged. Example: `Fixes #1234`

`master` is the default branch. Merged pull requests to `master` go live on the site automatically. Any requested changes to content on the `master` branch must be related to the released codebase. Any content related to future releases goes in the `develop` branch.

See Contribution guidelines (https://github.com/magento/devdocs/blob/master/.github/CONTRIBUTING.md) for more information.
-->
