### PR TITLE
UpdatingCron Configuration Document

### DIFF
--- a/src/_includes/config/setup-cron_about.md
+++ b/src/_includes/config/setup-cron_about.md
@@ -4,7 +4,13 @@ The Magento _crontab_ is the configuration used to run Magento cron jobs.
 
 Magento uses cron tasks that can run with different configurations. The PHP command-line configuration controls the general cron job that reindexes indexers, generates e-mails, generates the sitemap, and so on.
 
-{:.bs-callout-warning}
+{%
+include note.html
+type='warning'
+content='
 
 *  To avoid issues during installation and upgrade, we strongly recommend you apply the same PHP settings to both the PHP command-line configuration and to the PHP web server plug-in's configuration. For more information, see [Required PHP settings]({{ page.baseurl }}/install-gde/prereq/php-settings.html).
+
 *  In a multi-node system, crontab can run on only one node. This applies to you only if you set up more than one webnode for reasons related to performance or scalability.
+
+'%}

--- a/src/_includes/config/setup-cron_how-to.md
+++ b/src/_includes/config/setup-cron_how-to.md
@@ -16,10 +16,16 @@ To create the Commerce crontab:
 
 Use `--force` to rewrite an existing Magento crontab.
 
- {:.bs-callout-info}
+{%
+include note.html
+type='info'
+content='
 
-*  `magento cron:install` does not rewrite an existing crontab inside `#~ MAGENTO START` and `#~ MAGENTO END` comments in your crontab.
-*  `magento cron:install --force` has no effect on any cron jobs outside the Magento comments.
+*  `bin/magento cron:install` does not rewrite an existing crontab inside `#~ MAGENTO START` and `#~ MAGENTO END` comments in your crontab.
+
+*  `bin/magento cron:install --force` has no effect on any cron jobs outside the Magento comments.
+
+'%}
 
 To view the crontab, enter the following command as the file system owner:
 
@@ -31,7 +37,7 @@ A sample follows:
 
 ```terminal
 #~ MAGENTO START c5f9e5ed71cceaabc4d4fd9b3e827a2b
-* * * * * /usr/bin/php /var/www/html/magento2/bin/magento cron:run 2>&1 | grep -v "Ran jobs by schedule" >> /var/www/html/magento2/var/log/magento.cron.log
+* * * * * /usr/bin/php<php_version> <install_directory>/bin/magento cron:run 2>&1 | grep -v "Ran jobs by schedule" >> <install_directory>/var/log/magento.cron.log
 #~ MAGENTO END c5f9e5ed71cceaabc4d4fd9b3e827a2b
 ```
 


### PR DESCRIPTION
## Purpose of this pull request
This pull request (PR) for updating Cron Configuration documentation in Configuration Guide by resolving styling and wrong output issues.

- For **1**st Page listed underneath, I have updated the warning callout pattern by standard one to resolve styling-related issues(*bullet pointers were touching the outline of warning callout section*).
- For **2**st Page listed underneath, I have updated the info callout pattern by standard one to resolve styling-related issues(*bullet pointers were touching the outline of info callout section*). Along with this updated command by adding `bin` directory path before the command & updated the output of `crontab -l`  by generalizing the actual result of the same.

## Affected DevDocs pages
1 : https://devdocs.magento.com/guides/v2.4/config-guide/cli/config-cli-subcommands-cron.html#create-or-remove-the-magento-crontab : setup-cron_about.md

2 : https://devdocs.magento.com/guides/v2.4/config-guide/cli/config-cli-subcommands-cron.html#create-the-commerce-crontab : setup-cron_how-to.md
<!-- REQUIRED List the affected pages on devdocs.magento.com (URLs). Not needed for large numbers of files. -->
