### PR TITLE
Add section about inspecting compressed data

### DIFF
--- a/src/_includes/config/redis-verify.md
+++ b/src/_includes/config/redis-verify.md
@@ -50,6 +50,11 @@ If you use Redis for page caching, you'll see output similar to the following:
 ... more ...
 ```
 
+### Inspect Compressed Sesssion data and Page Cache with GUI tool
+
+To easily inspect compressed Session data and Page Cache you can use [RDM](https://flathub.org/apps/details/dev.rdm.RDM)
+It supports automatic decompression of Magento 2 Session and Page cache and displays PHP session data in human-readable form.
+
 ### Redis ping command
 
 Enter the following command:

--- a/src/_includes/config/redis-verify.md
+++ b/src/_includes/config/redis-verify.md
@@ -50,10 +50,9 @@ If you use Redis for page caching, you'll see output similar to the following:
 ... more ...
 ```
 
-### Inspect Compressed Session data and Page Cache with GUI tool
+### Inspecting compressed data
 
-To easily inspect compressed Session data and Page Cache you can use [RDM](https://flathub.org/apps/details/dev.rdm.RDM)
-It supports automatic decompression of Magento 2 Session and Page cache and displays PHP session data in human-readable form.
+To inspect compressed Session data and Page Cache, the [Redis Desktop Manager](https://flathub.org/apps/details/dev.rdm.RDM) supports the automatic decompression of Magento 2 Session and Page cache and displays PHP session data in a human-readable form.
 
 ### Redis ping command
 

--- a/src/_includes/config/redis-verify.md
+++ b/src/_includes/config/redis-verify.md
@@ -50,7 +50,7 @@ If you use Redis for page caching, you'll see output similar to the following:
 ... more ...
 ```
 
-### Inspect Compressed Sesssion data and Page Cache with GUI tool
+### Inspect Compressed Session data and Page Cache with GUI tool
 
 To easily inspect compressed Session data and Page Cache you can use [RDM](https://flathub.org/apps/details/dev.rdm.RDM)
 It supports automatic decompression of Magento 2 Session and Page cache and displays PHP session data in human-readable form.


### PR DESCRIPTION
## Purpose of this pull request

This pull request (PR) adds a section on how to easily inspect compressed Session and Cache data stored in Redis.
 This task is quite common for Magento developers and this is now supported out of the box in Open Source Redis GUI
More details are here: https://github.com/uglide/RedisDesktopManager/issues/5028

## Affected DevDocs pages

<!-- REQUIRED List the affected pages on devdocs.magento.com (URLs). Not needed for large numbers of files. -->

- https://devdocs.magento.com/guides/v2.4/config-guide/redis/redis-session.html
- https://devdocs.magento.com/guides/v2.4/config-guide/redis/redis-pg-cache.html
