### PR TITLE
Update best-practices.md

### DIFF
--- a/src/community/best-practices.md
+++ b/src/community/best-practices.md
@@ -23,15 +23,15 @@ They are available in DevDocs because the content has been well received within 
 
 The DevDocs and Magento teams verified and provide the following best practices and recommendations:
 
-*  [Best Practices and Benchmarking]({{ site.baseurl }}/guides/v2.3/migration/migration-overview-practices.html) for Migration
-*  [Best Practices for Extension Development]({{ site.baseurl }}/guides/v2.3/ext-best-practices/bk-ext-best-practices.html)
+*  [Best Practices and Benchmarking]({{ site.baseurl }}/guides/v2.4/migration/migration-overview-practices.html) for Migration
+*  [Best Practices for Extension Development]({{ site.baseurl }}/guides/v2.4/ext-best-practices/bk-ext-best-practices.html)
 
    We also recommend the [Magento Marketplace Help Center](https://marketplacesupport.magento.com/hc/en-us) for extension questions.
 
-*  [Programming Best Practices]({{ site.baseurl }}/guides/v2.3/ext-best-practices/extension-coding/common-programming-bp.html)
-*  [Observers Best Practices]({{ site.baseurl }}/guides/v2.3/ext-best-practices/extension-coding/observers-bp.html)
-*  [Theme Development Best Practices]({{ site.baseurl }}/guides/v2.3/frontend-dev-guide/theme-best-practice.html)
-*  [Performance Best Practices]({{ site.baseurl }}/guides/v2.3/performance-best-practices/)
+*  [Programming Best Practices]({{ site.baseurl }}/guides/v2.4/ext-best-practices/extension-coding/common-programming-bp.html)
+*  [Observers Best Practices]({{ site.baseurl }}/guides/v2.4/ext-best-practices/extension-coding/observers-bp.html)
+*  [Theme Development Best Practices]({{ site.baseurl }}/guides/v2.4/frontend-dev-guide/theme-best-practice.html)
+*  [Performance Best Practices]({{ site.baseurl }}/guides/v2.4/performance-best-practices/)
 *  [Best Practices for Store Configuration]({{ site.baseurl }}/cloud/configure/configure-best-practices.html) for {{ site.data.var.ece }}
 *  [Deployment Process]({{ site.baseurl }}/cloud/reference/discover-deploy.html) for {{ site.data.var.ece }}
 
@@ -41,4 +41,4 @@ You can [contribute](https://github.com/magento/devdocs/blob/master/.github/CONT
 
 Some PRs may require architectural and internal development reviews to verify and approve the contributed best practices. These reviews may require more time to complete before merging content.
 
-If you have any questions, contact us through [#DevDocs Slack](https://magentocommeng.slack.com/messages/CAN932A3H) (or [join us](https://t.co/9HImUyCmyh)) or Twitter [@MagentoDevDocs](https://twitter.com/MagentoDevDocs).
+If you have any questions, contact us through [#DevDocs Slack](https://magentocommeng.slack.com/archives/CAN932A3H) (or [join us](https://t.co/9HImUyCmyh)) or Twitter [@MagentoDevDocs](https://twitter.com/MagentoDevDocs).


### PR DESCRIPTION
Changing Magento version from **v2.3** to **v2.4** in links.
Added updated link for **devdocs** Slack channel, Which will redirect the user to the Slack Application instead of opening the Slack channel in the browser. If the user is not having a Slack Application, then **devdocs** Slack channel will open in the browser.

## Purpose of this pull request

This pull request (PR) ...

## Affected DevDocs pages

<!-- REQUIRED List the affected pages on devdocs.magento.com (URLs). Not needed for large numbers of files. -->

-  ...

## Links to Magento source code

<!--  OPTIONAL - REMOVE THIS SECTION IF NOT USED. If this pull request references a file in a Magento codebase repository, add it here. -->

-  ...

<!--
If you are fixing a GitHub issue, note it using GitHub keyword format (https://help.github.com/en/articles/closing-issues-using-keywords#closing-an-issue-in-a-different-repository) to close the issue when this pull request is merged. Example: `Fixes #1234`

`master` is the default branch. Merged pull requests to `master` go live on the site automatically. Any requested changes to content on the `master` branch must be related to the released codebase. Any content related to future releases goes in the `develop` branch.

See Contribution guidelines (https://github.com/magento/devdocs/blob/master/.github/CONTRIBUTING.md) for more information.
-->
