### PR TITLE
Config guide > Removing unnecessary code expression

### DIFF
--- a/src/guides/v2.3/config-guide/prod/prod_file-sys-perms.md
+++ b/src/guides/v2.3/config-guide/prod/prod_file-sys-perms.md
@@ -152,7 +152,7 @@ To set `setgid` and permissions for developer mode:
    ```
 
    ```bash
-   find var generated pub/static pub/media app/etc -type f -exec chmod g+w {} + &&
+   find var generated pub/static pub/media app/etc -type f -exec chmod g+w {} +
    ```
 
    ```bash


### PR DESCRIPTION
The code is not relevant in the specific section when the developer clicks in copy the code the `&&` is copied together and we might not be able to run it without removing the expression.

## Purpose of this pull request

Eliminate this expression:

![Screen Shot 2021-06-02 at 3 57 53 PM](https://user-images.githubusercontent.com/610598/120544502-7c800f00-c3bb-11eb-8422-126384358a82.png)

## Affected DevDocs pages

<!-- REQUIRED List the affected pages on devdocs.magento.com (URLs). Not needed for large numbers of files. -->

https://devdocs.magento.com/guides/v2.3/config-guide/prod/prod_file-sys-perms.html