### PR TITLE
Added a warning message about the need for a name when using cacheable false.

### DIFF
--- a/src/guides/v2.3/frontend-dev-guide/layouts/xml-instructions.md
+++ b/src/guides/v2.3/frontend-dev-guide/layouts/xml-instructions.md
@@ -58,6 +58,9 @@ Blocks employ templates to generate HTML. Examples of blocks include a [category
 {:.bs-callout-info}
 We recommend always adding a `name` to blocks. Otherwise, it is given a random name.
 
+{:.bs-callout-warning}
+If you are going to make the block non-cached, a `name` is required.
+
 | Attribute | Description | Values | Required? |
 |:------- |:------ |:------ |:------ |
 | `class` | Name of a class that implements rendering of a particular block. An object of this class is responsible for actual rendering of block output. | A fully-qualified class name, such as `Vendor\Module\Block\Class`. Defaults to `Magento\Framework\View\Element\Template`. | no |


### PR DESCRIPTION
Added a warning message about the need for a name when using cacheable false.

## Purpose of this pull request

This pull request (PR) ...
Fixes #8981.

## Affected DevDocs pages

<!-- REQUIRED List the affected pages on devdocs.magento.com (URLs). Not needed for large numbers of files. -->

https://devdocs.magento.com/guides/v2.4/frontend-dev-guide/layouts/xml-instructions.html#fedg_layout_xml-instruc_ex_block

<!--
If you are fixing a GitHub issue, note it using GitHub keyword format (https://help.github.com/en/articles/closing-issues-using-keywords#closing-an-issue-in-a-different-repository) to close the issue when this pull request is merged. Example: `Fixes #1234`

`master` is the default branch. Merged pull requests to `master` go live on the site automatically. Any requested changes to content on the `master` branch must be related to the released codebase. Any content related to future releases goes in the `develop` branch.

See Contribution guidelines (https://github.com/magento/devdocs/blob/master/.github/CONTRIBUTING.md) for more information.
-->
