### PR TITLE
Fixing Mutagen typo

### DIFF
--- a/src/cloud/docker/docker-development.md
+++ b/src/cloud/docker/docker-development.md
@@ -26,7 +26,7 @@ The Cloud Docker environment supports Linux, macOS, and Windows operating system
 
 -  [Git] for interaction between your local system and {{site.data.var.ece}} source repositories
 -  [Docker] for Mac 2.2.0.0 or later or Docker for Linux
--  Developer mode on macOS systems might require the [mutagen] option for file synchronization.
+-  Developer mode on macOS systems might require the [Mutagen] option for file synchronization.
 
 ### Docker engine
 

--- a/src/cloud/docker/docker-development.md
+++ b/src/cloud/docker/docker-development.md
@@ -111,7 +111,7 @@ Prior to setting up a local workspace, gather the following credentials and acco
 [Docker]: https://www.docker.com/get-started
 [Docker desktop]: https://docs.docker.com/desktop/#configure-docker-desktop
 [init-docker.sh]: https://github.com/magento/magento-cloud-docker/blob/develop/bin/init-docker.sh
-[mutagen]: https://mutagen.io/documentation/introduction/installation
+[Mutagen]: https://mutagen.io/documentation/introduction/installation
 [authentication keys]: {{site.baseurl}}/guides/v2.3/install-gde/prereq/connect-auth.html
 [Magento Cloud template]: https://github.com/magento/magento-cloud
 [Set up an account]: {{site.baseurl}}/cloud/before/before-workspace.html#newaccount


### PR DESCRIPTION
## Purpose of this pull request

This pull request (PR) fixes the Mutagen typo. All the time it's mentioned in other pages Mutagen with uppercase later has been used instead of lowercase.

## Affected DevDocs pages

<!-- REQUIRED List the affected pages on devdocs.magento.com (URLs). Not needed for large numbers of files. -->

-  https://devdocs.magento.com/cloud/docker/docker-development.html
