### PR TITLE
Updates the example admin controller code

### DIFF
--- a/src/guides/v2.3/ext-best-practices/extension-coding/example-module-adminpage.md
+++ b/src/guides/v2.3/ext-best-practices/extension-coding/example-module-adminpage.md
@@ -200,10 +200,8 @@ Inside `Controller/Adminhtml/HelloWorld` directory, create the file `Index.php`.
 namespace MyCompany\ExampleAdminNewPage\Controller\Adminhtml\HelloWorld;
 
 use Magento\Backend\App\Action;
-use Magento\Backend\App\Action\Context;
 use Magento\Framework\App\Action\HttpGetActionInterface;
-use Magento\Framework\View\Result\Page;
-use Magento\Framework\View\Result\PageFactory;
+use Magento\Framework\Controller\ResultFactory;
 
 /**
  * Class Index
@@ -213,33 +211,13 @@ class Index extends Action implements HttpGetActionInterface
     const MENU_ID = 'MyCompany_ExampleAdminNewPage::greetings_helloworld';
 
     /**
-     * @var PageFactory
-     */
-    protected $resultPageFactory;
-
-    /**
-     * Index constructor.
-     *
-     * @param Context $context
-     * @param PageFactory $resultPageFactory
-     */
-    public function __construct(
-        Context $context,
-        PageFactory $resultPageFactory
-    ) {
-        parent::__construct($context);
-
-        $this->resultPageFactory = $resultPageFactory;
-    }
-
-    /**
      * Load the page defined in view/adminhtml/layout/exampleadminnewpage_helloworld_index.xml
      *
      * @return Page
      */
     public function execute()
     {
-        $resultPage = $this->resultPageFactory->create();
+        $resultPage = $this->resultFactory->create(ResultFactory::TYPE_PAGE);
         $resultPage->setActiveMenu(static::MENU_ID);
         $resultPage->getConfig()->getTitle()->prepend(__('Hello World'));
 

--- a/src/guides/v2.3/ext-best-practices/extension-coding/example-module-adminpage.md
+++ b/src/guides/v2.3/ext-best-practices/extension-coding/example-module-adminpage.md
@@ -201,6 +201,7 @@ namespace MyCompany\ExampleAdminNewPage\Controller\Adminhtml\HelloWorld;
 
 use Magento\Backend\App\Action;
 use Magento\Framework\App\Action\HttpGetActionInterface;
+use Magento\Framework\View\Result\Page;
 use Magento\Framework\Controller\ResultFactory;
 
 /**


### PR DESCRIPTION
## Purpose of this pull request

This pull request updates the example controller code to use best practise, eliminating the need for DI via __constructor.

## Affected DevDocs pages

https://devdocs.magento.com/guides/v2.3/ext-best-practices/extension-coding/example-module-adminpage.html
https://devdocs.magento.com/guides/v2.4/ext-best-practices/extension-coding/example-module-adminpage.html

