### PR TITLE
add documentation for assignCustomerToGuestCart mutation

### DIFF
--- a/src/_data/toc/graphql.yml
+++ b/src/_data/toc/graphql.yml
@@ -295,6 +295,10 @@ pages:
           url: /graphql/mutations/assign-compare-list-to-customer.html
           exclude_versions: ["2.3"]
 
+        - label: assignCustomerToGuestCart mutation
+          url: /graphql/mutations/assign-customer-to-guest-cart.html
+          exclude_versions: [ "2.3" ]
+
         - label: changeCustomerPassword mutation
           url: /graphql/mutations/change-customer-password.html
 

--- a/src/guides/v2.4/graphql/mutations/assign-customer-to-guest-cart.md
+++ b/src/guides/v2.4/graphql/mutations/assign-customer-to-guest-cart.md
@@ -7,17 +7,17 @@ contributor_link: https://www.atwix.com/
 
 The `assignCustomerToGuestCart` mutation assigns a logged in customer and merge customer's shopping cart items to the specified guest shopping cart.
 
-The customer must be logged in (You must specify the customer’s authorization token in the headers).
-
 If this mutation is successful, the customer's shopping cart becomes inactive and all the products it contains are added to the contents of the guest cart (the active one).
 Customer now is assigned to that active cart.
 
-*Note:*
+{:.bs-callout-info}
 Customer cart becomes inactive and the guest cart remains active; but for guest cart new `masked_id` is being generated.
 `quote_id` remains same.
 
-The other similar mutation, [mergeCarts]({{page.baseurl}}/graphql/mutations/merge-carts.html), just merges cart items.
-Unlike `assignCustomerToGuestCart`, it transfers the contents of a guest cart into the customer's cart. The mutation deletes the original guest cart.
+This mutation requires a valid [customer authentication token]({{page.baseurl}}/graphql/mutations/generate-customer-token.html).
+
+{:.bs-callout-info}
+Use the [mergeCarts]({{page.baseurl}}/graphql/mutations/merge-carts.html) mutation to transfer the contents of a guest cart into a customer's cart.
 
 ## Syntax
 
@@ -33,7 +33,7 @@ mutation {
 
 ## Example usage
 
-Assuming that there is a logged in customer who has an item in the cart, this call will merge customer's cart item to the specified guest shopping cart (which also contains an item).
+In the following example, the customer and guest carts each contain one item. The mutation merges the customer's cart to the guest cart. As a result, the guest cart contains two items.
 
 **Request:**
 

--- a/src/guides/v2.4/graphql/mutations/assign-customer-to-guest-cart.md
+++ b/src/guides/v2.4/graphql/mutations/assign-customer-to-guest-cart.md
@@ -7,6 +7,18 @@ contributor_link: https://www.atwix.com/
 
 The `assignCustomerToGuestCart` mutation assigns a logged in customer and merge customer's shopping cart items to the specified guest shopping cart.
 
+The customer must be logged in (You must specify the customer’s authorization token in the headers).
+
+If this mutation is successful, the customer's shopping cart becomes inactive and all the products it contains are added to the contents of the guest cart (the active one).
+Customer now is assigned to that active cart.
+
+*Note:*
+Customer cart becomes inactive and the guest cart remains active; but for guest cart new `masked_id` is being generated.
+`quote_id` remains same.
+
+The other similar mutation, [mergeCarts]({{page.baseurl}}/graphql/mutations/merge-carts.html), just merges cart items.
+Unlike `assignCustomerToGuestCart`, it transfers the contents of a guest cart into the customer's cart. The mutation deletes the original guest cart.
+
 ## Syntax
 
 ```graphql
@@ -69,7 +81,7 @@ mutation {
 
 Attribute |  Data Type | Description
 --- | --- | ---
-`cart_id` | String! | The unique ID that identifies the customer's cart
+`cart_id` | String! | The unique ID that identifies the guest's cart
 
 ## Output attributes
 

--- a/src/guides/v2.4/graphql/mutations/assign-customer-to-guest-cart.md
+++ b/src/guides/v2.4/graphql/mutations/assign-customer-to-guest-cart.md
@@ -5,14 +5,10 @@ contributor_name: Atwix
 contributor_link: https://www.atwix.com/
 ---
 
-The `assignCustomerToGuestCart` mutation assigns a logged in customer and merge customer's shopping cart items to the specified guest shopping cart.
-
-If this mutation is successful, the customer's shopping cart becomes inactive and all the products it contains are added to the contents of the guest cart (the active one).
-Customer now is assigned to that active cart.
+The `assignCustomerToGuestCart` mutation merges a logged-in customer's shopping cart into the specified guest cart. The mutation inactivates the customer's shopping cart and moves the products to the guest cart. The guest cart is then assigned to the customer.
 
 {:.bs-callout-info}
-Customer cart becomes inactive and the guest cart remains active; but for guest cart new `masked_id` is being generated.
-`quote_id` remains same.
+The `masked_id` of the guest cart contains a new value. The `quote_id` remains the same.
 
 This mutation requires a valid [customer authentication token]({{page.baseurl}}/graphql/mutations/generate-customer-token.html).
 

--- a/src/guides/v2.4/graphql/mutations/assign-customer-to-guest-cart.md
+++ b/src/guides/v2.4/graphql/mutations/assign-customer-to-guest-cart.md
@@ -1,6 +1,8 @@
 ---
 group: graphql
 title: assignCustomerToGuestCart mutation
+contributor_name: Atwix
+contributor_link: https://www.atwix.com/
 ---
 
 The `assignCustomerToGuestCart` mutation assigns a logged in customer and merge customer's shopping cart items to the specified guest shopping cart.

--- a/src/guides/v2.4/graphql/mutations/assign-customer-to-guest-cart.md
+++ b/src/guides/v2.4/graphql/mutations/assign-customer-to-guest-cart.md
@@ -1,0 +1,94 @@
+---
+group: graphql
+title: assignCustomerToGuestCart mutation
+---
+
+The `assignCustomerToGuestCart` mutation assigns a logged in customer and merge customer's shopping cart items to the specified guest shopping cart.
+
+## Syntax
+
+```graphql
+mutation {
+    assignCustomerToGuestCart(
+        cart_id: String!
+    ) {
+        Cart!
+    }
+}
+```
+
+## Example usage
+
+Assuming that there is a logged in customer who has an item in the cart, this call will merge customer's cart item to the specified guest shopping cart (which also contains an item).
+
+**Request:**
+
+```graphql
+mutation {
+  assignCustomerToGuestCart(
+    cart_id: "MDYKgqIdWMKr7VD1zlYwxrB7kuX8lR5s"
+  ) {
+    items {
+      quantity
+      product {
+        sku
+      }
+    }
+  }
+}
+```
+
+**Response:**
+
+```json
+{
+  "data": {
+    "assignCustomerToGuestCart": {
+      "items": [
+        {
+          "quantity": 1,
+          "product": {
+            "sku": "customer_item"
+          }
+        },
+        {
+          "quantity": 1,
+          "product": {
+            "sku": "guest_item"
+          }
+        }
+      ]
+    }
+  }
+}
+```
+
+## Input attributes
+
+Attribute |  Data Type | Description
+--- | --- | ---
+`cart_id` | String! | The unique ID that identifies the customer's cart
+
+## Output attributes
+
+The `assignCustomerToGuestCart` mutation returns a `Cart` object.
+
+Attribute |  Data Type | Description
+--- | --- | ---
+`cart` |[Cart!](#CartObject) | Describes the contents of the specified shopping cart
+
+### Cart object {#CartObject}
+
+{% include graphql/cart-object-24.md %}
+
+[Cart query output]({{page.baseurl}}/graphql/queries/cart.html#cart-output) provides more information about the `Cart` object.
+
+## Errors
+
+Error | Description
+--- | ---
+`The current customer isn't authorized.` | The current customer is not currently logged in.
+`Unable to assign the customer to the guest cart` | The current customer can't be assigned to the provided guset cart.
+`The cart isn't active` | The cart with the specified cart ID is unavailable, because the items have been purchased and the cart ID becomes inactive.
+`Could not find a cart with ID "XXX"` | The specified `cart_id` value does not exist in the `quote_id_mask` table.
+`The current user cannot perform operations on cart "XXX"` | Tried to assign the customer to the customer's cart.

--- a/src/guides/v2.4/graphql/mutations/merge-carts.md
+++ b/src/guides/v2.4/graphql/mutations/merge-carts.md
@@ -7,6 +7,9 @@ The `mergeCarts` mutation transfers the contents of a guest cart into the cart o
 
 The mutation retains any items that were already in the logged-in customer's cart. If both the guest and customer carts contain the same item, `mergeCarts` adds the quantities. Upon success, the mutation deletes the original guest cart.
 
+There is a similar [assignCustomerToGuestCart]({{page.baseurl}}/graphql/mutations/assign-customer-to-guest-cart.html) mutation which works in a different way: it assigns a logged in customer and merge customer's shopping cart items to the guest shopping cart.
+Customer cart becomes inactive and the guest cart remains active.
+
 ## Syntax
 
 ```graphql

--- a/src/guides/v2.4/graphql/mutations/merge-carts.md
+++ b/src/guides/v2.4/graphql/mutations/merge-carts.md
@@ -7,7 +7,8 @@ The `mergeCarts` mutation transfers the contents of a guest cart into the cart o
 
 The mutation retains any items that were already in the logged-in customer's cart. If both the guest and customer carts contain the same item, `mergeCarts` adds the quantities. Upon success, the mutation deletes the original guest cart.
 
-There is a similar [assignCustomerToGuestCart]({{page.baseurl}}/graphql/mutations/assign-customer-to-guest-cart.html) mutation which works in a different way: it assigns a logged in customer and merge customer's shopping cart items to the guest shopping cart.
+{:.bs-callout-info}
+Use the [assignCustomerToGuestCart]({{page.baseurl}}/graphql/mutations/assign-customer-to-guest-cart.html) mutation to assign the contents of a logged-in customer's cart to a guest cart.
 Customer cart becomes inactive and the guest cart remains active.
 
 ## Syntax


### PR DESCRIPTION
## Purpose of this pull request

This pull request (PR) adds a documentation page for the `assignCustomerToGuestCart` mutation (GraphQL).

Magento 2 GitHub Issue: magento/magento2#32615
Magento 2 GitHub PR: magento/magento2#33106

Fixes #9248

## Affected DevDocs pages

<!-- REQUIRED List the affected pages on devdocs.magento.com (URLs). Not needed for large numbers of files. -->

-  ...

## Links to Magento source code

<!--  OPTIONAL - REMOVE THIS SECTION IF NOT USED. If this pull request references a file in a Magento codebase repository, add it here. -->

-  ...

whatsnew
Added the [`assignCustomerToGuestCart` mutation](https://devdocs.magento.com/guides/v2.4/graphql/mutations/assign-customer-to-guest-cart.html)