### PR TITLE
Adding a section on how to uninstall a custom patch

### DIFF
--- a/src/cloud/project/project-patch.md
+++ b/src/cloud/project/project-patch.md
@@ -228,7 +228,6 @@ To revert/uninstall a previously applied custom patch:
    {:.bs-callout-info}
    Make sure to test in a pre-production environment. For {{site.data.var.ece}}, you can create new branches with the `magento-cloud environment:branch <branch-name>` CLI command.
 
-
 ## Apply patches to a non-Cloud project {#standalone}
 
 Use the [Quality Patches Tool]({{ site.baseurl }}/quality-patches/usage.html) for {{ site.data.var.ce }} and {{ site.data.var.ee }} projects.

--- a/src/cloud/project/project-patch.md
+++ b/src/cloud/project/project-patch.md
@@ -205,6 +205,30 @@ To apply and test a custom patch on a Cloud environment:
    {:.bs-callout-info}
    Make sure to test all patches in a pre-production environment. For {{site.data.var.ece}}, you can create new branches with the `magento-cloud environment:branch <branch-name>` CLI command.
 
+## Revert a custom patch
+
+To revert/uninstall a previously applied custom patch:
+
+1. Delete the patch file from the `/m2-hotfixes` directory.
+
+1. Add, commit, and push code changes.
+
+   ```bash
+   git add m2-hotfixes/
+   ```
+
+   ```bash
+   git commit -m "Revert patch"
+   ```
+
+   ```bash
+   git push origin <branch-name>
+   ```
+
+   {:.bs-callout-info}
+   Make sure to test in a pre-production environment. For {{site.data.var.ece}}, you can create new branches with the `magento-cloud environment:branch <branch-name>` CLI command.
+
+
 ## Apply patches to a non-Cloud project {#standalone}
 
 Use the [Quality Patches Tool]({{ site.baseurl }}/quality-patches/usage.html) for {{ site.data.var.ce }} and {{ site.data.var.ee }} projects.

--- a/src/cloud/project/project-patch.md
+++ b/src/cloud/project/project-patch.md
@@ -207,7 +207,7 @@ To apply and test a custom patch on a Cloud environment:
 
 ## Revert a custom patch
 
-To revert/uninstall a previously applied custom patch:
+To revert or uninstall a previously applied custom patch:
 
 1. Delete the patch file from the `/m2-hotfixes` directory.
 


### PR DESCRIPTION
## Purpose of this pull request

This pull request (PR) is to add information about how to uninstall a custom patch.

## Affected DevDocs pages

https://devdocs.magento.com/cloud/project/project-patch.html#apply-a-custom-patch