### PR TITLE
Correct syntax for bs-callout-info and bs-callout-warning

### DIFF
--- a/src/cloud/release-notes/cloud-release-archive.md
+++ b/src/cloud/release-notes/cloud-release-archive.md
@@ -498,7 +498,7 @@ The ece-tools version 2002.0.11 is required for 2.2.4 compatibility.
 
 ## v2002.0.9
 
-{.bs-callout-info}
+{:.bs-callout-info}
 You must [upgrade the {{site.data.var.ece}} metapackage]({{ site.baseurl }}/cloud/project/project-upgrade-parent.html) to get this and all future updates.
 
 -  {:.new}<!-- MAGECLOUD-1086 -->**ece-tools**—The `{{site.data.var.ct}}` package now supports {{site.data.var.ee}} 2.1.x.

--- a/src/guides/v2.3/howdoi/checkout/checkout_order.md
+++ b/src/guides/v2.3/howdoi/checkout/checkout_order.md
@@ -113,7 +113,7 @@ In this file, add the following:
 
 ## Step 4: Deploy static content and clean cache
 
-{.bs-callout-info}
+{:.bs-callout-info}
 These commands are for production mode. They are not necessary when in developer mode.
 
 1. Deploy static content:

--- a/src/guides/v2.4/config-guide/mq/aws-mq.md
+++ b/src/guides/v2.4/config-guide/mq/aws-mq.md
@@ -36,7 +36,7 @@ where:
 *  `user`—The username value entered when creating the AWS MQ broker
 *  `password`—The password value entered when creating the AWS MQ broker
 
-{.bs-callout-info}
+{:.bs-callout-info}
 Amazon MQ supports TLS connections only. Peer verification is not supported.
 
 After editing the `env.php` file, run the following command to finish the setup:

--- a/src/guides/v2.4/config-guide/redis/redis-pg-cache.md
+++ b/src/guides/v2.4/config-guide/redis/redis-pg-cache.md
@@ -101,7 +101,7 @@ As a result of the two example commands, Magento adds lines similar to the follo
 
 As of Magento 2.4.3, Magento instances hosted on Amazon EC2 may use an AWS ElastiCache in place of a local Redis instance.
 
-{.bs-callout-warning}
+{:.bs-callout-warning}
 This section only works for Magento instances running on Amazon EC2 VPCs. It does not work for on-premises installations.
 
 ### Configure a Redis cluster


### PR DESCRIPTION
## Purpose of this pull request

When creating https://github.com/magento/devdocs/pull/9218 I was too narrowly focused on `bs-callout-tip` and missed other cases of the same problem. This pull request fixes all errors of this class that I could find.

## Affected DevDocs pages

- https://devdocs.magento.com/cloud/release-notes/cloud-release-archive.html#v200209
- https://devdocs.magento.com/guides/v2.4/howdoi/checkout/checkout_order.html#step-4-deploy-static-content-and-clean-cache
- https://devdocs.magento.com/guides/v2.4/config-guide/mq/aws-mq.html#configure-magento-for-aws-mq
- https://devdocs.magento.com/guides/v2.4/config-guide/redis/redis-pg-cache.html#using-aws-elasticache-with-your-ec2-instance