### PR TITLE
Added description for reindex in parallel mode command

### DIFF
--- a/src/guides/v2.3/config-guide/cli/config-cli-subcommands-index.md
+++ b/src/guides/v2.3/config-guide/cli/config-cli-subcommands-index.md
@@ -135,8 +135,6 @@ These indexes can be run in parallel mode:
 -  'Category Product' can be paralleled by store views.
 -  'Catalog Price' can be paralleled by website and customer groups.
 
-By default, Catalog Price does not use a partitioning into dimension.
-
 If you want to use parallelization, you need to set one of the available modes of dimensions for the product price indexer:
 
 -  `none` (default)

--- a/src/guides/v2.3/config-guide/cli/config-cli-subcommands-index.md
+++ b/src/guides/v2.3/config-guide/cli/config-cli-subcommands-index.md
@@ -66,11 +66,11 @@ Sample result:
 | Catalog Product Rule | Reindex required | Save      |                     |                     |
 | Catalog Rule Product | Reindex required | Save      |                     |                     |
 | Catalog Search       | Ready            | Save      |                     |                     |
-| Category Products    | Reindex required | Schedule  | idle (0 in backlog) | 2018-06-28 09:45:53 |
-| Customer Grid        | Ready            | Schedule  | idle (0 in backlog) | 2018-06-28 09:45:52 |
+| Category Products    | Reindex required | Schedule  | idle (0 in backlog) | 2021-06-28 09:45:53 |
+| Customer Grid        | Ready            | Schedule  | idle (0 in backlog) | 2021-06-28 09:45:52 |
 | Design Config Grid   | Ready            | Schedule  | idle (0 in backlog) | 2018-06-28 09:45:52 |
 | Inventory            | Ready            | Save      |                     |
-| Product Categories   | Reindex required | Schedule  | idle (0 in backlog) | 2018-06-28 09:45:53 |
+| Product Categories   | Reindex required | Schedule  | idle (0 in backlog) | 2021-06-28 09:45:53 |
 | Product EAV          | Reindex required | Save      |                     |                     |
 | Product Price        | Reindex required | Save      |                     |                     |
 | Stock                | Reindex required | Save      |                     |                     |
@@ -127,6 +127,8 @@ Reindexing all indexers can take a long time for stores with large numbers of pr
 
 Indexers are scoped and multi-threaded to support reindexing in parallel mode. It parallelizes by the indexer’s dimension and executes across multiple threads, reducing processing time.
 
+In this context, 'dimension' is the scope of the reindexing, for instance a `website` or just a specific `customer_group`.
+
 Index parallelization can affect only the indexers which are scoped, which means Magento splits the data into multiple tables using the indexer as its scope instead of keeping all data in one table.
 
 These indexes can be run in parallel mode:
@@ -142,13 +144,13 @@ If you want to use parallelization, you need to set one of the available modes o
 -  `customer_group`
 -  `website_and_customer_group`
 
-For example, to set the mode by website run:
+For example, to set the mode per website:
 
 ```bash
 bin/magento indexer:set-dimensions-mode catalog_product_price website
 ```
 
-To check the current mode you can use the command:
+Or to check the current mode:
 
 ```bash
 bin/magento indexer:show-dimensions-mode

--- a/src/guides/v2.3/config-guide/cli/config-cli-subcommands-index.md
+++ b/src/guides/v2.3/config-guide/cli/config-cli-subcommands-index.md
@@ -123,6 +123,45 @@ Catalog Search index has been rebuilt successfully in <time>
 {:.bs-callout-info}
 Reindexing all indexers can take a long time for stores with large numbers of products, customers, categories, and promotional rules.
 
+### Reindex in parallel mode
+
+Indexers are scoped and multi-threaded to support reindexing in parallel mode. This feature reduces processing time. It parallelizes by the indexer’s dimension and executes across multiple threads.
+
+These indexes can be run in parallel mode:
+
+-  Catalog Search Fulltext can be paralleled by store views.
+-  Category Product can be paralleled by store views.
+-  Catalog Price can be paralleled by website and customer groups.
+
+By default, Catalog Price does not use a partitioning into dimension.
+
+If you want to use parallelization you need to set one of available modes of dimensions for product price indexer:
+
+-  `none` (default)
+-  `website`
+-  `customer_group`
+-  `website_and_customer_group`
+
+For example, to set the mode by website run:
+
+```bash
+bin/magento indexer:set-dimensions-mode catalog_product_price website
+```
+
+To check the current mode you can use next command:
+
+```bash
+bin/magento indexer:show-dimensions-mode
+```
+
+To reindex in parallel mode, run the reindex command using the environment variable `MAGE_INDEXER_THREADS_COUNT`, or add an environment variable to `env.php`. This variable sets the number of threads for the reindex processing.
+
+For example, the following command runs the Catalog Search Fulltext indexer across three threads:
+
+```bash
+MAGE_INDEXER_THREADS_COUNT=3 php -f bin/magento indexer:reindex catalogsearch_fulltext
+```
+
 ## Reset indexer
 
 Use this command to invalidate the status of all indexers or specific indexers.

--- a/src/guides/v2.3/config-guide/cli/config-cli-subcommands-index.md
+++ b/src/guides/v2.3/config-guide/cli/config-cli-subcommands-index.md
@@ -123,21 +123,21 @@ Catalog Search index has been rebuilt successfully in <time>
 {:.bs-callout-info}
 Reindexing all indexers can take a long time for stores with large numbers of products, customers, categories, and promotional rules.
 
-### Reindex in parallel mode
+### Reindexing in parallel mode
 
-As of Magento 2.2.6 or later, Indexers are scoped and multi-threaded to support reindexing in parallel mode. This feature reduces processing time. It parallelizes by the indexer’s dimension and executes across multiple threads.
+Indexers are scoped and multi-threaded to support reindexing in parallel mode. It parallelizes by the indexer’s dimension and executes across multiple threads, reducing processing time.
 
-Index parallelization can affect only the indexers which are scoped, which means Magento split the data into multiple tables by indexer as its scope instead of keeping all data in one table.
+Index parallelization can affect only the indexers which are scoped, which means Magento splits the data into multiple tables using the indexer as its scope instead of keeping all data in one table.
 
 These indexes can be run in parallel mode:
 
--  Catalog Search Fulltext can be paralleled by store views.
--  Category Product can be paralleled by store views.
--  Catalog Price can be paralleled by website and customer groups.
+-  'Catalog Search Fulltext' can be paralleled by store views.
+-  'Category Product' can be paralleled by store views.
+-  'Catalog Price' can be paralleled by website and customer groups.
 
 By default, Catalog Price does not use a partitioning into dimension.
 
-If you want to use parallelization you need to set one of the available modes of dimensions for the product price indexer:
+If you want to use parallelization, you need to set one of the available modes of dimensions for the product price indexer:
 
 -  `none` (default)
 -  `website`
@@ -158,7 +158,7 @@ bin/magento indexer:show-dimensions-mode
 
 To reindex in parallel mode, run the reindex command using the environment variable `MAGE_INDEXER_THREADS_COUNT`, or add an environment variable to `env.php`. This variable sets the number of threads for the reindex processing.
 
-For example, the following command runs the Catalog Search Fulltext indexer across three threads:
+For example, the following command runs the 'Catalog Search Fulltext' indexer across three threads:
 
 ```bash
 MAGE_INDEXER_THREADS_COUNT=3 php -f bin/magento indexer:reindex catalogsearch_fulltext

--- a/src/guides/v2.3/config-guide/cli/config-cli-subcommands-index.md
+++ b/src/guides/v2.3/config-guide/cli/config-cli-subcommands-index.md
@@ -125,7 +125,9 @@ Reindexing all indexers can take a long time for stores with large numbers of pr
 
 ### Reindex in parallel mode
 
-Indexers are scoped and multi-threaded to support reindexing in parallel mode. This feature reduces processing time. It parallelizes by the indexer’s dimension and executes across multiple threads.
+As of Magento 2.2.6 or later, Indexers are scoped and multi-threaded to support reindexing in parallel mode. This feature reduces processing time. It parallelizes by the indexer’s dimension and executes across multiple threads.
+
+Index parallelization can affect only the indexers which are scoped, which means Magento split the data into multiple tables by indexer as its scope instead of keeping all data in one table.
 
 These indexes can be run in parallel mode:
 
@@ -135,7 +137,7 @@ These indexes can be run in parallel mode:
 
 By default, Catalog Price does not use a partitioning into dimension.
 
-If you want to use parallelization you need to set one of available modes of dimensions for product price indexer:
+If you want to use parallelization you need to set one of the available modes of dimensions for the product price indexer:
 
 -  `none` (default)
 -  `website`
@@ -148,7 +150,7 @@ For example, to set the mode by website run:
 bin/magento indexer:set-dimensions-mode catalog_product_price website
 ```
 
-To check the current mode you can use next command:
+To check the current mode you can use the command:
 
 ```bash
 bin/magento indexer:show-dimensions-mode


### PR DESCRIPTION
## Purpose of this pull request

This pull request helps users to understand reindex in parallel mode command

## Affected DevDocs pages

-  https://devdocs.magento.com/guides/v2.4/config-guide/cli/config-cli-subcommands-index.html
- https://devdocs.magento.com/guides/v2.3/config-guide/cli/config-cli-subcommands-index.html

## Description

- Added commands and description for `Reindex in parallel mode`

whatsnew
Added the 'Reindex in parallel mode` section to the [Manage the indexers](https://devdocs.magento.com/guides/v2.4/config-guide/cli/config-cli-subcommands-index.html) topic.