### PR TITLE
Updated spelling in example - proxyDeffered to proxyDeferred

### DIFF
--- a/src/guides/v2.3/extension-dev-guide/async-operations.md
+++ b/src/guides/v2.3/extension-dev-guide/async-operations.md
@@ -238,7 +238,7 @@ class EntityRepository
 
         //Returning deferred that will find all requested entities
         //and return the one with $id
-        return $this->proxyDefferedFactory->createFor(
+        return $this->proxyDeferredFactory->createFor(
             Entity::class,
             new CallbackDeferred(
                 function () use ($id) {


### PR DESCRIPTION
## Purpose of this pull request

This pull request (PR) simply updates the spelling of the word "deferred" to be consistent.   It was previously "deffered", but spelled correctly everywhere else.

## Affected DevDocs pages

- https://devdocs.magento.com/guides/v2.4/extension-dev-guide/async-operations.html
- https://devdocs.magento.com/guides/v2.3/extension-dev-guide/async-operations.html

<!--
If you are fixing a GitHub issue, note it using GitHub keyword format (https://help.github.com/en/articles/closing-issues-using-keywords#closing-an-issue-in-a-different-repository) to close the issue when this pull request is merged. Example: `Fixes #1234`

`master` is the default branch. Merged pull requests to `master` go live on the site automatically. Any requested changes to content on the `master` branch must be related to the released codebase. Any content related to future releases goes in the `develop` branch.

See Contribution guidelines (https://github.com/magento/devdocs/blob/master/.github/CONTRIBUTING.md) for more information.
-->
