### PR TITLE
Update invalid links on the SampleData page

### DIFF
--- a/src/_data/codebase/v2_3/mrg/ce/SampleData.yml
+++ b/src/_data/codebase/v2_3/mrg/ce/SampleData.yml
@@ -45,7 +45,7 @@ content: |-
 
   Where `<version>` is the version of the packages; it should correspond to the version of the Magento instance.
 
-  Each package corresponds to a sample data module. The complete list of available modules can be viewed in the [sample data GitHub repository] (https://github.com/magento/magento2-sample-data/tree/develop/app/code/Magento)
+  Each package corresponds to a sample data module. The complete list of available modules can be viewed in the [sample data GitHub repository](https://github.com/magento/magento2-sample-data/tree/2.4-develop/app/code/Magento)
 
   2. To update the dependencies, in the Magento root directory, run: `# composer update`
 

--- a/src/_data/codebase/v2_4/mrg/module-sample-data.yml
+++ b/src/_data/codebase/v2_4/mrg/module-sample-data.yml
@@ -42,7 +42,7 @@ content: |-
 
   Where `<version>` is the version of the packages; it should correspond to the version of the Magento instance.
 
-  Each package corresponds to a sample data module. The complete list of available modules can be viewed in the [sample data GitHub repository] (https://github.com/magento/magento2-sample-data/tree/develop/app/code/Magento)
+  Each package corresponds to a sample data module. The complete list of available modules can be viewed in the [sample data GitHub repository](https://github.com/magento/magento2-sample-data/tree/2.4-develop/app/code/Magento)
 
   2. To update the dependencies, in the Magento root directory, run: `# composer update`
 


### PR DESCRIPTION
## Purpose of this pull request

This pull request updates invalid links on the SampleData page

## Affected DevDocs pages

https://devdocs.magento.com/guides/v2.4/mrg/module-sample-data.html?itm_source=devdocs&itm_medium=search_page&itm_campaign=federated_search&itm_term=https%3A%2F%2Fgithub