### PR TITLE
The MFRGGZDF hash is the result of abcde

### DIFF
--- a/src/guides/v2.4/security/two-factor-authentication.md
+++ b/src/guides/v2.4/security/two-factor-authentication.md
@@ -81,7 +81,7 @@ MFTF uses Google Authenticator to execute tests with 2FA enabled. The following 
    bin/magento config:set twofactorauth/google/otp_window 60
    ```
 
-1. Generate a Base32-encoded string for the shared secret value.  For example, encoding the string `abcd` with the online [Base32 Encode](https://emn178.github.io/online-tools/base32_encode.html) tool returns the value `MFRGGZDF`. Use the following key to add the encoded value to the MFTF `.credentials` file:
+1. Generate a Base32-encoded string for the shared secret value.  For example, encoding the string `abcde` with the online [Base32 Encode](https://emn178.github.io/online-tools/base32_encode.html) tool returns the value `MFRGGZDF`. Use the following key to add the encoded value to the MFTF `.credentials` file:
 
    ```bash
    magento/tfa/OTP_SHARED_SECRET=MFRGGZDF


### PR DESCRIPTION
## Purpose of this pull request
This pull request (PR) is to indicate the correct string that is used to generate the `MFRGGZDF` hash

## Affected DevDocs pages
-  https://devdocs.magento.com/guides/v2.4/security/two-factor-authentication.html
