### PR TITLE
Fix path for "Send Emails To" config

### DIFF
--- a/src/guides/v2.3/config-guide/prod/config-reference-most.md
+++ b/src/guides/v2.3/config-guide/prod/config-reference-most.md
@@ -115,7 +115,7 @@ These configuration values are available in the Admin in **Stores** > Settings >
 Name  | Config path | EE only? |
 |--------------|--------------|--------------|
 Enable Contact Us | `contact/contact/enabled` | <!-- ![Not EE-only]({{ site.baseurl }}/common/images/red-x.png) --> |
-Send Emails To | `contact/contact/recipient_email` | <!-- ![Not EE-only]({{ site.baseurl }}/common/images/red-x.png) --> |
+Send Emails To | `contact/email/recipient_email` | <!-- ![Not EE-only]({{ site.baseurl }}/common/images/red-x.png) --> |
 Email Sender | `contact/email/sender_email_identity` | <!-- ![Not EE-only]({{ site.baseurl }}/common/images/red-x.png) --> |
 Email Template | `contact/email/email_template` | <!-- ![Not EE-only]({{ site.baseurl }}/common/images/red-x.png) --> |
 

--- a/src/guides/v2.4/config-guide/prod/config-reference-most.md
+++ b/src/guides/v2.4/config-guide/prod/config-reference-most.md
@@ -115,7 +115,7 @@ These configuration values are available in the Admin in **Stores** > Settings >
 Name  | Config path | EE only? |
 |--------------|--------------|--------------|
 Enable Contact Us | `contact/contact/enabled` | <!-- ![Not EE-only]({{ site.baseurl }}/common/images/red-x.png) --> |
-Send Emails To | `contact/contact/recipient_email` | <!-- ![Not EE-only]({{ site.baseurl }}/common/images/red-x.png) --> |
+Send Emails To | `contact/email/recipient_email` | <!-- ![Not EE-only]({{ site.baseurl }}/common/images/red-x.png) --> |
 Email Sender | `contact/email/sender_email_identity` | <!-- ![Not EE-only]({{ site.baseurl }}/common/images/red-x.png) --> |
 Email Template | `contact/email/email_template` | <!-- ![Not EE-only]({{ site.baseurl }}/common/images/red-x.png) --> |
 


### PR DESCRIPTION
## Purpose of this pull request

This pull request (PR) fixes a typo in config path for "Send Emails To" setting.  
In devdocs was `contact/contact/recipient_email` path, which is not exists. The correct one is `contact/email/recipient_email`.

<img width="1096" alt="Знімок екрана 2022-01-31 о 16 43 51" src="https://user-images.githubusercontent.com/20201927/151814599-5bd1feeb-cd7a-4b29-a5a8-5e11d8fe01f0.png">

## Affected DevDocs pages

<!-- REQUIRED List the affected pages on devdocs.magento.com (URLs). Not needed for large numbers of files. -->

-  https://devdocs.magento.com/guides/v2.4/config-guide/prod/config-reference-most.html


<!--
If you are fixing a GitHub issue, note it using GitHub keyword format (https://help.github.com/en/articles/closing-issues-using-keywords#closing-an-issue-in-a-different-repository) to close the issue when this pull request is merged. Example: `Fixes #1234`

`master` is the default branch. Merged pull requests to `master` go live on the site automatically. Any requested changes to content on the `master` branch must be related to the released codebase. Any content related to future releases goes in the `develop` branch.

See Contribution guidelines (https://github.com/magento/devdocs/blob/master/.github/CONTRIBUTING.md) for more information.
-->
## Fixed Issues (if relevant)  

Fixes  magento/magento2#35003


