### PR TITLE
Fastly CDN - migrate old geo namespace variables

### DIFF
--- a/src/cloud/cdn/fastly-vcl-blocking.md
+++ b/src/cloud/cdn/fastly-vcl-blocking.md
@@ -118,7 +118,7 @@ This example uses the two-character ISO 3166-1 country code for the country asso
   "dynamic": "0",
   "type": "recv",
   "priority": "5",
-  "content": "if ( geoip.country_code == \"HK\" ) { error 405 \"Not allowed\";}"
+  "content": "if ( client.geo.country_code == \"HK\" ) { error 405 \"Not allowed\";}"
 }
 ```
 


### PR DESCRIPTION
## Purpose of this pull request

Use the latest `client.geo.*` namespace geo variables.

## Affected DevDocs pages

- https://devdocs.magento.com/cloud/cdn/fastly-vcl-blocking.html#vcl-code-sample-block-by-country-code