### PR TITLE
Update db-schema.md

### DIFF
--- a/src/guides/v2.4/extension-dev-guide/declarative-schema/db-schema.md
+++ b/src/guides/v2.4/extension-dev-guide/declarative-schema/db-schema.md
@@ -266,7 +266,6 @@ In the following example, the `declarative_table` table was completely removed f
  {:.bs-callout-info}
 When dropping a table do not remove it from the `db_schema_whitelist.json` file, otherwise it will not be dropped.
 
-
 ### Rename a table
 
 Table renaming is supported. The declarative schema will create a new table with the new name and drop the table with the old name.

--- a/src/guides/v2.4/extension-dev-guide/declarative-schema/db-schema.md
+++ b/src/guides/v2.4/extension-dev-guide/declarative-schema/db-schema.md
@@ -263,6 +263,10 @@ In the following example, the `declarative_table` table was completely removed f
 </schema>
 ```
 
+ {:.bs-callout-info}
+When dropping a table do not remove it from the `db_schema_whitelist.json` file, otherwise it will not be dropped.
+
+
 ### Rename a table
 
 Table renaming is supported. The declarative schema will create a new table with the new name and drop the table with the old name.

--- a/src/guides/v2.4/extension-dev-guide/declarative-schema/db-schema.md
+++ b/src/guides/v2.4/extension-dev-guide/declarative-schema/db-schema.md
@@ -263,8 +263,8 @@ In the following example, the `declarative_table` table was completely removed f
 </schema>
 ```
 
- {:.bs-callout-info}
-When dropping a table do not remove it from the `db_schema_whitelist.json` file, otherwise it will not be dropped.
+{:.bs-callout-info}
+When dropping a table, do not remove it from the `db_schema_whitelist.json` file, otherwise it will not be dropped.
 
 ### Rename a table
 


### PR DESCRIPTION
## Purpose of this pull request

Make it explicit that you do not have to update the `db_schema_whitelist.json` when dropping a table. 

Create/Update both have explicit comments, the absence of a negative reinforcement here could lead to confusion and wasted developer time

## Affected DevDocs pages

- https://devdocs.magento.com/guides/v2.4/extension-dev-guide/declarative-schema/db-schema.html#drop-a-table