### PR TITLE
Remove outdated custom snippets instructions

### DIFF
--- a/src/_includes/cloud/cloud-fastly-manage-vcl-from-admin.md
+++ b/src/_includes/cloud/cloud-fastly-manage-vcl-from-admin.md
@@ -15,18 +15,24 @@
 1. After the upload completes, refresh the cache according to the notification at the top of the page.
 
 {:.bs-callout-warning}
-The *Custom VCL snippets* UI option shows only the snippets added through the Admin UI. You must use the Fastly API to [manage custom snippets added through the API]({{ site.baseurl }}/cloud/cdn/cloud-vcl-custom-snippets.html#manage-custom-vcl-snippets-using-the-api).
+The *Custom VCL snippets* UI option shows only the snippets added through the Admin UI. You must use the Fastly API to [manage custom snippets added through the Fastly API]({{ site.baseurl }}/cloud/cdn/cloud-vcl-custom-snippets.html#manage-custom-vcl-snippets-using-the-api).
 
 ## Delete the custom VCL snippet
 
-You can delete custom VCL snippet code from your Fastly configuration by uploading an empty version of the snippet from the Admin UI, or delete it completely using the Fastly API.
+1. [Log in]({{ site.baseurl }}/cloud/onboarding/onboarding-tasks.html#admin) to the Admin UI.
 
--  Upload an empty version of the snippet file to Fastly to remove the VCL logic from the active VCL version:
+1. Click **Stores** > **Settings** > **Configuration** > **Advanced** > **System**.
 
-   -  Edit the snippet and delete the **VCL** snippet content.
-   -  Save the configuration.
-   -  Upload the VCL to Fastly to apply your changes.
+1. Expand **Full Page Cache** > **Fastly Configuration** > **Custom VCL Snippets**.
 
+   ![Manage custom VCL snippets]
+
+1. In the _Action_ column, click the trash icon next to the snippet to delete.
+
+1. On the next modal window, click **DELETE** and activate a new version.
+
+{:.bs-callout-warning}
+The *Custom VCL snippets* UI option shows only the snippets added through the Admin UI. You must use the Fastly API to [manage custom snippets added through the Fastly API]({{ site.baseurl }}/cloud/cdn/cloud-vcl-custom-snippets.html#manage-custom-vcl-snippets-using-the-api).
 -  Use the Fastly API [Delete custom VCL snippet]({{ site.baseurl }}/cloud/cdn/cloud-vcl-custom-snippets.html#manage-vcl) operation to delete the snippet completely, or submit a support ticket to request deletion.
 
 [Manage custom VCL snippets]: {{site.baseurl}}/common/images/cloud/cloud-fastly-manage-snippets.png


### PR DESCRIPTION
This isn't the case anymore, see https://github.com/fastly/fastly-magento2/commit/4c97244f20087b30db046ea99cded8073fc768f6#

implementation: https://github.com/fastly/fastly-magento2/blob/master/Controller/Adminhtml/FastlyCdn/CustomSnippet/DeleteCustomSnippet.php

## Purpose of this pull request

Removing stale information that confuses users.

## Affected DevDocs pages

-  https://devdocs.magento.com/cloud/cdn/fastly-vcl-badreferer.html#delete-the-custom-vcl-snippet

## Links to Magento source code

N/A