### PR TITLE
Fix typo, we should use an alias for parent class

### DIFF
--- a/src/guides/v2.3/extension-dev-guide/admin-grid.md
+++ b/src/guides/v2.3/extension-dev-guide/admin-grid.md
@@ -416,9 +416,9 @@ The resource model class translates to `app/code/Dev/Grid/Model/ResourceModel/Ca
 
 namespace Dev\Grid\Model\ResourceModel;
 
-use Magento\Catalog\Model\ResourceModel\Category;
+use Magento\Catalog\Model\ResourceModel\Category as BaseCategory;
 
-class Category extends Category
+class Category extends BaseCategory
 {
 }
 ```


### PR DESCRIPTION
## Purpose of this pull request

This pull request (PR) fix an example of code by adding an alias to the parent class that have the same name as the child.

## Affected DevDocs pages

<!-- REQUIRED List the affected pages on devdocs.magento.com (URLs). Not needed for large numbers of files. -->

-  [Admin Grids](https://devdocs.magento.com/guides/v2.4/extension-dev-guide/admin-grid.html)

## Links to Magento source code

<!--
If you are fixing a GitHub issue, note it using GitHub keyword format (https://help.github.com/en/articles/closing-issues-using-keywords#closing-an-issue-in-a-different-repository) to close the issue when this pull request is merged. Example: `Fixes #1234`

`master` is the default branch. Merged pull requests to `master` go live on the site automatically. Any requested changes to content on the `master` branch must be related to the released codebase. Any content related to future releases goes in the `develop` branch.

See Contribution guidelines (https://github.com/magento/devdocs/blob/master/.github/CONTRIBUTING.md) for more information.
-->
