### PR TITLE
Update dev_install.md

### DIFF
--- a/src/guides/v2.4/install-gde/prereq/dev_install.md
+++ b/src/guides/v2.4/install-gde/prereq/dev_install.md
@@ -43,7 +43,7 @@ To create an authentication file:
                "username": "<public-key>",
                "password": "<private-key>"
            }
-       }
+       },
        "github-oauth": {
            "github.com": "<personal-access-token>"
        }


### PR DESCRIPTION
Adds missing comma to JSON example object

## Purpose of this pull request

This pull request (PR) updates the composer.json example code block to add a missing comma after the first JSON object in the example.

## Affected DevDocs pages
install-gde/prereq/dev_install.html
