### PR TITLE
Fix link by removing reference to local IP address

### DIFF
--- a/src/guides/v2.4/release-notes/2-4-2-p2.md
+++ b/src/guides/v2.4/release-notes/2-4-2-p2.md
@@ -12,7 +12,7 @@ Security-only patches typically include all hotfixes that have been released for
 
 ## Installation and upgrade instructions
 
-For instructions on downloading and applying security-only patches (including patch 2.4.2-p2), see [Quick start install](http://127.0.0.1:4000/guides/v2.4/install-gde/composer.html).
+For instructions on downloading and applying security-only patches (including patch 2.4.2-p2), see [Quick start install](/guides/v2.4/install-gde/composer.html).
 
 ## More information?
 

--- a/src/guides/v2.4/release-notes/2-4-2-p2.md
+++ b/src/guides/v2.4/release-notes/2-4-2-p2.md
@@ -12,7 +12,7 @@ Security-only patches typically include all hotfixes that have been released for
 
 ## Installation and upgrade instructions
 
-For instructions on downloading and applying security-only patches (including patch 2.4.2-p2), see [Quick start install](/guides/v2.4/install-gde/composer.html).
+For instructions on downloading and applying security-only patches (including patch 2.4.2-p2), see [Quick start install]({{site.baseurl}}/guides/v2.4/install-gde/composer.html).
 
 ## More information?
 


### PR DESCRIPTION
The "Quick start install" link was pointing to http://127.0.0.1:4000 which fails when browsing on https://devdocs.magento.com/. With this change the domain is removed, allowing the docs to be served from any domain. This matches the link format used elsewhere in the repo.

## Affected DevDocs pages

https://devdocs.magento.com/guides/v2.4/release-notes/2-4-2-p2.html
