### PR TITLE
Update resources.md

### DIFF
--- a/src/community/resources.md
+++ b/src/community/resources.md
@@ -7,7 +7,7 @@ redirect_from:
 
 ## Magento DevBlog
 
-The [Magento DevBlog][0] is a great resource for news about Magento, new community resources (articles, tutorials, etc.), events and other Magento-related items.
+The [Magento DevBlog][0] is a great resource for news about Magento, New Community resources (articles, tutorials, etc.), events and other Magento-related activities.
 
 ## Best practices
 
@@ -17,28 +17,32 @@ See our collection of best and leading practices, common solutions, and more in 
 
 To connect with Magento and the Community, join us on the [Magento Community Engineering Slack][]. If you are interested in joining Slack, or a specific channel, send us a request at [engcom@adobe.com](mailto:engcom@adobe.com) or [self signup][].
 
-We have [channels][] for each project, but the following channels are recommended for new members:
+We have [channels][] for each project, Following channels are recommended for new members:
 
--  [announcements][]: Introduce yourself and get quick updates for Magento Community Engineering
--  [general][]: Open chat for introductions and Magento 2 questions
--  [appdesign][]: Open chat for Magento architecture and [technical guidelines][]
--  [coding-standards][]: Open chat for developing [coding standards][] for Magento
--  [github][]: Support for GitHub issues, pull requests, and processes
--  [public-backlog][]: Discussions of the Magento 2 backlog
--  [devdocs][]: Documentation contribution support
+-  [beginners][]: Channel for contribution beginners to ask questions around contribution and share resources.
+-  [announcements][]: Introduce yourself and get quick updates for Magento Community Engineering.
+-  [general][]: Open chat for introductions and Magento 2 questions.
+-  [appdesign][]: Open chat for Magento Architecture and [Technical Guidelines][].
+-  [coding-standards][]: Open chat for developing [Coding Standards][] for Magento.
+-  [github][]: Discussion regarding Pull Request and Issues from the [Magento 2][] repository.
+-  [public-backlog][]: Community discussion around the [Public Backlog][].
+-  [devdocs][]: Discussions of the documentation impact of Community Contributions.
 
 [contribute]: https://github.com/magento/devdocs/blob/master/.github/CONTRIBUTING.md
-[technical guidelines]: {{ site.baseurl }}/guides/v2.3/coding-standards/technical-guidelines.html
-[coding standards]: {{ site.baseurl }}/guides/v2.3/coding-standards/bk-coding-standards.html
+[Public Backlog]: https://github.com/magento/backlog
+[Magento 2]: https://github.com/magento/magento2
+[Technical Guidelines]: {{ site.baseurl }}/guides/v2.4/coding-standards/technical-guidelines.html
+[Coding Standards]: {{ site.baseurl }}/guides/v2.4/coding-standards/bk-coding-standards.html
 [Magento Community Engineering Slack]: https://magentocommeng.slack.com
 [self signup]: https://opensource.magento.com/slack
-[general]: https://magentocommeng.slack.com/messages/C4YS78WE6
-[github]: https://magentocommeng.slack.com/messages/C7KB93M32
-[public-backlog]: https://magentocommeng.slack.com/messages/CCV3J3RV5
-[devdocs]: https://magentocommeng.slack.com/messages/CAN932A3H
-[appdesign]: https://magentocommeng.slack.com/messages/CBSL1DF8B
-[coding-standards]: https://magentocommeng.slack.com/messages/CFC88F1C6
-[announcements]: https://magentocommeng.slack.com/messages/C7FA71S3V
+[general]: https://magentocommeng.slack.com/archives/C4YS78WE6
+[github]: https://magentocommeng.slack.com/archives/C7KB93M32
+[public-backlog]: https://magentocommeng.slack.com/archives/CCV3J3RV5
+[devdocs]: https://magentocommeng.slack.com/archives/CAN932A3H
+[appdesign]: https://magentocommeng.slack.com/archives/CBSL1DF8B
+[coding-standards]: https://magentocommeng.slack.com/archives/CFC88F1C6
+[beginners]: https://magentocommeng.slack.com/archives/CH8BGFX9D
+[announcements]: https://magentocommeng.slack.com/archives/C7FA71S3V
 [0]: https://community.magento.com/t5/Magento-DevBlog/bg-p/devblog
 [1]: https://github.com/magento/devdocs/blob/master/.github/CONTRIBUTING.md
 [channels]: https://github.com/magento/magento2/wiki/Slack-Channels


### PR DESCRIPTION
Changing Magento version from **v2.3** to **v2.4** in links.
Added updated link for **Slack channels**, Which will redirect the user to the **Slack Application** instead of opening the Slack channel in the browser. If the user is not having a Slack Application, then the **Slack channel** will open in the browser.
Updated channel descriptions.
Added **beginners** channel and its description in _recommended for new members_ section.

## Purpose of this pull request

This pull request (PR) ...

## Affected DevDocs pages

<!-- REQUIRED List the affected pages on devdocs.magento.com (URLs). Not needed for large numbers of files. -->

-  ...

## Links to Magento source code

<!--  OPTIONAL - REMOVE THIS SECTION IF NOT USED. If this pull request references a file in a Magento codebase repository, add it here. -->

-  ...

<!--
If you are fixing a GitHub issue, note it using GitHub keyword format (https://help.github.com/en/articles/closing-issues-using-keywords#closing-an-issue-in-a-different-repository) to close the issue when this pull request is merged. Example: `Fixes #1234`

`master` is the default branch. Merged pull requests to `master` go live on the site automatically. Any requested changes to content on the `master` branch must be related to the released codebase. Any content related to future releases goes in the `develop` branch.

See Contribution guidelines (https://github.com/magento/devdocs/blob/master/.github/CONTRIBUTING.md) for more information.
-->
