### PR TITLE
Update lifecycle-policy.md

### DIFF
--- a/src/release/lifecycle-policy.md
+++ b/src/release/lifecycle-policy.md
@@ -20,7 +20,7 @@ For {{ site.data.var.ee }} 2.4 and subsequent releases:
 | {{site.data.var.ee}} 2.4.4-2.4.6 | TBA           | November 2024                       | PHP 8.1                     |
 
 <sup>1 End of Software Support includes both end of quality fixes and end of security fixes.</sup><br>
-<sup>2 The End of Software Support date for 2.3 has been extended to April 2022 due to impacts from COVID-19.</sup><br>
+<sup>2 The End of Software Support date for 2.3 has been extended to April 2022 due to impacts from  COVID-19.</sup><br>
 <sup>3 2.3.0-2.3.6 are dependent on PHP 7.3; 2.3.7 is dependent on PHP 7.4.</sup>
 
 {:.bs-callout-info}


### PR DESCRIPTION
## Purpose of this pull request

This pull request (PR) updates the following:

Adobe Commerce 2.3 row
- Change April 2022^2 to September 2022^2

Footnote 2
- Change copy to “The End of Software Support date for Adobe Commerce 2.3 has been extended to September 8, 2022 to allow more time for Customers to upgrade to the 2.4.4 release that will be generally available on March 8, 2022”

## Affected DevDocs pages

<!-- REQUIRED List the affected pages on devdocs.magento.com (URLs). Not needed for large numbers of files. -->

- https://devdocs.magento.com/release/lifecycle-policy.html

## Links to Magento source code

<!--  OPTIONAL - REMOVE THIS SECTION IF NOT USED. If this pull request references a file in a Magento codebase repository, add it here. -->

-  ...

<!--
If you are fixing a GitHub issue, note it using GitHub keyword format (https://help.github.com/en/articles/closing-issues-using-keywords#closing-an-issue-in-a-different-repository) to close the issue when this pull request is merged. Example: `Fixes #1234`

`master` is the default branch. Merged pull requests to `master` go live on the site automatically. Any requested changes to content on the `master` branch must be related to the released codebase. Any content related to future releases goes in the `develop` branch.

See Contribution guidelines (https://github.com/magento/devdocs/blob/master/.github/CONTRIBUTING.md) for more information.
-->

whatsnew
Added [extended support](https://devdocs.magento.com/release/lifecycle-policy.html) date for 2.3.