### PR TITLE
Correct syntax for bs-callout-tips

### DIFF
--- a/src/contributor-guide/contributing.md
+++ b/src/contributor-guide/contributing.md
@@ -390,7 +390,7 @@ If you are sure that the problem you are experiencing is a bug, file a new issue
 
 The [Issue Reporting Template](https://github.com/magento/magento2/blob/2.3-develop/.github/ISSUE_TEMPLATE.md) is a default placeholder for every new issue. Follow the sections carefully, as it ensures it will pass `Gate 1` quickly. More information on gates is available in [Magento Issue Gates](https://github.com/magento/magento2/wiki/Magento-Issue-Gates).
 
-{.bs-callout-tip}
+{:.bs-callout-tip}
 Note that a higher level of detail in the report increases the chance that someone will be able to reproduce the issue.
 
 ### Title

--- a/src/guides/v2.3/extension-dev-guide/security/uploads.md
+++ b/src/guides/v2.3/extension-dev-guide/security/uploads.md
@@ -14,7 +14,8 @@ store the file, you only need the contents of the file to add those SKUs to a ca
 SKUs, and delete it without ever moving it from the  temporary folder on the file system. Another, even better option for security and
 performance, is to never upload the file in the first place. The file can be handled on the frontend side using JavaScript
 to extract SKUs and quantities and send those to a web API endpoint on the server.
-{.:bs-callout-tip}
+
+{:.bs-callout-tip}
 The best way to avoid security issues with files is to not upload or store them in the first place
 if you don't have to.
 


### PR DESCRIPTION
## Purpose of this pull request

On some pages, an author has intended for a paragraph to be marked up as a "callout tip", but has not used the correct syntax for this. This pull request resolves the two instances that I have noticed.

## Affected DevDocs pages
- https://devdocs.magento.com/contributor-guide/contributing.html#issue-template
- https://devdocs.magento.com/guides/v2.4/extension-dev-guide/security/uploads.html#when-you-dont-need-a-file