### PR TITLE
Add valid link to the "Asynchronous web endpoints" page

### DIFF
--- a/src/guides/v2.3/rest/asynchronous-web-endpoints.md
+++ b/src/guides/v2.3/rest/asynchronous-web-endpoints.md
@@ -4,7 +4,7 @@ title: Asynchronous web endpoints
 contributor_name: comwrap GmbH
 contributor_link: http://comwrap.com/
 functional_areas:
-- Integration
+  - Integration
 ---
 
 An asynchronous web endpoint intercepts messages to a Web API and writes them to the message queue. Each time the system accepts such an API request, it generates a UUID identifier. Magento includes this UUID when it adds the message to the queue. Then, a consumer reads the messages from the queue and executes them one-by-one.
@@ -32,7 +32,7 @@ PUT /async/V1/products/:sku
 {{site.data.var.ce}} and {{site.data.var.ee}} installations support asynchronous web endpoints.
 
 The [REST API documentation](bk-rest.html) provides a list of all current synchronous Magento API routes.
- 
+
 The response of an asynchronous request contains the following fields:
 
 Field name | Data type | Description

--- a/src/guides/v2.3/rest/asynchronous-web-endpoints.md
+++ b/src/guides/v2.3/rest/asynchronous-web-endpoints.md
@@ -31,7 +31,7 @@ PUT /async/V1/products/:sku
 
 {{site.data.var.ce}} and {{site.data.var.ee}} installations support asynchronous web endpoints.
 
-The [REST API documentation](bk-rest.html) provides a list of all current synchronous Magento API routes.
+The [REST API documentation]({{page.baseurl}}/rest/bk-rest.html) provides a list of all current synchronous Magento API routes.
 
 The response of an asynchronous request contains the following fields:
 

--- a/src/guides/v2.3/rest/asynchronous-web-endpoints.md
+++ b/src/guides/v2.3/rest/asynchronous-web-endpoints.md
@@ -4,7 +4,7 @@ title: Asynchronous web endpoints
 contributor_name: comwrap GmbH
 contributor_link: http://comwrap.com/
 functional_areas:
-  - Integration
+- Integration
 ---
 
 An asynchronous web endpoint intercepts messages to a Web API and writes them to the message queue. Each time the system accepts such an API request, it generates a UUID identifier. Magento includes this UUID when it adds the message to the queue. Then, a consumer reads the messages from the queue and executes them one-by-one.

--- a/src/guides/v2.3/rest/asynchronous-web-endpoints.md
+++ b/src/guides/v2.3/rest/asynchronous-web-endpoints.md
@@ -31,8 +31,8 @@ PUT /async/V1/products/:sku
 
 {{site.data.var.ce}} and {{site.data.var.ee}} installations support asynchronous web endpoints.
 
-The [REST API documentation]({{site.baseurl}}/redoc/{{page.guide_version}}/) provides a list of all current synchronous Magento API routes.
-
+The [REST API documentation](bk-rest.html) provides a list of all current synchronous Magento API routes.
+ 
 The response of an asynchronous request contains the following fields:
 
 Field name | Data type | Description


### PR DESCRIPTION
## Purpose of this pull request

This pull request (PR) fixes [#9053](https://github.com/magento/devdocs/issues/9053)

This pull request adds a valid link to the "Asynchronous web endpoints" page

## Affected DevDocs pages

https://devdocs.magento.com/guides/v2.4/rest/asynchronous-web-endpoints.html
https://devdocs.magento.com/guides/v2.4/rest/bk-rest.html
