### PR TITLE
Edit broken links for the 2.4 Release Notes block

### DIFF
--- a/src/guides/v2.4/release-notes/commerce-2-4-1.md
+++ b/src/guides/v2.4/release-notes/commerce-2-4-1.md
@@ -1052,7 +1052,7 @@ We have fixed hundreds of issues in the Magento 2.4.1 core code.
 
 <!-- ENGCOM-7732 7733-->
 
-*  GraphQL product search now considers configured category permissions. Previously, product search ignored the **Enable** setting (**Stores**  >  **Configuration**  >  **Catalog**  >  **Catalog** > **Category Permissions**). _Fix submitted by Petkovski Marjan in pull request [28757](https://github.com/magento/magento2/pull/28757) and pull request 271 in private repo `partners-magento2ee`_. [GitHub-28563](https://github.com/magento/magento2/issues/28563
+*  GraphQL product search now considers configured category permissions. Previously, product search ignored the **Enable** setting (**Stores**  >  **Configuration**  >  **Catalog**  >  **Catalog** > **Category Permissions**). _Fix submitted by Petkovski Marjan in pull request [28757](https://github.com/magento/magento2/pull/28757) and pull request 271 in private repo `partners-magento2ee`_. [GitHub-28563](https://github.com/magento/magento2/issues/28563)
 
 <!--- MC-31084-->
 

--- a/src/guides/v2.4/release-notes/commerce-2-4-3.md
+++ b/src/guides/v2.4/release-notes/commerce-2-4-3.md
@@ -1256,7 +1256,7 @@ We have fixed hundreds of issues in the Magento 2.4.3 core code.
 
 <!--- ENGCOM-9073-->
 
-*  `ramsey/uuid` has been updated for compatibility with PHP 8.0. [GitHub-31777](https://github.com/magento/magento2/issues/31777), [GitHub-826](https://github.com/magento/magento2-functional-testing-framework/issues/8260
+*  `ramsey/uuid` has been updated for compatibility with PHP 8.0. [GitHub-31777](https://github.com/magento/magento2/issues/31777), [GitHub-826](https://github.com/magento/magento2-functional-testing-framework/issues/826)
 
 <!--- ENGCOM-8997-->
 

--- a/src/guides/v2.4/release-notes/open-source-2-4-1.md
+++ b/src/guides/v2.4/release-notes/open-source-2-4-1.md
@@ -1384,7 +1384,7 @@ _Fix submitted by Michał Derlatka in pull request [29256](https://github.com/ma
 
 <!-- ENGCOM-7593 -->
 
-*  Test coverage has been added for these cases of the `updateCustomer` mutation: invalid date of birth, invalid email address, and empty customer last name. _Fix submitted by Alexander Taranovsky in pull request [28304](https://github.com/magento/magento2/pull/28304)_. [GitHub-28394](https://github.com/magento/magento2/issues/28394
+*  Test coverage has been added for these cases of the `updateCustomer` mutation: invalid date of birth, invalid email address, and empty customer last name. _Fix submitted by Alexander Taranovsky in pull request [28304](https://github.com/magento/magento2/pull/28304)_. [GitHub-28394](https://github.com/magento/magento2/issues/28394)
 
 <!--- MC-30844-->
 

--- a/src/guides/v2.4/release-notes/open-source-2-4-3.md
+++ b/src/guides/v2.4/release-notes/open-source-2-4-3.md
@@ -1036,7 +1036,7 @@ We have fixed hundreds of issues in the Magento 2.4.3 core code.
 
 <!--- ENGCOM-9073-->
 
-*  `ramsey/uuid` has been updated for compatibility with PHP 8.0. [GitHub-31777](https://github.com/magento/magento2/issues/31777), [GitHub-826](https://github.com/magento/magento2-functional-testing-framework/issues/8260
+*  `ramsey/uuid` has been updated for compatibility with PHP 8.0. [GitHub-31777](https://github.com/magento/magento2/issues/31777), [GitHub-826](https://github.com/magento/magento2-functional-testing-framework/issues/826)
 
 <!--- ENGCOM-8997-->
 


### PR DESCRIPTION
## Purpose of this pull request

This pull request edits the broken links for the 2.4 Release Notes block

## Affected DevDocs pages

https://devdocs.magento.com/guides/v2.4/release-notes/open-source-2-4-3.html
https://devdocs.magento.com/guides/v2.4/release-notes/commerce-2-4-1.html
