### PR TITLE
A simple word mistake

### DIFF
--- a/src/cloud/docker/docker-development-debug.md
+++ b/src/cloud/docker/docker-development-debug.md
@@ -122,7 +122,7 @@ You can debug any {{site.data.var.ee}} command or PHP script using the following
 {:.procedure}
 To debug CLI commands:
 
-1. In your PhpStorm project, open the **Build, Extension, Deployment** > **Docker** panel, and then click `+` to add a new Docker server and update the following settings:
+1. In your PhpStorm project, open the **Build, Execution, Deployment** > **Docker** panel, and then click `+` to add a new Docker server and update the following settings:
 
    -  **Name**—Enter a name for the server, for example `Docker Cloud`.
    -  **Connect to Docker daemon with**—


### PR DESCRIPTION


## Purpose of this pull request

This pull request (PR) corrects the section name in PHPStorm, from "Extension" to "Execution".

## Affected DevDocs pages

https://devdocs.magento.com/cloud/docker/docker-development-debug.html


<!--
If you are fixing a GitHub issue, note it using GitHub keyword format (https://help.github.com/en/articles/closing-issues-using-keywords#closing-an-issue-in-a-different-repository) to close the issue when this pull request is merged. Example: `Fixes #1234`

`master` is the default branch. Merged pull requests to `master` go live on the site automatically. Any requested changes to content on the `master` branch must be related to the released codebase. Any content related to future releases goes in the `develop` branch.

See Contribution guidelines (https://github.com/magento/devdocs/blob/master/.github/CONTRIBUTING.md) for more information.
-->
