### PR TITLE
Correct indentation to appease markdownlint

### DIFF
--- a/src/guides/v2.3/get-started/create-integration.md
+++ b/src/guides/v2.3/get-started/create-integration.md
@@ -65,20 +65,20 @@ To develop a module, you must:
    The following example shows an example `etc/module.xml` file.
 
    ```xml
-   <?xml version="1.0"?>
-   <!--
-      /**
-      * Copyright © Magento, Inc. All rights reserved.
-      * See COPYING.txt for license details.
-      */
-      -->
-      <config xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="urn:magento:framework:Module/etc/module.xsd">
-          <module name="Vendor1_Module1" setup_version="2.0.0">
-               <sequence>
-                   <module name="Magento_Integration"/>
-               </sequence>
-          </module>
-        </config>
+    <?xml version="1.0"?>
+    <!--
+     /**
+     * Copyright © Magento, Inc. All rights reserved.
+     * See COPYING.txt for license details.
+     */
+    -->
+    <config xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="urn:magento:framework:Module/etc/module.xsd">
+        <module name="Vendor1_Module1" setup_version="2.0.0">
+            <sequence>
+                <module name="Magento_Integration"/>
+            </sequence>
+        </module>
+    </config>
    ```
 
    Module `Magento_Integration` is added to "sequence" to be loaded first. It helps to avoid the issue, when a module with integration config loaded, that leads to a malfunction.
@@ -107,7 +107,7 @@ To develop a module, you must:
      }
    ```
 
-    For more information, see [Create a component]({{ page.baseurl }}/extension-dev-guide/build/create_component.html).
+   For more information, see [Create a component]({{ page.baseurl }}/extension-dev-guide/build/create_component.html).
 
 1. **Create a `registration.php` file** The `registration.php` registers the module with the Magento system. It must be placed in the module's root directory.
 


### PR DESCRIPTION
## Purpose of this pull request

This pull request fixes complaints from `markdownlint` as seen in the 'super-lint' GitHub Action. After opening https://github.com/magento/devdocs/pull/9519, I noticed that there were complaints in one of the changed files (but not related to that pull request) which prevents that from being merged. Having run `markdownlint` on all files in `src/`, these are the only changes required for a clean result. It turns out that only white-space changes were required to appease the linter; viewing this pull request with "ignore white-space" should show no changes.

> src/guides/v2.3/get-started/create-integration.md:69 MD032/blanks-around-lists Lists should be surrounded by blank lines [Context: "<!--"]
src/guides/v2.3/get-started/create-integration.md:82 MD040/fenced-code-language Fenced code blocks should have a language specified [Context: "   ```"]
src/guides/v2.3/get-started/create-integration.md:110 MD046/code-block-style Code block style [Expected: fenced; Actual: indented]

## Affected DevDocs pages
- https://devdocs.magento.com/guides/v2.3/get-started/create-integration.html