### PR TITLE
Fix misleading variable name

### DIFF
--- a/src/guides/v2.3/extension-dev-guide/extension_attributes/adding-attributes.md
+++ b/src/guides/v2.3/extension-dev-guide/extension_attributes/adding-attributes.md
@@ -80,11 +80,11 @@ Function `afterGetList` is similar to `afterGet`:
 ```php
 public function afterGetList(
     \Magento\Catalog\Api\ProductRepositoryInterface $subject,
-    \Magento\Catalog\Api\Data\ProductSearchResultsInterface $searchCriteria
+    \Magento\Catalog\Api\Data\ProductSearchResultsInterface $searchResults
 ) : \Magento\Catalog\Api\Data\ProductSearchResultsInterface
 {
     $products = [];
-    foreach ($searchCriteria->getItems() as $entity) {
+    foreach ($searchResults->getItems() as $entity) {
         $ourCustomData = $this->customDataRepository->get($entity->getId());
 
         $extensionAttributes = $entity->getExtensionAttributes();
@@ -93,8 +93,8 @@ public function afterGetList(
 
         $products[] = $entity;
     }
-    $searchCriteria->setItems($products);
-    return $searchCriteria;
+    $searchResults->setItems($products);
+    return $searchResults;
 }
 ```
 

--- a/src/guides/v2.3/extension-dev-guide/extension_attributes/adding-attributes.md
+++ b/src/guides/v2.3/extension-dev-guide/extension_attributes/adding-attributes.md
@@ -98,7 +98,7 @@ public function afterGetList(
 }
 ```
 
- {:.bs-callout-info}
+{:.bs-callout-info}
 To add extension attributes to an entity without plugins, use the `extensionActions` argument of `\Magento\Framework\EntityManager\Operation\ExtensionPool`. See [\Magento\Catalog\Model\ProductRepository::getList()]({{ site.mage2bloburl }}/{{ page.guide_version }}/app/code/Magento/Catalog/Model/ProductRepository.php) as an example of an implementation.
 
 Likewise, the `afterSave` plugin should manipulate the entity data before returning it:


### PR DESCRIPTION
Replace $searchCriteria with $searchResults

## Purpose of this pull request

This pull request (PR) fixes a misleading variable name which was introduced by copy&paste.

## Affected DevDocs pages

- https://devdocs.magento.com/guides/v2.4/extension-dev-guide/extension_attributes/adding-attributes.html
- https://devdocs.magento.com/guides/v2.3/extension-dev-guide/extension_attributes/adding-attributes.html
