### PR TITLE
Update 2-3-7-p2.md

### DIFF
--- a/src/guides/v2.3/release-notes/2-3-7-p2.md
+++ b/src/guides/v2.3/release-notes/2-3-7-p2.md
@@ -37,7 +37,7 @@ This release includes fixes for the following known issues, which were first ide
 
 **Recent penetration test vulnerabilities** have been fixed in this release. <!--- MC-42431-->
 
-The Content Security Policy directive `frame-ancestors` now supports the source expression `unsafe-inline`.  [GitHub-33101](https://github.com/magento/magento2/issues/33101) <!--- MC-42632-->
+The unsupported source expression `'unsafe-inline'`, has been removed from the Content Security Policy directive `frame-ancestors`. [GitHub-33101](https://github.com/magento/magento2/issues/33101) <!--- MC-42632-->
 
 ## Known issue
 


### PR DESCRIPTION
Phrasing
> The Content Security Policy directive `frame-ancestors` now supports the source expression `unsafe-inline`

is totally incorrect, because in MDN Web Docs it literally says:
> Note: The `frame-ancestors` directive's syntax is similar to a source list of other directives (e.g. default-src), but **doesn't allow `'unsafe-eval'` or `'unsafe-inline'`** for example. It will also not fall back to a `default-src` setting.

See: https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Content-Security-Policy/frame-ancestors

## Purpose of this pull request

This pull request (PR) fixes misleading statement in release notes for 2.3.7-p2.

## Affected DevDocs pages

<!-- REQUIRED List the affected pages on devdocs.magento.com (URLs). Not needed for large numbers of files. -->

-  https://devdocs.magento.com/guides/v2.3/release-notes/2-3-7-p2.html

<!--
If you are fixing a GitHub issue, note it using GitHub keyword format (https://help.github.com/en/articles/closing-issues-using-keywords#closing-an-issue-in-a-different-repository) to close the issue when this pull request is merged. Example: `Fixes #1234`

`master` is the default branch. Merged pull requests to `master` go live on the site automatically. Any requested changes to content on the `master` branch must be related to the released codebase. Any content related to future releases goes in the `develop` branch.

See Contribution guidelines (https://github.com/magento/devdocs/blob/master/.github/CONTRIBUTING.md) for more information.
-->