### PR TITLE
prevent braintree card attack

### DIFF
--- a/src/_data/toc/payments-integrations.yml
+++ b/src/_data/toc/payments-integrations.yml
@@ -90,3 +90,6 @@ pages:
 
     - label: CardinalCommerce 3-D Secure
       url: /payments-integrations/cardinal/cardinal.html
+
+    - label: Prevent braintree card attack
+      url: /payments-integrations/braintree/braintree.html

--- a/src/guides/v2.3/payments-integrations/braintree/braintree.md
+++ b/src/guides/v2.3/payments-integrations/braintree/braintree.md
@@ -1,0 +1,114 @@
+---
+group: payments-integrations
+title: Prevent braintree card attack
+contributor_name: Ziffity
+contributor_link: https://www.ziffity.com/
+--- 
+
+Reference to [Carding Attack #28614](https://github.com/magento/magento2/issues/28614) Gene Commerce has come up with latest version [GitHub](https://github.com/genecommerce/module-braintree-magento2/releases/tag/4.0.7) 
+
+### Requirements
+
+**Magento** | **PHP** | **Braintree**
+--- | --- | ---
+`< 2.x` | `> 7.x` | `>= 4.0.7`
+
+### How to prevent braintree card bot attack ?
+
+1. Bot attacker will create the order several times using rest endpoint `POST <host>/rest/<store_code>/V1/guest-carts/<cart-id>/payment-information`.
+
+2. To avoid card bot attack, we need to enable the default `Magento` & `Braintree` reCaptcha configuration from admin.
+
+### How to enable the configuration ?
+
+1. Log in to [Admin](https://glossary.magento.com/admin). 
+2. These configuration values are available in the `Magento` Admin.
+
+   * Go to *Stores* > *Settings* > *Configuration* > *Security* > *Google reCaptcha* > *Frontend* > *Enable* > *Yes*.
+   * Go to *Stores* > *Settings* > *Configuration* > *Security* > *Google reCaptcha* > *General* > *reCaptcha type* > *Invisible reCaptcha v2*
+   * Go to *Stores* > *Settings* > *Configuration* > *Sales* > *Payment Methods* > *Recommended Solutions* > *Braintree Payments* > *Configure* > *Advanced Braintree Settings* > *Enable ReCaptcha* > *Yes*.
+
+{:.bs-callout-info}
+For More Information :- [reCaptcha Configuration](https://docs.magento.com/user-guide/stores/security-google-recaptcha.html)
+
+### Send payment information using REST endpoints
+
+**Endpoint:**
+
+```http
+POST <host>/rest/<store_code>/V1/guest-carts/<cart-id>/payment-information
+```
+
+**Headers:**
+
+`Content-Type: application/json`
+
+**Payload:**
+
+{% collapsible Show request %}
+
+```json
+{
+   "cartId":"xxxxxxxxxxxxxxxxxxxxxxxxx",
+   "billingAddress":{
+      "email":"xxxx@gmail.com",
+      "countryId":"xxxxxxxxxxxxxxxxxxxxxxxxx",
+      "regionId":"xxxxxxxxxxxxxxxxxxxxxxxxx",
+      "regionCode":"xxxxxxxxxxxxxxxxxxxxxxxxx",
+      "region":"xxxxxxxxxxxxxxxxxxxxxxxxx",
+      "street":[
+         "xxxxxxxxxxxxxxxxxxxxxxxxx"
+      ],
+      "company":"xxxxxxxxxxxxxxxxxxxxxxxxx",
+      "telephone":"xxxxxxxxxxxxxxxxxxxxxxxxx",
+      "postcode":"xxxxxxxxxxxxxxxxxxxxxxxxx",
+      "city":"xxxxxxxxxxxxxxxxxxxxxxxxx",
+      "firstname":"xxxxxxxxxxxxxxxxxxxxxxxxx",
+      "lastname":"xxxxxxxxxxxxxxxxxxxxxxxxx",
+      "region_id":"",
+      "region_code":"xxxxxxxxxxxxxxxxxxxxxxxxx",
+      "country_id":"xxxxxxxxxxxxxxxxxxxxxxxxx",
+      "extension_attributes":{
+         "advanced_conditions":{
+            "payment_method":null,
+            "shipping_address_line":[
+               "xxxxxxxxxxxxxxxxxxxxxxxxx"
+            ],
+            "city":"xxxxxxxxxxxxxxxxxxxxxxxxx",
+            "billing_address_country":"xxxxxxxxxxxxxxxxxxxxxxxxx",
+            "currency":"xxxxxxxxxxxxxxxxxxxxxxxxx"
+         }
+      },
+      "saveInAddressBook":null
+   },
+   "paymentMethod":{
+      "method":"braintree",
+      "po_number":null,
+      "additional_data":{
+         "cc_cid":"xxxxxxxxxxxxxxxxxxxxxxxxx",
+         "cc_type":"xxxxxxxxxxxxxxxxxxxxxxxxx",
+         "cc_exp_year":"xxxxxxxxxxxxxxxxxxxxxxxxx",
+         "cc_exp_month":"xxxxxxxxxxxxxxxxxxxxxxxxx",
+         "cc_number":"xxxxxxxxxxxxxxxxxxxxxxxxx"
+      }
+   },
+   "email":"xxxx@gmail.com"
+}
+```
+
+{% endcollapsible %}
+
+**Response:**
+
+{% collapsible Show response %}
+
+```json
+{
+  "message": "Can not resolve reCaptcha response."
+}
+```
+
+{% endcollapsible %}
+
+{:.bs-callout-info}
+For More Information :- [REST tutorials]({{ site.baseurl }}/guides/v2.3/rest/tutorials/index.html)

--- a/src/guides/v2.3/payments-integrations/braintree/braintree.md
+++ b/src/guides/v2.3/payments-integrations/braintree/braintree.md
@@ -5,13 +5,13 @@ contributor_name: Ziffity
 contributor_link: https://www.ziffity.com/
 --- 
 
-Reference to [Carding Attack #28614](https://github.com/magento/magento2/issues/28614) Gene Commerce has come up with latest version [GitHub](https://github.com/genecommerce/module-braintree-magento2/releases/tag/4.0.7) 
+Reference to [Carding Attack #28614](https://github.com/magento/magento2/issues/28614) Gene Commerce has come up with latest version [GitHub](https://github.com/genecommerce/module-braintree-magento2/releases/tag/4.0.7)
 
 ### Requirements
 
 **Magento** | **PHP** | **Braintree**
 --- | --- | ---
-`< 2.x` | `> 7.x` | `>= 4.0.7`
+`2.3,2.4` | `> 7.x` | `>= 4.0.7`
 
 ### How to prevent braintree card bot attack ?
 
@@ -21,7 +21,7 @@ Reference to [Carding Attack #28614](https://github.com/magento/magento2/issues/
 
 ### How to enable the configuration ?
 
-1. Log in to [Admin](https://glossary.magento.com/admin). 
+1. Log in to [Admin](https://glossary.magento.com/admin).
 2. These configuration values are available in the `Magento` Admin.
 
    * Go to *Stores* > *Settings* > *Configuration* > *Security* > *Google reCaptcha* > *Frontend* > *Enable* > *Yes*.

--- a/src/guides/v2.3/payments-integrations/braintree/braintree.md
+++ b/src/guides/v2.3/payments-integrations/braintree/braintree.md
@@ -13,13 +13,13 @@ Reference to [Carding Attack #28614](https://github.com/magento/magento2/issues/
 --- | --- | ---
 `2.3,2.4` | `> 7.x` | `>= 4.0.7`
 
-### How to prevent braintree card bot attack ?
+### How to prevent a Braintree card bot attack
 
-1. Bot attacker will create the order several times using rest endpoint `POST <host>/rest/<store_code>/V1/guest-carts/<cart-id>/payment-information`.
+1. The bot attacker will create the order several times using the REST endpoint `POST <host>/rest/<store_code>/V1/guest-carts/<cart-id>/payment-information`.
 
-1. To avoid card bot attack, we need to enable the default `Magento` & `Braintree` reCaptcha configuration from admin.
+1. To avoid the card bot attack, it is necessary to enable the default `Magento` & `Braintree` reCaptcha configuration from admin.
 
-### How to enable the configuration ?
+### How to enable the configuration
 
 1. Log in to [Admin](https://glossary.magento.com/admin).
 1. These configuration values are available in the `Magento` Admin.
@@ -29,7 +29,7 @@ Reference to [Carding Attack #28614](https://github.com/magento/magento2/issues/
    *  Go to *Stores* > *Settings* > *Configuration* > *Sales* > *Payment Methods* > *Recommended Solutions* > *Braintree Payments* > *Configure* > *Advanced Braintree Settings* > *Enable ReCaptcha* > *Yes*.
 
 {:.bs-callout-info}
-For More Information :- [reCaptcha Configuration](https://docs.magento.com/user-guide/stores/security-google-recaptcha.html)
+For more information :- [reCaptcha Configuration](https://docs.magento.com/user-guide/stores/security-google-recaptcha.html)
 
 ### Send payment information using REST endpoints
 
@@ -104,11 +104,11 @@ POST <host>/rest/<store_code>/V1/guest-carts/<cart-id>/payment-information
 
 ```json
 {
-  "message": "Can not resolve reCaptcha response."
+  "message": "Cannot resolve reCaptcha response."
 }
 ```
 
 {% endcollapsible %}
 
 {:.bs-callout-info}
-For More Information :- [REST tutorials]({{ site.baseurl }}/guides/v2.3/rest/tutorials/index.html)
+For more information :- [REST tutorials]({{ site.baseurl }}/guides/v2.3/rest/tutorials/index.html)

--- a/src/guides/v2.3/payments-integrations/braintree/braintree.md
+++ b/src/guides/v2.3/payments-integrations/braintree/braintree.md
@@ -17,16 +17,16 @@ Reference to [Carding Attack #28614](https://github.com/magento/magento2/issues/
 
 1. Bot attacker will create the order several times using rest endpoint `POST <host>/rest/<store_code>/V1/guest-carts/<cart-id>/payment-information`.
 
-2. To avoid card bot attack, we need to enable the default `Magento` & `Braintree` reCaptcha configuration from admin.
+1. To avoid card bot attack, we need to enable the default `Magento` & `Braintree` reCaptcha configuration from admin.
 
 ### How to enable the configuration ?
 
 1. Log in to [Admin](https://glossary.magento.com/admin).
-2. These configuration values are available in the `Magento` Admin.
+1. These configuration values are available in the `Magento` Admin.
 
-   * Go to *Stores* > *Settings* > *Configuration* > *Security* > *Google reCaptcha* > *Frontend* > *Enable* > *Yes*.
-   * Go to *Stores* > *Settings* > *Configuration* > *Security* > *Google reCaptcha* > *General* > *reCaptcha type* > *Invisible reCaptcha v2*
-   * Go to *Stores* > *Settings* > *Configuration* > *Sales* > *Payment Methods* > *Recommended Solutions* > *Braintree Payments* > *Configure* > *Advanced Braintree Settings* > *Enable ReCaptcha* > *Yes*.
+   *  Go to *Stores* > *Settings* > *Configuration* > *Security* > *Google reCaptcha* > *Frontend* > *Enable* > *Yes*.
+   *  Go to *Stores* > *Settings* > *Configuration* > *Security* > *Google reCaptcha* > *General* > *reCaptcha type* > *Invisible reCaptcha v2*
+   *  Go to *Stores* > *Settings* > *Configuration* > *Sales* > *Payment Methods* > *Recommended Solutions* > *Braintree Payments* > *Configure* > *Advanced Braintree Settings* > *Enable ReCaptcha* > *Yes*.
 
 {:.bs-callout-info}
 For More Information :- [reCaptcha Configuration](https://docs.magento.com/user-guide/stores/security-google-recaptcha.html)

--- a/src/guides/v2.4/payments-integrations/braintree/braintree.md
+++ b/src/guides/v2.4/payments-integrations/braintree/braintree.md
@@ -1,0 +1,1 @@
+../../../v2.3/payments-integrations/braintree/braintree.md


### PR DESCRIPTION
## Purpose of this pull request

This pull request (PR) to avoid bot attacker using the rest endpoint _payment information_ several times as Braintree come up with the solution with the latest version by enabling the default & Braintree reCaptcha configuration from admin.

## Affected DevDocs pages

<!-- REQUIRED List the affected pages on devdocs.magento.com (URLs). Not needed for large numbers of files. -->

-  New Topic

<!--
If you are fixing a GitHub issue, note it using GitHub keyword format (https://help.github.com/en/articles/closing-issues-using-keywords#closing-an-issue-in-a-different-repository) to close the issue when this pull request is merged. Example: `Fixes #1234`

`master` is the default branch. Merged pull requests to `master` go live on the site automatically. Any requested changes to content on the `master` branch must be related to the released codebase. Any content related to future releases goes in the `develop` branch.

See Contribution guidelines (https://github.com/magento/devdocs/blob/master/.github/CONTRIBUTING.md) for more information.
-->
