### PR TITLE
Cleared a wrong comment regarding path repository support

### DIFF
--- a/src/guides/v2.3/extension-dev-guide/build/composer-integration.md
+++ b/src/guides/v2.3/extension-dev-guide/build/composer-integration.md
@@ -12,7 +12,7 @@ Composer reads a `composer.json` file in Magento's root directory to download th
 We recommend you include `composer.json` in your component's root directory even if you do not intend to distribute it to other merchants using Magento.
 
  {:.bs-callout-info}
-Magento does not support the [`path`][3] repository.
+Magento does not support the [`path`][3] repository pointing to a folder outside of Magento root.
 
 ## composer.json
 

--- a/src/guides/v2.3/extension-dev-guide/build/composer-integration.md
+++ b/src/guides/v2.3/extension-dev-guide/build/composer-integration.md
@@ -12,7 +12,7 @@ Composer reads a `composer.json` file in Magento's root directory to download th
 We recommend you include `composer.json` in your component's root directory even if you do not intend to distribute it to other merchants using Magento.
 
  {:.bs-callout-info}
-Magento does not support the [`path`][3] repository pointing to a folder outside of Magento root.
+Magento does not support the [`path`][3] repository pointing to a folder outside of the Magento root.
 
 ## composer.json
 


### PR DESCRIPTION
## Purpose of this pull request

Clarify support of the Path repository type

## Affected DevDocs pages

<!-- REQUIRED List the affected pages on devdocs.magento.com (URLs). Not needed for large numbers of files. -->

👉 [The composer.json file](https://devdocs.magento.com/guides/v2.4/extension-dev-guide/build/composer-integration.html) 👈

