### PR TITLE
API > Special price > Fix syntax

### DIFF
--- a/src/guides/v2.3/rest/modules/catalog-pricing.md
+++ b/src/guides/v2.3/rest/modules/catalog-pricing.md
@@ -140,7 +140,7 @@ The following call returns the special price information for three SKU values.
 
 ### Delete a special price
 
-If any item to be deleted has an invalid `price`, `store_id`, `sku` or date, Magento marks the item as failed and excludes it from the delete list. Valid items are deleted as requested.
+If any item to be deleted has an invalid `price`, `store_id`, `sku` or `date`, Magento marks the item as failed and excludes it from the delete list. Valid items are deleted as requested.
 
 **Sample Usage:**
 


### PR DESCRIPTION
## Purpose of this pull request

The syntax of the last attribute is now following the pattern.

![Screen Shot 2021-05-21 at 4 12 22 PM](https://user-images.githubusercontent.com/610598/119193426-9599cf00-ba4f-11eb-9120-6e6916de59b9.png)

## Affected DevDocs pages

https://devdocs.magento.com/guides/v2.4/rest/modules/catalog-pricing.html#delete-a-special-price