### PR TITLE
Fix broken RedisDesktopManager link

### DIFF
--- a/src/_includes/config/redis-verify.md
+++ b/src/_includes/config/redis-verify.md
@@ -52,7 +52,7 @@ If you use Redis for page caching, you'll see output similar to the following:
 
 ### Inspecting compressed data
 
-To inspect compressed Session data and Page Cache, the [RESP.app](https://flathub.org/apps/details/app.resp.RESP) supports the automatic decompression of Magento 2 Session and Page cache and displays PHP session data in a human-readable form.
+To inspect compressed Session data and Page Cache, the [RESP.app - GUI for Redis](https://flathub.org/apps/details/app.resp.RESP) supports the automatic decompression of Magento 2 Session and Page cache and displays PHP session data in a human-readable form.
 
 ### Redis ping command
 

--- a/src/_includes/config/redis-verify.md
+++ b/src/_includes/config/redis-verify.md
@@ -52,7 +52,7 @@ If you use Redis for page caching, you'll see output similar to the following:
 
 ### Inspecting compressed data
 
-To inspect compressed Session data and Page Cache, the [Redis Desktop Manager](https://flathub.org/apps/details/dev.rdm.RDM) supports the automatic decompression of Magento 2 Session and Page cache and displays PHP session data in a human-readable form.
+To inspect compressed Session data and Page Cache, the [RESP.app](https://flathub.org/apps/details/app.resp.RESP) supports the automatic decompression of Magento 2 Session and Page cache and displays PHP session data in a human-readable form.
 
 ### Redis ping command
 


### PR DESCRIPTION

## Purpose of this pull request

This pull request (PR) fixes the broken link to the RedisDesktopManager app in FlatHub. More details https://github.com/flathub/flathub/pull/2760

## Affected DevDocs pages

- https://devdocs.magento.com/guides/v2.4/config-guide/redis/redis-session.html
- https://devdocs.magento.com/guides/v2.4/config-guide/redis/redis-pg-cache.html
