### PR TITLE
Add SCD_MATRIX example for build three themes with three locales and update backend theme name to avoid warning: Theme magento/backend does not exist

### DIFF
--- a/src/cloud/env/variables-build.md
+++ b/src/cloud/env/variables-build.md
@@ -126,11 +126,21 @@ The following example builds the three themes with three locales:
 stage:
   build:
     SCD_MATRIX:
-          {
-            "Magento/backend": { "language": ["en_US", "fr_FR", "af_ZA"] },
-            "Magento/blank": { "language": ["en_US", "fr_FR", "af_ZA"] },
-            "Magento/luma": { "language": ["en_US", "fr_FR", "af_ZA"] },
-          }
+        "Magento/backend":
+          language:
+            - en_US
+            - fr_FR
+            - af_ZA
+        "Magento/blank":
+          language:
+            - en_US
+            - fr_FR
+            - af_ZA
+        "Magento/luma":
+          language:
+            - en_US
+            - fr_FR
+            - af_ZA
 ```
 
 Also, you can choose to _not_ deploy a theme:

--- a/src/cloud/env/variables-build.md
+++ b/src/cloud/env/variables-build.md
@@ -120,31 +120,30 @@ stage:
           - fr_FR
           - af_ZA
 ```
-
-The following example builds the three themes with three locales:
+The following example builds three themes with three locales:
 
 ```yaml
 stage:
   build:
     SCD_MATRIX:
-        "Magento/backend":
-          language:
-            - en_US
-            - fr_FR
-            - af_ZA
-        "Magento/blank":
-          language:
-            - en_US
-            - fr_FR
-            - af_ZA
-        "Magento/luma":
-          language:
-            - en_US
-            - fr_FR
-            - af_ZA
+      "Magento/backend":
+        language:
+          - en_US
+          - fr_FR
+          - af_ZA
+      "Magento/blank":
+        language:
+          - en_US
+          - fr_FR
+          - af_ZA
+      "Magento/luma":
+        language:
+          - en_US
+          - fr_FR
+          - af_ZA
 ```
 
-You can also choose to _not_ deploy a theme:
+Or, you can choose to _not_ deploy a theme:
 
 ```yaml
 stage:

--- a/src/cloud/env/variables-build.md
+++ b/src/cloud/env/variables-build.md
@@ -120,6 +120,7 @@ stage:
           - fr_FR
           - af_ZA
 ```
+
 The following example builds the three themes with three locales:
 
 ```yaml
@@ -143,7 +144,7 @@ stage:
             - af_ZA
 ```
 
-Also, you can choose to _not_ deploy a theme:
+You can also choose to _not_ deploy a theme:
 
 ```yaml
 stage:

--- a/src/cloud/env/variables-build.md
+++ b/src/cloud/env/variables-build.md
@@ -108,17 +108,29 @@ stage:
 
 You can configure multiple locales per theme. This customization helps speed up the build process by reducing the number of unnecessary theme files. For example, you can build the _magento/backend_ theme in English and a custom theme in other languages.
 
-The following example builds the `magento/backend` theme with three locales:
+The following example builds the `Magento/backend` theme with three locales:
 
 ```yaml
 stage:
   build:
     SCD_MATRIX:
-      "magento/backend":
+      "Magento/backend":
         language:
           - en_US
           - fr_FR
           - af_ZA
+```
+The following example builds the three themes with three locales:
+
+```yaml
+stage:
+  build:
+    SCD_MATRIX:
+          {
+            "Magento/backend": { "language": ["en_US", "fr_FR", "af_ZA"] },
+            "Magento/blank": { "language": ["en_US", "fr_FR", "af_ZA"] },
+            "Magento/luma": { "language": ["en_US", "fr_FR", "af_ZA"] },
+          }
 ```
 
 Also, you can choose to _not_ deploy a theme:
@@ -127,7 +139,7 @@ Also, you can choose to _not_ deploy a theme:
 stage:
   build:
     SCD_MATRIX:
-      "magento/backend": [ ]
+      "Magento/backend": [ ]
 ```
 
 ### `SCD_MAX_EXECUTION_TIME`


### PR DESCRIPTION

## Purpose of this pull request

This pull request (PR) ...
Add SCD_MATRIX example for build three themes with three locales and update backend theme name to avoid warning: Theme magento/backend does not exist

with magento/backend build show WARNING: Theme magento/backend does not exist, attempting to resolve.
WARNING: Theme found as Magento/backend.  Using corrected name instead.

## Affected DevDocs pages

<!-- REQUIRED List the affected pages on devdocs.magento.com (URLs). Not needed for large numbers of files. -->

- https://devdocs.magento.com/cloud/env/variables-build.html#scd_matrix

## Links to Magento source code

<!--  OPTIONAL - REMOVE THIS SECTION IF NOT USED. If this pull request references a file in a Magento codebase repository, add it here. -->

-  ...

<!--
If you are fixing a GitHub issue, note it using GitHub keyword format (https://help.github.com/en/articles/closing-issues-using-keywords#closing-an-issue-in-a-different-repository) to close the issue when this pull request is merged. Example: `Fixes #1234`

`master` is the default branch. Merged pull requests to `master` go live on the site automatically. Any requested changes to content on the `master` branch must be related to the released codebase. Any content related to future releases goes in the `develop` branch.

See Contribution guidelines (https://github.com/magento/devdocs/blob/master/.github/CONTRIBUTING.md) for more information.
-->
