### PR TITLE
targetWidget parameter and return was missing

### DIFF
--- a/src/guides/v2.3/frontend-dev-guide/validations/custom-validation.md
+++ b/src/guides/v2.3/frontend-dev-guide/validations/custom-validation.md
@@ -47,7 +47,6 @@ define(['jquery'], function($) {
       },
       $.mage.__('Please enter exactly five words')
     )
-    
     return targetWidget;
   }
 });

--- a/src/guides/v2.3/frontend-dev-guide/validations/custom-validation.md
+++ b/src/guides/v2.3/frontend-dev-guide/validations/custom-validation.md
@@ -39,7 +39,7 @@ var config = {
 define(['jquery'], function($) {
   'use strict';
 
-  return function() {
+  return function(targetWidget) {
     $.validator.addMethod(
       'validate-five-words',
       function(value, element) {
@@ -47,6 +47,8 @@ define(['jquery'], function($) {
       },
       $.mage.__('Please enter exactly five words')
     )
+    
+    return targetWidget;
   }
 });
 ```


### PR DESCRIPTION
## Purpose of this pull request

As stated in https://devdocs.magento.com/guides/v2.4/javascript-dev-guide/javascript/js_mixins.html#examples, when writing a mixin for jQuery widgets you should have a parameter "targetWidget" and also return a jQuery widget. In this case about adding validation rules we don't change the targetWidget, so we should just return this. Not returning the targetWidget will throw a JS error.

## Affected DevDocs pages

- https://devdocs.magento.com/guides/v2.3/frontend-dev-guide/validations/custom-validation.html
- https://devdocs.magento.com/guides/v2.4/frontend-dev-guide/validations/custom-validation.html