### PR TITLE
magento/devdocs#9037 Fixing example with the block inside page layout…

### DIFF
--- a/src/guides/v2.3/frontend-dev-guide/layouts/layout-create.md
+++ b/src/guides/v2.3/frontend-dev-guide/layouts/layout-create.md
@@ -23,8 +23,9 @@ If the new page has a `3-columns-double-footer` layout, create a custom page-lay
 </layout>
 ```
 
-Add a block to the container.
-Create the layout `app/design/frontend/<VendorName>/<ThemeName>/Magento_Theme/layout/3-columns-double-footer.xml`.
+To add a block to the container, create the layout:
+
+`app/design/frontend/<VendorName>/<ThemeName>/Magento_Theme/layout/3-columns-double-footer.xml`
 
 ```xml
 <?xml version="1.0"?>

--- a/src/guides/v2.3/frontend-dev-guide/layouts/layout-create.md
+++ b/src/guides/v2.3/frontend-dev-guide/layouts/layout-create.md
@@ -17,12 +17,22 @@ If the new page has a `3-columns-double-footer` layout, create a custom page-lay
     <update handle="3columns"/>
     <referenceContainer name="page.wrapper">
         <container name="footer-bottom" as="footer-bottom" after="footer" label="Footer Bottom" htmlTag="footer" htmlClass="page-footer-bottom">
-            <container name="footer-bottom-content" as="footer-bottom-content" htmlTag="div" htmlClass="footer content">
-                <block class="Magento\Framework\View\Element\Template" name="report.bugs.bottom" template="Magento_Theme::html/bugreport.phtml"/>
-            </container>
+            <container name="footer-bottom-content" as="footer-bottom-content" htmlTag="div" htmlClass="footer content" />
         </container>
     </referenceContainer>
 </layout>
+```
+
+Add a block to the container.
+Create the layout `app/design/frontend/<VendorName>/<ThemeName>/Magento_Theme/layout/3-columns-double-footer.xml`.
+
+```xml
+<?xml version="1.0"?>
+<page xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="urn:magento:framework:View/Layout/etc/page_configuration.xsd">
+    <referenceContainer name="footer-bottom-content">
+        <block class="Magento\Framework\View\Element\Template" name="report.bugs.bottom" template="Magento_Theme::html/bugreport.phtml"/>
+    </referenceContainer>
+</page>
 ```
 
 ## Add the new layout to the layouts.xml file


### PR DESCRIPTION
magento/devdocs#9037

## Purpose of this pull request

This pull request (PR) - fixing example with page_layout declaration.
We can't use the "**block**" node in the _app/design/frontend/<VendorName>/<ThemeName>/Magento_Theme/page_layout/example.xml_
The it is not allowed in the schema - _urn:magento:framework:View/Layout/etc/page_layout.xsd_

## Affected DevDocs pages

-  https://devdocs.magento.com/guides/v2.4/frontend-dev-guide/layouts/layout-create.html

## Links to Magento source code

-  src/guides/v2.4/frontend-dev-guide/layouts/layout-create.md