### PR TITLE
Fix wrong XPath to `media_gallery_image_folders`

### DIFF
--- a/src/guides/v2.3/ext-best-practices/tutorials/modify-image-library-permissions/index.md
+++ b/src/guides/v2.3/ext-best-practices/tutorials/modify-image-library-permissions/index.md
@@ -5,7 +5,7 @@ title: Modify Media Library folder permissions
 
 The Magento Media Gallery gives admins the ability to upload image files in specific folders. The Storage class for images in the CMS module manages image file uploads, file retrievals, and directory creation.
 
-For security purposes, Magento provides Media Gallery access to contents in specific folders. The configuration path `system/media_storage_configuration/media_storage/allowed_resource/media_gallery_image_folders` in `config.xml` is used to define "Media Gallery Allowed" folders
+For security purposes, Magento provides Media Gallery access to contents in specific folders. The configuration path `system/media_storage_configuration/allowed_resources/media_gallery_image_folders` in `config.xml` is used to define "Media Gallery Allowed" folders
 
 By default, Magento allows Media Gallery access to the following two directories under `/pub/media`:
 


### PR DESCRIPTION
My Magento version is 2.4.3-p1.

## Purpose of this pull request

This pull request (PR) ...

## Affected DevDocs pages

<!-- REQUIRED List the affected pages on devdocs.magento.com (URLs). Not needed for large numbers of files. -->

-  ...

## Links to Magento source code

<!--  OPTIONAL - REMOVE THIS SECTION IF NOT USED. If this pull request references a file in a Magento codebase repository, add it here. -->

-  ...

<!--
If you are fixing a GitHub issue, note it using GitHub keyword format (https://help.github.com/en/articles/closing-issues-using-keywords#closing-an-issue-in-a-different-repository) to close the issue when this pull request is merged. Example: `Fixes #1234`

`master` is the default branch. Merged pull requests to `master` go live on the site automatically. Any requested changes to content on the `master` branch must be related to the released codebase. Any content related to future releases goes in the `develop` branch.

See Contribution guidelines (https://github.com/magento/devdocs/blob/master/.github/CONTRIBUTING.md) for more information.
-->
