### PR TITLE
Update config-remote-storage.md

### DIFF
--- a/src/guides/v2.4/config-guide/remote-storage/config-remote-storage.md
+++ b/src/guides/v2.4/config-guide/remote-storage/config-remote-storage.md
@@ -12,6 +12,9 @@ The Remote Storage module provides the option to store media files and schedule 
 {:.bs-callout-info}
 Remote storage is available in version 2.4.2 and later only. See the [2.4.2 release notes]({{page.baseurl}}/release-notes/open-source-2-4-2.html).
 
+{:.bs-callout-info}
+Remote storage is not supported on Cloud Commerce environemnts.
+
 ![schema image]
 
 ## Remote storage options

--- a/src/guides/v2.4/config-guide/remote-storage/config-remote-storage.md
+++ b/src/guides/v2.4/config-guide/remote-storage/config-remote-storage.md
@@ -13,7 +13,7 @@ The Remote Storage module provides the option to store media files and schedule 
 Remote storage is available in version 2.4.2 and later only. See the [2.4.2 release notes]({{page.baseurl}}/release-notes/open-source-2-4-2.html).
 
 {:.bs-callout-info}
-Remote storage is not supported on Cloud Commerce environemnts.
+Remote storage is not supported on Cloud Commerce environments.
 
 ![schema image]
 


### PR DESCRIPTION
## Purpose of this pull request

This pull request (PR) adds a note the Remote Storage functionality is not supported on Commerce Cloud

## Affected DevDocs pages

* https://devdocs.magento.com/guides/v2.4/config-guide/remote-storage/config-remote-storage.html

## Links to Magento source code

<!--  OPTIONAL - REMOVE THIS SECTION IF NOT USED. If this pull request references a file in a Magento codebase repository, add it here. -->

-  ...

<!--
If you are fixing a GitHub issue, note it using GitHub keyword format (https://help.github.com/en/articles/closing-issues-using-keywords#closing-an-issue-in-a-different-repository) to close the issue when this pull request is merged. Example: `Fixes #1234`

`master` is the default branch. Merged pull requests to `master` go live on the site automatically. Any requested changes to content on the `master` branch must be related to the released codebase. Any content related to future releases goes in the `develop` branch.

See Contribution guidelines (https://github.com/magento/devdocs/blob/master/.github/CONTRIBUTING.md) for more information.
-->
