### PR TITLE
Closing backticks missing - now added

### DIFF
--- a/src/cloud/project/services-opensearch.md
+++ b/src/cloud/project/services-opensearch.md
@@ -81,3 +81,4 @@ opensearch:
         plugins:
             - analysis-icu
             - analysis-phonetic
+```


### PR DESCRIPTION


## Purpose of this pull request

The closing backticks for the final code block were missing, so it didn't display correctly. Now added.

## Affected DevDocs pages

<!-- REQUIRED List the affected pages on devdocs.magento.com (URLs). Not needed for large numbers of files. -->

-  https://devdocs.magento.com/cloud/project/services-opensearch.html
