### PR TITLE
Correct description of Pro integration branch architecture

### DIFF
--- a/src/cloud/architecture/pro-develop-deploy-workflow.md
+++ b/src/cloud/architecture/pro-develop-deploy-workflow.md
@@ -17,7 +17,9 @@ The following graphic demonstrates the Pro develop and deploy workflow, which us
 
 ## Development workflow {#develop}
 
-The Integration environment provides a single, base `integration` branch containing your {{site.data.var.ece}} code. You can create up to four additional branches for developing your custom code, extensions, and third party integrations. This allows for a maximum of five _active_ branches deployed to Platform-as-a-Service (PaaS) containers.
+The Integration environment provides a single, base `integration` branch containing your {{site.data.var.ece}} code. You can create one additional, environment branch. This allows for up to two active branches deployed to Platform-as-a-Service (PaaS) containers.(PaaS) containers.
+
+{% include cloud/note-enhanced-integration-envs-kb.md%}
 
 The {{site.data.var.ece}} environments support a flexible, continuous integration process. Begin by cloning the `integration` branch to your local project folder. Create a new branch, or multiple branches, to develop new features, configure changes, add extensions, and deploy updates:
 


### PR DESCRIPTION
Fixes #9062 

## Purpose of this pull request

This pull request corrects information about the number of integration branches for Cloud Pro environments.

## Affected DevDocs pages

<!-- REQUIRED List the affected pages on devdocs.magento.com (URLs). Not needed for large numbers of files. -->

-  [Pro develop and deploy workflow](https://devdocs.magento.com/cloud/architecture/pro-develop-deploy-workflow.html#develop)
