### PR TITLE
Corrected the COnfiguration section tab Name

### DIFF
--- a/src/cloud/cdn/fastly-vcl-wordpress.md
+++ b/src/cloud/cdn/fastly-vcl-wordpress.md
@@ -27,7 +27,7 @@ To reroute requests from {{ site.data.var.ee }} to WordPress:
 
    -  Log in to the Magento Admin.
 
-   -  Navigate to **Stores** > Settings > **Configuration** > **Advanced** > **System** > **Full Page Cache** > **Fastly Configuration** > **Advanced**.
+   -  Navigate to **Stores** > Settings > **Configuration** > **Advanced** > **System** > **Full Page Cache** > **Fastly Configuration** > **Advanced Configuration**.
 
    -  Set the value for **Fastly Edge Modules** to **Yes**.
 


### PR DESCRIPTION
Corrected the COnfiguration section tab Name

## Purpose of this pull request

The Configuration Tab name was mentioned as  "Advanced" the correct name is "Advanced Configuration"
**Stores** > Settings > **Configuration** > **Advanced** > **System** > **Full Page Cache** > **Fastly Configuration** > **Advanced Configuration**.

## Affected DevDocs pages

<!-- REQUIRED List the affected pages on devdocs.magento.com (URLs). Not needed for large numbers of files. -->

-  https://devdocs.magento.com/cloud/cdn/fastly-vcl-wordpress.html

## Links to Magento source code

<!--  OPTIONAL - REMOVE THIS SECTION IF NOT USED. If this pull request references a file in a Magento codebase repository, add it here. -->

-  ...

<!--
If you are fixing a GitHub issue, note it using GitHub keyword format (https://help.github.com/en/articles/closing-issues-using-keywords#closing-an-issue-in-a-different-repository) to close the issue when this pull request is merged. Example: `Fixes #1234`

`master` is the default branch. Merged pull requests to `master` go live on the site automatically. Any requested changes to content on the `master` branch must be related to the released codebase. Any content related to future releases goes in the `develop` branch.

See Contribution guidelines (https://github.com/magento/devdocs/blob/master/.github/CONTRIBUTING.md) for more information.
-->
