### PR TITLE
Mask cart_id in GraphQL request

### DIFF
--- a/src/guides/v2.3/graphql/tutorials/checkout/checkout-shipping-address.md
+++ b/src/guides/v2.3/graphql/tutorials/checkout/checkout-shipping-address.md
@@ -30,7 +30,7 @@ If using a logged in customer, send the customer's authorization token in the `A
 mutation {
   setShippingAddressesOnCart(
     input: {
-      cart_id: "hD5ac9d7N5539DMVhs5uIzwS04hsD3vy"
+      cart_id: "{ CART_ID }"
       shipping_addresses: [
         {
           address: {


### PR DESCRIPTION
## Purpose of this pull request

This pull request (PR) masks cart_id in GraphQL request as it done in other examples.

## Affected DevDocs pages

<!-- REQUIRED List the affected pages on devdocs.magento.com (URLs). Not needed for large numbers of files. -->

-  https://devdocs.magento.com/guides/v2.4/graphql/tutorials/checkout/checkout-shipping-address.html



<!--
If you are fixing a GitHub issue, note it using GitHub keyword format (https://help.github.com/en/articles/closing-issues-using-keywords#closing-an-issue-in-a-different-repository) to close the issue when this pull request is merged. Example: `Fixes #1234`

`master` is the default branch. Merged pull requests to `master` go live on the site automatically. Any requested changes to content on the `master` branch must be related to the released codebase. Any content related to future releases goes in the `develop` branch.

See Contribution guidelines (https://github.com/magento/devdocs/blob/master/.github/CONTRIBUTING.md) for more information.
-->
