### PR TITLE
Correct syntax for @inheritDoc tag

### DIFF
--- a/src/guides/v2.3/ext-best-practices/tutorials/create-custom-rest-api.md
+++ b/src/guides/v2.3/ext-best-practices/tutorials/create-custom-rest-api.md
@@ -415,7 +415,7 @@ class ProductRepository implements ProductRepositoryInterface
     }
 
     /**
-     * {@inheritDoc}
+     * @inheritDoc
      *
      * @param int $id
      * @return ResponseItemInterface
@@ -436,7 +436,7 @@ class ProductRepository implements ProductRepositoryInterface
     }
 
     /**
-     * {@inheritDoc}
+     * @inheritDoc
      *
      * @param RequestItemInterface[] $products
      * @return void

--- a/src/guides/v2.3/ext-best-practices/tutorials/serialized-to-json-data-upgrade.md
+++ b/src/guides/v2.3/ext-best-practices/tutorials/serialized-to-json-data-upgrade.md
@@ -107,7 +107,7 @@ class UpgradeData implements UpgradeDataInterface
     }
 
     /**
-     * {@inheritdoc}
+     * @inheritDoc
      */
     public function upgrade(
         ModuleDataSetupInterface $setup,

--- a/src/guides/v2.3/extension-dev-guide/prepare/lifecycle.md
+++ b/src/guides/v2.3/extension-dev-guide/prepare/lifecycle.md
@@ -153,7 +153,7 @@ use Magento\Framework\Setup\InstallDataInterface;
 class InstallData implements InstallDataInterface
 {
     /**
-     * {@inheritdoc}
+     * @inheritDoc
      */
     public function install(ModuleDataSetupInterface $setup, ModuleContextInterface $context)
     {
@@ -267,7 +267,7 @@ class DefaultCustomerGroupsAndAttributes implements DataPatchInterface, PatchVer
         $this->moduleDataSetup = $moduleDataSetup;
     }
     /**
-     * {@inheritdoc}
+     * @inheritDoc
      * @SuppressWarnings(PHPMD.ExcessiveMethodLength)
      */
     public function apply()

--- a/src/guides/v2.3/extension-dev-guide/searching-with-repositories.md
+++ b/src/guides/v2.3/extension-dev-guide/searching-with-repositories.md
@@ -438,7 +438,7 @@ Below is an example of how the [`CustomerRepositoryInterface`]({{ site.mage2blob
         }
         ...
         /**
-         * {@inheritdoc}
+         * @inheritDoc
          **/
         public function getList(SearchCriteriaInterface $searchCriteria)
         {

--- a/src/guides/v2.3/get-started/create-integration.md
+++ b/src/guides/v2.3/get-started/create-integration.md
@@ -156,7 +156,7 @@ To develop a module, you must:
        }
 
        /**
-        * {@inheritdoc}
+        * @inheritDoc
         */
 
        public function install(ModuleDataSetupInterface $setup, ModuleContextInterface $context)

--- a/src/guides/v2.3/howdoi/customize-modifier-class.md
+++ b/src/guides/v2.3/howdoi/customize-modifier-class.md
@@ -81,7 +81,7 @@ class Example extends AbstractModifier
     }
 
     /**
-     * {@inheritdoc}
+     * @inheritDoc
      */
     public function modifyData(array $data)
     {

--- a/src/guides/v2.3/ui_comp_guide/components/ui-urlinput.md
+++ b/src/guides/v2.3/ui_comp_guide/components/ui-urlinput.md
@@ -61,7 +61,7 @@ class MyLink implements ConfigInterface
 {
 
     /**
-     * {@inheritdoc}
+     * @inheritDoc
      */
     public function getConfig()
     {

--- a/src/guides/v2.3/ui_comp_guide/components/ui-wysiwyg.md
+++ b/src/guides/v2.3/ui_comp_guide/components/ui-wysiwyg.md
@@ -207,7 +207,7 @@ class ModifierPoolDataProvider extends AbstractDataProvider
     }
 
     /**
-     * {@inheritdoc}
+     * @inheritDoc
      */
     public function getData()
     {
@@ -221,7 +221,7 @@ class ModifierPoolDataProvider extends AbstractDataProvider
     }
 
     /**
-     * {@inheritdoc}
+     * @inheritDoc
      */
     public function getMeta()
     {

--- a/src/guides/v2.3/ui_comp_guide/components/wysiwyg/configure-tinymce-editor.md
+++ b/src/guides/v2.3/ui_comp_guide/components/wysiwyg/configure-tinymce-editor.md
@@ -101,7 +101,7 @@ class DefaultConfigProvider implements \Magento\Framework\Data\Wysiwyg\ConfigPro
     ...
 
     /**
-     * {@inheritdoc}
+     * @inheritDoc
      */
     public function getConfig(\Magento\Framework\DataObject $config) : \Magento\Framework\DataObject
     {

--- a/src/guides/v2.3/ui_comp_guide/concepts/ui_comp_modifier_concept.md
+++ b/src/guides/v2.3/ui_comp_guide/concepts/ui_comp_modifier_concept.md
@@ -71,7 +71,7 @@ class Example implements ModifierInterface
     }
 
     /**
-     * {@inheritdoc}
+     * @inheritDoc
      */
     public function modifyData(array $data)
     {

--- a/src/guides/v2.3/ui_comp_guide/howto/update-url-type.md
+++ b/src/guides/v2.3/ui_comp_guide/howto/update-url-type.md
@@ -49,7 +49,7 @@ class Page implements \Magento\Ui\Model\UrlInput\ConfigInterface
         $this->urlBuilder = $urlBuilder;
     }
     /**
-     * {@inheritdoc}
+     * @inheritDoc
      */
     public function getConfig(): array
     {

--- a/src/guides/v2.4/ext-best-practices/tutorials/create-custom-rest-api.md
+++ b/src/guides/v2.4/ext-best-practices/tutorials/create-custom-rest-api.md
@@ -417,7 +417,7 @@ class ProductRepository implements ProductRepositoryInterface
     }
 
     /**
-     * {@inheritDoc}
+     * @inheritDoc
      *
      * @param int $id
      * @return ResponseItemInterface
@@ -438,7 +438,7 @@ class ProductRepository implements ProductRepositoryInterface
     }
 
     /**
-     * {@inheritDoc}
+     * @inheritDoc
      *
      * @param RequestItemInterface[] $products
      * @return void

--- a/src/guides/v2.4/ext-best-practices/tutorials/serialized-to-json-data-upgrade.md
+++ b/src/guides/v2.4/ext-best-practices/tutorials/serialized-to-json-data-upgrade.md
@@ -109,7 +109,7 @@ class UpgradeData implements UpgradeDataInterface
     }
 
     /**
-     * {@inheritdoc}
+     * @inheritDoc
      */
     public function upgrade(
         ModuleDataSetupInterface $setup,

--- a/src/guides/v2.4/extension-dev-guide/prepare/lifecycle.md
+++ b/src/guides/v2.4/extension-dev-guide/prepare/lifecycle.md
@@ -155,7 +155,7 @@ use Magento\Framework\Setup\InstallDataInterface;
 class InstallData implements InstallDataInterface
 {
     /**
-     * {@inheritdoc}
+     * @inheritDoc
      */
     public function install(ModuleDataSetupInterface $setup, ModuleContextInterface $context)
     {
@@ -269,7 +269,7 @@ class DefaultCustomerGroupsAndAttributes implements DataPatchInterface, PatchVer
         $this->moduleDataSetup = $moduleDataSetup;
     }
     /**
-     * {@inheritdoc}
+     * @inheritDoc
      * @SuppressWarnings(PHPMD.ExcessiveMethodLength)
      */
     public function apply()

--- a/src/guides/v2.4/extension-dev-guide/searching-with-repositories.md
+++ b/src/guides/v2.4/extension-dev-guide/searching-with-repositories.md
@@ -442,7 +442,7 @@ Below is an example of how the [`CustomerRepositoryInterface`]({{ site.mage2blob
         }
         ...
         /**
-         * {@inheritdoc}
+         * @inheritDoc
          **/
         public function getList(SearchCriteriaInterface $searchCriteria)
         {

--- a/src/guides/v2.4/get-started/create-integration.md
+++ b/src/guides/v2.4/get-started/create-integration.md
@@ -151,7 +151,7 @@ For more information, see [Create a component]({{ page.baseurl }}/extension-dev-
        }
 
        /**
-        * {@inheritdoc}
+        * @inheritDoc
         */
 
        public function install(ModuleDataSetupInterface $setup, ModuleContextInterface $context)

--- a/src/guides/v2.4/howdoi/customize-modifier-class.md
+++ b/src/guides/v2.4/howdoi/customize-modifier-class.md
@@ -83,7 +83,7 @@ class Example extends AbstractModifier
     }
 
     /**
-     * {@inheritdoc}
+     * @inheritDoc
      */
     public function modifyData(array $data)
     {

--- a/src/guides/v2.4/ui_comp_guide/components/ui-urlinput.md
+++ b/src/guides/v2.4/ui_comp_guide/components/ui-urlinput.md
@@ -63,7 +63,7 @@ class MyLink implements ConfigInterface
 {
 
     /**
-     * {@inheritdoc}
+     * @inheritDoc
      */
     public function getConfig()
     {

--- a/src/guides/v2.4/ui_comp_guide/components/ui-wysiwyg.md
+++ b/src/guides/v2.4/ui_comp_guide/components/ui-wysiwyg.md
@@ -209,7 +209,7 @@ class ModifierPoolDataProvider extends AbstractDataProvider
     }
 
     /**
-     * {@inheritdoc}
+     * @inheritDoc
      */
     public function getData()
     {
@@ -223,7 +223,7 @@ class ModifierPoolDataProvider extends AbstractDataProvider
     }
 
     /**
-     * {@inheritdoc}
+     * @inheritDoc
      */
     public function getMeta()
     {

--- a/src/guides/v2.4/ui_comp_guide/components/wysiwyg/configure-tinymce-editor.md
+++ b/src/guides/v2.4/ui_comp_guide/components/wysiwyg/configure-tinymce-editor.md
@@ -103,7 +103,7 @@ class DefaultConfigProvider implements \Magento\Framework\Data\Wysiwyg\ConfigPro
     ...
 
     /**
-     * {@inheritdoc}
+     * @inheritDoc
      */
     public function getConfig(\Magento\Framework\DataObject $config) : \Magento\Framework\DataObject
     {

--- a/src/guides/v2.4/ui_comp_guide/concepts/ui_comp_modifier_concept.md
+++ b/src/guides/v2.4/ui_comp_guide/concepts/ui_comp_modifier_concept.md
@@ -73,7 +73,7 @@ class Example implements ModifierInterface
     }
 
     /**
-     * {@inheritdoc}
+     * @inheritDoc
      */
     public function modifyData(array $data)
     {

--- a/src/guides/v2.4/ui_comp_guide/howto/update-url-type.md
+++ b/src/guides/v2.4/ui_comp_guide/howto/update-url-type.md
@@ -51,7 +51,7 @@ class Page implements \Magento\Ui\Model\UrlInput\ConfigInterface
         $this->urlBuilder = $urlBuilder;
     }
     /**
-     * {@inheritdoc}
+     * @inheritDoc
      */
     public function getConfig(): array
     {


### PR DESCRIPTION
## Purpose of this pull request

This pull request corrects the use of the `@inheritDoc` tag. The changes here are being made in accordance with the Magento2 coding standard: https://github.com/magento/magento-coding-standard/blob/v25/Magento2/Sniffs/Annotation/AnnotationFormatValidator.php#L129

## Links to Magento source code
- https://github.com/magento/magento-coding-standard/blob/v25/Magento2/Sniffs/Annotation/AnnotationFormatValidator.php#L129