### PR TITLE
Returned lost closing quotes

### DIFF
--- a/src/guides/v2.3/config-guide/cli/logging.md
+++ b/src/guides/v2.3/config-guide/cli/logging.md
@@ -65,6 +65,7 @@ By default, Magento writes database activity logs to the `var/debug/db.log` file
 
    ```bash
    bin/magento app:config:import
+   ```
 
 1. Flush the cache.
 


### PR DESCRIPTION
### Purpose of this pull request
This pull request (PR) is related with [this one](https://github.com/magento/devdocs/pull/9448). Before merging someone deleted quotes for markdown command markup. I return them in this PR

### Affected DevDocs pages
[Database logging](https://devdocs.magento.com/guides/v2.3/config-guide/cli/logging.html#database-logging)

### Links to Magento source code
[dev:query-log:disable command code](https://github.com/magento/magento2/blob/2.4.2/app/code/Magento/Developer/Console/Command/QueryLogDisableCommand.php)
[dev:query-log:enable command code](https://github.com/magento/magento2/blob/2.4.2/app/code/Magento/Developer/Console/Command/QueryLogEnableCommand.php)

`whatsnew`
Added [config import command point](https://devdocs.magento.com/guides/v2.3/config-guide/cli/logging.html#to-enable-database-logging) to the [Logging](https://devdocs.magento.com/guides/v2.3/config-guide/cli/logging.html) topic.
