### PR TITLE
Add example for reset user 2FA configuration command for 2.3 and 2.4

### DIFF
--- a/src/guides/v2.3/security/two-factor-authentication.md
+++ b/src/guides/v2.3/security/two-factor-authentication.md
@@ -63,13 +63,13 @@ If you need to manually reset a single user configuration, enter the following c
 bin/magento msp:security:tfa:reset <username> <provider>
 ```
 
-For example
+For example:
 
-`bin/magento msp:security:tfa:reset admin google`
+```bash
+bin/magento msp:security:tfa:reset admin google
 
-`bin/magento msp:security:tfa:reset admin u2fkey`
-
-`bin/magento msp:security:tfa:reset admin authy`
+bin/magento msp:security:tfa:reset admin u2fkey
+```
 
 ### Advanced emergency steps
 

--- a/src/guides/v2.3/security/two-factor-authentication.md
+++ b/src/guides/v2.3/security/two-factor-authentication.md
@@ -63,6 +63,14 @@ If you need to manually reset a single user configuration, enter the following c
 bin/magento msp:security:tfa:reset <username> <provider>
 ```
 
+For example
+
+`bin/magento msp:security:tfa:reset admin google`
+
+`bin/magento msp:security:tfa:reset admin u2fkey`
+
+`bin/magento msp:security:tfa:reset admin authy`
+
 ### Advanced emergency steps
 
 {:.bs-callout-warning}

--- a/src/guides/v2.4/security/two-factor-authentication.md
+++ b/src/guides/v2.4/security/two-factor-authentication.md
@@ -105,13 +105,13 @@ If you need to manually reset a single user configuration, enter the following c
 bin/magento security:tfa:reset <user> <provider>
 ```
 
-For example
+For example:
 
-`bin/magento security:tfa:reset admin google`
+```bash
+bin/magento msp:security:tfa:reset admin google
 
-`bin/magento security:tfa:reset admin u2fkey`
-
-`bin/magento security:tfa:reset admin authy`
+bin/magento msp:security:tfa:reset admin u2fkey
+```
 
 ### Advanced emergency steps
 

--- a/src/guides/v2.4/security/two-factor-authentication.md
+++ b/src/guides/v2.4/security/two-factor-authentication.md
@@ -105,6 +105,14 @@ If you need to manually reset a single user configuration, enter the following c
 bin/magento security:tfa:reset <user> <provider>
 ```
 
+For example
+
+`bin/magento security:tfa:reset admin google`
+
+`bin/magento security:tfa:reset admin u2fkey`
+
+`bin/magento security:tfa:reset admin authy`
+
 ### Advanced emergency steps
 
 {:.bs-callout-warning}


### PR DESCRIPTION
## Purpose of this pull request

This pull request (PR) ...
Add example for reset user 2FA configuration command for 2.3 and 2.4

## Affected DevDocs pages

<!-- REQUIRED List the affected pages on devdocs.magento.com (URLs). Not needed for large numbers of files. -->

- https://devdocs.magento.com/guides/v2.4/security/two-factor-authentication.html
- https://devdocs.magento.com/guides/v2.3/security/two-factor-authentication.html


## Links to Magento source code

<!--  OPTIONAL - REMOVE THIS SECTION IF NOT USED. If this pull request references a file in a Magento codebase repository, add it here. -->

-  ...

<!--
If you are fixing a GitHub issue, note it using GitHub keyword format (https://help.github.com/en/articles/closing-issues-using-keywords#closing-an-issue-in-a-different-repository) to close the issue when this pull request is merged. Example: `Fixes #1234`

`master` is the default branch. Merged pull requests to `master` go live on the site automatically. Any requested changes to content on the `master` branch must be related to the released codebase. Any content related to future releases goes in the `develop` branch.

See Contribution guidelines (https://github.com/magento/devdocs/blob/master/.github/CONTRIBUTING.md) for more information.
-->
