### PR TITLE
Update link to AWS OpenSearch documentation

### DIFF
--- a/src/guides/v2.4/install-gde/prereq/es-aws.md
+++ b/src/guides/v2.4/install-gde/prereq/es-aws.md
@@ -56,5 +56,5 @@ For additional information, see the [OpenSearch AWS documentation][].
 [Elasticdump]: https://www.npmjs.com/package/elasticdump
 [Elasticsearch documentation]: https://www.elastic.co/guide/en/elasticsearch/reference/current/index.html
 [Migrating to Amazon OpenSearch Service]: https://docs.aws.amazon.com/opensearch-service/latest/developerguide/migration.html
-[OpenSearch AWS documentation]: https://github.com/magento/devdocs/edit/master/src/guides/v2.4/install-gde/prereq/es-aws.md
+[OpenSearch AWS documentation]: https://docs.aws.amazon.com/opensearch-service/index.html
 [Advanced Install]: {{ page.baseurl }}/install-gde/install/cli/install-cli.html

--- a/src/guides/v2.4/install-gde/prereq/es-aws.md
+++ b/src/guides/v2.4/install-gde/prereq/es-aws.md
@@ -56,4 +56,5 @@ For additional information, see the [OpenSearch AWS documentation][].
 [Elasticdump]: https://www.npmjs.com/package/elasticdump
 [Elasticsearch documentation]: https://www.elastic.co/guide/en/elasticsearch/reference/current/index.html
 [Migrating to Amazon OpenSearch Service]: https://docs.aws.amazon.com/opensearch-service/latest/developerguide/migration.html
+[OpenSearch AWS documentation]: https://github.com/magento/devdocs/edit/master/src/guides/v2.4/install-gde/prereq/es-aws.md
 [Advanced Install]: {{ page.baseurl }}/install-gde/install/cli/install-cli.html


### PR DESCRIPTION
## Purpose of this pull request

This pull request (PR) is for add link to AWS OpenSearch documentation.

## Affected DevDocs pages

-  https://devdocs.magento.com/guides/v2.4/install-gde/prereq/es-aws.html

<!--
If you are fixing a GitHub issue, note it using GitHub keyword format (https://help.github.com/en/articles/closing-issues-using-keywords#closing-an-issue-in-a-different-repository) to close the issue when this pull request is merged. Example: `Fixes #1234`

`master` is the default branch. Merged pull requests to `master` go live on the site automatically. Any requested changes to content on the `master` branch must be related to the released codebase. Any content related to future releases goes in the `develop` branch.

See Contribution guidelines (https://github.com/magento/devdocs/blob/master/.github/CONTRIBUTING.md) for more information.
-->
