### PR TITLE
Fix ES stopwords directory argument name

### DIFF
--- a/src/guides/v2.3/config-guide/elasticsearch/es-config-stopwords.md
+++ b/src/guides/v2.3/config-guide/elasticsearch/es-config-stopwords.md
@@ -116,7 +116,7 @@ To change the directory:
 
    If you got an archive or the metapackage, it's located at `vendor/magento/module-elasticsearch/etc/di.xml`
 
-1. Change the value of `fileDir` to the desired directory:
+1. Change the value of `stopwordsDirectory` to the desired directory:
 
    ```xml
    <type name="Magento\Elasticsearch\SearchAdapter\Query\Preprocessor\Stopwords">


### PR DESCRIPTION
## Purpose of this pull request

This PR fix ES stopwords directory name

## Affected DevDocs pages

<!-- REQUIRED List the affected pages on devdocs.magento.com (URLs). Not needed for large numbers of files. -->

-  https://devdocs.magento.com/guides/v2.4/config-guide/elasticsearch/es-config-stopwords.html


<!--
If you are fixing a GitHub issue, note it using GitHub keyword format (https://help.github.com/en/articles/closing-issues-using-keywords#closing-an-issue-in-a-different-repository) to close the issue when this pull request is merged. Example: `Fixes #1234`

`master` is the default branch. Merged pull requests to `master` go live on the site automatically. Any requested changes to content on the `master` branch must be related to the released codebase. Any content related to future releases goes in the `develop` branch.

See Contribution guidelines (https://github.com/magento/devdocs/blob/master/.github/CONTRIBUTING.md) for more information.
-->
