### PR TITLE
Add the "EXAMPLE NON-MATCHING TOPICS" option to the Configure message queues page

### DIFF
--- a/src/guides/v2.4/extension-dev-guide/message-queues/config-mq.md
+++ b/src/guides/v2.4/extension-dev-guide/message-queues/config-mq.md
@@ -206,7 +206,7 @@ Example topic names that include wildcards:
 `*.*.*` | Matches any topic that contains exactly two periods. | `mytopic.createOrder.success`, `mytopic.updatePrice.item1` | `mytopic.createOrder`, `mytopic.createOrder.success.true`
 `#`| Matches any topic name.  | `mytopic`, `mytopic.createOrder.success`, `this.is.a.long.topic.name` | Not applicable
 `mytopic.#` | Matches any topic name that begins with `mytopic` and has a period afterward. |  `mytopic.success`, `mytopic.createOrder.error` | `new.mytopic.success`,
-`*.Order.#` | There must be one string before __.Order__. There can be any number of strings (including 0) after that.  | `mytopic.Order`, `mytopic.Order.Create`, `newtopic.Order.delete.success` |
+`*.Order.#` | There must be one string before __.Order__. There can be any number of strings (including 0) after that.  | `mytopic.Order`, `mytopic.Order.Create`, `newtopic.Order.delete.success` | `mytopic.Sales.Order.Create`
 
 #### `arguments` element
 {:.no_toc}


### PR DESCRIPTION
## Purpose of this pull request

This pull request adds the "EXAMPLE NON-MATCHING TOPICS" option to the Configure message queues page

## Affected DevDocs pages

https://devdocs.magento.com/guides/v2.4/extension-dev-guide/message-queues/config-mq.html

<img width="926" alt="Screenshot 2021-06-17 at 13 26 40" src="https://user-images.githubusercontent.com/79835574/122379608-afa3d000-cf6f-11eb-835f-3221e0598854.png">
