### PR TITLE
Removed composer require command as an installation way for UCT

### DIFF
--- a/src/upgrade-compatibility-tool/install.md
+++ b/src/upgrade-compatibility-tool/install.md
@@ -71,16 +71,8 @@ This recommendation also helps with memory issues that can occur when executing 
 To download the {{site.data.var.uct}}, run the following command:
 
 ```bash
-composer create-project magento/upgrade-compatibility-tool uct  --repository https://repo.magento.com
+composer create-project magento/upgrade-compatibility-tool uct --repository https://repo.magento.com
 ```
-
-As the {{site.data.var.uct}} is an independent tool, if you try to run:
-
-```bash
-composer require magento/upgrade-compatibility-tool
-```
-
-It might add the {{site.data.var.uct}} as a dependency for an {{site.data.var.ee}} project.
 
 ## Install
 


### PR DESCRIPTION
## Purpose of this pull request

Corrected installation guide for UCT. UCT is not compatible with Adobe Commerce and should be installed as an independent project.

## Affected DevDocs pages

-  https://devdocs.magento.com/upgrade-compatibility-tool/install.html
