### PR TITLE
Update commerce-2-4-4.md

### DIFF
--- a/src/guides/v2.4/release-notes/commerce-2-4-4.md
+++ b/src/guides/v2.4/release-notes/commerce-2-4-4.md
@@ -520,10 +520,6 @@ We are fixing hundreds of issues in the {{ site.data.var.ee }} 2.4.4 core code. 
 
 *  {{ site.data.var.ee }} no longer modifies related product prices when the configurable product attributes are changed. Previously, the Minimum Advertised Price (MAP) for a configurable product overwrote the price of related products on the store front.
 
-<!--- MC-41796-->
-
-*  {{ site.data.var.ee }} no longer throws an exception when performing a mass attribute update action on the product grid when a product has a `datetime` attribute.
-
 <!--- MC-42659-->
 
 *  Administrators can now re-assign the last product remaining in a category and save the empty category.


### PR DESCRIPTION
Remove duplicate if Adobe Commerce no longer throws an exception when performing a mass attribute update action on the product grid when a product has a datetime attribute.

## Purpose of this pull request

This pull request (PR) ...

## Affected DevDocs pages

https://devdocs.magento.com/guides/v2.4/release-notes/commerce-2-4-4.html#catalog
<!-- REQUIRED List the affected pages on devdocs.magento.com (URLs). Not needed for large numbers of files. -->

-  ...

## Links to Magento source code

<!--  OPTIONAL - REMOVE THIS SECTION IF NOT USED. If this pull request references a file in a Magento codebase repository, add it here. -->

-  ...

<!--
If you are fixing a GitHub issue, note it using GitHub keyword format (https://help.github.com/en/articles/closing-issues-using-keywords#closing-an-issue-in-a-different-repository) to close the issue when this pull request is merged. Example: `Fixes #1234`

`master` is the default branch. Merged pull requests to `master` go live on the site automatically. Any requested changes to content on the `master` branch must be related to the released codebase. Any content related to future releases goes in the `develop` branch.

See Contribution guidelines (https://github.com/magento/devdocs/blob/master/.github/CONTRIBUTING.md) for more information.
-->
