### PR TITLE
Adding reference to db table in documentation

### DIFF
--- a/src/guides/v2.3/inventory/inventory-cli-reference.md
+++ b/src/guides/v2.3/inventory/inventory-cli-reference.md
@@ -32,7 +32,7 @@ These commands include:
 -  Refund order or issue a credit memo (compensation reservation)
 -  Order cancellation (compensation reservation)
 
-Reservation inconsistencies may occur when {{site.data.var.im}} loses the initial reservation and enters too many reservation compensations (overcompensating and leading to inconsistent amounts), or correctly places the initial reservation but loses compensational reservations. Reservations can be manually reviewed and checked in the table `inventory_reservation`.
+Reservation inconsistencies may occur when {{site.data.var.im}} loses the initial reservation and enters too many reservation compensations (overcompensating and leading to inconsistent amounts), or correctly places the initial reservation but loses compensational reservations. Reservations can be manually reviewed and checked in the `inventory_reservation` table.
 
 The following configurations and events can cause reservation inconsistencies:
 


### PR DESCRIPTION
## Purpose of this pull request

This pull request (PR) add reference to the corresponding db table, that should make it easier for developers to find the source of root causes when debugging inventory reservations.

## Affected DevDocs pages

<!-- REQUIRED List the affected pages on devdocs.magento.com (URLs). Not needed for large numbers of files. -->

-  https://devdocs.magento.com/guides/v2.4/inventory/inventory-cli-reference.html

## Links to Magento source code

<!--  OPTIONAL - REMOVE THIS SECTION IF NOT USED. If this pull request references a file in a Magento codebase repository, add it here. -->

-  ...

<!--
If you are fixing a GitHub issue, note it using GitHub keyword format (https://help.github.com/en/articles/closing-issues-using-keywords#closing-an-issue-in-a-different-repository) to close the issue when this pull request is merged. Example: `Fixes #1234`

`master` is the default branch. Merged pull requests to `master` go live on the site automatically. Any requested changes to content on the `master` branch must be related to the released codebase. Any content related to future releases goes in the `develop` branch.

See Contribution guidelines (https://github.com/magento/devdocs/blob/master/.github/CONTRIBUTING.md) for more information.
-->
