### PR TITLE
ACP2E-954: Fixed the invalid filter definition for FilterMatchTypeInput

### DIFF
--- a/src/guides/v2.3/graphql/custom-filters.md
+++ b/src/guides/v2.3/graphql/custom-filters.md
@@ -18,7 +18,7 @@ You have several options when enabling a custom attribute (or any attribute that
 The [`filter`]({{page.baseurl}}/graphql/queries/products.html#ProductFilterInput) definition for your custom attribute requires one of the following input data types:
 
 -  `FilterEqualTypeInput` - Specify this data type when the **Catalog Input Type for Store Owner** field for your custom attribute is set to Yes/No, Select, or Multiple select. Your filter can contain the `eq` or `in` attribute. Use the `eq` attribute to exactly match the specified string. Use the `in` attribute to filter on a comma-separated list of values.
--  `FilterMatchTypeInput` - Specify this data type when the **Catalog Input Type for Store Owner** field for your custom attribute is set to Text Field or Text Area. Your filter must contain the `match` attribute, which will return all items that exactly match the specified string.
+-  `FilterMatchTypeInput` - Specify this data type when the **Catalog Input Type for Store Owner** field for your custom attribute is set to Text Field or Text Area. Your filter must contain the `match` attribute, which will defines a filter that performs a fuzzy search.
 -  `FilterRangeTypeInput` - Specify this data type when the **Catalog Input Type for Store Owner** field for your custom attribute is set to Price or Date. Your filter can contain one or both of the `to` and `from` attributes, which serve to provide a range of values to filter on.
 
 ## Example

--- a/src/guides/v2.3/graphql/custom-filters.md
+++ b/src/guides/v2.3/graphql/custom-filters.md
@@ -18,7 +18,7 @@ You have several options when enabling a custom attribute (or any attribute that
 The [`filter`]({{page.baseurl}}/graphql/queries/products.html#ProductFilterInput) definition for your custom attribute requires one of the following input data types:
 
 -  `FilterEqualTypeInput` - Specify this data type when the **Catalog Input Type for Store Owner** field for your custom attribute is set to Yes/No, Select, or Multiple select. Your filter can contain the `eq` or `in` attribute. Use the `eq` attribute to exactly match the specified string. Use the `in` attribute to filter on a comma-separated list of values.
--  `FilterMatchTypeInput` - Specify this data type when the **Catalog Input Type for Store Owner** field for your custom attribute is set to Text Field or Text Area. Your filter must contain the `match` attribute, which will defines a filter that performs a fuzzy search.
+-  `FilterMatchTypeInput` - Specify this data type when the **Catalog Input Type for Store Owner** field for your custom attribute is set to Text Field or Text Area. Your filter must contain the `match` attribute, which will define a filter that performs a fuzzy search.
 -  `FilterRangeTypeInput` - Specify this data type when the **Catalog Input Type for Store Owner** field for your custom attribute is set to Price or Date. Your filter can contain one or both of the `to` and `from` attributes, which serve to provide a range of values to filter on.
 
 ## Example


### PR DESCRIPTION
## Purpose of this pull request

This pull request (PR) ACP2E-954: Fixed the invalid filter definition for FilterMatchTypeInput

## Affected DevDocs pages
- https://devdocs.magento.com/guides/v2.3/graphql/custom-filters.html
