### PR TITLE
Typo in ContactUsInput Type

### DIFF
--- a/src/guides/v2.4/graphql/mutations/contact-us.md
+++ b/src/guides/v2.4/graphql/mutations/contact-us.md
@@ -8,7 +8,7 @@ The `contactUs` mutation submits the contents of the Contact Us form.
 
 ## Syntax
 
- `mutation: contactUs(input: ContacUsInput!): ContactUsOutput`
+ `mutation: contactUs(input: ContactUsInput!): ContactUsOutput`
 
 ## Example usage
 


### PR DESCRIPTION
I'm not sure if the type in PWA studio is ContactUsInput or StoreContacUsInput if it's ContacUsInput maybe also fix the graphql type!

## Purpose of this pull request

This pull request (PR) ...

## Affected DevDocs pages

<!-- REQUIRED List the affected pages on devdocs.magento.com (URLs). Not needed for large numbers of files. -->

-  ...

## Links to Magento source code

<!--  OPTIONAL - REMOVE THIS SECTION IF NOT USED. If this pull request references a file in a Magento codebase repository, add it here. -->

-  ...

<!--
If you are fixing a GitHub issue, note it using GitHub keyword format (https://help.github.com/en/articles/closing-issues-using-keywords#closing-an-issue-in-a-different-repository) to close the issue when this pull request is merged. Example: `Fixes #1234`

`master` is the default branch. Merged pull requests to `master` go live on the site automatically. Any requested changes to content on the `master` branch must be related to the released codebase. Any content related to future releases goes in the `develop` branch.

See Contribution guidelines (https://github.com/magento/devdocs/blob/master/.github/CONTRIBUTING.md) for more information.
-->
