### PR TITLE
Update config-reference-config

### DIFF
--- a/src/guides/v2.3/config-guide/prod/config-reference-configphp.md
+++ b/src/guides/v2.3/config-guide/prod/config-reference-configphp.md
@@ -55,7 +55,7 @@ Contains an array of scope configuration values. It has the following subnodes:
     ]
   ],
   'groups' => [
-    [
+    0 => [
       'group_id' => '0',
       'website_id' => '0',
       'code' => 'default',


### PR DESCRIPTION

## Purpose of this pull request

This pull request (PR) fix resolve group if loaded by \Magento\Store\Model\GroupRepository::get
In this case, an id must be specified in the config path ($this->getAppConfig()->get('scopes', "groups/$id", [])
Without that, group can not be resolved

## Affected DevDocs pages

- https://devdocs.magento.com/guides/v2.4/config-guide/prod/config-reference-configphp.html
<!--
If you are fixing a GitHub issue, note it using GitHub keyword format (https://help.github.com/en/articles/closing-issues-using-keywords#closing-an-issue-in-a-different-repository) to close the issue when this pull request is merged. Example: `Fixes #1234`

`master` is the default branch. Merged pull requests to `master` go live on the site automatically. Any requested changes to content on the `master` branch must be related to the released codebase. Any content related to future releases goes in the `develop` branch.

See Contribution guidelines (https://github.com/magento/devdocs/blob/master/.github/CONTRIBUTING.md) for more information.
-->
