### PR TITLE
Updated Commerce application version to 2.4.x to keep relevancy with …

### DIFF
--- a/src/guides/v2.4/install-gde/composer.md
+++ b/src/guides/v2.4/install-gde/composer.md
@@ -56,28 +56,28 @@ To get the Magento metapackage:
 
 ### Example - Minor release
 
-Minor releases contain new features, quality fixes, and security fixes. Use Composer to specify a minor release. For example, to specify the {{site.data.var.ee}} 2.4.0 metapackage:
+Minor releases contain new features, quality fixes, and security fixes. Use Composer to specify a minor release. For example, to specify the {{site.data.var.ee}} 2.4.3 metapackage:
 
 ```bash
-composer create-project --repository-url=https://repo.magento.com/ magento/project-enterprise-edition=2.4.0 <install-directory-name>
+composer create-project --repository-url=https://repo.magento.com/ magento/project-enterprise-edition=2.4.3 <install-directory-name>
 ```
 
 ### Example - Quality patch
 
-Quality patches primarily contain functional _and_ security fixes. However, they can also sometimes contain new, backward-compatible features. Use Composer to download a quality patch. For example, to specify the {{site.data.var.ee}} 2.3.4 metapackage:
+Quality patches primarily contain functional _and_ security fixes. However, they can also sometimes contain new, backward-compatible features. Use Composer to download a quality patch. For example, to specify the {{site.data.var.ee}} 2.4.3 metapackage:
 
 ```bash
-composer create-project --repository-url=https://repo.magento.com/ magento/project-enterprise-edition=2.3.4 <install-directory-name>
+composer create-project --repository-url=https://repo.magento.com/ magento/project-enterprise-edition=2.4.3 <install-directory-name>
 ```
 
 ### Example - Security patch
 
 Security patches contain security fixes only. They are designed to make the upgrade process faster and easier.
 
-Security patches use the Composer naming convention `2.3.2-px`. Use Composer to specify a patch. For example, to download the {{site.data.var.ee}} 2.3.2-p1 metapackage:
+Security patches use the Composer naming convention `2.4.3-px`. Use Composer to specify a patch. For example, to download the {{site.data.var.ee}} 2.4.3-p1 metapackage:
 
 ```bash
-composer create-project --repository-url=https://repo.magento.com/ magento/project-enterprise-edition=2.3.2-p1 <install-directory-name>
+composer create-project --repository-url=https://repo.magento.com/ magento/project-enterprise-edition=2.4.3-p1 <install-directory-name>
 ```
 
 ## Set file permissions


### PR DESCRIPTION
Updated Commerce application version to 2.4.x to keep relevancy with doc version chooser.

## Purpose of this pull request

Updated Commerce application version to 2.4.x to keep relevancy with doc version chooser.

## Affected DevDocs pages

-  https://devdocs.magento.com/guides/v2.4/install-gde/composer.html


Please advise/update the target branch if master not appropriate.
