### PR TITLE
Add input_type to customAttributeMetadata query

### DIFF
--- a/src/guides/v2.3/graphql/functional-testing.md
+++ b/src/guides/v2.3/graphql/functional-testing.md
@@ -55,6 +55,7 @@ class ProductAttributeTypeTest extends GraphQlAbstract
       attribute_code
       attribute_type
       entity_type
+      input_type
     }
   }
  }
@@ -75,7 +76,8 @@ QUERY;
             \Magento\Catalog\Api\Data\ProductInterface::class
         ];
         $attributeTypes = ['String', 'Int', 'Float','Boolean', 'Float'];
-        $this->assertAttributeType($attributeTypes, $expectedAttributeCodes, $entityType, $response);
+        $inputTypes = ['textarea', 'select', 'price', 'boolean', 'price'];
+        $this->assertAttributeType($attributeTypes, $expectedAttributeCodes, $entityType, $inputTypes, $response);
     }
 ```
 


### PR DESCRIPTION
## Purpose of this pull request

This pull request (PR) will add input_type to customAttributeMetadata query.

## Affected DevDocs pages

<!-- REQUIRED List the affected pages on devdocs.magento.com (URLs). Not needed for large numbers of files. -->

- https://devdocs.magento.com/guides/v2.3/graphql/functional-testing.html
- https://devdocs.magento.com/guides/v2.4/graphql/functional-testing.html

## Links to Magento source code

<!--  OPTIONAL - REMOVE THIS SECTION IF NOT USED. If this pull request references a file in a Magento codebase repository, add it here. -->

- https://github.com/magento/magento2/commit/ab3b7d8d4ea35e5728a20a6916d00b25093c937a

<!--
If you are fixing a GitHub issue, note it using GitHub keyword format (https://help.github.com/en/articles/closing-issues-using-keywords#closing-an-issue-in-a-different-repository) to close the issue when this pull request is merged. Example: `Fixes #1234`

`master` is the default branch. Merged pull requests to `master` go live on the site automatically. Any requested changes to content on the `master` branch must be related to the released codebase. Any content related to future releases goes in the `develop` branch.

See Contribution guidelines (https://github.com/magento/devdocs/blob/master/.github/CONTRIBUTING.md) for more information.
-->
