### PR TITLE
Fixed variable declaration error in code example

### DIFF
--- a/src/guides/v2.3/howdoi/custom-attributes/text-field.md
+++ b/src/guides/v2.3/howdoi/custom-attributes/text-field.md
@@ -229,22 +229,22 @@ class ExternalId implements DataPatchInterface
     /**
      * @var ModuleDataSetupInterface
      */
-    private ModuleDataSetupInterface $moduleDataSetup;
+    private $moduleDataSetup;
 
     /**
      * @var CustomerSetup
      */
-    private CustomerSetup $customerSetup;
+    private $customerSetup;
 
     /**
      * @var AttributeResource
      */
-    private AttributeResource $attributeResource;
+    private $attributeResource;
 
     /**
      * @var LoggerInterface
      */
-    private LoggerInterface $logger;
+    private $logger;
 
     /**
      * Constructor


### PR DESCRIPTION
## Purpose of this pull request

This pull request for fixes errors in the code example

## Affected DevDocs pages

-  https://devdocs.magento.com/guides/v2.3/howdoi/custom-attributes/text-field.html
-  https://devdocs.magento.com/guides/v2.4/howdoi/custom-attributes/text-field.html

## Description

Error throws when run the example code

## Actual result

```syntax error, unexpected 'ModuleDataSetupInterface' (T_STRING), expecting function (T_FUNCTION) or const (T_CONST)#0 /var/www/html/magentoEE/vendor/composer/ClassLoader.php(322): Composer\Autoload\includeFile('/var/www/html/m...')```

## Expected result

`bin/magento setup:upgrade` command should be executed successfully 


