### PR TITLE
Don't recommend overriding _isAllowed

### DIFF
--- a/src/guides/v2.3/ext-best-practices/tutorials/create-access-control-list-rule.md
+++ b/src/guides/v2.3/ext-best-practices/tutorials/create-access-control-list-rule.md
@@ -96,26 +96,19 @@ The menu displays as follows:
 
 ### Restrict admin controllers
 
-We can restrict the access to admin controllers by overriding the `_isAllowed` method of the `\Magento\Backend\App\Action` class.
+We can restrict the access to admin controllers by setting the `ADMIN_RESOURCE` const.
 
 Add the following to your module's `Controller/Adminhtml/Create/Index.php` file:
 
 ```php
-protected function _isAllowed()
-{
- return $this->_authorization->isAllowed('Vendor_MyModule::create');
-}
+const ADMIN_RESOURCE = 'Vendor_MyModule::create'
 ```
 
 Add the following to your module's `Controller/Adminhtml/Delete/Index.php` file:
 
 ```php
-protected function _isAllowed()
-{
- return $this->_authorization->isAllowed('Vendor_MyModule::delete');
-}
+const ADMIN_RESOURCE = 'Vendor_MyModule::delete';
 ```
-
 If the user does not have permission, the action page displays an "Access Denied" message.
 
 ### Content restrictions for admin users

--- a/src/guides/v2.3/ext-best-practices/tutorials/create-access-control-list-rule.md
+++ b/src/guides/v2.3/ext-best-practices/tutorials/create-access-control-list-rule.md
@@ -96,7 +96,7 @@ The menu displays as follows:
 
 ### Restrict admin controllers
 
-We can restrict the access to admin controllers by setting the `ADMIN_RESOURCE` const.
+We can restrict the access to admin controllers by setting the `ADMIN_RESOURCE` constant.
 
 Add the following to your module's `Controller/Adminhtml/Create/Index.php` file:
 


### PR DESCRIPTION
## Purpose of this pull request

Recommend the better way for binding a controller action to an admin resource

## Affected DevDocs pages

https://devdocs.magento.com/guides/v2.3/ext-best-practices/tutorials/create-access-control-list-rule.html

## Links to Magento source code

Declaring `ADMIN_RESOURCE` is the better way and is how it's done in core.

https://github.com/magento/magento2/blob/2.4.2/app/code/Magento/Tax/Controller/Adminhtml/Tax.php#L23
https://github.com/magento/magento2/blob/2.4.2/app/code/Magento/Rss/Controller/Adminhtml/Feed.php#L17
https://github.com/magento/magento2/blob/2.4.2/app/code/Magento/Cms/Controller/Adminhtml/Block.php#L15

There's no need to override `_isAllowed` as it will check that const

https://github.com/magento/magento2/blob/2.4.2/app/code/Magento/Backend/App/AbstractAction.php#L213

