### PR TITLE
Update warning regarding GTID consistency

### DIFF
--- a/src/guides/v2.4/install-gde/prereq/mysql.md
+++ b/src/guides/v2.4/install-gde/prereq/mysql.md
@@ -14,7 +14,7 @@ Magento _strongly_ recommends you observe the following standard when you set up
 *  If you use MySQL database replication, be aware that Magento does _not_ support MySQL statement-based replication. Make sure you use _only_ [row-based replication](https://dev.mysql.com/doc/refman/8.0/en/replication-formats.htmll){:target="_blank"}.
 
 {:.bs-callout-warning}
-Magento 2 currently utilizes `CREATE TEMPORARY TABLE` statements inside transactions, which are [incompatible](https://dev.mysql.com/doc/refman/5.7/en/replication-gtids-restrictions.html) with database implementations utilizing GTID-based replication, such as [Google Cloud SQL second-generation instances](https://cloud.google.com/sql/docs/features#differences). You might use MySQL for Cloud SQL 8.0 that don't have such limitation.
+Magento 2 currently utilizes `CREATE TEMPORARY TABLE` statements inside transactions, which are [incompatible](https://dev.mysql.com/doc/refman/5.7/en/replication-gtids-restrictions.html) with database implementations utilizing GTID-based replication, such as [Google Cloud SQL second-generation instances](https://cloud.google.com/sql/docs/features#differences). Consider MySQL for Cloud SQL 8.0 as an alternative.
 
 {:.bs-callout-info}
 If your web server and database server are on different hosts, perform the tasks discussed in this topic on the database server host then see [Set up a remote MySQL database connection]({{page.baseurl }}/install-gde/prereq/mysql_remote.html).


### PR DESCRIPTION
## Purpose of this pull request

This pull request (PR) updated the warning that was added in https://github.com/magento/devdocs/pull/4129.

According to https://cloud.google.com/sql/docs/features#differences, MySQL for Cloud SQL 8.0 does support CREATE TEMPORARY TABLE statement, and Magento 2.4 does support MySQL 8.
![image](https://user-images.githubusercontent.com/1873745/130910492-238136e6-0d0e-4458-95bc-58591ebf1c90.png)


## Affected DevDocs pages

<!-- REQUIRED List the affected pages on devdocs.magento.com (URLs). Not needed for large numbers of files. -->

-  https://devdocs.magento.com/guides/v2.4/install-gde/prereq/mysql.html

## Links to Magento source code

<!--  OPTIONAL - REMOVE THIS SECTION IF NOT USED. If this pull request references a file in a Magento codebase repository, add it here. -->

- Fixes https://github.com/magento/magento2/issues/15209
- Fixes https://github.com/magento/magento2/issues/12124

<!--
If you are fixing a GitHub issue, note it using GitHub keyword format (https://help.github.com/en/articles/closing-issues-using-keywords#closing-an-issue-in-a-different-repository) to close the issue when this pull request is merged. Example: `Fixes #1234`

`master` is the default branch. Merged pull requests to `master` go live on the site automatically. Any requested changes to content on the `master` branch must be related to the released codebase. Any content related to future releases goes in the `develop` branch.

See Contribution guidelines (https://github.com/magento/devdocs/blob/master/.github/CONTRIBUTING.md) for more information.
-->
