### PR TITLE
Don't install dev dependencies by default

### DIFF
--- a/src/cloud/project/magento-app-properties.md
+++ b/src/cloud/project/magento-app-properties.md
@@ -64,7 +64,7 @@ dependencies:
 hooks:
     build: |
         set -e
-        composer --no-ansi --no-interaction install --no-progress --prefer-dist --optimize-autoloader
+        composer --no-dev --no-ansi --no-interaction install --no-progress --prefer-dist --optimize-autoloader
 ```
 
 ## `access`


### PR DESCRIPTION
## Purpose of this pull request

This pull request corrects a glaring oversight of composer installing development packages.

## Affected DevDocs pages
https://devdocs.magento.com/cloud/project/magento-app-properties.html