### PR TITLE
Add info about the log rotation on Magento Cloud environment

### DIFF
--- a/src/cloud/project/log-locations.md
+++ b/src/cloud/project/log-locations.md
@@ -18,6 +18,9 @@ You can view the logs from the file system, the project web UI, and the `magento
 
 -  **Magento Cloud CLI**—You can view logs using the `magento-cloud log` command.
 
+{:.bs-callout-tip}
+Automatic log rotation, compression, and removal are enabled in the Cloud environment. Every type of log file has its own rotating pattern and lifetime.
+
 ## Manage log data
 
 On Pro Production and Staging environments, use the New Relic Logs application integrated with your project to manage aggregated log data from all logs associated with your {{ site.data.var.ece }} project.
@@ -143,16 +146,31 @@ Log file            | Starter and Pro Integration | Pro Staging                 
 **PHP access log**  | `/var/log/php.access.log`   | `/var/log/platform/<project_id>_stg/php.access.log` | `/var/log/platform/<project_id>/php.access.log`
 **PHP FPM log**     | `/var/log/app.log`          | `/var/log/platform/<project_id>_stg/php5-fpm.log` | `/var/log/platform/<project_id>/php5-fpm.log`
 
+The application logs are compressed and archived once per day and kept for one year. The compressed logs are named using a unique ID that corresponds to the `Number of Days Ago + 1`.
+For example, the PHP access log for 21 days in the past, on the Pro production environments, is stored and named as follows:
+
+```terminal
+/var/log/platform/<project_id>/php.access.log.22.gz
+```
+
+The archived log files are always stored in the directory where the original file was located before compression.
+
+{:.bs-callout-info}
+**Deploy** and **Post-deploy** log files are not rotated and archived. The entire deployment history is written within those log files.
+
 ## Service logs
 
 Because each service runs in a separate container, the service logs are not available in the Integration environment. {{ site.data.var.ece }} provides access to the web server container in the Integration environment only. The following service log locations are for the Pro Production and Staging environments:
 
 -  **Redis log**: `/var/log/platform/<project_id>_stg/redis-server-<project_id>_stg.log`
 -  **Elasticsearch log**: `/var/log/elasticsearch/elasticsearch.log`
+-  **Java garbage collection log**: `/var/log/elasticsearch/gc.log`
 -  **Mail log**: `/var/log/mail.log`
 -  **MySQL error log**: `/var/log/mysql/mysql-error.log`
 -  **MySQL slow log**: `/var/log/mysql/mysql-slow.log`
 -  **RabbitMQ log**: `/var/log/rabbitmq/rabbit@host1.log`
+
+Service logs are archived and saved for different periods of time, depending on the log type. For example, MySQL logs have the shortest lifetime—removed after 7 days.
 
 {:.bs-callout-tip}
 Log file locations in the scaled architecture depend on the node type. See [Log locations in the Scaled architecture][scaled] topic.


### PR DESCRIPTION
## Purpose of this pull request

This pull request introduces the documentation for log rotation flow on the Cloud environment, including the information about achieved logs files location and other minor improvements.

## Affected DevDocs pages

- https://devdocs.magento.com/cloud/project/log-locations.html

## Links to Magento source code

N/A

