### PR TITLE
Update url-library.md

### DIFF
--- a/src/guides/v2.3/extension-dev-guide/framework/url-library.md
+++ b/src/guides/v2.3/extension-dev-guide/framework/url-library.md
@@ -33,7 +33,7 @@ The [`Magento\Framework\Url\DecoderInterface`]({{ site.mage2bloburl }}/{{ page.g
 
 ## Usage
 
-Declare `SerializerInterface` as a [constructor dependency]({{ page.baseurl }}/extension-dev-guide/depend-inj.html) to get an instance of a serializer class.
+Declare `DecoderInterface` and `EncoderInterface` as a [constructor dependency]({{ page.baseurl }}/extension-dev-guide/depend-inj.html) to get an instance of these classes.
 
 ```php
 use Magento\Framework\Url\DecoderInterface;


### PR DESCRIPTION

Re-creating the PR: https://github.com/magento/devdocs/pull/8978

This will fix an error in the Title of the Url Library page.
#8977

Affected DevDocs pages
https://devdocs.magento.com/guides/v2.4/extension-dev-guide/framework/url-library.html