### PR TITLE
Update index.md

### DIFF
--- a/src/release/policy/index.md
+++ b/src/release/policy/index.md
@@ -85,7 +85,7 @@ Hotfixes can contain backward incompatible changes.
 
 ## Individual patch
 
-Individual patches contain low-impact quality fixes for a specific issue. These fixes are applied to the supported minor versions of {{site.data.var.ee}}. Adobe releases individual patches as needed for {{site.data.var.ee}} in accordance with our [Software Lifecycle Policy](https://magento.com/sites/default/files/magento-software-lifecycle-policy.pdf).
+Individual patches contain low-impact quality fixes for a specific issue. These fixes are applied to the supported minor versions of {{site.data.var.ee}}. Adobe releases individual patches as needed for {{site.data.var.ee}} in accordance with our [Software Lifecycle Policy](https://www.adobe.com/content/dam/cc/en/legal/terms/enterprise/pdfs/Adobe-Commerce-Software-Lifecycle-Policy.pdf).
 
 {:.bs-callout-info}
 Individual patches do not contain backward incompatible changes.
@@ -100,4 +100,4 @@ Related topics
 -  [Planning and Budgeting for Commerce Upgrade Cycles](https://magento.com/sites/default/files8/2019-08/Magento-Release-Cycle-Infosheet_Aug_2019.pdf)
 -  [Versioning]({{ site.baseurl }}/guides/v2.3/extension-dev-guide/versioning/).
 -  [Upcoming releases]({{ site.baseurl }}/release/)
--  [Software Lifecycle Policy](https://magento.com/sites/default/files/magento-software-lifecycle-policy.pdf)
+-  [Software Lifecycle Policy](https://www.adobe.com/content/dam/cc/en/legal/terms/enterprise/pdfs/Adobe-Commerce-Software-Lifecycle-Policy.pdf)


### PR DESCRIPTION
changing the two software lifecycle links. They were supposed to redirect to new policy, but doesn't seem like the redirect is working, so just adding the new link in

## Purpose of this pull request

This pull request (PR) ...

## Affected DevDocs pages

<!-- REQUIRED List the affected pages on devdocs.magento.com (URLs). Not needed for large numbers of files. -->

-  ...

## Links to Magento source code

<!--  OPTIONAL - REMOVE THIS SECTION IF NOT USED. If this pull request references a file in a Magento codebase repository, add it here. -->

-  ...

<!--
If you are fixing a GitHub issue, note it using GitHub keyword format (https://help.github.com/en/articles/closing-issues-using-keywords#closing-an-issue-in-a-different-repository) to close the issue when this pull request is merged. Example: `Fixes #1234`

`master` is the default branch. Merged pull requests to `master` go live on the site automatically. Any requested changes to content on the `master` branch must be related to the released codebase. Any content related to future releases goes in the `develop` branch.

See Contribution guidelines (https://github.com/magento/devdocs/blob/master/.github/CONTRIBUTING.md) for more information.
-->
