### PR TITLE
Migrate the Quality Patches Tool home page to Experience League

### DIFF
--- a/src/quality-patches/tool.md
+++ b/src/quality-patches/tool.md
@@ -1,10 +1,8 @@
 ---
 group: tools
 title: Quality Patches Tool
-group: tools
 functional_areas:
   - Upgrade
-redirect_from: https://devdocs.magento.com/quality-patches/tool.html
 migrated_to: https://experienceleague.adobe.com/tools/commerce-quality-patches/index.html
 layout: migrated
 ---

--- a/src/quality-patches/tool.md
+++ b/src/quality-patches/tool.md
@@ -1,6 +1,7 @@
 ---
 group: tools
 title: Quality Patches Tool
+group: tools
 functional_areas:
   - Upgrade
 redirect_from: https://devdocs.magento.com/quality-patches/tool.html

--- a/src/quality-patches/tool.md
+++ b/src/quality-patches/tool.md
@@ -3,6 +3,9 @@ group: tools
 title: Quality Patches Tool
 functional_areas:
   - Upgrade
+redirect_from: https://devdocs.magento.com/quality-patches/tool.html
+migrated_to: https://experienceleague.adobe.com/tools/commerce-quality-patches/index.html
+layout: migrated
 ---
 
 The [Quality Patches Tool][github] is a command-line tool that delivers


### PR DESCRIPTION
## Purpose of this pull request

This pull request (PR) is to add meta data about migration of this page to Adobe Experience League Commerce Operations 

## Affected DevDocs pages

https://devdocs.magento.com/quality-patches/tool.html

whatsnew
The Quality Patches Tool [home page](https://devdocs.magento.com/quality-patches/tool.html) moved to [Experience League](https://experienceleague.adobe.com/tools/commerce-quality-patches/index.html) and will be redirected soon.