### PR TITLE
Fixed list on Extension subscriptions page

### DIFF
--- a/src/marketplace/sellers/subscriptions/extension-subscriptions.md
+++ b/src/marketplace/sellers/subscriptions/extension-subscriptions.md
@@ -13,7 +13,7 @@ Extensions sold under subscription license will include basic support into the s
 
 To learn more about buying or selling subscription-licensed extensions, visit:
 
-- [Buying Subscription-based Extensions]({{ site.baseurl }}/marketplace/sellers/subscriptions/buying-subscriptions.html)
-- [Selling Subscription-based Extensions]({{ site.baseurl }}/marketplace/sellers/subscriptions/selling-subscriptions.html)
+-  [Buying Subscription-based Extensions]({{ site.baseurl }}/marketplace/sellers/subscriptions/buying-subscriptions.html)
+-  [Selling Subscription-based Extensions]({{ site.baseurl }}/marketplace/sellers/subscriptions/selling-subscriptions.html)
 
 Thank you for using the Adobe Commerce Marketplace. For all questions and suggestions regarding extension subscriptions, please contact [Marketplace Support](https://marketplacesupport.magento.com) or find us in the [Community Slack workspace](https://opensource.magento.com/slack).

--- a/src/marketplace/sellers/subscriptions/extension-subscriptions.md
+++ b/src/marketplace/sellers/subscriptions/extension-subscriptions.md
@@ -13,7 +13,7 @@ Extensions sold under subscription license will include basic support into the s
 
 To learn more about buying or selling subscription-licensed extensions, visit:
 
--[Buying Subscription-based Extensions]({{ site.baseurl }}/marketplace/sellers/subscriptions/buying-subscriptions.html)
--[Selling Subscription-based Extensions]({{ site.baseurl }}/marketplace/sellers/subscriptions/selling-subscriptions.html)
+- [Buying Subscription-based Extensions]({{ site.baseurl }}/marketplace/sellers/subscriptions/buying-subscriptions.html)
+- [Selling Subscription-based Extensions]({{ site.baseurl }}/marketplace/sellers/subscriptions/selling-subscriptions.html)
 
 Thank you for using the Adobe Commerce Marketplace. For all questions and suggestions regarding extension subscriptions, please contact [Marketplace Support](https://marketplacesupport.magento.com) or find us in the [Community Slack workspace](https://opensource.magento.com/slack).


### PR DESCRIPTION
## Purpose of this pull request

The list containing links to sub-pages on the Extension Subscriptions page was broken while fixing linter warnings. I added spaces to fix the list.

## Affected DevDocs pages

<!-- REQUIRED List the affected pages on devdocs.magento.com (URLs). Not needed for large numbers of files. -->

-  [Extension Subscriptions](https://devdocs.magento.com/marketplace/sellers/subscriptions/extension-subscriptions.html)

<!--
If you are fixing a GitHub issue, note it using GitHub keyword format (https://help.github.com/en/articles/closing-issues-using-keywords#closing-an-issue-in-a-different-repository) to close the issue when this pull request is merged. Example: `Fixes #1234`

`master` is the default branch. Merged pull requests to `master` go live on the site automatically. Any requested changes to content on the `master` branch must be related to the released codebase. Any content related to future releases goes in the `develop` branch.

See Contribution guidelines (https://github.com/magento/devdocs/blob/master/.github/CONTRIBUTING.md) for more information.
-->
