### PR TITLE
Updated env reference with cache and system node

### DIFF
--- a/src/guides/v2.4/config-guide/prod/config-reference-envphp.md
+++ b/src/guides/v2.4/config-guide/prod/config-reference-envphp.md
@@ -26,8 +26,8 @@ The `env.php` file contains the following sections:
 | `queue`                       | [Message queues][message-queues] settings                       |
 | `resource`                    | Mapping of resource name to a connection                        |
 | `session`                     | Session storage data                                            |
+| `system`                      | Disables the field for editing in the admin                     |
 | `x-frame-options`             | Setting for [x-frame-options][x-frame-options]                  |
-| `system`                      | Disables the field for editing in Admin                         |
 
 ## backend
 


### PR DESCRIPTION
## Purpose of this pull request

This pull request (PR) to update the missing node (cache, system) in `app/etc/env.php`

## Affected DevDocs pages

https://devdocs.magento.com/guides/v2.4/config-guide/prod/config-reference-envphp.html

## Additional Information
#8854 - Seems this PR merged in V2.3, not in V2.4.

whatsnew
Added the "cache" and "system"  descriptions to the [env.php reference](https://devdocs.magento.com/guides/v2.4/config-guide/prod/config-reference-envphp.html) topic.