### PR TITLE
Add caveat for configuring robots.txt with PWA

### DIFF
--- a/src/cloud/trouble/robots-sitemap.md
+++ b/src/cloud/trouble/robots-sitemap.md
@@ -114,6 +114,6 @@ In the `sitemap` admin config, you must specify the location of the file using `
 To activate `robots.txt` customizations, you must enable the **Indexing by search engines is On for <environment>** option in your project settings.
 
 ![Use the Project Web Interface to manage environments]({{ site.baseurl }}/common/images/cloud/cloud_project-robots-indexing-by-search-engine.png)
-  
+
 {:.bs-callout-info}
 If you are using PWA and are unable to access your configured robots.txt file, please add `robots.txt` into the [Front Name Allowlist](https://github.com/magento/magento2-upward-connector#front-name-allowlist) at Stores > Configuration > General > Web > UPWARD PWA Configuration.

--- a/src/cloud/trouble/robots-sitemap.md
+++ b/src/cloud/trouble/robots-sitemap.md
@@ -116,4 +116,4 @@ To activate `robots.txt` customizations, you must enable the **Indexing by searc
 ![Use the Project Web Interface to manage environments]({{ site.baseurl }}/common/images/cloud/cloud_project-robots-indexing-by-search-engine.png)
 
 {:.bs-callout-info}
-If you are using PWA and are unable to access your configured robots.txt file, please add `robots.txt` into the [Front Name Allowlist](https://github.com/magento/magento2-upward-connector#front-name-allowlist) at Stores > Configuration > General > Web > UPWARD PWA Configuration.
+If you are using PWA Studio and are unable to access your configured `robots.txt` file, add `robots.txt` to the [Front Name Allowlist](https://github.com/magento/magento2-upward-connector#front-name-allowlist) at **Stores** > Configuration > **General** > **Web** > UPWARD PWA Configuration.

--- a/src/cloud/trouble/robots-sitemap.md
+++ b/src/cloud/trouble/robots-sitemap.md
@@ -114,3 +114,6 @@ In the `sitemap` admin config, you must specify the location of the file using `
 To activate `robots.txt` customizations, you must enable the **Indexing by search engines is On for <environment>** option in your project settings.
 
 ![Use the Project Web Interface to manage environments]({{ site.baseurl }}/common/images/cloud/cloud_project-robots-indexing-by-search-engine.png)
+  
+{:.bs-callout-info}
+If you are using PWA and are unable to access your configured robots.txt file, please add `robots.txt` into the [Front Name Allowlist](https://github.com/magento/magento2-upward-connector#front-name-allowlist) at Stores > Configuration > General > Web > UPWARD PWA Configuration.


### PR DESCRIPTION
## Purpose of this pull request

This pull request (PR) adds notes for PWA users setting up their robots.txt

When enabling the robots.txt through Magento, only  `Allow: / `or `Disallow: /` will show based on the project configuration shown here:
https://devdocs.magento.com/cloud/trouble/robots-sitemap.html#configure-indexing-by-search-engine

## Affected DevDocs pages

https://devdocs.magento.com/cloud/trouble/robots-sitemap.html#configure-indexing-by-search-engine
-  ...

## Reference to this configuration

https://github.com/magento/magento2-upward-connector#front-name-allowlist


-->
