### PR TITLE
magento/devdocs#8989 Add information how to override a mixin

### DIFF
--- a/src/guides/v2.3/javascript-dev-guide/javascript/js_mixins.md
+++ b/src/guides/v2.3/javascript-dev-guide/javascript/js_mixins.md
@@ -185,7 +185,7 @@ var config = {
 
 ## Overwriting a mixin
 
-A mixin can be overwritten by another mixin and can't be disabled separately.
+A mixin can be overwritten by another mixin but cannot be disabled separately.
 
 ### Example
 
@@ -204,8 +204,8 @@ var config = {
 };
 ```
 
-In this case the `ExampleCorp_Sample/js/original-add-to-cart-mixin` will be overwritten by `ExampleCorp_CartFix/js/overwritten-add-to-cart-mixin`.
-Also, add the origin module as the over written module dependency (sequence tag in `etc/module.xml`).
+In this case, the `ExampleCorp_Sample/js/original-add-to-cart-mixin` is overwritten by `ExampleCorp_CartFix/js/overwritten-add-to-cart-mixin`.
+Be sure to add the origin module as the over-written module dependency (use the sequence tag in `etc/module.xml`).
 
 ```xml
 <?xml version="1.0"?>
@@ -218,7 +218,7 @@ Also, add the origin module as the over written module dependency (sequence tag 
 </config>
 ```
 
-After making changes to `requirejs-config.js` config you need to clean cache and regenerate the static files.
+After making changes to the `requirejs-config.js` configuration, you must clean the cache and regenerate static files.
 
 ## Mixin examples in Magento
 

--- a/src/guides/v2.3/javascript-dev-guide/javascript/js_mixins.md
+++ b/src/guides/v2.3/javascript-dev-guide/javascript/js_mixins.md
@@ -185,7 +185,7 @@ var config = {
 
 ## Overwriting a mixin
 
-A mixin can be overwritten by another mixin, and can't be disabled separately.
+A mixin can be overwritten by another mixin and can't be disabled separately.
 
 ### Example
 

--- a/src/guides/v2.3/javascript-dev-guide/javascript/js_mixins.md
+++ b/src/guides/v2.3/javascript-dev-guide/javascript/js_mixins.md
@@ -183,6 +183,43 @@ var config = {
 };
 ```
 
+## Overwriting a mixin
+
+A mixin can be overwritten by another mixin, and can't be disabled separately.
+
+### Example
+
+**File:** `ExampleCorp/CartFix/view/base/requirejs-config.js`
+
+```javascript
+var config = {
+    config: {
+        mixins: {
+            'Magento_Catalog/js/catalog-add-to-cart': {
+                'ExampleCorp_Sample/js/original-add-to-cart-mixin': false,
+                'ExampleCorp_CartFix/js/overwritten-add-to-cart-mixin': true
+            }
+        }
+    }
+};
+```
+
+In this case the `ExampleCorp_Sample/js/original-add-to-cart-mixin` will be overwritten by `ExampleCorp_CartFix/js/overwritten-add-to-cart-mixin`.
+Also, add the origin module as the over written module dependency (sequence tag in `etc/module.xml`).
+
+```xml
+<?xml version="1.0"?>
+<config xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="urn:magento:framework:Module/etc/module.xsd">
+    <module name="ExampleCorp_CartFix" setup_version="0.0.1">
+        <sequence>
+            <module name="ExampleCorp_Sample" />
+        </sequence>
+    </module>
+</config>
+```
+
+After making changes to `requirejs-config.js` config you need to clean cache and regenerate the static files.
+
 ## Mixin examples in Magento
 
 The following is a list of files in the [`Magento_CheckoutAgreement`] module that declare and define mixins that modify checkout behavior:


### PR DESCRIPTION
## Purpose of this pull request

This pull request (PR) adds an example to the instruction about how to or override a mixin.

Fixes #8989

## Affected DevDocs pages
-  https://devdocs.magento.com/guides/v2.4/javascript-dev-guide/javascript/js_mixins.html

## Links to Magento source code
-  guides/v2.4/javascript-dev-guide/javascript/js_mixins.md

whatsnew
Added the 'Overwriting a mixin' section to the [Javascript mixins](https://devdocs.magento.com/guides/v2.4/javascript-dev-guide/javascript/js_mixins.html) topic.