### PR TITLE
Fix Router DI folder

### DIFF
--- a/src/guides/v2.4/extension-dev-guide/routing.md
+++ b/src/guides/v2.4/extension-dev-guide/routing.md
@@ -71,7 +71,7 @@ define the `match()` function in this class to use your own route matching logic
 
 If you need route configuration data, use the Route [`Config`] class.
 
-To add your custom router to the list of routers for the `FrontController`, add the following entry in your module's `di.xml` file:
+To add your custom router to the list of routers for the `FrontController`, add the following entry in your module's `frontend/di.xml` file:
 
 ```xml
 <type name="Magento\Framework\App\RouterList">


### PR DESCRIPTION
## Purpose of this pull request

This pull request (PR) fixes the `di.xml` folder for the routers, it has to be in `frontend` folder.

## Affected DevDocs pages

<!-- REQUIRED List the affected pages on devdocs.magento.com (URLs). Not needed for large numbers of files. -->

-  https://devdocs.magento.com/guides/v2.4/extension-dev-guide/routing.html