### PR TITLE
Document where the GraphQL schema is cached.

### DIFF
--- a/src/guides/v2.4/graphql/caching.md
+++ b/src/guides/v2.4/graphql/caching.md
@@ -5,6 +5,8 @@ title: GraphQL caching
 
 Magento can cache pages rendered from the results of certain GraphQL queries with [full-page caching]({{page.baseurl}}/extension-dev-guide/cache/page-caching.html). Full-page caching improves response time and reduces the load on the server. Without caching, each page might need to run blocks of code and retrieve large amounts of information from the database. Only queries submitted with an HTTP GET operation can be cached. POST queries cannot be cached.
 
+The GraphQL schema is cached in the Configuration cache, which can be refreshed from the Cache Management page (**System** > **Tools** > **Cache Management**).
+
 ## Cached and uncached queries
 
 The definitions for some queries include cache tags. Full page caching uses these tags to keep track of cached content. They also allow public content to be invalidated. Private content invalidation is handled on the client side.
@@ -151,7 +153,3 @@ Magento invalidates the cache when any of the following events occur:
 *  The `Preview-Version` header is specified in a query that supports caching.
 *  The system configuration changes.
 *  An administrator flushes or disables the cache from the Admin or with the `bin/magento cache` command.
-
-### GraphQL Schema
-
-The GraphQL schema is cached in the Configuration cache, which can be refreshed from the Cache Management page (System > Tools > Cache Management).

--- a/src/guides/v2.4/graphql/caching.md
+++ b/src/guides/v2.4/graphql/caching.md
@@ -151,3 +151,6 @@ Magento invalidates the cache when any of the following events occur:
 *  The `Preview-Version` header is specified in a query that supports caching.
 *  The system configuration changes.
 *  An administrator flushes or disables the cache from the Admin or with the `bin/magento cache` command.
+
+### GraphQL Schema
+The GraphQL schema is cached in the Configuration cache, which can be refreshed from the Cache Management page (System > Tools > Cache Management).

--- a/src/guides/v2.4/graphql/caching.md
+++ b/src/guides/v2.4/graphql/caching.md
@@ -153,4 +153,5 @@ Magento invalidates the cache when any of the following events occur:
 *  An administrator flushes or disables the cache from the Admin or with the `bin/magento cache` command.
 
 ### GraphQL Schema
+
 The GraphQL schema is cached in the Configuration cache, which can be refreshed from the Cache Management page (System > Tools > Cache Management).


### PR DESCRIPTION
## Purpose of this pull request
This pull request (PR) documents where the GraphQL schema is cached and how to refresh it.

## Affected DevDocs pages
-  https://devdocs.magento.com/guides/v2.4/graphql/caching.html
