### PR TITLE
Update v2.4/security/two-factor-authentication.md

### DIFF
--- a/src/guides/v2.4/security/two-factor-authentication.md
+++ b/src/guides/v2.4/security/two-factor-authentication.md
@@ -67,7 +67,7 @@ Two-Factor Authentication is implemented for Magento Web APIs with the following
 
 ## Magento Functional Testing Framework
 
-MFTF uses Google Authenticator to execute tests with 2FA enabled. The following steps summarize how to configure MFTF with an encoded shared secret. For more information, see [Configuring MFTF for Two-Factor Authentication (2FA)]({{ page.baseurl }}/security/two-factor-authentication.html#magento-functional-testing-framework).
+MFTF uses Google Authenticator to execute tests with 2FA enabled. The following steps summarize how to configure MFTF with an encoded shared secret. 
 
 1. Select Google Authenticator as the 2FA provider:
 


### PR DESCRIPTION
## Purpose of this pull request

This pull request (PR) removes a self-referencing link from the Magento Functional Testing Framework section of the Two-Factor Authentication documentation

## Affected DevDocs pages

https://devdocs.magento.com/guides/v2.4/security/two-factor-authentication.html#magento-functional-testing-framework


