### PR TITLE
Incorrect instructions for "reloading ssh config"

### DIFF
--- a/src/cloud/before/before-workspace-ssh.md
+++ b/src/cloud/before/before-workspace-ssh.md
@@ -54,7 +54,6 @@ To add your SSH key to the local configuration:
    {:.bs-callout-info}
    You can specify multiple SSH keys by adding multiple `IdentityFile` entries to your configuration.
 
-
 {:.ref-header}
 Next step
 

--- a/src/cloud/before/before-workspace-ssh.md
+++ b/src/cloud/before/before-workspace-ssh.md
@@ -54,11 +54,6 @@ To add your SSH key to the local configuration:
    {:.bs-callout-info}
    You can specify multiple SSH keys by adding multiple `IdentityFile` entries to your configuration.
 
-1. Reload your SSH configuration to apply the changes.
-
-    ```bash
-    source ~/.ssh/config
-    ```
 
 {:.ref-header}
 Next step


### PR DESCRIPTION

## Purpose of this pull request

This pull request (PR) removes impossible instructions; you can't source an ssh config file, it's not for the environment.

## Affected DevDocs pages

 https://devdocs.magento.com/cloud/before/before-workspace-ssh.html#unable-to-access-projects-without-mfa


<!--
If you are fixing a GitHub issue, note it using GitHub keyword format (https://help.github.com/en/articles/closing-issues-using-keywords#closing-an-issue-in-a-different-repository) to close the issue when this pull request is merged. Example: `Fixes #1234`

`master` is the default branch. Merged pull requests to `master` go live on the site automatically. Any requested changes to content on the `master` branch must be related to the released codebase. Any content related to future releases goes in the `develop` branch.

See Contribution guidelines (https://github.com/magento/devdocs/blob/master/.github/CONTRIBUTING.md) for more information.
-->
