### PR TITLE
fixes typo from en dash to hyphen

### DIFF
--- a/src/live-search/install.md
+++ b/src/live-search/install.md
@@ -219,7 +219,7 @@ To update to a major version such as from 1.0 to 2.0, edit the project’s root 
 1. **Save** `composer.json`. Then, run the following from the command line:
 
    ```bash
-   composer update magento/live-search –-with-dependencies
+   composer update magento/live-search --with-dependencies
    ```
 
 ## Uninstalling Live Search


### PR DESCRIPTION
## Purpose of this pull request

This pull request (PR) fixes a typo on the documentation. A command has an `en dash` instead of a `hyphen`.

## Affected DevDocs pages

<!-- REQUIRED List the affected pages on devdocs.magento.com (URLs). Not needed for large numbers of files. -->

-  https://experienceleague.adobe.com/docs/commerce-merchant-services/live-search/onboard/install.html

<!--
If you are fixing a GitHub issue, note it using GitHub keyword format (https://help.github.com/en/articles/closing-issues-using-keywords#closing-an-issue-in-a-different-repository) to close the issue when this pull request is merged. Example: `Fixes #1234`

`master` is the default branch. Merged pull requests to `master` go live on the site automatically. Any requested changes to content on the `master` branch must be related to the released codebase. Any content related to future releases goes in the `develop` branch.

See Contribution guidelines (https://github.com/magento/devdocs/blob/master/.github/CONTRIBUTING.md) for more information.
-->
