### PR TITLE
Minor fix under [nginx configs] link fixing #9064

### DIFF
--- a/src/cloud/docker/docker-containers-service.md
+++ b/src/cloud/docker/docker-containers-service.md
@@ -322,7 +322,7 @@ To mount the custom index.php file using volumes:
 [mariadb Docker documentation]: https://hub.docker.com/_/mariadb
 [mariadb]: https://hub.docker.com/_/mariadb
 [nginx config]: https://github.com/magento-dockerhub/magento-cloud-docker/blob/master/images/nginx/1.9/etc/vhost.conf
-[nginx configs]: https://github.com/magento/magento-cloud-docker/tree/develop/images/nginx/1.9/etc
+[nginx configs]: https://github.com/magento/magento-cloud-docker/tree/develop/images/nginx/1.19/etc
 [nginx]: https://hub.docker.com/r/magento/magento-cloud-docker-nginx
 [PHP extensions]: {{site.baseurl}}/cloud/project/magento-app-php-application.html#php-extensions
 [php-cloud]: https://hub.docker.com/r/magento/magento-cloud-docker-php


### PR DESCRIPTION
After created a issue was found the solution just updating the correct url.

## Purpose of this pull request

to fix a issue under url of nginx templates files

## Affected DevDocs pages

https://devdocs.magento.com/cloud/docker/docker-containers-service.html#web-container

Fixes #9064
