### PR TITLE
Fix erroneous info on collapse icon placement

### DIFF
--- a/src/guides/v2.3/javascript-dev-guide/widgets/widget_collapsible.md
+++ b/src/guides/v2.3/javascript-dev-guide/widgets/widget_collapsible.md
@@ -295,7 +295,7 @@ $("#element").collapsible("option","header",".header");
 ```
 
 ### `icons` {#fedg_collaps_icons}
-The classes for icons to be used in headers. If no classes are specified, icons are not be created. A new span is created and appended to the header, the classes for this span are automatically changed whenever the content gets expanded/collapsed.
+The classes for icons to be used in headers. If no classes are specified, icons are not be created. A new span is created and prepended to the header, the classes for this span are automatically changed whenever the content gets expanded/collapsed.
 
 **Type**: String
 


### PR DESCRIPTION
Docs say "append" while the code does "prepend." Result on page is it's prepended.

## Purpose of this pull request

This pull request (PR) ...

## Affected DevDocs pages

https://devdocs.magento.com/guides/v2.3/javascript-dev-guide/widgets/widget_collapsible.html
https://devdocs.magento.com/guides/v2.4/javascript-dev-guide/widgets/widget_collapsible.html
