### PR TITLE
Fixing MD syntax > Composer page

### DIFF
--- a/src/guides/v2.3/comp-mgr/patching/composer.md
+++ b/src/guides/v2.3/comp-mgr/patching/composer.md
@@ -9,7 +9,7 @@ functional_areas:
 {:.bs-callout-warning}
 Always perform comprehensive testing before deploying any custom patch.
 
-{.:procedure}
+{:.procedure}
 To apply a custom patch using Composer:
 
 1. Open your command line application and navigate to your project directory.


### PR DESCRIPTION
## Purpose of this pull request

This PR fix MD syntax. Instead of using `{.:procedure}` it must be `{:.procedure}`.

![Capture d’écran, le 2021-07-27 à 17 16 31](https://user-images.githubusercontent.com/610598/127228581-273c8c82-421b-4485-b721-01c70bd9be07.png)

## Affected DevDocs pages

https://devdocs.magento.com/guides/v2.4/comp-mgr/patching/composer.html

## Links to Magento source code

https://github.com/magento/devdocs/blob/master/src/guides/v2.3/comp-mgr/patching/composer.md

<!--
If you are fixing a GitHub issue, note it using GitHub keyword format (https://help.github.com/en/articles/closing-issues-using-keywords#closing-an-issue-in-a-different-repository) to close the issue when this pull request is merged. Example: `Fixes #1234`

`master` is the default branch. Merged pull requests to `master` go live on the site automatically. Any requested changes to content on the `master` branch must be related to the released codebase. Any content related to future releases goes in the `develop` branch.

See Contribution guidelines (https://github.com/magento/devdocs/blob/master/.github/CONTRIBUTING.md) for more information.
-->
