### PR TITLE
Change `:version` to `:hash` for L2 caching docs

### DIFF
--- a/src/guides/v2.3/config-guide/cache/two-level-cache.md
+++ b/src/guides/v2.3/config-guide/cache/two-level-cache.md
@@ -14,7 +14,7 @@ To reduce the network bandwidth to Redis, we can store cache data locally on eac
 -  To check the cache data version, ensuring we have the latest cache stored locally.
 -  If the data is out of date, transfer the latest cache from the remote machine to the local machine.
 
-Magento stores the hashed data version in Redis, with the suffix ':version' appended to the regular key. In case of an outdated local cache, the data is transferred to the local machine with a cache adapter.
+Magento stores the hashed data version in Redis, with the suffix ':hash' appended to the regular key. In case of an outdated local cache, the data is transferred to the local machine with a cache adapter.
 
 ## Configuration example
 
@@ -58,4 +58,4 @@ Where:
 -  `cache_dir` is a directory where the local cache will be stored. It is suggested to use `/dev/shm/`.
 
 We recommend the use of Redis for remote caching - `\Magento\Framework\Cache\Backend\Redis`, and the File cache implementation - `Cm_Cache_Backend_File` as the local cache.
-We also recommend the use of the [`cache preload`]({{page.baseurl}}/config-guide/redis/redis-pg-cache.html#redis-preload-feature) feature, as it will drastically decrease the pressure on Redis. Do not forget to add suffix ':version' for preload keys.
+We also recommend the use of the [`cache preload`]({{page.baseurl}}/config-guide/redis/redis-pg-cache.html#redis-preload-feature) feature, as it will drastically decrease the pressure on Redis. Do not forget to add suffix ':hash' for preload keys.

--- a/src/guides/v2.4/config-guide/cache/two-level-cache.md
+++ b/src/guides/v2.4/config-guide/cache/two-level-cache.md
@@ -14,7 +14,7 @@ To reduce the network bandwidth to Redis, we can store cache data locally on eac
 -  To check the cache data version, ensuring we have the latest cache stored locally.
 -  If the data is out of date, transfer the latest cache from the remote machine to the local machine.
 
-Magento stores the hashed data version in Redis, with the suffix ':version' appended to the regular key. In case of an outdated local cache, the data is transferred to the local machine with a cache adapter.
+Magento stores the hashed data version in Redis, with the suffix ':hash' appended to the regular key. In case of an outdated local cache, the data is transferred to the local machine with a cache adapter.
 
 ## Configuration example
 
@@ -64,7 +64,7 @@ Where:
    -  `use_stale_cache` is a flag that enables or disables the use of stale cache.
 
 We recommend using Redis for remote caching (`\Magento\Framework\Cache\Backend\Redis`) and `Cm_Cache_Backend_File` for the local caching of data in shared memory, using `'local_backend_options' => ['cache_dir' => '/dev/shm/']`.
-We also recommend the use of the [`cache preload`](https://devdocs.magento.com/guides/v2.4/config-guide/redis/redis-pg-cache.html#redis-preload-feature) feature, as it will drastically decrease the pressure on Redis. Do not forget to add suffix ':version' for preload keys.
+We also recommend the use of the [`cache preload`](https://devdocs.magento.com/guides/v2.4/config-guide/redis/redis-pg-cache.html#redis-preload-feature) feature, as it will drastically decrease the pressure on Redis. Do not forget to add suffix ':hash' for preload keys.
 
 ## Stale cache options
 


### PR DESCRIPTION
## Purpose of this pull request

This is a continuation of #9228 in order to fix the remaining few (incorrect) references to the `:version` suffix for L2 caching.

## Affected DevDocs pages

<!-- REQUIRED List the affected pages on devdocs.magento.com (URLs). Not needed for large numbers of files. -->

-  https://devdocs.magento.com/guides/v2.3/config-guide/cache/two-level-cache.html
- https://devdocs.magento.com/guides/v2.4/config-guide/cache/two-level-cache.html

## Links to Magento source code

<!--  OPTIONAL - REMOVE THIS SECTION IF NOT USED. If this pull request references a file in a Magento codebase repository, add it here. -->

- https://github.com/magento/magento2/blob/6b196b5df43f63c7364f7e193709694abca576d0/lib/internal/Magento/Framework/Cache/Backend/RemoteSynchronizedCache.php#L47
