### PR TITLE
Adding note below release calendar. Can we highlight some rows in calendar?

### DIFF
--- a/src/release/index.md
+++ b/src/release/index.md
@@ -24,6 +24,7 @@ The following table provides the dates for scheduled releases (dates are subject
 <sup>\-\- Indicates items that are not applicable to this release.</sup><br>
 <sup>1 This is the last patch release for the 2.3.x release line. The 2.3.x release line reaches End of Life (EOL) in April 2022.</sup><br>
 <sup>2 There is no full patch release in October 2022.</sup><br>
+Note: Releases highlighted in gray (Patch and Security Patch) are three opportunities for you to upgrade your core code in 2022 to keep your platform secure, reliable and performant. Feature releases will occur every other month. New releases will be available via external module or extension. Updates to independent features already implemented will happen automatically.
 
 {:.bs-callout-info}
 We have introduced a [new policy](https://magento.com/sites/default/files/magento-software-lifecycle-policy.pdf) that applies to our supported release lines. To learn more about the new strategy behind our 2022 release calendar and lifecycle policy, visit our [blog](https://magento.com/blog/accelerating-innovation-through-simplified-release-strategy).


### PR DESCRIPTION
Adding note below release calendar. Are we able to highlight the third and last two rows in the calendar?

## Purpose of this pull request

This pull request (PR) ...

## Affected DevDocs pages

<!-- REQUIRED List the affected pages on devdocs.magento.com (URLs). Not needed for large numbers of files. -->

-  ...

## Links to Magento source code

<!--  OPTIONAL - REMOVE THIS SECTION IF NOT USED. If this pull request references a file in a Magento codebase repository, add it here. -->

-  ...

<!--
If you are fixing a GitHub issue, note it using GitHub keyword format (https://help.github.com/en/articles/closing-issues-using-keywords#closing-an-issue-in-a-different-repository) to close the issue when this pull request is merged. Example: `Fixes #1234`

`master` is the default branch. Merged pull requests to `master` go live on the site automatically. Any requested changes to content on the `master` branch must be related to the released codebase. Any content related to future releases goes in the `develop` branch.

See Contribution guidelines (https://github.com/magento/devdocs/blob/master/.github/CONTRIBUTING.md) for more information.
-->
