### PR TITLE
magento/devdocs#9059 Fixing path in the new layout example

### DIFF
--- a/src/guides/v2.3/frontend-dev-guide/layouts/layout-create.md
+++ b/src/guides/v2.3/frontend-dev-guide/layouts/layout-create.md
@@ -25,7 +25,7 @@ If the new page has a `3-columns-double-footer` layout, create a custom page-lay
 
 To add a block to the container, create the layout:
 
-`app/design/frontend/<VendorName>/<ThemeName>/Magento_Theme/layout/3-columns-double-footer.xml`
+`app/design/frontend/<VendorName>/<ThemeName>/Magento_Theme/layout/default.xml`
 
 ```xml
 <?xml version="1.0"?>


### PR DESCRIPTION
magento/devdocs#9059

## Purpose of this pull request
This pull request (PR) Fixing path in the new layout example

## Affected DevDocs pages
-  https://devdocs.magento.com/guides/v2.4/frontend-dev-guide/layouts/layout-create.html

## Links to Magento source code
-  https://devdocs.magento.com/guides/v2.4/frontend-dev-guide/layouts/layout-create.md

## Description
It seems the path _app/design/frontend/<VendorName>/<ThemeName>/Magento_Theme/layout/3-columns-double-footer.xml_ as example is a bit confusion, we need to use real path. I have changed it to default.xml in this case the block will be rendered on all pages with the necessary layout "3 Columns Double Footer"

The result of the example:
![test-07231609-43](https://user-images.githubusercontent.com/7371730/126787373-e6e1dd1d-c7c1-4ba0-a858-ea5925fd9951.png)

