### PR TITLE
Remove setup_version

### DIFF
--- a/src/guides/v2.3/javascript-dev-guide/javascript/js_mixins.md
+++ b/src/guides/v2.3/javascript-dev-guide/javascript/js_mixins.md
@@ -210,7 +210,7 @@ Be sure to add the origin module as the over-written module dependency (use the 
 ```xml
 <?xml version="1.0"?>
 <config xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="urn:magento:framework:Module/etc/module.xsd">
-    <module name="ExampleCorp_CartFix" setup_version="0.0.1">
+    <module name="ExampleCorp_CartFix">
         <sequence>
             <module name="ExampleCorp_Sample" />
         </sequence>


### PR DESCRIPTION
## Purpose of this pull request

This pull request helps with clarity by reducing unnecessary code.

`setup_version` is used for very specific types of `Setup/*.php` scripts. Not all modules make use of such scripts. Including reference to it here in this guide serves only as a distraction as there is no reference to it explaining what it does, nor should there as that is not the topic of this guide.

Some people including myself might even argue use of `setup_version` should be discouraged in favor of other practices available to us when performing Magento development.

Similar PR: https://github.com/magento/devdocs/pull/8980

## Affected DevDocs pages

- https://devdocs.magento.com/guides/v2.4/javascript-dev-guide/javascript/js_mixins.html
- https://devdocs.magento.com/guides/v2.3/javascript-dev-guide/javascript/js_mixins.html

## Links to Magento source code

Not Applicable
