### PR TITLE
Changes path of where to save file in email migration topic so it dis…

### DIFF
--- a/src/guides/v2.3/frontend-dev-guide/templates/template-email-migration.md
+++ b/src/guides/v2.3/frontend-dev-guide/templates/template-email-migration.md
@@ -165,7 +165,7 @@ In this example, we will create and pass a `lifetime_spend` custom value.
     }
    ```
 
-   and save the file to <Vendor>/<module>/Model.
+   and save the file to `<Vendor>/<module>/Model`.
 
 1. Add the new directive to the pool by adding this block to `di.xml`.
 

--- a/src/guides/v2.4/frontend-dev-guide/templates/template-email-migration.md
+++ b/src/guides/v2.4/frontend-dev-guide/templates/template-email-migration.md
@@ -173,7 +173,7 @@ In this example, we will create and pass a `lifetime_spend` custom value.
     }
    ```
 
-   and save the file to <Vendor>/<module>/Model.
+   and save the file to `<Vendor>/<module>/Model`.
 
 1. Add the new directive to the pool by adding this block to `di.xml`.
 


### PR DESCRIPTION
…plays as intended.

## Purpose of this pull request

This pull request fixes the rendering of the path from `//Model` to `<Vendor>/<module>/Model` on the email templates migration guides:
- https://devdocs.magento.com/guides/v2.3/frontend-dev-guide/templates/template-email-migration.html#create-a-custom-directive
- https://devdocs.magento.com/guides/v2.4/frontend-dev-guide/templates/template-email-migration.html#create-a-custom-directive

It's currently being rendered as follows, which is not as it was intended I think:
<img width="657" alt="Screenshot 2022-04-25 at 15 51 00" src="https://user-images.githubusercontent.com/85479/165103014-5630eef1-3a2c-48c0-bd1b-d7c88a1b6f03.png">

## Affected DevDocs pages

See above

## Links to Magento source code

N/A
