### PR TITLE
Remove the duplicate field from the help page for other configuration paths

### DIFF
--- a/src/guides/v2.3/config-guide/prod/config-reference-most.md
+++ b/src/guides/v2.3/config-guide/prod/config-reference-most.md
@@ -84,6 +84,7 @@ Use SID on Storefront | `web/session/use_frontend_sid` | <!-- ![Not EE-only]({{ 
 Redirect to CMS-page if Cookies are Disabled | `web/browser_capabilities/cookies` | <!-- ![Not EE-only]({{ site.baseurl }}/common/images/red-x.png) --> |
 Show Notice if JavaScript is Disabled | `web/browser_capabilities/javascript` | <!-- ![Not EE-only]({{ site.baseurl }}/common/images/red-x.png) --> |
 Show Notice if Local Storage is Disabled | `web/browser_capabilities/local_storage` | <!-- ![Not EE-only]({{ site.baseurl }}/common/images/red-x.png) --> |
+Add Store Code to Urls | `web/url
 
 ### Currency setup paths
 

--- a/src/guides/v2.3/config-guide/prod/config-reference-most.md
+++ b/src/guides/v2.3/config-guide/prod/config-reference-most.md
@@ -84,7 +84,6 @@ Use SID on Storefront | `web/session/use_frontend_sid` | <!-- ![Not EE-only]({{ 
 Redirect to CMS-page if Cookies are Disabled | `web/browser_capabilities/cookies` | <!-- ![Not EE-only]({{ site.baseurl }}/common/images/red-x.png) --> |
 Show Notice if JavaScript is Disabled | `web/browser_capabilities/javascript` | <!-- ![Not EE-only]({{ site.baseurl }}/common/images/red-x.png) --> |
 Show Notice if Local Storage is Disabled | `web/browser_capabilities/local_storage` | <!-- ![Not EE-only]({{ site.baseurl }}/common/images/red-x.png) --> |
-Add Store Code to Urls | `web/url
 
 ### Currency setup paths
 

--- a/src/guides/v2.4/config-guide/prod/config-reference-most.md
+++ b/src/guides/v2.4/config-guide/prod/config-reference-most.md
@@ -84,7 +84,6 @@ Use SID on Storefront | `web/session/use_frontend_sid` | <!-- ![Not EE-only]({{ 
 Redirect to CMS-page if Cookies are Disabled | `web/browser_capabilities/cookies` | <!-- ![Not EE-only]({{ site.baseurl }}/common/images/red-x.png) --> |
 Show Notice if JavaScript is Disabled | `web/browser_capabilities/javascript` | <!-- ![Not EE-only]({{ site.baseurl }}/common/images/red-x.png) --> |
 Show Notice if Local Storage is Disabled | `web/browser_capabilities/local_storage` | <!-- ![Not EE-only]({{ site.baseurl }}/common/images/red-x.png) --> |
-Add Store Code to Urls | `web/url
 
 ### Currency setup paths
 


### PR DESCRIPTION
## Purpose of this pull request

This pull request removes the duplicate field from the help page for other configuration paths
- 2.4
- 2.3

## Affected DevDocs pages

https://devdocs.magento.com/guides/v2.4/config-guide/prod/config-reference-most.html
