### PR TITLE
Remove duplicate key 'type' in example config

### DIFF
--- a/src/guides/v2.4/config-guide/cache/cache-types.md
+++ b/src/guides/v2.4/config-guide/cache/cache-types.md
@@ -33,8 +33,6 @@ The following example shows how to define it in `env.php` (which overrides `di.x
          <cache type 1> => [
              'frontend' => '<unique frontend id>'
         ],
-    ],
-    'type' => [
          <cache type 2> => [
              'frontend' => '<unique frontend id>'
         ],


### PR DESCRIPTION
## Purpose of this pull request

This pull request corrects an example configuration. The duplication of the key 'type' overides the former config for <cache type 1>

## Affected DevDocs pages

- src/guides/v2.4/config-guide/cache/cache-types.md

## Links to Magento source code

- [Magento\Framework\App\Cache\Type\FrontendPool](https://github.com/magento/magento2/blob/edcd0dcc87e7096cedf35304187eff2c336751a7/lib/internal/Magento/Framework/App/Cache/Type/FrontendPool.php#L109) where this config is actually evaluated.
