### PR TITLE
Removed list of ece-tools commands

### DIFF
--- a/src/cloud/reference/ece-tools-reference.md
+++ b/src/cloud/reference/ece-tools-reference.md
@@ -18,48 +18,6 @@ php ./vendor/bin/ece-tools list
 ```
 
 ```terminal
-Available commands:
-  build                    Builds application.
-  db-dump                  Creates database backups.
-  deploy                   Deploys application.
-  help                     Displays help for a command.
-  list                     Lists commands.
-  patch                    Applies custom patches.
-  post-deploy              Performs after deploy operations.
-  run                      Execute scenario(s).
- backup
-  backup:list              Shows the list of backup files.
-  backup:restore           Restore important configuration files. Run backup:list to show the list of backup files
- build.
-  build:generate           Generates all necessary files for build stage.
-  build:transfer           Transfers generated files into init directory.
- cloud
-  cloud:config:create      Creates a `.magento.env.yaml` file with the specified build, deploy, and post-deploy variable configuration. Overwrites any existing `.magento,.env.yaml` file.
-  cloud:config:update      Updates the existing `.magento.env.yaml` file with the specified configuration. Creates `.magento.env.yaml` file if it does not exist.
- config
-  config:dump              [dump] Dump configuration for static content deployment.
- cron
-  cron:disable             Disable all Magento cron processes and kills currently running.
-  cron:enable              Enable Magento cron processes.
-  cron:kill                Kill all Magento cron processes.
-  cron:unlock              Unlock cron jobs that stuck in "running" state.
- dev
-  dev:git:update-composer  Updates composer for deployment from git.
- env
-  env:config:show          Display encoded cloud configuration environment variables.
- error
-  error:show               Display info about error by error id or info about all errors from the last deployment.
- module
-  module:refresh           Refresh config to enable newly added modules.
- wizard
-  wizard:ideal-state       Verifies ideal state of configuration.
-  wizard:master-slave      Verifies master-slave configuration.
-  wizard:scd-on-build      Verifies SCD on build configuration.
-  wizard:scd-on-demand     Verifies SCD on demand configuration.
-  wizard:scd-on-deploy     Verifies SCD on deploy configuration.
-  wizard:split-db-state    Verifies ability to split DB and whether DB was already split or not.
-```
-{:.no-copy}
 
 ## Build and deploy
 


### PR DESCRIPTION
## Purpose of this pull request

This pull request (PR) removes the list of available commands for ece-tools

## Affected DevDocs pages

<!-- REQUIRED List the affected pages on devdocs.magento.com (URLs). Not needed for large numbers of files. -->

-  src/cloud/reference/ece-tools-reference.md
- 
## Links to Magento source code

<!--  OPTIONAL - REMOVE THIS SECTION IF NOT USED. If this pull request references a file in a Magento codebase repository, add it here. -->

-  src/cloud/reference/ece-tools-reference.md
<!--
If you are fixing a GitHub issue, note it using GitHub keyword format (https://help.github.com/en/articles/closing-issues-using-keywords#closing-an-issue-in-a-different-repository) to close the issue when this pull request is merged. Example: `Fixes #1234`

`master` is the default branch. Merged pull requests to `master` go live on the site automatically. Any requested changes to content on the `master` branch must be related to the released codebase. Any content related to future releases goes in the `develop` branch.

See Contribution guidelines (https://github.com/magento/devdocs/blob/master/.github/CONTRIBUTING.md) for more information.
-->
