### PR TITLE
Have fixed typo in $params array for DirectoryList::PUB key

### DIFF
--- a/src/guides/v2.3/config-guide/bootstrap/mage-dirs.md
+++ b/src/guides/v2.3/config-guide/bootstrap/mage-dirs.md
@@ -34,7 +34,7 @@ You can set `MAGE_DIRS` in any of the following ways:
    require __DIR__ . '/app/bootstrap.php';
    $params = $_SERVER;
    $params[Bootstrap::INIT_PARAM_FILESYSTEM_DIR_PATHS] = [
-        DirectoryList::PUB => [DirectoryList::URL_PATH => '',
+        DirectoryList::PUB => [DirectoryList::URL_PATH => ''],
         DirectoryList::MEDIA => [DirectoryList::PATH => '/mnt/nfs/media', DirectoryList::URL_PATH => ''],
         DirectoryList::STATIC_VIEW => [DirectoryList::URL_PATH => 'static'],
         DirectoryList::UPLOAD => [DirectoryList::URL_PATH => '/mnt/nfs/media/upload'],


### PR DESCRIPTION
## Purpose of this pull request

This pull request (PR) fixes typo in $params array declaration for **DirectoryList::PUB** key

## Affected DevDocs pages

<!-- REQUIRED List the affected pages on devdocs.magento.com (URLs). Not needed for large numbers of files. -->

-  https://devdocs.magento.com/guides/v2.3/config-guide/bootstrap/mage-dirs.html
-  https://devdocs.magento.com/guides/v2.4/config-guide/bootstrap/mage-dirs.html


<!--
If you are fixing a GitHub issue, note it using GitHub keyword format (https://help.github.com/en/articles/closing-issues-using-keywords#closing-an-issue-in-a-different-repository) to close the issue when this pull request is merged. Example: `Fixes #1234`

`master` is the default branch. Merged pull requests to `master` go live on the site automatically. Any requested changes to content on the `master` branch must be related to the released codebase. Any content related to future releases goes in the `develop` branch.

See Contribution guidelines (https://github.com/magento/devdocs/blob/master/.github/CONTRIBUTING.md) for more information.
-->
