### PR TITLE
Remove Azure mention

### DIFF
--- a/src/guides/v2.4/config-guide/remote-storage/config-remote-storage.md
+++ b/src/guides/v2.4/config-guide/remote-storage/config-remote-storage.md
@@ -7,7 +7,7 @@ functional_areas:
   - Setup
 ---
 
-The Remote Storage module provides the option to store media files and schedule imports/exports in a persistent, remote storage container using a storage service, such as AWS S3 or Azure Blob Storage. By default, Magento stores media files in the same filesystem that contains the application. This is inefficient for complex, multi-server configurations, and can result in degraded performance when sharing resources. With the Remote Storage module, you can store media files in the `pub/media` directory and import/export files in the `var` directory of the remote object storage to take advantage of server-side image resizing.
+The Remote Storage module provides the option to store media files and schedule imports/exports in a persistent, remote storage container using a storage service, such as AWS S3. By default, Magento stores media files in the same filesystem that contains the application. This is inefficient for complex, multi-server configurations, and can result in degraded performance when sharing resources. With the Remote Storage module, you can store media files in the `pub/media` directory and import/export files in the `var` directory of the remote object storage to take advantage of server-side image resizing.
 
 {:.bs-callout-info}
 Remote storage is available in version 2.4.2 and later only. See the [2.4.2 release notes]({{page.baseurl}}/release-notes/open-source-2-4-2.html).


### PR DESCRIPTION
Please remove Azure mention, since we do not support Azure yet and this wording is confusing.

## Purpose of this pull request

This pull request (PR) removes mention of Azure in remote storage configuration section.

## Affected DevDocs pages

- https://devdocs-beta.magento.com/guides/v2.4/config-guide/remote-storage/config-remote-storage.html#storage-adapters