### PR TITLE
Add Link to REST Api Docs for Condition Types

### DIFF
--- a/src/guides/v2.4/extension-dev-guide/searching-with-repositories.md
+++ b/src/guides/v2.4/extension-dev-guide/searching-with-repositories.md
@@ -41,6 +41,9 @@ $filter
 
 This filter will find all urls with the suffix of "magento.com".
 
+{:.bs-callout-info}
+A full list of condition types can be found in the [Rest API Reference]({{ page.baseurl }}/rest/performing-searches.html).
+
 ### Filter Group
 
 The [`FilterGroup`]({{ site.mage2bloburl }}/{{ page.guide_version }}/lib/internal/Magento/Framework/Api/Search/FilterGroup.php) class acts like a collection of Filters that apply one or more criteria to a search.


### PR DESCRIPTION
## Purpose of this pull request
This pull request (PR) adds a link to the REST API documentation for ease of referencing permitted condition types for repository search criteria 

## Affected DevDocs pages
-  [Searching with Repositories](https://devdocs.magento.com/guides/v2.4/extension-dev-guide/searching-with-repositories.html)

## Links to Magento source code
N/A

<!--
If you are fixing a GitHub issue, note it using GitHub keyword format (https://help.github.com/en/articles/closing-issues-using-keywords#closing-an-issue-in-a-different-repository) to close the issue when this pull request is merged. Example: `Fixes #1234`

`master` is the default branch. Merged pull requests to `master` go live on the site automatically. Any requested changes to content on the `master` branch must be related to the released codebase. Any content related to future releases goes in the `develop` branch.

See Contribution guidelines (https://github.com/magento/devdocs/blob/master/.github/CONTRIBUTING.md) for more information.
-->
