### PR TITLE
Override all conflicting custom values with the expected Magento default values for command line upgrade

### DIFF
--- a/src/guides/v2.3/comp-mgr/cli/cli-upgrade.md
+++ b/src/guides/v2.3/comp-mgr/cli/cli-upgrade.md
@@ -76,6 +76,8 @@ See the examples at the end of this section for help specifying different releas
    The first time you upgrade using the plugin, you can interactively view and update any out-of-date values that may be remaining from previous versions.
    To enable this, use the `--interactive-magento-conflicts` option on the `composer require` commands.
 
+   To override all conflicting custom values with the expected Magento values, re-run the `composer require` command with the `--use-default-magento-values` option.
+
    {:.bs-callout-tip}
    Use `composer require --help` to learn more about available options.
    To learn more about usage of the plugin, refer to the [Plugin Usage](https://github.com/magento/composer-root-update-plugin/blob/0.1/src/Magento/ComposerRootUpdatePlugin/README.md#usage).

--- a/src/guides/v2.4/comp-mgr/cli/cli-upgrade.md
+++ b/src/guides/v2.4/comp-mgr/cli/cli-upgrade.md
@@ -78,6 +78,8 @@ See the examples at the end of this section for help specifying different releas
    The first time you upgrade using the plugin, you can interactively view and update any out-of-date values that may be remaining from previous versions.
    To enable this, use the `--interactive-magento-conflicts` option on the `composer require` commands.
 
+   To override all conflicting custom values with the expected Magento values, re-run the `composer require` command with the `--use-default-magento-values` option.
+
    {:.bs-callout-tip}
    Use `composer require --help` to learn more about available options.
    To learn more about usage of the plugin, refer to the [Plugin Usage](https://github.com/magento/composer-root-update-plugin/blob/0.1/src/Magento/ComposerRootUpdatePlugin/README.md#usage).


### PR DESCRIPTION

## Purpose of this pull request

This pull request (PR) ...
Override all conflicting custom values with the expected Magento default values for command-line upgrade
## Affected DevDocs pages

<!-- REQUIRED List the affected pages on devdocs.magento.com (URLs). Not needed for large numbers of files. -->

-  ...

## Links to Magento source code

<!--  OPTIONAL - REMOVE THIS SECTION IF NOT USED. If this pull request references a file in a Magento codebase repository, add it here. -->

-  ...

<!--
If you are fixing a GitHub issue, note it using GitHub keyword format (https://help.github.com/en/articles/closing-issues-using-keywords#closing-an-issue-in-a-different-repository) to close the issue when this pull request is merged. Example: `Fixes #1234`

`master` is the default branch. Merged pull requests to `master` go live on the site automatically. Any requested changes to content on the `master` branch must be related to the released codebase. Any content related to future releases goes in the `develop` branch.

See Contribution guidelines (https://github.com/magento/devdocs/blob/master/.github/CONTRIBUTING.md) for more information.
-->
