### PR TITLE
Update use-multiple-varnish-cache.md

### DIFF
--- a/src/guides/v2.3/config-guide/varnish/use-multiple-varnish-cache.md
+++ b/src/guides/v2.3/config-guide/varnish/use-multiple-varnish-cache.md
@@ -21,7 +21,7 @@ The parameter format must be `<hostname or ip>:<listen port>`, where you can omi
 For example,
 
 ```bash
-bin/magento setup:config:set --http-cache-hosts=192.0.2.100,192.0.2.155:6081
+bin/magento setup:config:set --http-cache-hosts=192.0.2.100,192.0.2.155:8080
 ```
 
 You can then purge all Varnish hosts when you refresh the Magento cache (also referred to as *cleaning* the cache) in the Admin or using the command line.


### PR DESCRIPTION
change example varnish port to non telnet port

## Purpose of this pull request

the example show how to set varnish port, but the example port is the defauilt varnish telnet port and not a http port.

## Affected DevDocs pages

-  https://devdocs.magento.com/guides/v2.4/config-guide/varnish/use-multiple-varnish-cache.html
- https://devdocs.magento.com/guides/v2.3/config-guide/varnish/use-multiple-varnish-cache.html

