### PR TITLE
Github issue 8304: remove obsolete sample payment module from payment pages

### DIFF
--- a/src/guides/v2.3/payments-integrations/base-integration/integration-intro.md
+++ b/src/guides/v2.3/payments-integrations/base-integration/integration-intro.md
@@ -19,9 +19,6 @@ The Magento payment provider gateway allows creating secure and PCI-compliant in
 The topics in this chapter explain how to add an integration with a custom payment service provider (in other words, add a new payment method) and implement the authorize payment action for this [payment method](https://glossary.magento.com/payment-method). For illustration, we use code
 samples from the [Braintree]({{ site.mage2bloburl }}/{{ page.guide_version }}/app/code/Magento/Braintree) payment integration.
 
-To simplify the development of a new payment integration, Magento developed the [Payment sample module](https://github.com/magento/magento2-samples/tree/master/sample-module-payment-gateway).
-It contains all required infrastructure and you can use it as starting point.
-
 To add a new payment method, take the following high-level steps:
 
 1. Configure general payment method module options. Described in the [Payment method module configuration]({{ page.baseurl }}/payments-integrations/base-integration/module-configuration.html) topic.

--- a/src/guides/v2.3/payments-integrations/base-integration/integration-intro.md
+++ b/src/guides/v2.3/payments-integrations/base-integration/integration-intro.md
@@ -19,6 +19,10 @@ The Magento payment provider gateway allows creating secure and PCI-compliant in
 The topics in this chapter explain how to add an integration with a custom payment service provider (in other words, add a new payment method) and implement the authorize payment action for this [payment method](https://glossary.magento.com/payment-method). For illustration, we use code
 samples from the [Braintree]({{ site.mage2bloburl }}/{{ page.guide_version }}/app/code/Magento/Braintree) payment integration.
 
+{:.bs-callout-info}
+You can also view the [Payment sample module](https://github.com/magento/magento2-samples/tree/master/sample-module-payment-gateway) in the `magento/magento2-samples`
+repository to understand the underlying principles. However, be aware that this code is NOT supported.
+
 To add a new payment method, take the following high-level steps:
 
 1. Configure general payment method module options. Described in the [Payment method module configuration]({{ page.baseurl }}/payments-integrations/base-integration/module-configuration.html) topic.

--- a/src/guides/v2.3/payments-integrations/base-integration/module-configuration.md
+++ b/src/guides/v2.3/payments-integrations/base-integration/module-configuration.md
@@ -10,8 +10,6 @@ functional_areas:
 
 For the sake of compatibility, upgradability and easy maintenance, do not edit the default Magento code; add your customizations in a separate [module](https://glossary.magento.com/module).
 
-You can use the [sample Magento_SamplePaymentGateway module](https://github.com/magento/magento2-samples/tree/master/sample-module-payment-gateway) files as basis for your custom module structure and files.
-
 ## Specify your module dependencies
 
 Your custom payment integration module must have at least the following dependencies:

--- a/src/guides/v2.3/payments-integrations/base-integration/module-configuration.md
+++ b/src/guides/v2.3/payments-integrations/base-integration/module-configuration.md
@@ -10,6 +10,9 @@ functional_areas:
 
 For the sake of compatibility, upgradability and easy maintenance, do not edit the default Magento code; add your customizations in a separate [module](https://glossary.magento.com/module).
 
+{:.bs-callout-info}
+You can use the [sample Magento_SamplePaymentGateway module](https://github.com/magento/magento2-samples/tree/master/sample-module-payment-gateway) files as the basis for your custom module structure and files. However, be aware that this code is NOT supported.
+
 ## Specify your module dependencies
 
 Your custom payment integration module must have at least the following dependencies:


### PR DESCRIPTION
Fixes #8304
Remove obsolete sample payment module from payment pages

## Purpose of this pull request

Remove obsolete sample payment module from payment pages

## Affected DevDocs pages

- https://devdocs.magento.com/guides/v2.4/payments-integrations/base-integration/integration-intro.html
- https://devdocs.magento.com/guides/v2.4/payments-integrations/base-integration/module-configuration.html
- https://devdocs.magento.com/guides/v2.3/payments-integrations/base-integration/integration-intro.html
- https://devdocs.magento.com/guides/v2.3/payments-integrations/base-integration/module-configuration.html