### PR TITLE
Correct inconsistent example of creating a foreign key constraint

### DIFF
--- a/src/guides/v2.3/extension-dev-guide/declarative-schema/db-schema.md
+++ b/src/guides/v2.3/extension-dev-guide/declarative-schema/db-schema.md
@@ -197,7 +197,7 @@ To keep entity identifiers as immutable values, the declarative schema does not 
 Example:
 
 ```xml
-<constraint xsi:type="foreign" referenceId="COMPANY_CREDIT_COMPANY_ID_DIRECTORY_COUNTRY_COUNTRY_ID" table="company_credit" column="company_id" referenceTable="company" referenceColumn="entity_id" onDelete="CASCADE"/>
+<constraint xsi:type="foreign" referenceId="COMPANY_CREDIT_COMPANY_ID_COMPANY_ENTITY_ID" table="company_credit" column="company_id" referenceTable="company" referenceColumn="entity_id" onDelete="CASCADE"/>
 ```
 
 #### `index` subnode

--- a/src/guides/v2.4/extension-dev-guide/declarative-schema/db-schema.md
+++ b/src/guides/v2.4/extension-dev-guide/declarative-schema/db-schema.md
@@ -198,7 +198,7 @@ To keep entity identifiers as immutable values, the declarative schema does not 
 Example:
 
 ```xml
-<constraint xsi:type="foreign" referenceId="COMPANY_CREDIT_COMPANY_ID_DIRECTORY_COUNTRY_COUNTRY_ID" table="company_credit" column="company_id" referenceTable="directory_country" referenceColumn="country_id" onDelete="CASCADE"/>
+<constraint xsi:type="foreign" referenceId="COMPANY_CREDIT_COMPANY_ID_COMPANY_ENTITY_ID" table="company_credit" column="company_id" referenceTable="company" referenceColumn="entity_id" onDelete="CASCADE"/>
 ```
 
 #### `index` subnode

--- a/src/guides/v2.4/extension-dev-guide/declarative-schema/db-schema.md
+++ b/src/guides/v2.4/extension-dev-guide/declarative-schema/db-schema.md
@@ -198,7 +198,7 @@ To keep entity identifiers as immutable values, the declarative schema does not 
 Example:
 
 ```xml
-<constraint xsi:type="foreign" referenceId="COMPANY_CREDIT_COMPANY_ID_DIRECTORY_COUNTRY_COUNTRY_ID" table="company_credit" column="company_id" referenceTable="company" referenceColumn="entity_id" onDelete="CASCADE"/>
+<constraint xsi:type="foreign" referenceId="COMPANY_CREDIT_COMPANY_ID_DIRECTORY_COUNTRY_COUNTRY_ID" table="company_credit" column="company_id" referenceTable="directory_country" referenceColumn="country_id" onDelete="CASCADE"/>
 ```
 
 #### `index` subnode


### PR DESCRIPTION
# Bug report

## Description

The foreign key constraint reference id does not match the reference table and column defined.

### Steps to reproduce

N/A

## Expected result

The constraint node's reference table and column should be updated to match the reference id:

```
<constraint xsi:type="foreign" referenceId="COMPANY_CREDIT_COMPANY_ID_COMPANY_ENTITY_ID" table="company_credit" column="company_id" referenceTable="company" referenceColumn="entity_id" onDelete="CASCADE"/>
```