### PR TITLE
Fix internal links in elasticsearch.md

### DIFF
--- a/src/guides/v2.4/install-gde/prereq/elasticsearch.md
+++ b/src/guides/v2.4/install-gde/prereq/elasticsearch.md
@@ -22,8 +22,8 @@ Refer to the [System Requirements][] for specific version information.
 
 We recommend the following:
 
-*  [Configure nginx and Elasticsearch][]
-*  [Configure Apache and Elasticsearch][]
+*  [Configure nginx for your search engine][]
+*  [Configure Apache for your search engine][]
 
 ## Installation location {#es-host}
 


### PR DESCRIPTION
## Purpose of this pull request

This pull request fixes two links in "Search engine prerequisites" that were broken after ES generalization.

## Affected DevDocs pages

- https://devdocs.magento.com/guides/v2.4/install-gde/prereq/elasticsearch.html