### PR TITLE
Fixed claimed composer version compatibility with Magento 2.3.7-p3

### DIFF
--- a/src/_data/codebase/v2_3/system-requirements.yml
+++ b/src/_data/codebase/v2_3/system-requirements.yml
@@ -12,7 +12,7 @@
   Apache: '2.4'
   nginx: '1.8'
 2.3.7:
-  Composer: '2'
+  Composer: '1'
   Elasticsearch: '7.9'
   MariaDB: '10.3'
   MySQL: '5.7'


### PR DESCRIPTION
## Purpose of this pull request

This pull request fixes the composer version that Adobe recommends for Magento 2.3.7-p3

Claiming support for composer version 1 on Magento 2.3.7-p3 makes no sense, because composer version 2 was supported with the release of 2.3.7 (and continued in 2.3.7-p1 and 2.3.7-p2).
And in my experience on about 10 different Magento projects running on 2.3.7-p3, it works perfectly fine.

In my opinion version 2 should be added as well to Magento 2.4.2 and higher, but there is still some ongoing [discussion around that](https://github.com/magento/devdocs/issues/9390).

## Affected DevDocs pages

-  https://devdocs.magento.com/guides/v2.4/install-gde/system-requirements.html

## Links to Magento source code

N/A
