### PR TITLE
Fastly module does not support redirections between websites.

### DIFF
--- a/src/cloud/cdn/configure-fastly-customize-cache.md
+++ b/src/cloud/cdn/configure-fastly-customize-cache.md
@@ -99,7 +99,7 @@ To set up GeoIp handling:
 1. After page reload, click **Upload VCL to Fastly** in the *Fastly Configuration* section.
 
 {:.bs-callout-info}
-The current Adobe Commerce Fastly GeoIP module implementation does not support redirections between websites.
+The current Adobe Commerce Fastly GeoIP module implementation does not support redirections between multiple websites.
 
 Fastly also provides a series of [geolocation-related VCL features](https://docs.fastly.com/guides/vcl/geolocation-related-vcl-features) for customized geolocation coding.
 

--- a/src/cloud/cdn/configure-fastly-customize-cache.md
+++ b/src/cloud/cdn/configure-fastly-customize-cache.md
@@ -98,6 +98,9 @@ To set up GeoIp handling:
 
 1. After page reload, click **Upload VCL to Fastly** in the *Fastly Configuration* section.
 
+{:.bs-callout-info}
+The current Adobe Commerce Fastly GeoIP module implementation does not support redirections between websites.
+
 Fastly also provides a series of [geolocation-related VCL features](https://docs.fastly.com/guides/vcl/geolocation-related-vcl-features) for customized geolocation coding.
 
 ## Enable Fastly Edge modules


### PR DESCRIPTION
## Purpose of this pull request
Update the fastly GeoIP implementation 
Adobe Commerce support ticket reference https://magento.zendesk.com/agent/tickets/535551

## Affected DevDocs pages
- https://devdocs.magento.com/cloud/cdn/configure-fastly-customize-cache.html#configure-geoip-handling