### PR TITLE
From ES to OS

### DIFF
--- a/src/cloud/before/before-setup-env-install.md
+++ b/src/cloud/before/before-setup-env-install.md
@@ -138,8 +138,8 @@ To install {{site.data.var.ee}} using the command line:
      --timezone=America/Chicago \
      --language=en_US \
      --use-rewrites=1 \
-     --search-engine=elasticsearch7 \
-     --elasticsearch-host=es-host.example.com \
+     --search-engine=opensearch \
+     --elasticsearch-host=os-host.example.com \
      --elasticsearch-port=9200
    ```
 


### PR DESCRIPTION
## Purpose of this pull request

Since ElasticSearch won't be supported anymore by the Cloud version and this doc is under the Cloud section, in this PR I'm switching the installation instructions to OpenSearch.

## Affected DevDocs pages

<!-- REQUIRED List the affected pages on devdocs.magento.com (URLs). Not needed for large numbers of files. -->

-  https://devdocs.magento.com/cloud/before/before-setup-env-install.html

Ref:
- https://devdocs.magento.com/cloud/project/services-elastic.html
- https://devdocs.magento.com/cloud/project/services-opensearch.html
