### PR TITLE
remove setup_version

### DIFF
--- a/src/guides/v2.3/extension-dev-guide/admin-grid.md
+++ b/src/guides/v2.3/extension-dev-guide/admin-grid.md
@@ -25,7 +25,7 @@ Here are the required files to get started:
 ```xml
 <?xml version="1.0"?>
 <config xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="urn:magento:framework:Module/etc/module.xsd">
- <module name="Dev_Grid" setup_version="1.0.0">
+ <module name="Dev_Grid">
   <sequence>
    <module name="Magento_Backend"/>
    <module name="Magento_Ui"/>


### PR DESCRIPTION
## Purpose of this pull request

This pull request helps with clarity by reducing unnecessary code.

The `setup_version` attribute of the `module` node is used to support upgrade logic in extension `Setup/UpgradeSchema.php` and `Setup/UpgradeData.php` scripts. However this guide makes no use of such scripts, and therefore `setup_version` is unnecessary in these code examples.

Omitting it 
- is safe for modules which do not rely on it
- it avoids creating an entry in the `setup_module` table
- avoids creating unnecessary confusion for developers who may not fully understand its purpose

## Affected DevDocs pages

- https://devdocs.magento.com/guides/v2.3/extension-dev-guide/admin-grid.html
- https://devdocs.magento.com/guides/v2.4/extension-dev-guide/admin-grid.html
