### PR TITLE
map directive replaced and configuration step added

### DIFF
--- a/src/guides/v2.3/config-guide/multi-site/ms_nginx.md
+++ b/src/guides/v2.3/config-guide/multi-site/ms_nginx.md
@@ -235,7 +235,7 @@ location ~ (index|get|static|report|404|503|health_check)\.php$ {
 
 ## Step 4: Update the Base URL configuration {#update-base-url}
 
-You need to update the Base URL for the `french` and the `german` websites on the Magento admin.
+It is necessary to update the Base URL for the `french` and the `german` websites in the Magento admin.
 
 ### Update French Website Base URL
 
@@ -243,7 +243,7 @@ You need to update the Base URL for the `french` and the `german` websites on th
 1. Change the _configuration scope_ to the `french` website.
 1. Expand **Base URLs** section and update the **Base URL** and **Base Link URL** value to `http://french.magento24.com/`.
 1. Expand **Base URLs (Secure)** section and update the **Secure Base URL** and **Secure Base Link URL** value to `http://french.magento24.com/`.
-1. Click **Save Config** and save the configuraiton changes.
+1. Click **Save Config** and save the configuration changes.
 
 ### Update German Website Base URL
 
@@ -251,11 +251,11 @@ You need to update the Base URL for the `french` and the `german` websites on th
 1. Change the _configuration scope_ to the `german` website.
 1. Expand **Base URLs** section and update the **Base URL** and **Base Link URL** value to `http://german.magento24.com/`.
 1. Expand **Base URLs (Secure)** section and update the **Secure Base URL** and **Secure Base Link URL** value to `http://german.magento24.com/`.
-1. Click **Save Config** and save the configuraiton changes.
+1. Click **Save Config** and save the configuration changes.
 
 ### Clean the Cache
 
-Run the below command to clean the `config` and `full_page` cache.
+Run the command below to clean the `config` and `full_page` caches.
 
 ```bash
 bin/magento cache:clean config full_page

--- a/src/guides/v2.3/config-guide/multi-site/ms_nginx.md
+++ b/src/guides/v2.3/config-guide/multi-site/ms_nginx.md
@@ -47,6 +47,7 @@ To set up multiple stores:
       *  Use `store` to load any store view in your storefront.
 
    *  `$MAGE_RUN_CODE` is the unique website or store view code that corresponds to `$MAGE_RUN_TYPE`.
+1. Update the Base URL configuration on the Magento admin.
 
 ## Step 2: Create nginx virtual hosts {#ms-nginx-vhosts}
 
@@ -112,16 +113,13 @@ To create multiple virtual hosts:
 1. Open a text editor and add the following contents to a new file named `/etc/nginx/sites-available/french.mysite.mg`:
 
    ```conf
-   map $http_host $MAGE_RUN_CODE {
-       french.mysite.mg french;
-   }
-
    server {
        listen 80;
        server_name french.mysite.mg;
        set $MAGE_ROOT /var/www/html/magento2;
        set $MAGE_MODE developer;
        set $MAGE_RUN_TYPE website; #or set $MAGE_RUN_TYPE store;
+       set $MAGE_RUN_CODE french;
        include /var/www/html/magento2/nginx.conf;
    }
    ```
@@ -129,16 +127,13 @@ To create multiple virtual hosts:
 1. Create another file named `german.mysite.mg` in the same directory with the following contents:
 
    ```conf
-   map $http_host $MAGE_RUN_CODE {
-       german.mysite.mg german;
-   }
-
    server {
        listen 80;
        server_name german.mysite.mg;
        set $MAGE_ROOT /var/www/html/magento2;
        set $MAGE_MODE developer;
        set $MAGE_RUN_TYPE website; #or set $MAGE_RUN_TYPE store;
+       set $MAGE_RUN_CODE german;
        include /var/www/html/magento2/nginx.conf;
    }
    ```
@@ -171,8 +166,6 @@ To create multiple virtual hosts:
    ```bash
    ln -s /etc/nginx/sites-available/german.mysite.mg german.mysite.mg
    ```
-
-For more details about the map directive, see [nginx documentation on the map directive](http://nginx.org/en/docs/http/ngx_http_map_module.html#map).
 
 {% endcollapsible %}
 
@@ -239,6 +232,34 @@ location ~ (index|get|static|report|404|503|health_check)\.php$ {
 ```
 
 {% endcollapsible %}
+
+## Step 4: Update the Base URL configuration {#update-base-url}
+
+You need to update the Base URL for the `french` and the `german` websites on the Magento admin.
+
+### Update French Website Base URL
+
+1. Log in to the Magento admin and navigate to **Stores** > **Settings** > **Configuration** > **General** > **Web**.
+1. Change the _configuration scope_ to the `french` website.
+1. Expand **Base URLs** section and update the **Base URL** and **Base Link URL** value to `http://french.magento24.com/`.
+1. Expand **Base URLs (Secure)** section and update the **Secure Base URL** and **Secure Base Link URL** value to `http://french.magento24.com/`.
+1. Click **Save Config** and save the configuraiton changes.
+
+### Update German Website Base URL
+
+1. Log in to the Magento admin and navigate to **Stores** > **Settings** > **Configuration** > **General** > **Web**.
+1. Change the _configuration scope_ to the `german` website.
+1. Expand **Base URLs** section and update the **Base URL** and **Base Link URL** value to `http://german.magento24.com/`.
+1. Expand **Base URLs (Secure)** section and update the **Secure Base URL** and **Secure Base Link URL** value to `http://german.magento24.com/`.
+1. Click **Save Config** and save the configuraiton changes.
+
+### Clean the Cache
+
+Run the below command to clean the `config` and `full_page` cache.
+
+```bash
+bin/magento cache:clean config full_page
+```
 
 ## Verify your site  {#ms-nginx-verify}
 

--- a/src/guides/v2.3/config-guide/multi-site/ms_nginx.md
+++ b/src/guides/v2.3/config-guide/multi-site/ms_nginx.md
@@ -235,7 +235,7 @@ location ~ (index|get|static|report|404|503|health_check)\.php$ {
 
 ## Step 4: Update the Base URL configuration {#update-base-url}
 
-It is necessary to update the Base URL for the `french` and the `german` websites in the Magento admin.
+You must update the Base URL for the `french` and the `german` websites in the Magento admin.
 
 ### Update French Website Base URL
 
@@ -255,7 +255,7 @@ It is necessary to update the Base URL for the `french` and the `german` website
 
 ### Clean the Cache
 
-Run the command below to clean the `config` and `full_page` caches.
+Run the following command to clean the `config` and `full_page` caches.
 
 ```bash
 bin/magento cache:clean config full_page


### PR DESCRIPTION
## Purpose of this pull request

This pull request (PR) updates the following changes to the Set up multiple websites with the Nginx page.

- Map directive example is replaced with the $MAGE_RUN_CODE variable.
- Additional steps added to modify the Base URLs for the newly created stores on the Magento admin.

## Affected DevDocs pages

<!-- REQUIRED List the affected pages on devdocs.magento.com (URLs). Not needed for large numbers of files. -->

-  https://devdocs.magento.com/guides/v2.3/config-guide/multi-site/ms_nginx.html
- https://devdocs.magento.com/guides/v2.4/config-guide/multi-site/ms_nginx.html

## Notes

I have verified the updated Nginx virtual hosts configuration file in my local development environment and I can confirm that the multi-stores are working as expected.

Fixes #6317 
<!--
If you are fixing a GitHub issue, note it using GitHub keyword format (https://help.github.com/en/articles/closing-issues-using-keywords#closing-an-issue-in-a-different-repository) to close the issue when this pull request is merged. Example: `Fixes #1234`

`master` is the default branch. Merged pull requests to `master` go live on the site automatically. Any requested changes to content on the `master` branch must be related to the released codebase. Any content related to future releases goes in the `develop` branch.

See Contribution guidelines (https://github.com/magento/devdocs/blob/master/.github/CONTRIBUTING.md) for more information.
-->

whatsnew
Updated and expanded [Set up multiple websites or stores with nginx](https://devdocs.magento.com/guides/v2.4/config-guide/multi-site/ms_nginx.html) tutorial.