### PR TITLE
Fix documentation for clearCustomerCart

### DIFF
--- a/src/guides/v2.4/graphql/mutations/clear-customer-cart.md
+++ b/src/guides/v2.4/graphql/mutations/clear-customer-cart.md
@@ -57,7 +57,7 @@ The `clearCustomerCart` mutation requires the following input.
 
 Attribute |  Data Type | Description
 --- | --- | ---
-`cartUid`| String! | Indicates whether cart was cleared
+`cartUid`| String! | The masked ID of the cart.
 
 ## Output attributes
 
@@ -65,8 +65,8 @@ The `clearCustomerCart` object returns the status and cart object.
 
 Attribute |  Data Type | Description
 --- | --- | ---
-`cart` | [Cart](#CartObject) | The cart after clearing items
-`status` | Boolean! | The requisition list after the items were added
+`cart` | [Cart](#CartObject) | The cart after clearing items.
+`status` | Boolean! | Indicates whether cart was cleared.
 
 ### Cart object {#CartObject}
 


### PR DESCRIPTION
Update documentation to match definitions in the schema files.

## Purpose of this pull request

This pull request (PR) fixes descriptions of input/output for clearCustomerCart.

## Affected DevDocs pages
- https://devdocs.magento.com/guides/v2.4/graphql/mutations/clear-customer-cart.html
<!-- REQUIRED List the affected pages on devdocs.magento.com (URLs). Not needed for large numbers of files. -->



## Links to Magento source code
- https://github.com/magento-commerce/magento2b2b/blob/caae8db28cc56efce89fbc707d06b195285ff814/app/code/Magento/RequisitionListGraphQl/etc/schema.graphqls#L185
- https://github.com/magento-commerce/magento2b2b/blob/caae8db28cc56efce89fbc707d06b195285ff814/app/code/Magento/RequisitionListGraphQl/etc/schema.graphqls#L98

<!--  OPTIONAL - REMOVE THIS SECTION IF NOT USED. If this pull request references a file in a Magento codebase repository, add it here. -->

<!--
If you are fixing a GitHub issue, note it using GitHub keyword format (https://help.github.com/en/articles/closing-issues-using-keywords#closing-an-issue-in-a-different-repository) to close the issue when this pull request is merged. Example: `Fixes #1234`

`master` is the default branch. Merged pull requests to `master` go live on the site automatically. Any requested changes to content on the `master` branch must be related to the released codebase. Any content related to future releases goes in the `develop` branch.

See Contribution guidelines (https://github.com/magento/devdocs/blob/master/.github/CONTRIBUTING.md) for more information.
-->
