### PR TITLE
Added Release Notes Links To Release Information

### DIFF
--- a/src/_data/core-releases.json
+++ b/src/_data/core-releases.json
@@ -8,18 +8,24 @@
             {
                 "publishedAt": "2021-10-12T14:41:27Z",
                 "tagName": "2.4.3-p1",
-                "combinedReleaseNotes": "guides/v2.4/release-notes/2-4-3-p1.html"
+                "releaseNotes" : {
+                    "common": "https://devdocs.magento.com/guides/v2.4/release-notes/2-4-3-p1.html"
+                }
             },
             {
                 "publishedAt": "2021-08-10T16:44:14Z",
                 "tagName": "2.4.3",
-                "commerceReleaseNotes": "guides/v2.4/release-notes/commerce-2-4-3.html",
-                "opensourceReleaseNotes": "guides/v2.4/release-notes/open-source-2-4-3.html"
+                "releaseNotes" : {
+                    "commerce": "https://devdocs.magento.com/guides/v2.4/release-notes/commerce-2-4-3.html",
+                    "opensource": "https://devdocs.magento.com/guides/v2.4/release-notes/open-source-2-4-3.html"
+                }
             },
             {
                 "publishedAt": "2021-08-10T16:44:09Z",
                 "tagName": "2.4.2-p2",
-                "combinedReleaseNotes": "guides/v2.4/release-notes/2-4-2-p2.html"
+                "releaseNotes" : {
+                    "common": "https://devdocs.magento.com/guides/v2.4/release-notes/2-4-2-p2.html"
+                }
             },
             {
                 "publishedAt":"2021-05-11T15:16:17Z",
@@ -28,8 +34,10 @@
             {
                 "publishedAt":"2021-02-09T18:05:14Z",
                 "tagName":"2.4.2",
-                "commerceReleaseNotes": "guides/v2.4/release-notes/commerce-2-4-2.html",
-                "opensourceReleaseNotes": "guides/v2.4/release-notes/open-source-2-4-2.html"
+                "releaseNotes" : {
+                    "commerce": "https://devdocs.magento.com/guides/v2.4/release-notes/commerce-2-4-2.html",
+                    "opensource": "https://devdocs.magento.com/guides/v2.4/release-notes/open-source-2-4-2.html"
+                }
             },
             {
                 "publishedAt":"2021-02-09T18:05:10Z",
@@ -38,8 +46,10 @@
             {
                 "publishedAt":"2020-10-15T14:21:36Z",
                 "tagName":"2.4.1",
-                "commerceReleaseNotes": "guides/v2.4/release-notes/commerce-2-4-1.html",
-                "opensourceReleaseNotes": "guides/v2.4/release-notes/open-source-2-4-1.html"
+                "releaseNotes" : {
+                    "commerce": "https://devdocs.magento.com/guides/v2.4/release-notes/commerce-2-4-1.html",
+                    "opensource": "https://devdocs.magento.com/guides/v2.4/release-notes/open-source-2-4-1.html"
+                }
             },
             {
                 "publishedAt":"2020-10-15T14:21:04Z",
@@ -48,26 +58,38 @@
             {
                 "publishedAt":"2020-07-28T14:40:42Z",
                 "tagName":"2.4.0",
-                "commerceReleaseNotes": "guides/v2.4/release-notes/release-notes-2-4-0-commerce.html",
-                "opensourceReleaseNotes": "guides/v2.4/release-notes/release-notes-2-4-0-open-source.html"
+                "releaseNotes" : {
+                    "commerce": "https://devdocs.magento.com/guides/v2.4/release-notes/release-notes-2-4-0-commerce.html",
+                    "opensource": "https://devdocs.magento.com/guides/v2.4/release-notes/release-notes-2-4-0-open-source.html"
+                }
             }
         ],
-        "end-of-support": "2022-11-??",
-        "release-notes" : true
+        "end-of-support": "2022-11-??"
     },
     "2.3": {
         "releases": [
             {
                 "publishedAt": "2021-10-12T14:41:22Z",
-                "tagName": "2.3.7-p2"
+                "tagName": "2.3.7-p2",
+                "commerce": "",
+                "releaseNotes" : {
+                    "common": "https://devdocs.magento.com/guides/v2.3/release-notes/2-3-7-p2.html"
+                }
             },
             {
                 "publishedAt": "2021-08-10T16:44:05Z",
-                "tagName": "2.3.7-p1"
+                "tagName": "2.3.7-p1",
+                "releaseNotes" : {
+                    "common": "https://devdocs.magento.com/guides/v2.3/release-notes/2-3-7-p1.html"
+                }
             },
             {
                 "publishedAt":"2021-05-11T15:16:04Z",
-                "tagName":"2.3.7"
+                "tagName":"2.3.7",
+                "releaseNotes" : {
+                    "commerce": "https://devdocs.magento.com/guides/v2.3/release-notes/commerce-2-3-7.html",
+                    "opensource": "https://devdocs.magento.com/guides/v2.3/release-notes/open-source-2-3-7.html"
+                }
             },
             {
                 "publishedAt":"2021-02-09T18:05:03Z",
@@ -75,7 +97,11 @@
             },
             {
                 "publishedAt":"2020-10-15T14:20:33Z",
-                "tagName":"2.3.6"
+                "tagName":"2.3.6",
+                "releaseNotes" : {
+                    "commerce": "https://devdocs.magento.com/guides/v2.3/release-notes/commerce-2-3-6.html",
+                    "opensource": "https://devdocs.magento.com/guides/v2.3/release-notes/open-source-2-3-6.html"
+                }
             },
             {
                 "publishedAt":"2020-07-28T14:49:50Z",
@@ -91,7 +117,11 @@
             },
             {
                 "publishedAt":"2020-04-28T14:36:19Z",
-                "tagName":"2.3.5"
+                "tagName":"2.3.5",
+                "releaseNotes" : {
+                    "commerce": "https://devdocs.magento.com/guides/v2.3/release-notes/release-notes-2-3-5-commerce.html",
+                    "opensource": "https://devdocs.magento.com/guides/v2.3/release-notes/release-notes-2-3-5-open-source.html"
+                }
             },
             {
                 "publishedAt":"2020-01-28T16:03:47Z",
@@ -99,7 +129,11 @@
             },
             {
                 "publishedAt":"2020-01-28T16:34:02Z",
-                "tagName":"2.3.4"
+                "tagName":"2.3.4",
+                "releaseNotes" : {
+                    "commerce": "https://devdocs.magento.com/guides/v2.3/release-notes/release-notes-2-3-4-commerce.html",
+                    "opensource": "https://devdocs.magento.com/guides/v2.3/release-notes/release-notes-2-3-4-open-source.html"
+                }
             },
             {
                 "publishedAt":"2019-10-09T01:49:34Z",
@@ -107,19 +141,35 @@
             },
             {
                 "publishedAt":"2019-10-08T14:19:13Z",
-                "tagName":"2.3.3"
+                "tagName":"2.3.3",
+                "releaseNotes" : {
+                    "commerce": "https://devdocs.magento.com/guides/v2.3/release-notes/release-notes-2-3-3-commerce.html",
+                    "opensource": "https://devdocs.magento.com/guides/v2.3/release-notes/release-notes-2-3-3-open-source.html"
+                }
             },
             {
                 "publishedAt":"2019-06-25T14:13:00Z",
-                "tagName":"2.3.2"
+                "tagName":"2.3.2",
+                "releaseNotes" : {
+                    "commerce": "https://devdocs.magento.com/guides/v2.3/release-notes/ReleaseNotes2.3.2Commerce.html",
+                    "opensource": "https://devdocs.magento.com/guides/v2.3/release-notes/ReleaseNotes2.3.2OpenSource.html"
+                }
             },
             {
                 "publishedAt":"2019-03-26T14:43:59Z",
-                "tagName":"2.3.1"
+                "tagName":"2.3.1",
+                "releaseNotes" : {
+                    "commerce": "https://devdocs.magento.com/guides/v2.3/release-notes/ReleaseNotes2.3.1Commerce.html",
+                    "opensource": "https://devdocs.magento.com/guides/v2.3/release-notes/ReleaseNotes2.3.1OpenSource.html"
+                }
             },
             {
                 "publishedAt":"2018-11-28T17:55:38Z",
-                "tagName":"2.3.0"
+                "tagName":"2.3.0",
+                "releaseNotes" : {
+                    "commerce": "https://devdocs.magento.com/guides/v2.3/release-notes/ReleaseNotes2.3.0Commerce.html",
+                    "opensource": "https://devdocs.magento.com/guides/v2.3/release-notes/ReleaseNotes2.3.0OpenSource.html"
+                }
             }
         ],
         "end-of-support": "2022-04-??"
@@ -128,51 +178,99 @@
         "releases": [
             {
                 "publishedAt":"2020-01-28T15:20:55Z",
-                "tagName":"2.2.11"
+                "tagName":"2.2.11",
+                "releaseNotes" : {
+                    "commerce": "https://devdocs.magento.com/guides/v2.2/release-notes/release-notes-2-2-11-commerce.html",
+                    "opensource": "https://devdocs.magento.com/guides/v2.2/release-notes/release-notes-2-2-11-open-source.html"
+                }
             },
             {
                 "publishedAt":"2019-10-08T14:14:32Z",
-                "tagName":"2.2.10"
+                "tagName":"2.2.10",
+                "releaseNotes" : {
+                    "commerce": "https://devdocs.magento.com/guides/v2.2/release-notes/release-notes-2-2-10-commerce.html",
+                    "opensource": "https://devdocs.magento.com/guides/v2.2/release-notes/release-notes-2-2-10-open-source.html"
+                }
             },
             {
                 "publishedAt":"2019-06-25T14:06:46Z",
-                "tagName":"2.2.9"
+                "tagName":"2.2.9",
+                "releaseNotes" : {
+                    "commerce": "https://devdocs.magento.com/guides/v2.2/release-notes/ReleaseNotes2.2.9EE.html",
+                    "opensource": "https://devdocs.magento.com/guides/v2.2/release-notes/ReleaseNotes2.2.9CE.html"
+                }
             },
             {
                 "publishedAt":"2019-03-26T14:05:48Z",
-                "tagName":"2.2.8"
+                "tagName":"2.2.8",
+                "releaseNotes" : {
+                    "commerce": "https://devdocs.magento.com/guides/v2.2/release-notes/ReleaseNotes2.2.8EE.html",
+                    "opensource": "https://devdocs.magento.com/guides/v2.2/release-notes/ReleaseNotes2.2.8CE.html"
+                }
             },
             {
                 "publishedAt":"2018-11-28T15:58:45Z",
-                "tagName":"2.2.7"
+                "tagName":"2.2.7",
+                "releaseNotes" : {
+                    "commerce": "https://devdocs.magento.com/guides/v2.2/release-notes/ReleaseNotes2.2.7EE.html",
+                    "opensource": "https://devdocs.magento.com/guides/v2.2/release-notes/ReleaseNotes2.2.7CE.html"
+                }
             },
             {
                 "publishedAt":"2018-09-18T13:52:51Z",
-                "tagName":"2.2.6"
+                "tagName":"2.2.6",
+                "releaseNotes" : {
+                    "commerce": "https://devdocs.magento.com/guides/v2.2/release-notes/ReleaseNotes2.2.6EE.html",
+                    "opensource": "https://devdocs.magento.com/guides/v2.2/release-notes/ReleaseNotes2.2.6CE.html"
+                }
             },
             {
                 "publishedAt":"2018-06-27T14:12:48Z",
-                "tagName":"2.2.5"
+                "tagName":"2.2.5",
+                "releaseNotes" : {
+                    "commerce": "https://devdocs.magento.com/guides/v2.2/release-notes/ReleaseNotes2.2.5EE.html",
+                    "opensource": "https://devdocs.magento.com/guides/v2.2/release-notes/ReleaseNotes2.2.5CE.html"
+                }
             },
             {
                 "publishedAt":"2018-05-02T14:07:21Z",
-                "tagName":"2.2.4"
+                "tagName":"2.2.4",
+                "releaseNotes" : {
+                    "commerce": "https://devdocs.magento.com/guides/v2.2/release-notes/ReleaseNotes2.2.4EE.html",
+                    "opensource": "https://devdocs.magento.com/guides/v2.2/release-notes/ReleaseNotes2.2.4CE.html"
+                }
             },
             {
                 "publishedAt":"2018-02-27T15:04:42Z",
-                "tagName":"2.2.3"
+                "tagName":"2.2.3",
+                "releaseNotes" : {
+                    "commerce": "https://devdocs.magento.com/guides/v2.2/release-notes/ReleaseNotes2.2.3EE.html",
+                    "opensource": "https://devdocs.magento.com/guides/v2.2/release-notes/ReleaseNotes2.2.3CE.html"
+                }
             },
             {
                 "publishedAt":"2017-12-12T19:18:33Z",
-                "tagName":"2.2.2"
+                "tagName":"2.2.2",
+                "releaseNotes" : {
+                    "commerce": "https://devdocs.magento.com/guides/v2.2/release-notes/ReleaseNotes2.2.2EE.html",
+                    "opensource": "https://devdocs.magento.com/guides/v2.2/release-notes/ReleaseNotes2.2.2CE.html"
+                }
             },
             {
                 "publishedAt":"2017-11-07T15:14:24Z",
-                "tagName":"2.2.1"
+                "tagName":"2.2.1",
+                "releaseNotes" : {
+                    "commerce": "https://devdocs.magento.com/guides/v2.2/release-notes/ReleaseNotes2.2.1EE.html",
+                    "opensource": "https://devdocs.magento.com/guides/v2.2/release-notes/ReleaseNotes2.2.1CE.html"
+                }
             },
             {
                 "publishedAt":"2017-09-26T19:29:17Z",
-                "tagName":"2.2.0"
+                "tagName":"2.2.0",
+                "releaseNotes" : {
+                    "commerce": "https://devdocs.magento.com/guides/v2.2/release-notes/ReleaseNotes2.2.0EE.html",
+                    "opensource": "https://devdocs.magento.com/guides/v2.2/release-notes/ReleaseNotes2.2.0CE.html"
+                }
             }
         ],
         "end-of-support": "2019-12-01"
@@ -297,8 +395,8 @@
                 "tagName":"2.0.10"
             },
             {
-            "publishedAt":"2016-08-10T22:02:13Z",
-            "tagName":"2.0.9"
+                 "publishedAt":"2016-08-10T22:02:13Z",
+                 "tagName":"2.0.9"
             },
             {
                 "publishedAt":"2016-07-19T16:31:26Z",

--- a/src/_data/core-releases.json
+++ b/src/_data/core-releases.json
@@ -7,15 +7,19 @@
         "releases": [
             {
                 "publishedAt": "2021-10-12T14:41:27Z",
-                "tagName": "2.4.3-p1"
+                "tagName": "2.4.3-p1",
+                "combinedReleaseNotes": "guides/v2.4/release-notes/2-4-3-p1.html"
             },
             {
                 "publishedAt": "2021-08-10T16:44:14Z",
-                "tagName": "2.4.3"
+                "tagName": "2.4.3",
+                "commerceReleaseNotes": "guides/v2.4/release-notes/commerce-2-4-3.html",
+                "opensourceReleaseNotes": "guides/v2.4/release-notes/open-source-2-4-3.html"
             },
             {
                 "publishedAt": "2021-08-10T16:44:09Z",
-                "tagName": "2.4.2-p2"
+                "tagName": "2.4.2-p2",
+                "combinedReleaseNotes": "guides/v2.4/release-notes/2-4-2-p2.html"
             },
             {
                 "publishedAt":"2021-05-11T15:16:17Z",
@@ -23,7 +27,9 @@
             },
             {
                 "publishedAt":"2021-02-09T18:05:14Z",
-                "tagName":"2.4.2"
+                "tagName":"2.4.2",
+                "commerceReleaseNotes": "guides/v2.4/release-notes/commerce-2-4-2.html",
+                "opensourceReleaseNotes": "guides/v2.4/release-notes/open-source-2-4-2.html"
             },
             {
                 "publishedAt":"2021-02-09T18:05:10Z",
@@ -31,7 +37,9 @@
             },
             {
                 "publishedAt":"2020-10-15T14:21:36Z",
-                "tagName":"2.4.1"
+                "tagName":"2.4.1",
+                "commerceReleaseNotes": "guides/v2.4/release-notes/commerce-2-4-1.html",
+                "opensourceReleaseNotes": "guides/v2.4/release-notes/open-source-2-4-1.html"
             },
             {
                 "publishedAt":"2020-10-15T14:21:04Z",
@@ -39,10 +47,13 @@
             },
             {
                 "publishedAt":"2020-07-28T14:40:42Z",
-                "tagName":"2.4.0"
+                "tagName":"2.4.0",
+                "commerceReleaseNotes": "guides/v2.4/release-notes/release-notes-2-4-0-commerce.html",
+                "opensourceReleaseNotes": "guides/v2.4/release-notes/release-notes-2-4-0-open-source.html"
             }
         ],
-        "end-of-support": "2022-11-??"
+        "end-of-support": "2022-11-??",
+        "release-notes" : true
     },
     "2.3": {
         "releases": [

--- a/src/_includes/release-notes/core-releases.md
+++ b/src/_includes/release-notes/core-releases.md
@@ -5,6 +5,7 @@
 {% assign minor_release_version = minor_release[0] %}
 {% assign patch_releases = minor_release[1].releases %}
 {% assign end_of_support = minor_release[1].end-of-support %}
+{% assign release_notes = minor_release[1].release-notes %}
 {% assign end_of_support_array = end_of_support | split: '-' %}
 ## {{ minor_release_version }}
 
@@ -27,6 +28,7 @@ Support for the {{ minor_release_version }} release line ends on {{ end_of_suppo
     <tr>
       <th>Patch version</th>
       <th>Release date</th>
+      {% if release_notes %}<th>Release notes</th>{% endif %}
     </tr>
   </thead>
   <tbody>
@@ -34,6 +36,13 @@ Support for the {{ minor_release_version }} release line ends on {{ end_of_suppo
     <tr>
         <td>{{ patch_release.tagName }}</td>
         <td>{{ patch_release.publishedAt | date: "%B&nbsp;%e, %Y" }}</td>
+        {% if release_notes %}
+          <td>
+              {% if patch_release.commerceReleaseNotes %}<a href="{{ site.baseurl }}/{{ patch_release.commerceReleaseNotes}}">Adobe Commerce Release Notes</a><br>{% endif %}
+              {% if patch_release.opensourceReleaseNotes %}<a href="{{ site.baseurl }}/{{ patch_release.opensourceReleaseNotes}}">Magento Open Source Release Notes</a><br>{% endif %}
+              {% if patch_release.combinedReleaseNotes %}<a href="{{ site.baseurl }}/{{ patch_release.combinedReleaseNotes}}">Release Notes</a><br>{% endif %}
+          </td>
+        {% endif %}
     </tr>
     {% else %}
     <tr>

--- a/src/_includes/release-notes/core-releases.md
+++ b/src/_includes/release-notes/core-releases.md
@@ -5,9 +5,15 @@
 {% assign minor_release_version = minor_release[0] %}
 {% assign patch_releases = minor_release[1].releases %}
 {% assign end_of_support = minor_release[1].end-of-support %}
-{% assign release_notes = minor_release[1].release-notes %}
 {% assign end_of_support_array = end_of_support | split: '-' %}
 ## {{ minor_release_version }}
+
+{% assign release_notes = false %}
+{% for patch_release in patch_releases %}
+{% if patch_release.releaseNotes %}
+{% assign release_notes = true %}
+{% endif %}
+{% endfor %}
 
 {% if end_of_support_array[0] contains '?' %}
 The date when support of the {{ minor_release_version }} release line ends has not been set yet.
@@ -38,9 +44,9 @@ Support for the {{ minor_release_version }} release line ends on {{ end_of_suppo
         <td>{{ patch_release.publishedAt | date: "%B&nbsp;%e, %Y" }}</td>
         {% if release_notes %}
           <td>
-              {% if patch_release.commerceReleaseNotes %}<a href="{{ site.baseurl }}/{{ patch_release.commerceReleaseNotes}}">Adobe Commerce Release Notes</a><br>{% endif %}
-              {% if patch_release.opensourceReleaseNotes %}<a href="{{ site.baseurl }}/{{ patch_release.opensourceReleaseNotes}}">Magento Open Source Release Notes</a><br>{% endif %}
-              {% if patch_release.combinedReleaseNotes %}<a href="{{ site.baseurl }}/{{ patch_release.combinedReleaseNotes}}">Release Notes</a><br>{% endif %}
+              {% if patch_release.releaseNotes.commerce %}<a href="{{ patch_release.releaseNotes.commerce}}">Adobe Commerce Release Notes</a><br>{% endif %}
+              {% if patch_release.releaseNotes.opensource %}<a href="{{ patch_release.releaseNotes.opensource}}">Magento Open Source Release Notes</a><br>{% endif %}
+              {% if patch_release.releaseNotes.common %}<a href="{{ patch_release.releaseNotes.common}}">Release Notes</a><br>{% endif %}
           </td>
         {% endif %}
     </tr>


### PR DESCRIPTION
## Purpose of this pull request

This pull request (PR) addresses issue #9355 

Using an enhancement to the JSON file, the links to the Release notes can be added which will then display on the page.

A special value indicates if there are any release notes in the section so the table can be created with a third column

Currently only v2.4 has had links added. If the solution is approved, then I will add 2.3 & 2.2 release note links to the PR for approval 

## Affected DevDocs pages
https://devdocs.magento.com/release/released-versions.html

## Screenshot
https://capture.dropbox.com/pj2P8gznSBrsQdmo?src=ss

whatsnew
Added release notes data to `src/_data/core-releases.json` and [Released versions](https://devdocs.magento.com/release/released-versions.html).