### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ Welcome! This site contains the latest Adobe Commerce and Magento Open Source de
 
 > **Important update**
 >
-> The developer documentation for Adobe Commerce and Magento Open Source is moving to the [Adobe Developer](developer.adobe.com/commerce) and [Adobe Experience League](https://experienceleague.adobe.com/docs/commerce.html) sites. After a topic is moved, use the link in the topic header to find the new location.
+> The developer documentation for Adobe Commerce and Magento Open Source is moving to the [Adobe Developer](https://developer.adobe.com/commerce) and [Adobe Experience League](https://experienceleague.adobe.com/docs/commerce.html) sites. After a topic is moved, use the link in the topic header to find the new location.
 >
 >![Example of a topic header](https://user-images.githubusercontent.com/6391769/166058975-15c288d6-b266-4f1d-8b52-08ada3ca026f.png)
 >


### PR DESCRIPTION
Clicking on the Adobe Developer link fails to redirect to the website. Added 'https://' to properly redirect.

## Purpose of this pull request

This pull request (PR) fixes the redirect link.