### PR TITLE
Fix small typo in example

### DIFF
--- a/src/guides/v2.3/extension-dev-guide/extension_attributes/adding-attributes.md
+++ b/src/guides/v2.3/extension-dev-guide/extension_attributes/adding-attributes.md
@@ -115,7 +115,7 @@ public function afterSave
     $ourCustomData = $extensionAttributes->getOurCustomData();
     $this->customDataRepository->save($ourCustomData);
 
-    $resultAttributes = $result->getExtentionAttributes(); /** get extension attributes as they exist after save **/
+    $resultAttributes = $result->getExtensionAttributes(); /** get extension attributes as they exist after save **/
     $resultAttributes->setOurCustomData($ourCustomData); /** update the extension attributes with correct data **/
     $result->setExtensionAttributes($resultAttributes);
 


### PR DESCRIPTION
## Purpose of this pull request

This pull request (PR) fixes a small typo in an example on extension attributes.

## Affected DevDocs pages

https://devdocs.magento.com/guides/v2.3/extension-dev-guide/extension_attributes/adding-attributes.html
https://devdocs.magento.com/guides/v2.4/extension-dev-guide/extension_attributes/adding-attributes.html