### PR TITLE
Missing command for applying changes after dev:query-log command

### DIFF
--- a/src/guides/v2.3/config-guide/cli/logging.md
+++ b/src/guides/v2.3/config-guide/cli/logging.md
@@ -61,7 +61,7 @@ By default, Magento writes database activity logs to the `var/debug/db.log` file
    bin/magento dev:query-log:disable
    ```
    
-2. In the [production mode](https://devdocs.magento.com/guides/v2.4/config-guide/cli/config-cli-subcommands-mode.html#config-mode-show) run the command for [import configuration](https://devdocs.magento.com/guides/v2.4/config-guide/cli/config-cli-subcommands-config-mgmt-import.html), because the command `bin/magento dev:query-log:disable` adds settings to the `app/etc/env.php` file:
+1. In the [production mode]({{ page.baseurl }}/config-guide/cli/config-cli-subcommands-mode.html#config-mode-show), run the command for [import configuration]({{ page.baseurl }}/config-guide/cli/config-cli-subcommands-config-mgmt-import.html), because the `bin/magento dev:query-log:disable` command adds settings to the `app/etc/env.php` file:
   
   ```bash
   bin/magento app:config:import

--- a/src/guides/v2.3/config-guide/cli/logging.md
+++ b/src/guides/v2.3/config-guide/cli/logging.md
@@ -60,8 +60,14 @@ By default, Magento writes database activity logs to the `var/debug/db.log` file
    ```bash
    bin/magento dev:query-log:disable
    ```
+   
+2. In the [production mode](https://devdocs.magento.com/guides/v2.4/config-guide/cli/config-cli-subcommands-mode.html#config-mode-show) run the command for [import configuration](https://devdocs.magento.com/guides/v2.4/config-guide/cli/config-cli-subcommands-config-mgmt-import.html), because the command `bin/magento dev:query-log:disable` sets settings into app/etc/env.php file:
+  
+  ```bash
+  bin/magento app:config:import
+  ```
 
-1. Flush the cache.
+3. Flush the cache.
 
    ```bash
    bin/magento cache:flush

--- a/src/guides/v2.3/config-guide/cli/logging.md
+++ b/src/guides/v2.3/config-guide/cli/logging.md
@@ -60,12 +60,11 @@ By default, Magento writes database activity logs to the `var/debug/db.log` file
    ```bash
    bin/magento dev:query-log:disable
    ```
-   
+
 1. In the [production mode]({{ page.baseurl }}/config-guide/cli/config-cli-subcommands-mode.html#config-mode-show), run the command for [import configuration]({{ page.baseurl }}/config-guide/cli/config-cli-subcommands-config-mgmt-import.html), because the `bin/magento dev:query-log:disable` command adds settings to the `app/etc/env.php` file:
-  
-  ```bash
-  bin/magento app:config:import
-  ```
+
+   ```bash
+   bin/magento app:config:import
 
 1. Flush the cache.
 

--- a/src/guides/v2.3/config-guide/cli/logging.md
+++ b/src/guides/v2.3/config-guide/cli/logging.md
@@ -67,7 +67,7 @@ By default, Magento writes database activity logs to the `var/debug/db.log` file
   bin/magento app:config:import
   ```
 
-3. Flush the cache.
+1. Flush the cache.
 
    ```bash
    bin/magento cache:flush

--- a/src/guides/v2.3/config-guide/cli/logging.md
+++ b/src/guides/v2.3/config-guide/cli/logging.md
@@ -61,7 +61,7 @@ By default, Magento writes database activity logs to the `var/debug/db.log` file
    bin/magento dev:query-log:disable
    ```
    
-2. In the [production mode](https://devdocs.magento.com/guides/v2.4/config-guide/cli/config-cli-subcommands-mode.html#config-mode-show) run the command for [import configuration](https://devdocs.magento.com/guides/v2.4/config-guide/cli/config-cli-subcommands-config-mgmt-import.html), because the command `bin/magento dev:query-log:disable` sets settings into app/etc/env.php file:
+2. In the [production mode](https://devdocs.magento.com/guides/v2.4/config-guide/cli/config-cli-subcommands-mode.html#config-mode-show) run the command for [import configuration](https://devdocs.magento.com/guides/v2.4/config-guide/cli/config-cli-subcommands-config-mgmt-import.html), because the command `bin/magento dev:query-log:disable` adds settings to the `app/etc/env.php` file:
   
   ```bash
   bin/magento app:config:import


### PR DESCRIPTION
## Purpose of this pull request

This pull request (PR) fills in missing command, that give understanding how does dev:query-log commands work.

In my case when I ran the command `bin/magento dev:query-log:disable` and then `cache:flush` on Magento 2.4.2 production server, it didn't disable db-logging, so the `var/debug/db.log` file continued filling. I went to see the logging command code to figure out why the logging haven't stopped, so I found that the command set config into `env.php` file, not into DB.

## Affected DevDocs pages

<!-- REQUIRED List the affected pages on devdocs.magento.com (URLs). Not needed for large numbers of files. -->

-  [Database logging](https://devdocs.magento.com/guides/v2.3/config-guide/cli/logging.html#database-logging)

## Links to Magento source code

<!--  OPTIONAL - REMOVE THIS SECTION IF NOT USED. If this pull request references a file in a Magento codebase repository, add it here. -->

-  [dev:query-log:disable command code](https://github.com/magento/magento2/blob/2.4.2/app/code/Magento/Developer/Console/Command/QueryLogDisableCommand.php)
- [dev:query-log:enable command code](https://github.com/magento/magento2/blob/2.4.2/app/code/Magento/Developer/Console/Command/QueryLogEnableCommand.php)

<!--
If you are fixing a GitHub issue, note it using GitHub keyword format (https://help.github.com/en/articles/closing-issues-using-keywords#closing-an-issue-in-a-different-repository) to close the issue when this pull request is merged. Example: Fixes #1234

master is the default branch. Merged pull requests to master go live on the site automatically. Any requested changes to content on the master branch must be related to the released codebase. Any content related to future releases goes in the develop branch.

See Contribution guidelines (https://github.com/magento/devdocs/blob/master/.github/CONTRIBUTING.md) for more information.
-->

`whatsnew`
Added [config import command point](https://devdocs.magento.com/guides/v2.3/config-guide/cli/logging.html#to-enable-database-logging) to the [Logging](https://devdocs.magento.com/guides/v2.3/config-guide/cli/logging.html) topic.