### PR TITLE
magento/devdocs#9049 fixing missing a comma in the example

### DIFF
--- a/src/guides/v2.3/javascript-dev-guide/widgets/widget_alert.md
+++ b/src/guides/v2.3/javascript-dev-guide/widgets/widget_alert.md
@@ -30,7 +30,7 @@ $('#init_element').alert({
 
 ```javascript
 require([
-    'Magento_Ui/js/modal/alert'
+    'Magento_Ui/js/modal/alert',
     'jquery'
 ], function(alert, $) { // Variable that represents the `alert` function
 


### PR DESCRIPTION
magento/devdocs#9049

## Purpose of this pull request
This pull request (PR) fixed missing a comma after 'Magento_Ui/js/modal/alert' in the example.

## Affected DevDocs pages
-  https://devdocs.magento.com/guides/v2.4/javascript-dev-guide/widgets/widget_alert.html

## Links to Magento source code
-  src/guides/v2.4/javascript-dev-guide/widgets/widget_alert.md
