### PR TITLE
Remove incorrect content for Dependency injection page

### DIFF
--- a/src/guides/v2.3/extension-dev-guide/depend-inj.md
+++ b/src/guides/v2.3/extension-dev-guide/depend-inj.md
@@ -85,7 +85,7 @@ class Builder
 
 ### Constructor injection
 
-In the code sample, the `Builder` class declares its dependency on the `Factory` and `Menu` classes in its constructor.
+In the code sample, the `Builder` class declares its dependency on the `Factory` class in its constructor.
 Magento uses the `di.xml` file to determine which implementations to inject into the `Builder` class.
 
 #### Optional dependencies


### PR DESCRIPTION
## Purpose of this pull request

Remove incorrect content for the Dependency injection page.

`Menu` class should be removed since the code changed in that pull request:  https://github.com/magento/devdocs/pull/4016
## Affected DevDocs pages

- https://devdocs.magento.com/guides/v2.4/extension-dev-guide/depend-inj.html
- https://devdocs.magento.com/guides/v2.3/extension-dev-guide/depend-inj.html
