### PR TITLE
Replace a wrong "PHPUnit Manual" source link to correct one

### DIFF
--- a/src/guides/v2.3/test/integration/integration_test_execution.md
+++ b/src/guides/v2.3/test/integration/integration_test_execution.md
@@ -345,5 +345,5 @@ This folder contains the following sub-folders and files:
 [setup]: #setup
 [cli run]: #cli-run
 [phpstorm run]: {{ page.baseurl }}/test/unit/unit_test_execution_phpstorm.html
-[PHPUnit documentation]: https://phpunit.de/manual/4.1/en/appendixes.configuration.html
+[PHPUnit documentation]: https://phpunit.readthedocs.io/en/9.5/
 [RabbitMQ Management Plugin]: https://www.rabbitmq.com/management.html


### PR DESCRIPTION
## Purpose of this pull request

This pull request (PR) replaces a wrong "PHPUnit Manual" source link to correct one

Actual result:
![image](https://user-images.githubusercontent.com/78729171/119673676-37e8f680-be44-11eb-98d6-1b4ad0e640f1.png)
![image](https://user-images.githubusercontent.com/78729171/119673716-3fa89b00-be44-11eb-8150-06d192ea2efc.png)

Expected result:
![image](https://user-images.githubusercontent.com/78729171/119673791-518a3e00-be44-11eb-9fde-e57cccca20a1.png)

## Affected DevDocs pages

<!-- REQUIRED List the affected pages on devdocs.magento.com (URLs). Not needed for large numbers of files. -->

-  https://devdocs.magento.com/guides/v2.4/test/integration/integration_test_execution.html#setup
