### PR TITLE
Removing incorrect line about 2FA admin workflows

### DIFF
--- a/src/guides/v2.4/security/two-factor-authentication.md
+++ b/src/guides/v2.4/security/two-factor-authentication.md
@@ -17,7 +17,7 @@ Two-Factor Authentication gives you the ability to:
 
 Magento has new workflows for _Admin_ users, including:
 
--  The ability to configure the 2FA provider globally or individually.
+- Initially configure the global 2FA providers.
 -  The "Trust this device" option has been removed.
 
 For more information, see [Two-Factor Authentication](https://docs.magento.com/m2/ee/user_guide/stores/security-two-factor-authentication.html) in the _Magento User Guide_.

--- a/src/guides/v2.4/security/two-factor-authentication.md
+++ b/src/guides/v2.4/security/two-factor-authentication.md
@@ -17,7 +17,7 @@ Two-Factor Authentication gives you the ability to:
 
 Magento has new workflows for _Admin_ users, including:
 
-- Initially configure the global 2FA providers.
+-  Initially configure the global 2FA providers.
 -  The "Trust this device" option has been removed.
 
 For more information, see [Two-Factor Authentication](https://docs.magento.com/m2/ee/user_guide/stores/security-two-factor-authentication.html) in the _Magento User Guide_.

--- a/src/guides/v2.4/security/two-factor-authentication.md
+++ b/src/guides/v2.4/security/two-factor-authentication.md
@@ -18,7 +18,6 @@ Two-Factor Authentication gives you the ability to:
 Magento has new workflows for _Admin_ users, including:
 
 -  The ability to configure the 2FA provider globally or individually.
--  _Admin_ users set their own personal 2FA at first login, and receive a confirmation email to verify their identity.
 -  The "Trust this device" option has been removed.
 
 For more information, see [Two-Factor Authentication](https://docs.magento.com/m2/ee/user_guide/stores/security-two-factor-authentication.html) in the _Magento User Guide_.


### PR DESCRIPTION
Admin users have never been able to set their own personal 2FA providers. Currently, the 2FA provider is globally configured for admins.

## Purpose of this pull request

Clean invalid line in 2FA dev docs to alleviate 2FA configuration confusion.

## Affected DevDocs pages

<!-- REQUIRED List the affected pages on devdocs.magento.com (URLs). Not needed for large numbers of files. -->

-  https://devdocs.magento.com/guides/v2.4/security/two-factor-authentication.html

<!--
If you are fixing a GitHub issue, note it using GitHub keyword format (https://help.github.com/en/articles/closing-issues-using-keywords#closing-an-issue-in-a-different-repository) to close the issue when this pull request is merged. Example: `Fixes #1234`

`master` is the default branch. Merged pull requests to `master` go live on the site automatically. Any requested changes to content on the `master` branch must be related to the released codebase. Any content related to future releases goes in the `develop` branch.

See Contribution guidelines (https://github.com/magento/devdocs/blob/master/.github/CONTRIBUTING.md) for more information.
-->
