### PR TITLE
Fix incorrect class name in the "Example - logging to a custom log file" page

### DIFF
--- a/src/_includes/config-guide/custom-logger-handler-examples.md
+++ b/src/_includes/config-guide/custom-logger-handler-examples.md
@@ -41,7 +41,7 @@ This example shows how to use [virtual types]({{page.baseurl}}/extension-dev-gui
    </type>
    ```
 
-1. The virtual class `Magento\Payment\Model\Method\MyCustomLogger` will be injected into the `debug` handler of the `$logger` property in the `Magento\Payment\Model\Method\Logger` class.
+1. The virtual class `Magento\Payment\Model\Method\MyCustomDebug` will be injected into the `debug` handler of the `$logger` property in the `Magento\Payment\Model\Method\Logger` class.
 
    ```xml
    ...


### PR DESCRIPTION
## Purpose of this pull request

Fix incorrect class name in the "Example - logging to a custom log file" page

## Affected DevDocs pages

-  https://devdocs.magento.com/guides/v2.4/config-guide/log/custom-logger-handler.html#set-up-a-custom-log-file-in-the-dixml
-  https://devdocs.magento.com/guides/v2.3/config-guide/log/custom-logger-handler.html#set-up-a-custom-log-file-in-the-dixml