### PR TITLE
Improvements on event observer topic

### DIFF
--- a/src/guides/v2.3/extension-dev-guide/events-and-observers.md
+++ b/src/guides/v2.3/extension-dev-guide/events-and-observers.md
@@ -59,9 +59,31 @@ class MyClass
 
 Custom events can be dispatched by simply passing in a unique event name to the event manager when you call the `dispatch` function. Your unique event name is referenced in your module's `events.xml` file where you specify which observers will react to that event.
 
+Custom event `my_module_event_after` can be subscribed by declaring the `MyCompany/MyModule/etc/events.xml` file like below:
+
+```xml
+<config xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="urn:magento:framework:Event/etc/events.xsd">
+    <event name="my_module_event_after">
+        <observer name="my_module_event_after_observer" instance="MyCompany\MyModule\Observer\MyEvent"/>
+    </event>
+</config>
+```
+
 ### Event areas
 
 Generally, the location of the `events.xml` file will be under the `<module-root>/etc` directory. Observers that are associated with events here will watch for these events globally. The `events.xml` file can also be defined under the `<module-root>/etc/frontend` and `<module-root>/etc/adminhtml` directories to configure observers to only watch for events in those specific areas.
+
+Make your observer as specific as it needs to be. Declare your observer in the appropriate area:
+
+| Area | File location | Description |
+| --- | --- | --- |
+| `global` | `<module-dir>/etc/events.xml` | Observer will be executed in all areas: `adminhtml`, `crontab`, `frontend`, `graphql`, `webapi_rest`, `webapi_soap`. |
+| `adminhtml` | `<module-dir>/etc/adminhtml/events.xml` | Observer will be executed in the `adminhtml` area only. |
+| `crontab` | `<module-dir>/etc/crontab/events.xml` | Observer will be executed in the `crontab` area only. |
+| `frontend` | `<module-dir>/etc/frontend/events.xml` | Observer will be executed in the `frontend` area only. |
+| `graphql` | `<module-dir>/etc/graphql/events.xml` | Observer will be executed in the `graphql` area only. |
+| `webapi_rest` | `<module-dir>/etc/webapi_rest/events.xml` | Observer will be executed in the `webapi_rest` area only. |
+| `webapi_soap` | `<module-dir>/etc/webapi_soap/events.xml` | Observer will be executed in the `webapi_soap` area only. |
 
 ## Observers
 

--- a/src/guides/v2.3/extension-dev-guide/events-and-observers.md
+++ b/src/guides/v2.3/extension-dev-guide/events-and-observers.md
@@ -59,7 +59,7 @@ class MyClass
 
 Custom events can be dispatched by simply passing in a unique event name to the event manager when you call the `dispatch` function. Your unique event name is referenced in your module's `events.xml` file where you specify which observers will react to that event.
 
-Custom event `my_module_event_after` can be subscribed by declaring the `MyCompany/MyModule/etc/events.xml` file like below:
+The custom event `my_module_event_after` can be subscribed to by declaring the `MyCompany/MyModule/etc/events.xml` file as below:
 
 ```xml
 <config xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="urn:magento:framework:Event/etc/events.xsd">
@@ -73,7 +73,7 @@ Custom event `my_module_event_after` can be subscribed by declaring the `MyCompa
 
 Generally, the location of the `events.xml` file will be under the `<module-root>/etc` directory. Observers that are associated with events here will watch for these events globally. The `events.xml` file can also be defined under the `<module-root>/etc/frontend` and `<module-root>/etc/adminhtml` directories to configure observers to only watch for events in those specific areas.
 
-Make your observer as specific as it needs to be. Declare your observer in the appropriate area:
+Declare the observer in the appropriate area:
 
 | Area | File location | Description |
 | --- | --- | --- |

--- a/src/guides/v2.3/extension-dev-guide/events-and-observers.md
+++ b/src/guides/v2.3/extension-dev-guide/events-and-observers.md
@@ -59,7 +59,7 @@ class MyClass
 
 Custom events can be dispatched by simply passing in a unique event name to the event manager when you call the `dispatch` function. Your unique event name is referenced in your module's `events.xml` file where you specify which observers will react to that event.
 
-The custom event `my_module_event_after` can be subscribed to by declaring the `MyCompany/MyModule/etc/events.xml` file as below:
+You can make the custom event `my_module_event_after` subscribable by declaring the `MyCompany/MyModule/etc/events.xml` file as below:
 
 ```xml
 <config xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="urn:magento:framework:Event/etc/events.xsd">
@@ -73,17 +73,17 @@ The custom event `my_module_event_after` can be subscribed to by declaring the `
 
 Generally, the location of the `events.xml` file will be under the `<module-root>/etc` directory. Observers that are associated with events here will watch for these events globally. The `events.xml` file can also be defined under the `<module-root>/etc/frontend` and `<module-root>/etc/adminhtml` directories to configure observers to only watch for events in those specific areas.
 
-Declare the observer in the appropriate area:
+Declare the observer in the appropriate area. The `global` area allows the observer to run in all areas (`adminhtml`, `crontab`, `frontend`, `graphql`, `webapi_rest`, `webapi_soap`).
 
-| Area | File location | Description |
-| --- | --- | --- |
-| `global` | `<module-dir>/etc/events.xml` | Observer will be executed in all areas: `adminhtml`, `crontab`, `frontend`, `graphql`, `webapi_rest`, `webapi_soap`. |
-| `adminhtml` | `<module-dir>/etc/adminhtml/events.xml` | Observer will be executed in the `adminhtml` area only. |
-| `crontab` | `<module-dir>/etc/crontab/events.xml` | Observer will be executed in the `crontab` area only. |
-| `frontend` | `<module-dir>/etc/frontend/events.xml` | Observer will be executed in the `frontend` area only. |
-| `graphql` | `<module-dir>/etc/graphql/events.xml` | Observer will be executed in the `graphql` area only. |
-| `webapi_rest` | `<module-dir>/etc/webapi_rest/events.xml` | Observer will be executed in the `webapi_rest` area only. |
-| `webapi_soap` | `<module-dir>/etc/webapi_soap/events.xml` | Observer will be executed in the `webapi_soap` area only. |
+| Area | File location |
+| --- | --- |
+| `global` | `<module-dir>/etc/events.xml` |
+| `adminhtml` | `<module-dir>/etc/adminhtml/events.xml` |
+| `crontab` | `<module-dir>/etc/crontab/events.xml` |
+| `frontend` | `<module-dir>/etc/frontend/events.xml` |
+| `graphql` | `<module-dir>/etc/graphql/events.xml` |
+| `webapi_rest` | `<module-dir>/etc/webapi_rest/events.xml` |
+| `webapi_soap` | `<module-dir>/etc/webapi_soap/events.xml` |
 
 ## Observers
 


### PR DESCRIPTION
## Purpose of this pull request

This pull request (PR) includes the below improvements:

- Added example of subscribing to the custom event.
- Added information on the list of valid areas for observers.

## Affected DevDocs pages

<!-- REQUIRED List the affected pages on devdocs.magento.com (URLs). Not needed for large numbers of files. -->

-  https://devdocs.magento.com/guides/v2.3/extension-dev-guide/events-and-observers.html
-  https://devdocs.magento.com/guides/v2.4/extension-dev-guide/events-and-observers.html

## Links to Magento source code

<!--  OPTIONAL - REMOVE THIS SECTION IF NOT USED. If this pull request references a file in a Magento codebase repository, add it here. -->

-  https://github.com/magento/magento2/blob/2.4-develop/app/code/Magento/Sales/etc/events.xml

<!--
If you are fixing a GitHub issue, note it using GitHub keyword format (https://help.github.com/en/articles/closing-issues-using-keywords#closing-an-issue-in-a-different-repository) to close the issue when this pull request is merged. Example: `Fixes #1234`

`master` is the default branch. Merged pull requests to `master` go live on the site automatically. Any requested changes to content on the `master` branch must be related to the released codebase. Any content related to future releases goes in the `develop` branch.

See Contribution guidelines (https://github.com/magento/devdocs/blob/master/.github/CONTRIBUTING.md) for more information.
-->

whatsnew
Added an example and table to the [Events and observers](https://devdocs.magento.com/guides/v2.4/extension-dev-guide/events-and-observers.html)
