### PR TITLE
Fix small typo in MediaGalleryCatalog content

### DIFF
--- a/src/_data/codebase/v2_4/mrg/module-media-gallery-catalog.yml
+++ b/src/_data/codebase/v2_4/mrg/module-media-gallery-catalog.yml
@@ -2,7 +2,7 @@
 title: MediaGalleryCatalog
 release: 2.4.3
 content: |-
-  The Magento_MediaGalleryCatalog module is responsible for for catalog gallery processor delete operation handling
+  The Magento_MediaGalleryCatalog module is responsible for catalog gallery processor delete operation handling
 
   ## Installation details
 


### PR DESCRIPTION
## Purpose of this pull request

This pull request (PR) ...
Fix small typo in MediaGalleryCatalog content
## Affected DevDocs pages

<!-- REQUIRED List the affected pages on devdocs.magento.com (URLs). Not needed for large numbers of files. -->

-  ...

## Links to Magento source code

<!--  OPTIONAL - REMOVE THIS SECTION IF NOT USED. If this pull request references a file in a Magento codebase repository, add it here. -->

-  ...

<!--
If you are fixing a GitHub issue, note it using GitHub keyword format (https://help.github.com/en/articles/closing-issues-using-keywords#closing-an-issue-in-a-different-repository) to close the issue when this pull request is merged. Example: `Fixes #1234`

`master` is the default branch. Merged pull requests to `master` go live on the site automatically. Any requested changes to content on the `master` branch must be related to the released codebase. Any content related to future releases goes in the `develop` branch.

See Contribution guidelines (https://github.com/magento/devdocs/blob/master/.github/CONTRIBUTING.md) for more information.
-->
