### PR TITLE
Fix and improve examples for Fastly API usage

### DIFF
--- a/src/cloud/cdn/trouble-fastly.md
+++ b/src/cloud/cdn/trouble-fastly.md
@@ -294,13 +294,13 @@ To rollback the VCL version:
 1. To get a list of the available VCL versions for a service, run the following command
 
    ```bash
-   curl -H "Fastly-Key: <FASTLY_API_TOKEN>" https://api.fastly.com/service/<FASTLY_SERVICE_ID>/version/
+   curl -H "Fastly-Key: <FASTLY_API_TOKEN>" -H "Accept: application/json" https://api.fastly.com/service/<FASTLY_SERVICE_ID>/version
    ```
 
 1. Run the following command to change the active VCL version to a specified version.
 
    ```bash
-   curl -H "Fastly-Key: <FASTLY_API_TOKEN>" -H 'Content-Type: application/json' -H "Accept: application/json" -X PUT https://api.fastly.com/service/<FASTLY_SERVICE_ID>/version/<Version #>/activate
+   curl -H "Fastly-Key: <FASTLY_API_TOKEN>" -H "Content-Type: application/x-www-form-urlencoded" -H "Accept: application/json" -X PUT https://api.fastly.com/service/<FASTLY_SERVICE_ID>/version/<VERSION_ID>/activate
    ```
 
 For details about using the Fastly API to review and manage VCL, see [Manage VCL using the API]({{ site.baseurl }}/cloud/cdn/cloud-vcl-custom-snippets.html#manage-custom-vcl-snippets-using-the-api).


### PR DESCRIPTION
## Purpose of this pull request

This pull request fixes the not working example of getting a list of available VCL versions using Fastly API.
The issue is caused by a redundant trailing slash in the specified URI, and results in the following error:
```
{"msg":"Not found","detail":"Route not found"}
```

Also applied minor fixes for other examples by correcting the request headers and improving the consistency between both example commands.

## Affected DevDocs pages
-  https://devdocs.magento.com/cloud/cdn/trouble-fastly.html

## Links to Magento source code

-  N/A

## Links to the related documentation
- https://developer.fastly.com/reference/api/services/version/#list-service-versions
