### PR TITLE
Documented an alternative Integration Tests data fixture declaration …

### DIFF
--- a/src/guides/v2.4/test/integration/annotations/magento-data-fixture.md
+++ b/src/guides/v2.4/test/integration/annotations/magento-data-fixture.md
@@ -42,29 +42,29 @@ As mentioned above, there are two ways to declare fixtures:
 ### Fixture as a separate file
 
 Define the fixture in a separate file when you want to reuse it in different test cases.
-To declare the fixture, use one of the following conventions 
+To declare the fixture, use one of the following conventions:
 
-- Fixture declaration as a path relative to the testsuite directory
-
-  - Relative to `dev/tests/integration/<test suite directory>`
-  - With forward slashes `/`
-  - No leading slash
+-  Fixture declaration as a path relative to the testsuite directory
+   -  Relative to `dev/tests/integration/<test suite directory>`
+   -  With forward slashes `/`
+   -  No leading slash
 
   Example:
-  ```
+
+  ```php
   /**
    * @magentoDataFixture Magento/Cms/_files/pages.php
    */
   ```
 
-- Fixture declaration as a path relative to a module
-
-  - Relative to the directory of a module available in the project
-  - With forward slashes `/`
-  - No leading slash in the path part of the declaration
+-  Fixture declaration as a path relative to a module
+   -  Relative to the directory of a module available in the project
+   -  With forward slashes `/`
+   -  No leading slash in the path part of the declaration
 
   Example:
-  ```
+
+  ```php
   /**
    * @magentoDataFixture VendorName_ModuleName::Test/Integration/_files/fixture_name.php
    */

--- a/src/guides/v2.4/test/integration/annotations/magento-data-fixture.md
+++ b/src/guides/v2.4/test/integration/annotations/magento-data-fixture.md
@@ -1,1 +1,125 @@
-../../../../v2.3/test/integration/annotations/magento-data-fixture.md
+---
+group: testing
+title: Data fixture annotation
+---
+
+A data fixture is a PHP script that sets data you want to reuse in your test.
+The script can be defined in a separate file or as a local test case method.
+
+Use data fixtures to prepare a database for tests.
+The Integration Testing Framework (ITF) reverts the database to its initial state automatically.
+To set up a date fixture, use the `@magentoDataFixture` annotation.
+
+## Format
+
+`@magentoDataFixture` takes an argument that points to the data fixture as a filename or local method.
+
+```php?start_inline=1
+/**
+ * @magentoDataFixture <script_filename>|<method_name>
+ */
+```
+
+-  `<script_filename>` is a filename of the PHP script.
+-  `<method_name>` is a name of the method declared in the current class.
+
+## Principles
+
+1. Do not use a direct database connection in fixtures to avoid dependencies on the database structure and vendor.
+1. Use an application API to implement your data fixtures.
+1. A method that implements a data fixture must be declared as `public` and `static`.
+1. Fixtures declared at a test level have a higher priority then fixtures declared at a test case level.
+1. Test case fixtures are applied to each test in the test case, unless a test has its own fixtures declared.
+1. Annotation declaration at a test case level doesn't affect tests that have their own annotation declarations.
+
+## Usage
+
+As mentioned above, there are two ways to declare fixtures:
+
+-  as a PHP script file that is used by other tests and test cases.
+-  as a local method that is used by other tests in the test cases.
+
+### Fixture as a separate file
+
+Define the fixture in a separate file when you want to reuse it in different test cases.
+To declare the fixture, use one of the following conventions 
+
+- Fixture declaration as a path relative to the testsuite directory
+
+  - Relative to `dev/tests/integration/<test suite directory>`
+  - With forward slashes `/`
+  - No leading slash
+
+  Example:
+  ```
+  /**
+   * @magentoDataFixture Magento/Cms/_files/pages.php
+   */
+  ```
+
+- Fixture declaration as a path relative to a module
+
+  - Relative to the directory of a module available in the project
+  - With forward slashes `/`
+  - No leading slash in the path part of the declaration
+
+  Example:
+  ```
+  /**
+   * @magentoDataFixture VendorName_ModuleName::Test/Integration/_files/fixture_name.php
+   */
+  ```
+
+The ITF includes the declared PHP script to your test and executes it during test run.
+
+The following example demonstrates a simple implementation of a Cms module page test from the Magento codebase.
+
+Data fixture to test a Cms module page: [`dev/tests/integration/testsuite/Magento/Cms/_files/pages.php`][].
+
+Test case that uses the above data fixture: [`dev/tests/integration/testsuite/Magento/Cms/Block/PageTest.php`][].
+
+### Fixture as a method
+
+[`dev/tests/integration/testsuite/Magento/Cms/Controller/PageTest.php`][] demonstrates an example of the `testCreatePageWithSameModuleName()` test method that uses data from the `cmsPageWithSystemRouteFixture()` data fixture.
+
+### Test case and test method scopes
+
+The `@magentoDataFixture` can be specified for a particular test or for an entire test case.
+The basic rules for fixture annotation at different levels are:
+
+-  `@magentoDataFixture` at a test case level makes the framework to apply the declared fixtures to each test in the test case.
+  When the final test is complete, all class-level fixtures are reverted.
+-  `@magentoDataFixture` for a particular test signals the framework to revert the fixtures declared on a test case level and applies the fixtures declared at a test method level instead.
+  When the test is complete, the ITF reverts the applied fixtures.
+
+ {:.bs-callout-info}
+The integration testing framework interacts with a database to revert the applied fixtures.
+
+### Fixture rollback
+
+A fixture that contains database transactions only are reverted automatically.
+Otherwise, when a fixture creates files or performs any actions other than database transaction, provide the corresponding rollback logic.
+Rollbacks are run after reverting all the fixtures related to database transactions.
+
+A fixture rollback must be of the same format as the corresponding fixture: a script or a method:
+
+-  A rollback script must be named according to the corresponding fixture suffixed with `_rollback` and stored in the same directory.
+-  Rollback methods must be of the same class as the corresponding fixture and suffixed with `Rollback`.
+
+Examples:
+
+Fixture/Rollback | Fixture name                                         | Rollback name
+-----------------|------------------------------------------------------|-------------------------------------------------------------
+Script           | `Magento/Catalog/_files/categories.php`              | `Magento/Catalog/_files/categories_rollback.php`
+Method           | `\Magento\Catalog\Model\ProductTest::prepareProduct` | `\Magento\Catalog\Model\ProductTest::prepareProductRollback`
+
+### Restrictions
+
+Do not rely on and do not modify an application state from within a fixture, because [application isolation annotation][magentoAppIsolation] can reset the application state at any moment.
+
+<!-- Link definitions -->
+
+[magentoAppIsolation]: magento-app-isolation.html
+[`dev/tests/integration/testsuite/Magento/Cms/_files/pages.php`]: {{ site.mage2bloburl }}/{{ page.guide_version }}/dev/tests/integration/testsuite/Magento/Cms/_files/pages.php
+[`dev/tests/integration/testsuite/Magento/Cms/Block/PageTest.php`]: {{ site.mage2bloburl }}/{{ page.guide_version }}/dev/tests/integration/testsuite/Magento/Cms/Block/PageTest.php
+[`dev/tests/integration/testsuite/Magento/Cms/Controller/PageTest.php`]: {{ site.mage2bloburl }}/{{ page.guide_version }}/dev/tests/integration/testsuite/Magento/Cms/Controller/PageTest.php


### PR DESCRIPTION
…using the @magentoDataFixture annotation

## Important:
The current (pre-PR) version of the modified file is just a symlink to the same file from the 2.3 docs. You'd have to use it if you want to display the diff yourself.
This is a screenshot of what's changed:
https://tinyurl.com/yhycp2fq

## Purpose of this pull request

This pull request documents an alternative fixture declaration which is available in Magento for some time already, but not documented in the devdocs at all.
The documented way's example:
```php
/**
 * @magentoDataFixture Magento/Cms/_files/pages.php
 */
```
The undocumented way's example:
```php
/**
 * @magentoDataFixture VendorName_ModuleName::Test/Integration/_files/fixture_name.php
 */
```

## Affected DevDocs pages

<!-- REQUIRED List the affected pages on devdocs.magento.com (URLs). Not needed for large numbers of files. -->
- https://devdocs.magento.com/guides/v2.4/test/integration/annotations/magento-data-fixture.html

## Links to Magento source code
Although this kind of data fixture declaration is not documented in the devdocs, it's documented in the Integration Test Framework in the method that's responsible for resolving the path to the fixture.
[`dev/tests/integration/framework/Magento/TestFramework/Workaround/Override/Fixture/Resolver.php`](https://github.com/magento/magento2/blob/2.4-develop/dev/tests/integration/framework/Magento/TestFramework/Workaround/Override/Fixture/Resolver.php#L251) contains the following method:
```php
    /**
     * Check is the Annotation like Magento_InventoryApi::Test/_files/products.php
     *
     * @param string $fixture
     * @return bool
     */
    private function isModuleAnnotation(string $fixture): bool
    {
        return (strpos($fixture, '::') !== false);
    }
```
The method is called in the same file by the `processFixturePath` method:
```php
    /**
     * Converts fixture path.
     *
     * @param TestCase $test
     * @param string $fixture
     * @return string|array
     * @throws LocalizedException
     */
    private function processFixturePath(TestCase $test, string $fixture)
    {
        if (strpos($fixture, '\\') !== false) {
            // usage of a single directory separator symbol streamlines search across the source code
            throw new LocalizedException(__('Directory separator "\\" is prohibited in fixture declaration.'));
        }

        $fixtureMethod = [get_class($test), $fixture];
        if (is_callable($fixtureMethod)) {
            $result = $fixtureMethod;
        } elseif ($this->isModuleAnnotation($fixture)) {
            $result = $this->getModulePath($fixture);
        } else {
            $result = INTEGRATION_TESTS_DIR . '/testsuite/' . $fixture;
        }

        return $result;
    }
```
In case of module annotations, it goes into the `elseif` there and uses `$this->getModulePath($fixture);` to resolve the path. That method, in turn, uses the ComponentRegistrar to determine the module path (usually either `app/code/...` or `vendor/...`). It uses ComponentRegistrar::MODULE there, which means it won't work for libraries, lang packs, themes or setup, only for modules (which makes sense).

<!--
If you are fixing a GitHub issue, note it using GitHub keyword format (https://help.github.com/en/articles/closing-issues-using-keywords#closing-an-issue-in-a-different-repository) to close the issue when this pull request is merged. Example: `Fixes #1234`

`master` is the default branch. Merged pull requests to `master` go live on the site automatically. Any requested changes to content on the `master` branch must be related to the released codebase. Any content related to future releases goes in the `develop` branch.

See Contribution guidelines (https://github.com/magento/devdocs/blob/master/.github/CONTRIBUTING.md) for more information.
-->
