### PR TITLE
Update index.md

### DIFF
--- a/src/release/index.md
+++ b/src/release/index.md
@@ -43,7 +43,7 @@ For more information, refer to the [Beta program][].
 
 -  **Patch releases**—Updates to the core {{site.data.var.ee}} and {{site.data.var.ce}} application that include security, compliance, performance, and high-priority quality fixes.
 -  **Security patch releases**—Security-only updates to the {{site.data.var.ee}} and {{site.data.var.ce}} application released to keep merchants secure and compliant.
--  **Feature releases**—New features and feature updates that are delivered as independent services, separate from the patch releases. Examples include services like Product Recommendations and Live Search, independent modules like PWA Studio and Inventory Management (MSI), and updates to our cloud services and infrastructure.
+-  **Feature releases**—New features and feature updates that are delivered as independent services, separate from the patch releases. Examples include services like Product Recommendations and Live Search, independent modules like PWA Studio and Inventory Management (MSI), and updates to our cloud services and infrastructure. 
 
 <!-- Link definitions -->
 [Beta program]: {{site.baseurl}}/release/beta-program.html


### PR DESCRIPTION
## Purpose of this pull request

This pull request (PR) introduces the following changes:

March 2022 row
- Remove superscript from 2.3.7-p31
- Edit “Feature + patch release” to “Feature + patch release + security patch releases” 

August 2022 row
- Edit “Feature + patch release” to “Feature + patch release + security patch releases” 
- Add “2.3.7-p41” to Versions column
- Add “2.4.3-p3” to Versions column

Edit calendar footnote 1
- “This is the last patch release for the 2.3.x release line. The 2.3.x release line reaches End of Support (EOS) in September 2022.”

## Affected DevDocs pages

- https://devdocs.magento.com/release/

whatsnew
Updated the [release schedule](https://devdocs.magento.com/release/).