### PR TITLE
Added a namespace to the example code

### DIFF
--- a/src/guides/v2.3/ui_comp_guide/howto/add_category_attribute.md
+++ b/src/guides/v2.3/ui_comp_guide/howto/add_category_attribute.md
@@ -14,6 +14,8 @@ The following is a full example of an install script that creates a [category](h
 ```php
 // File: Namespace/Module/Setup/InstallData.php
 
+namespace Namespace\Module\Setup;
+
 use Magento\Framework\Setup\{
     ModuleContextInterface,
     ModuleDataSetupInterface,


### PR DESCRIPTION
## Purpose of this pull request

Namespace is often forgotten to be added, leading to questions like https://stackoverflow.com/questions/60037472/my-new-category-attribute-is-not-saving-to-the-aev-table

This adds a dummy namespace, that IDE's will trigger an error on.

## Affected DevDocs pages

<!-- REQUIRED List the affected pages on devdocs.magento.com (URLs). Not needed for large numbers of files. -->
https://devdocs.magento.com/guides/v2.4/ui_comp_guide/howto/add_category_attribute.html
