### PR TITLE
Added PHP8.1

### DIFF
--- a/src/_data/features.yml
+++ b/src/_data/features.yml
@@ -231,6 +231,14 @@ features:
           2.3: false
           2.4: true
       -
+        name: PHP 8.1
+        support:
+          2.0: false
+          2.1: false
+          2.2: false
+          2.3: false
+          2.4: true
+      -
         name: PHP 7.4
         support:
           2.0: false


### PR DESCRIPTION
Added PHP 8.1 to the features table.

## Purpose of this pull request
Adding PHP 8.1 to the features table.

This pull request (PR) ...

## Affected DevDocs pages

<!-- REQUIRED List the affected pages on devdocs.magento.com (URLs). Not needed for large numbers of files. -->

-  https://devdocs.magento.com/release/commerce-features.html


<!--
If you are fixing a GitHub issue, note it using GitHub keyword format (https://help.github.com/en/articles/closing-issues-using-keywords#closing-an-issue-in-a-different-repository) to close the issue when this pull request is merged. Example: `Fixes #1234`

`master` is the default branch. Merged pull requests to `master` go live on the site automatically. Any requested changes to content on the `master` branch must be related to the released codebase. Any content related to future releases goes in the `develop` branch.

See Contribution guidelines (https://github.com/magento/devdocs/blob/master/.github/CONTRIBUTING.md) for more information.
-->
