### PR TITLE
Add missing mode value

### DIFF
--- a/src/guides/v2.3/config-guide/cli/config-cli-subcommands-mode.md
+++ b/src/guides/v2.3/config-guide/cli/config-cli-subcommands-mode.md
@@ -68,7 +68,7 @@ bin/magento deploy:mode:set {mode} [-s|--skip-compilation]
 
 where:
 
--  **`{mode}`** is required; it can be either `developer` or `production`
+-  **`{mode}`** is required; it can be either `default`, `developer` or `production`
 
 -  **`--skip-compilation`** is an optional parameter you can use to skip [code compilation]({{ page.baseurl }}/config-guide/cli/config-cli-subcommands-compiler.html) when you change to production mode.
 


### PR DESCRIPTION
## Purpose of this pull request

This pull request (PR) adds a missing mode value in the Change modes's command explaination.

## Affected DevDocs pages

-  https://devdocs.magento.com/guides/v2.3/config-guide/cli/config-cli-subcommands-mode.html
-  https://devdocs.magento.com/guides/v2.4/config-guide/cli/config-cli-subcommands-mode.html