### PR TITLE
Encode "<" as "&lt;"

### DIFF
--- a/src/guides/v2.3/coding-standards/docblock-standard-javascript.md
+++ b/src/guides/v2.3/coding-standards/docblock-standard-javascript.md
@@ -388,7 +388,7 @@ new Date()</pre></td>
       <td>An array of numbers</td>
    </tr>
    <tr>
-      <td>Array.<Array.&lt;string>></td>
+      <td>Array.&lt;Array.&lt;string>></td>
       <td><pre>[['one', 'two', 'three'], ['foo', 'bar']]</pre></td>
       <td>Array of arrays of strings</td>
    </tr>
@@ -404,7 +404,7 @@ new Date()</pre></td>
       <td>An object. In the object, the values are strings.</td>
    </tr>
    <tr>
-      <td>Object.<number, string></td>
+      <td>Object.&lt;number, string></td>
       <td><pre>var obj = {};
 obj[1] = 'bar';</pre></td>
       <td>An object. In the object, the keys are numbers and the values are strings.


### PR DESCRIPTION
Fixes #9439 by replacing literal less-than characters with HTML character entities where appropriate (type applications in type examples).

## Purpose of this pull request

Fixes #9439.

## Affected DevDocs pages

<!-- REQUIRED List the affected pages on devdocs.magento.com (URLs). Not needed for large numbers of files. -->

-  [JavaScript DocBlock standard](https://devdocs.magento.com/guides/v2.3/coding-standards/docblock-standard-javascript.html)

<!--
If you are fixing a GitHub issue, note it using GitHub keyword format (https://help.github.com/en/articles/closing-issues-using-keywords#closing-an-issue-in-a-different-repository) to close the issue when this pull request is merged. Example: `Fixes #1234`

`master` is the default branch. Merged pull requests to `master` go live on the site automatically. Any requested changes to content on the `master` branch must be related to the released codebase. Any content related to future releases goes in the `develop` branch.

See Contribution guidelines (https://github.com/magento/devdocs/blob/master/.github/CONTRIBUTING.md) for more information.
-->
