### PR TITLE
Remove Unused dependency and wrong Constant

### DIFF
--- a/src/guides/v2.3/howdoi/custom-attributes/text-field.md
+++ b/src/guides/v2.3/howdoi/custom-attributes/text-field.md
@@ -155,7 +155,7 @@ There are five steps in developing a data patch. All the steps below are written
     ```php
     // Get the newly created attribute's model
     $attribute = $this->customerSetup->getEavConfig()
-        ->getAttribute(CustomerMetadataInterface::ENTITY, 'externalcorp_external_id');
+        ->getAttribute(CustomerMetadataInterface::ENTITY_TYPE_CUSTOMER, 'externalcorp_external_id');
 
     // Make attribute visible in Admin customer form
     $attribute->setData('used_in_forms', [
@@ -214,7 +214,6 @@ namespace ExampleCorp\Customer\Setup\Patch\Data;
 use Exception;
 use Psr\Log\LoggerInterface;
 use Magento\Customer\Api\CustomerMetadataInterface;
-use Magento\Customer\Model\Customer;
 use Magento\Customer\Model\ResourceModel\Attribute as AttributeResource;
 use Magento\Customer\Setup\CustomerSetup;
 use Magento\Customer\Setup\CustomerSetupFactory;
@@ -329,7 +328,7 @@ class ExternalId implements DataPatchInterface
 
             // Get the newly created attribute's model
             $attribute = $this->customerSetup->getEavConfig()
-                ->getAttribute(Customer::ENTITY, 'externalcorp_external_id');
+                ->getAttribute(CustomerMetadataInterface::ENTITY_TYPE_CUSTOMER, 'externalcorp_external_id');
 
             // Make attribute visible in Admin customer form
             $attribute->setData('used_in_forms', [


### PR DESCRIPTION
Fixes #9297 
Unused dependency and wrong Constant

## Purpose of this pull request

This pull request:
- Remove Unused dependency 
- Update Class for used  Constant

## Affected DevDocs pages

<!-- REQUIRED List the affected pages on devdocs.magento.com (URLs). Not needed for large numbers of files. -->

-  https://devdocs.magento.com/guides/v2.4/howdoi/custom-attributes/text-field.html
- https://devdocs.magento.com/guides/v2.3/howdoi/custom-attributes/text-field.html



<!--
If you are fixing a GitHub issue, note it using GitHub keyword format (https://help.github.com/en/articles/closing-issues-using-keywords#closing-an-issue-in-a-different-repository) to close the issue when this pull request is merged. Example: `Fixes #1234`

`master` is the default branch. Merged pull requests to `master` go live on the site automatically. Any requested changes to content on the `master` branch must be related to the released codebase. Any content related to future releases goes in the `develop` branch.

See Contribution guidelines (https://github.com/magento/devdocs/blob/master/.github/CONTRIBUTING.md) for more information.
-->
