### PR TITLE
Add message that grid snapshots are not automated.

### DIFF
--- a/src/cloud/project/project-webint-snap.md
+++ b/src/cloud/project/project-webint-snap.md
@@ -9,6 +9,9 @@ You can back up and restore specific environments at any time using a snapshot. 
 
 The Pro Staging and Production environments receive regular backups for disaster recovery purposes by default, see [Pro Backup & Disaster Recovery]({{ site.baseurl }}/cloud/architecture/pro-architecture.html#backup-and-disaster-recovery). However, these backups are not publicly accessible because they are stored in a separate system. You can open a ticket to request a backup with a specific date, time, and timezone. Then we can extract it from the external system and provide it to you.
 
+{:.bs-callout-warning}
+Snapshots for Starter and Pro Integration environments are not taken automatically.  It is the your responsibility to take manual snapshots or setup a con job to automatically take snapshots for these environments.
+
 A _snapshot_ is a complete backup of an environment that includes all persistent data from all running services (for example, your MySQL database, Redis, and so on) and any files stored on the mounted volumes. Because an environment deploys as a read-only file system, restoring a snapshot is very fast.
 
 {:.bs-callout-warning}

--- a/src/cloud/project/project-webint-snap.md
+++ b/src/cloud/project/project-webint-snap.md
@@ -10,7 +10,7 @@ You can back up and restore specific environments at any time using a snapshot. 
 The Pro Staging and Production environments receive regular backups for disaster recovery purposes by default, see [Pro Backup & Disaster Recovery]({{ site.baseurl }}/cloud/architecture/pro-architecture.html#backup-and-disaster-recovery). However, these backups are not publicly accessible because they are stored in a separate system. You can open a ticket to request a backup with a specific date, time, and timezone. Then we can extract it from the external system and provide it to you.
 
 {:.bs-callout-warning}
-Snapshots for Starter and Pro Integration environments are not taken automatically.  It is the your responsibility to take manual snapshots or setup a con job to automatically take snapshots for these environments.
+Snapshots for Starter and Pro Integration environments are different from Pro backup and disaster recovery backups. Snapshots are **not** automatic. It is _your_ responsibility to manually create a snapshot or set up a con job to periodically take snapshots of your Starter or Pro Integration environments.
 
 A _snapshot_ is a complete backup of an environment that includes all persistent data from all running services (for example, your MySQL database, Redis, and so on) and any files stored on the mounted volumes. Because an environment deploys as a read-only file system, restoring a snapshot is very fast.
 

--- a/src/cloud/project/project-webint-snap.md
+++ b/src/cloud/project/project-webint-snap.md
@@ -9,7 +9,7 @@ You can back up and restore specific environments at any time using a snapshot. 
 
 The Pro Staging and Production environments receive regular backups for disaster recovery purposes by default, see [Pro Backup & Disaster Recovery]({{ site.baseurl }}/cloud/architecture/pro-architecture.html#backup-and-disaster-recovery). However, these backups are not publicly accessible because they are stored in a separate system. You can open a ticket to request a backup with a specific date, time, and timezone. Then we can extract it from the external system and provide it to you.
 
-{:.bs-callout-warning}
+{:.bs-callout-tip}
 Snapshots for Starter and Pro Integration environments are different from Pro backup and disaster recovery backups. Snapshots are **not** automatic. It is _your_ responsibility to manually create a snapshot or set up a con job to periodically take snapshots of your Starter or Pro Integration environments.
 
 A _snapshot_ is a complete backup of an environment that includes all persistent data from all running services (for example, your MySQL database, Redis, and so on) and any files stored on the mounted volumes. Because an environment deploys as a read-only file system, restoring a snapshot is very fast.


### PR DESCRIPTION
## Purpose of this pull request

This adds a message that snapshots on integration and starter environments are not automatically taken, and that it's the customer's reasonability to take these.  This isn't called out clearly and may cause headaches if customers expect some form of automated backups.

## Affected DevDocs pages

-  https://devdocs.magento.com/cloud/project/project-webint-snap.html