### PR TITLE
Removed duplicate datatype in example of date component

### DIFF
--- a/src/guides/v2.3/ui_comp_guide/components/ui-datecolumn.md
+++ b/src/guides/v2.3/ui_comp_guide/components/ui-datecolumn.md
@@ -33,7 +33,6 @@ This is an example of how the DateColumn component integrates with the [Listing]
             <settings>
                 <filter>dateRange</filter>
                 <dataType>date</dataType>
-                <dataType>date</dataType>
                 <label translate="true">Date Column Example 1</label>
             </settings>
         </column>


### PR DESCRIPTION
## Purpose of this pull request

This pull request (PR) to remove duplicate datatype in example of date component.

## Affected DevDocs pages

-  https://devdocs.magento.com/guides/v2.4/ui_comp_guide/components/ui-datecolumn.html.
- https://devdocs.magento.com/guides/v2.3/ui_comp_guide/components/ui-datecolumn.html.

