### PR TITLE
Corrected the broken github url for "Data fixture annotation" documentation

### DIFF
--- a/src/guides/v2.4/test/integration/parameterized_data_fixture.md
+++ b/src/guides/v2.4/test/integration/parameterized_data_fixture.md
@@ -98,4 +98,4 @@ class PriceTest extends \PHPUnit\Framework\TestCase
 
 <!-- Link definitions -->
 
-[`Magento\Catalog\Test\Fixture\Product`]: {{ site.mage2bloburl }}/{{ page.guide_version }}/app/code/Magento/Catalog/Test/Fixture/Product.php
+[`Magento\Catalog\Test\Fixture\Product`]: {{ site.mage2bloburl }}/{{ page.guide_version }}-develop/app/code/Magento/Catalog/Test/Fixture/Product.php


### PR DESCRIPTION
## Purpose of this pull request

This pull request (PR) is to fix the broken URL leading to an example file in the GitHub code repository.
The sample code only resides in the 2.4-develop branch until the 2.4.5 release.

## Affected DevDocs pages

<!-- REQUIRED List the affected pages on devdocs.magento.com (URLs). Not needed for large numbers of files. -->

-  https://devdocs.magento.com/guides/v2.4/test/integration/parameterized_data_fixture.html

<!--
If you are fixing a GitHub issue, note it using GitHub keyword format (https://help.github.com/en/articles/closing-issues-using-keywords#closing-an-issue-in-a-different-repository) to close the issue when this pull request is merged. Example: `Fixes #1234`

`master` is the default branch. Merged pull requests to `master` go live on the site automatically. Any requested changes to content on the `master` branch must be related to the released codebase. Any content related to future releases goes in the `develop` branch.

See Contribution guidelines (https://github.com/magento/devdocs/blob/master/.github/CONTRIBUTING.md) for more information.
-->
