### PR TITLE
remove preceding `$` from opcache config examples

### DIFF
--- a/src/guides/v2.4/performance-best-practices/software.md
+++ b/src/guides/v2.4/performance-best-practices/software.md
@@ -76,19 +76,19 @@ realpath_cache_ttl=7200
 
 To get maximum speed out of Magento 2 on PHP 7, you must activate the OpCache module and properly configure it. These settings are recommended for the module:
 
-```bash
-  opcache.memory_consumption=512MB
-  opcache.max_accelerated_files=60000
-  opcache.consistency_checks=0
-  opcache.validate_timestamps=0
-  opcache.enable_cli=1
+```text
+opcache.memory_consumption=512MB
+opcache.max_accelerated_files=60000
+opcache.consistency_checks=0
+opcache.validate_timestamps=0
+opcache.enable_cli=1
 ```
 
 When you fine-tune the memory allocation for opcache, take into account the size of Magento’s code base and all your extensions. Magento’s performance team uses the values in the preceding example for testing because it provides enough space in opcache for the average number of installed extensions.
 
 If you have a low-memory machine and you do not have many extensions or customizations installed, use the following settings to get a similar result:
 
-```bash
+```text
 opcache.memory_consumption=64
 opcache.max_accelerated_files=60000
 ```


### PR DESCRIPTION
## Purpose of this pull request

this is to remove preceding `$` from the opcache configuration examples

## Affected DevDocs pages

- https://devdocs.magento.com/guides/v2.4/performance-best-practices/software.html#php-settings
