### PR TITLE
Updated extension packaging guidelines with Marketplace-specific rules

### DIFF
--- a/src/guides/v2.3/extension-dev-guide/package/package_module.md
+++ b/src/guides/v2.3/extension-dev-guide/package/package_module.md
@@ -29,7 +29,7 @@ Element | Description
 `autoload` | Specify necessary information to be loaded, such as [registration.php]({{ page.baseurl }}/extension-dev-guide/build/component-registration.html). For more information, see [Autoloading](https://getcomposer.org/doc/01-basic-usage.md#autoloading) from Composer.
 
 {:.bs-callout-info}
-Note that Commerce Marketplace does not support `source` and `dist`properties. All extensions distributed via Marketplace are installed from the Commerce package repository. If your `composer.json` contains `source` or `dist` properties, it will cause failures in the EQP automation.
+The Commerce Marketplace does not support the Composer `source` and `dist` properties. All extensions distributed via the Marketplace are installed from the Commerce package repository. If your `composer.json` contains `source` or `dist` properties, it will cause failures in the EQP automation.
 
 {% include php-dev/composer-types.md %}
 

--- a/src/guides/v2.3/extension-dev-guide/package/package_module.md
+++ b/src/guides/v2.3/extension-dev-guide/package/package_module.md
@@ -28,6 +28,9 @@ Element | Description
 `type` | For modules, this value must be set to `magento2-module`. Other possible types are `metapackage`, `magento2-theme`, and `magento2-language`.
 `autoload` | Specify necessary information to be loaded, such as [registration.php]({{ page.baseurl }}/extension-dev-guide/build/component-registration.html). For more information, see [Autoloading](https://getcomposer.org/doc/01-basic-usage.md#autoloading) from Composer.
 
+{:.bs-callout-info}
+Note that Commerce Marketplace does not support `source` and `dist`properties. All extensions distributed via Marketplace are installed from the Commerce package repository. If your `composer.json` contains `source` or `dist` properties, it will cause failures in the EQP automation.
+
 {% include php-dev/composer-types.md %}
 
 ### Using metapackages {#package-metapackage}


### PR DESCRIPTION
## Purpose of this pull request

This pull request (PR) addresses a previously undocumented lack of support for "source" and "dist" parameters in composer.json for Marketplace extension submissions.

## Affected DevDocs pages

- https://devdocs.magento.com/guides/v2.4/extension-dev-guide/package/package_module.html
- https://devdocs.magento.com/guides/v2.3/extension-dev-guide/package/package_module.html