### PR TITLE
Update documentation to match new feature - localised error pages

### DIFF
--- a/src/guides/v2.3/install-gde/install/cli/install-cli-subcommands-maint.md
+++ b/src/guides/v2.3/install-gde/install/cli/install-cli-subcommands-maint.md
@@ -86,7 +86,10 @@ bin/magento maintenance:allow-ips <ip address> .. <ip address> [--none]
 
 ## Multi-store setups
 
-If you want to set up multiple stores, each with a different layout and localized content, pass the `$_GET['skin']` parameter to the intended processor.
+If you want to set up multiple stores, each with a different layout and localized content, this can be achieved by creating a skin for each and putting this into `pub/errors/{name}` where `{name}` matches the store code set in Magento and in `MAGE_RUN_CODE` in your server configuration. To distinguish between stores and websites with the same code, use `pub/errors/{type}-{name}` where `{type}` is either `store` or `website` and matches what's set in `MAGE_RUN_TYPE` in your server configuration.
+
+Another option is to pass the `$_GET['skin']` parameter to the intended processor. This method requires specific configuration on your server.
+
 In the following example, we are using a `503` type error template file, which requires localized content.
 
 The constructor of the `Error_Processor` class accepts a `skin` GET parameter to change the layout:


### PR DESCRIPTION
## Purpose of this pull request

This pull request updates the documentation regarding localised error pages. This is a companion to https://github.com/magento/magento2/pull/35095 where the referenced feature is being introduced.

## Affected DevDocs pages
- https://devdocs.magento.com/guides/v2.3/install-gde/install/cli/install-cli-subcommands-maint.html#multi-store-setups
- https://devdocs.magento.com/guides/v2.4/install-gde/install/cli/install-cli-subcommands-maint.html#multi-store-setups

## Links to Magento source code
- https://github.com/magento/magento2/pull/35095
