### PR TITLE
define provider for custom checkout form

### DIFF
--- a/src/guides/v2.3/howdoi/checkout/checkout_form.md
+++ b/src/guides/v2.3/howdoi/checkout/checkout_form.md
@@ -128,6 +128,7 @@ It should be similar to the following:
                                                                 <item name="custom-checkout-form-container" xsi:type="array">
                                                                     <!-- Add this item to configure your js file  -->
                                                                     <item name="component" xsi:type="string">VendorName_ModuleName/js/view/custom-checkout-form</item>
+                                                                    <item name="provider" xsi:type="string">checkoutProvider</item>
                                                                     <item name="config" xsi:type="array">
                                                                         <!-- And this to add your html template  -->
                                                                         <item name="template" xsi:type="string">VendorName_ModuleName/custom-checkout-form</item>


### PR DESCRIPTION
## Purpose of this pull request

This pull request (PR) fixes a 'this.source is undefined' error when submitting the custom form that is created when following the tutorial on this DevDocs page

## Affected DevDocs pages

<!-- REQUIRED List the affected pages on devdocs.magento.com (URLs). Not needed for large numbers of files. -->

-  https://devdocs.magento.com/guides/v2.3/howdoi/checkout/checkout_form.html

<!--
If you are fixing a GitHub issue, note it using GitHub keyword format (https://help.github.com/en/articles/closing-issues-using-keywords#closing-an-issue-in-a-different-repository) to close the issue when this pull request is merged. Example: `Fixes #1234`

`master` is the default branch. Merged pull requests to `master` go live on the site automatically. Any requested changes to content on the `master` branch must be related to the released codebase. Any content related to future releases goes in the `develop` branch.

See Contribution guidelines (https://github.com/magento/devdocs/blob/master/.github/CONTRIBUTING.md) for more information.
-->
