### PR TITLE
Update b2b_roles.md

### DIFF
--- a/src/_includes/webapi/b2b_roles.md
+++ b/src/_includes/webapi/b2b_roles.md
@@ -14,13 +14,13 @@ Display name | Resource name
 &emsp; &emsp; &emsp; &emsp; Checkout with Quote | Magento_NegotiableQuote::checkout
 &emsp; &emsp; &emsp; View quotes of subordinate users | Magento_NegotiableQuote::view_quotes_sub
 &emsp; Order Approvals | Magento_PurchaseOrder::all
-&emsp; &emsp; View My Purchase Orders | Magento_PurchaseOrder:view_purchase_orders
-&emsp; &emsp; &emsp; View for subordinates | Magento_PurchaseOrder:view_purchase_orders_for_subordinates
-&emsp; &emsp; &emsp; View for all company | Magento_PurchaseOrder:view_purchase_orders_for_company
-&emsp; &emsp; Auto-approve POs created within this role | Magento_PurchaseOrder:autoapprove_purchase_order
-&emsp; &emsp; Approve Purchase Orders without other approvals | Magento_PurchaseOrder:super_approve_purchase_order
-&emsp; &emsp; View Approval Rules | Magento_PurchaseOrder:view_approval_rules
-&emsp; &emsp; &emsp; Create, Edit and Delete | Magento_PurchaseOrder:manage_approval_rules
+&emsp; &emsp; View My Purchase Orders | Magento_PurchaseOrder::view_purchase_orders
+&emsp; &emsp; &emsp; View for subordinates | Magento_PurchaseOrder::view_purchase_orders_for_subordinates
+&emsp; &emsp; &emsp; View for all company | Magento_PurchaseOrder::view_purchase_orders_for_company
+&emsp; &emsp; Auto-approve POs created within this role | Magento_PurchaseOrder::autoapprove_purchase_order
+&emsp; &emsp; Approve Purchase Orders without other approvals | Magento_PurchaseOrderRule::super_approve_purchase_order
+&emsp; &emsp; View Approval Rules | Magento_PurchaseOrderRule::view_approval_rules
+&emsp; &emsp; &emsp; Create, Edit and Delete | Magento_PurchaseOrderRule::manage_approval_rules
 &emsp; &emsp; Company Profile | Magento_Company::view
 &emsp; &emsp; &emsp; Account Information (View) | Magento_Company::view_account
 &emsp; &emsp; &emsp; &emsp; Edit | Magento_Company::edit_account


### PR DESCRIPTION
few resource names contains ':' value instead of "::", replaced with '::'
Few resource names were wrong, replace with the new resource names "Magento_PurchaseOrderRule"

## Purpose of this pull request

This pull request (PR) ...

## Affected DevDocs pages

<!-- REQUIRED List the affected pages on devdocs.magento.com (URLs). Not needed for large numbers of files. -->

-  ...

## Links to Magento source code

<!--  OPTIONAL - REMOVE THIS SECTION IF NOT USED. If this pull request references a file in a Magento codebase repository, add it here. -->

-  ...

<!--
If you are fixing a GitHub issue, note it using GitHub keyword format (https://help.github.com/en/articles/closing-issues-using-keywords#closing-an-issue-in-a-different-repository) to close the issue when this pull request is merged. Example: `Fixes #1234`

`master` is the default branch. Merged pull requests to `master` go live on the site automatically. Any requested changes to content on the `master` branch must be related to the released codebase. Any content related to future releases goes in the `develop` branch.

See Contribution guidelines (https://github.com/magento/devdocs/blob/master/.github/CONTRIBUTING.md) for more information.
-->
