### PR TITLE
Update Elasticsearch version for 2.3.5 and 2.4.x

### DIFF
--- a/src/_includes/cloud/cloud-elasticsearch-client-compatibility.md
+++ b/src/_includes/cloud/cloud-elasticsearch-client-compatibility.md
@@ -4,4 +4,4 @@ Elasticsearch service   |  Elasticsearch composer package | Status
 --------- | ------------- | -------------------------
 5.2.x | 5.x.x | default versions for {{ site.data.var.ee }} versions 2.2.x to 2.2.7 and 2.3.0
 6.8 | 6.7.x | recommended, default versions for {{ site.data.var.ee }} versions 2.2.8 and 2.3.4
-7.7 | 7.x | recommended, default versions for {{ site.data.var.ee }} versions 2.3.5 and 2.4.x
+7.9 | 7.x | recommended, default versions for {{ site.data.var.ee }} versions 2.3.5 and 2.4.x


### PR DESCRIPTION
Fixes #9360 
## Purpose of this pull request

This pull request (PR) updating Elasticsearch version for 2.3.5 and 2.4.x

## Affected DevDocs pages

-  https://devdocs.magento.com/cloud/project/services-elastic.html