### PR TITLE
Code demarcation standard > Fix syntax

### DIFF
--- a/src/guides/v2.3/coding-standards/code-standard-demarcation.md
+++ b/src/guides/v2.3/coding-standards/code-standard-demarcation.md
@@ -257,7 +257,7 @@ this.element.on('click', function() {
 ```js
 options {
  deleteAction:  '[data-action="delete"]',
- tooltip: '[data-role="tooltip]'
+ tooltip: '[data-role="tooltip"]'
 }
 ...
 this.element.find(this.options.deleteAction).on( ... );


### PR DESCRIPTION
## Purpose of this pull request

This PR fixes a JS syntax in the Code demarcation standard page.

![Screen Shot 2021-09-08 at 7 39 21 AM](https://user-images.githubusercontent.com/610598/132503057-160e3085-ccf0-4ac7-83bf-91638dfd2d70.png)


## Affected DevDocs pages

<!-- REQUIRED List the affected pages on devdocs.magento.com (URLs). Not needed for large numbers of files. -->

- https://devdocs.magento.com/guides/v2.4/coding-standards/code-standard-demarcation.html
- https://devdocs.magento.com/guides/v2.3/coding-standards/code-standard-demarcation.html
