### PR TITLE
MCLOUD-7934: Hardcoded magento.com in the CN name in the ssl certificate

### DIFF
--- a/src/_includes/cloud/note-docker-ssl-not-private-connection.md
+++ b/src/_includes/cloud/note-docker-ssl-not-private-connection.md
@@ -1,3 +1,2 @@
 {:.bs-callout-info}
-If you see `Your connection is not private` error message while using `https` connection press `Advanced` button and then `Proceed to magento2.docker (unsafe)` link.
-In case if you are using Google Chrome and there is no `Advanced` button just simply type `thisisunsafe` 
+If you see the `Your connection is not private` error message while using an HTTPS connection, click **Advanced**, then click the **Proceed to magento2.docker (unsafe)** link. If you use Google Chrome and there is no **Advanced** button, then type `thisisunsafe` to bypass the security warnings.

--- a/src/_includes/cloud/note-docker-ssl-not-private-connection.md
+++ b/src/_includes/cloud/note-docker-ssl-not-private-connection.md
@@ -1,3 +1,3 @@
 {:.bs-callout-info}
 If you see the `Your connection is not private` error message while using an HTTPS connection, click **Advanced**, then click the **Proceed to magento2.docker (unsafe)** link. If you use Google Chrome and there is no **Advanced** button, then type `thisisunsafe` to bypass the security warnings.
-For `CURL` requests add `-k` or `--insecure` option to ignore certificate warnings.
+For `CURL` requests, add the `-k` or `--insecure` option to ignore certificate warnings.

--- a/src/_includes/cloud/note-docker-ssl-not-private-connection.md
+++ b/src/_includes/cloud/note-docker-ssl-not-private-connection.md
@@ -1,2 +1,3 @@
 {:.bs-callout-info}
 If you see the `Your connection is not private` error message while using an HTTPS connection, click **Advanced**, then click the **Proceed to magento2.docker (unsafe)** link. If you use Google Chrome and there is no **Advanced** button, then type `thisisunsafe` to bypass the security warnings.
+For `CURL` requests add `-k` or `--insecure` option to ignore certificate warnings.

--- a/src/_includes/cloud/note-docker-ssl-not-private-connection.md
+++ b/src/_includes/cloud/note-docker-ssl-not-private-connection.md
@@ -1,0 +1,3 @@
+{:.bs-callout-info}
+If you see `Your connection is not private` error message while using `https` connection press `Advanced` button and then `Proceed to magento2.docker (unsafe)` link.
+In case if you are using Google Chrome and there is no `Advanced` button just simply type `thisisunsafe` 

--- a/src/cloud/docker/docker-mode-developer.md
+++ b/src/cloud/docker/docker-mode-developer.md
@@ -127,6 +127,8 @@ To launch the Docker environment in developer mode:
 
 1. Access the default email service: `http://magento2.docker:8025`
 
+{%include cloud/note-docker-ssl-not-private-connection.md%}
+
 <!--Link definitions-->
 
 [{{site.data.var.mcd-prod}} Docker image]: https://hub.docker.com/r/magento/magento-cloud-docker-php/tags

--- a/src/cloud/docker/docker-mode-production.md
+++ b/src/cloud/docker/docker-mode-production.md
@@ -91,6 +91,8 @@ To launch the Docker environment in production mode:
 
 1. Access the default email service: `http://magento2.docker:8025`
 
+{%include cloud/note-docker-ssl-not-private-connection.md%}
+
 <!--Link definitions-->
 [configure Xdebug]: {{site.baseurl}}/cloud/docker/docker-development-debug.html#configure-xdebug
 [Configuration sources]: {{site.baseurl}}/docker/docker-config.html


### PR DESCRIPTION
## Purpose of this pull request

This pull request (PR) will add info on how to resolve an issue with an untrusted certificate while using cloud docker

## Affected DevDocs pages

<!-- REQUIRED List the affected pages on devdocs.magento.com (URLs). Not needed for large numbers of files. -->

-  https://devdocs.magento.com/cloud/docker/docker-mode-production.html
- https://devdocs.magento.com/cloud/docker/docker-mode-developer.html

<!--
If you are fixing a GitHub issue, note it using GitHub keyword format (https://help.github.com/en/articles/closing-issues-using-keywords#closing-an-issue-in-a-different-repository) to close the issue when this pull request is merged. Example: `Fixes #1234`

`master` is the default branch. Merged pull requests to `master` go live on the site automatically. Any requested changes to content on the `master` branch must be related to the released codebase. Any content related to future releases goes in the `develop` branch.

See Contribution guidelines (https://github.com/magento/devdocs/blob/master/.github/CONTRIBUTING.md) for more information.
-->
