### PR TITLE
Magento 2.4.4 > Typo fix

### DIFF
--- a/src/guides/v2.4/release-notes/backward-incompatible-changes/index.md
+++ b/src/guides/v2.4/release-notes/backward-incompatible-changes/index.md
@@ -16,7 +16,7 @@ Disabling the inventory check can improve performance for checkout steps, especi
 *  `The requested qty is not available`
 *  `Unable to place order: Enter a valid payment method and try again.`
 *  `Unable to place order: There are no source items with the in stock status.`
-*  `The shipping method is missing. Selefct the shipping method and try again.`
+*  `The shipping method is missing. Select the shipping method and try again.`
 
 The following table contains metrics of checkout with a large amount of products (750) and additional product by guest:
 


### PR DESCRIPTION
Typo fix to the [Magento 2.4.4 backward incompatible changes page](https://devdocs-beta.magento.com/guides/v2.4/release-notes/backward-incompatible-changes/index.html).

![Screen Shot 2021-11-19 at 5 04 43 PM](https://user-images.githubusercontent.com/610598/142697433-45b91a59-3452-46f7-925c-8209b6397558.png)


